### PR TITLE
feat(organization): add a resend action to pending invitations

### DIFF
--- a/apps/docs/content/docs/heroui/plugins/organization.mdx
+++ b/apps/docs/content/docs/heroui/plugins/organization.mdx
@@ -796,7 +796,12 @@ Searchable, sortable, filter-by-role table of the active organization's members 
 
 ### `<OrganizationInvitations />`
 
-Pending invitations for the active organization as a table aligned with `<OrganizationMembers />`. Includes role / status filters and a per-row cancel action.
+Pending invitations for the active organization as a table aligned with `<OrganizationMembers />`. Includes role / status filters, plus per-row resend and cancel actions.
+
+Resending re-invites the same address with `resend: true`, which pushes the
+invitation's expiry out and sends the email again instead of creating a second
+invitation. The action needs the `invitation: ["create"]` permission, the same
+one that gates `<InviteMemberDialog />`.
 
 <ComponentPreview name="heroui-organization-invitations" />
 

--- a/apps/docs/content/docs/shadcn/plugins/organization.mdx
+++ b/apps/docs/content/docs/shadcn/plugins/organization.mdx
@@ -832,7 +832,12 @@ Searchable, sortable, filter-by-role table of the active organization's members 
 
 ### `<OrganizationInvitations />`
 
-Pending invitations for the active organization as a table aligned with `<OrganizationMembers />`. Includes role / status filters and a per-row cancel action.
+Pending invitations for the active organization as a table aligned with `<OrganizationMembers />`. Includes role / status filters, plus per-row resend and cancel actions.
+
+Resending re-invites the same address with `resend: true`, which pushes the
+invitation's expiry out and sends the email again instead of creating a second
+invitation. The action needs the `invitation: ["create"]` permission, the same
+one that gates `<InviteMemberDialog />`.
 
 <ComponentPreview name="shadcn-organization-invitations" />
 

--- a/apps/docs/content/docs/zaidan/plugins/organization.mdx
+++ b/apps/docs/content/docs/zaidan/plugins/organization.mdx
@@ -647,7 +647,12 @@ Searchable, sortable, filter-by-role table of the active organization's members 
 
 ### `<OrganizationInvitations />`
 
-Pending invitations for the active organization as a table aligned with `<OrganizationMembers />`. Includes role / status filters and a per-row cancel action.
+Pending invitations for the active organization as a table aligned with `<OrganizationMembers />`. Includes role / status filters, plus per-row resend and cancel actions.
+
+Resending re-invites the same address with `resend: true`, which pushes the
+invitation's expiry out and sends the email again instead of creating a second
+invitation. The action needs the `invitation: ["create"]` permission, the same
+one that gates `<InviteMemberDialog />`.
 
 <ZaidanStory
   storyId="zaidan-plugins-organization--organization-invitations-preview"

--- a/apps/docs/src/components/auth/organization/organization-invitation-row.tsx
+++ b/apps/docs/src/components/auth/organization/organization-invitation-row.tsx
@@ -4,10 +4,12 @@ import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organi
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
   useCancelInvitation,
-  useHasPermission
+  useHasPermission,
+  useInviteMember
 } from "@better-auth-ui/react/plugins/organization"
 import type { Invitation } from "better-auth/client"
-import { X } from "lucide-react"
+import { Send, X } from "lucide-react"
+import { toast } from "sonner"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -45,6 +47,19 @@ export function OrganizationInvitationRow({
   const { mutate: cancelInvitation, isPending: cancelPending } =
     useCancelInvitation(authClient)
 
+  const { data: inviteMemberPermission, isPending: invitePermissionPending } =
+    useHasPermission(authClient, {
+      permissions: { invitation: ["create"] }
+    })
+
+  // Better Auth treats a re-invite as a resend: it extends the existing
+  // invitation's expiry and sends the email again rather than creating a
+  // second row.
+  const { mutate: resendInvitation, isPending: resendPending } =
+    useInviteMember(authClient, {
+      onSuccess: () => toast.success(organizationLocalization.invitationResent)
+    })
+
   const roleLabel = roles?.[invitation.role] ?? invitation.role
 
   const statusLabel =
@@ -52,9 +67,11 @@ export function OrganizationInvitationRow({
       invitation.status as keyof typeof organizationLocalization
     ] ?? invitation.status
 
-  if (cancelPermissionPending) {
+  if (cancelPermissionPending || invitePermissionPending) {
     return <OrganizationInvitationRowSkeleton />
   }
+
+  const isPending = invitation.status === "pending"
 
   return (
     <TableRow>
@@ -79,8 +96,30 @@ export function OrganizationInvitationRow({
       </TableCell>
 
       <TableCell className="text-end">
-        {cancelInvitationPermission?.success &&
-          invitation.status === "pending" && (
+        <div className="flex justify-end gap-2">
+          {inviteMemberPermission?.success && isPending && (
+            <Button
+              size="icon"
+              variant="outline"
+              className="size-8"
+              disabled={resendPending}
+              onClick={() =>
+                resendInvitation({
+                  email: invitation.email,
+                  organizationId: invitation.organizationId,
+                  role: invitation.role as Parameters<
+                    typeof resendInvitation
+                  >[0]["role"],
+                  resend: true
+                })
+              }
+              aria-label={organizationLocalization.resendInvitation}
+            >
+              {resendPending ? <Spinner /> : <Send />}
+            </Button>
+          )}
+
+          {cancelInvitationPermission?.success && isPending && (
             <Button
               size="icon"
               variant="outline"
@@ -92,6 +131,7 @@ export function OrganizationInvitationRow({
               {cancelPending ? <Spinner /> : <X />}
             </Button>
           )}
+        </div>
       </TableCell>
     </TableRow>
   )

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-invitation-row.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-invitation-row.tsx
@@ -4,10 +4,12 @@ import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organi
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
   useCancelInvitation,
-  useHasPermission
+  useHasPermission,
+  useInviteMember
 } from "@better-auth-ui/react/plugins/organization"
 import type { Invitation } from "better-auth/client"
-import { X } from "lucide-react"
+import { Send, X } from "lucide-react"
+import { toast } from "sonner"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -45,6 +47,19 @@ export function OrganizationInvitationRow({
   const { mutate: cancelInvitation, isPending: cancelPending } =
     useCancelInvitation(authClient)
 
+  const { data: inviteMemberPermission, isPending: invitePermissionPending } =
+    useHasPermission(authClient, {
+      permissions: { invitation: ["create"] }
+    })
+
+  // Better Auth treats a re-invite as a resend: it extends the existing
+  // invitation's expiry and sends the email again rather than creating a
+  // second row.
+  const { mutate: resendInvitation, isPending: resendPending } =
+    useInviteMember(authClient, {
+      onSuccess: () => toast.success(organizationLocalization.invitationResent)
+    })
+
   const roleLabel = roles?.[invitation.role] ?? invitation.role
 
   const statusLabel =
@@ -52,9 +67,11 @@ export function OrganizationInvitationRow({
       invitation.status as keyof typeof organizationLocalization
     ] ?? invitation.status
 
-  if (cancelPermissionPending) {
+  if (cancelPermissionPending || invitePermissionPending) {
     return <OrganizationInvitationRowSkeleton />
   }
+
+  const isPending = invitation.status === "pending"
 
   return (
     <TableRow>
@@ -79,8 +96,30 @@ export function OrganizationInvitationRow({
       </TableCell>
 
       <TableCell className="text-end">
-        {cancelInvitationPermission?.success &&
-          invitation.status === "pending" && (
+        <div className="flex justify-end gap-2">
+          {inviteMemberPermission?.success && isPending && (
+            <Button
+              size="icon"
+              variant="outline"
+              className="size-8"
+              disabled={resendPending}
+              onClick={() =>
+                resendInvitation({
+                  email: invitation.email,
+                  organizationId: invitation.organizationId,
+                  role: invitation.role as Parameters<
+                    typeof resendInvitation
+                  >[0]["role"],
+                  resend: true
+                })
+              }
+              aria-label={organizationLocalization.resendInvitation}
+            >
+              {resendPending ? <Spinner /> : <Send />}
+            </Button>
+          )}
+
+          {cancelInvitationPermission?.success && isPending && (
             <Button
               size="icon"
               variant="outline"
@@ -92,6 +131,7 @@ export function OrganizationInvitationRow({
               {cancelPending ? <Spinner /> : <X />}
             </Button>
           )}
+        </div>
       </TableCell>
     </TableRow>
   )

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-invitation-row.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-invitation-row.tsx
@@ -4,10 +4,12 @@ import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organi
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
   useCancelInvitation,
-  useHasPermission
+  useHasPermission,
+  useInviteMember
 } from "@better-auth-ui/react/plugins/organization"
 import type { Invitation } from "better-auth/client"
-import { X } from "lucide-react"
+import { Send, X } from "lucide-react"
+import { toast } from "sonner"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -45,6 +47,19 @@ export function OrganizationInvitationRow({
   const { mutate: cancelInvitation, isPending: cancelPending } =
     useCancelInvitation(authClient)
 
+  const { data: inviteMemberPermission, isPending: invitePermissionPending } =
+    useHasPermission(authClient, {
+      permissions: { invitation: ["create"] }
+    })
+
+  // Better Auth treats a re-invite as a resend: it extends the existing
+  // invitation's expiry and sends the email again rather than creating a
+  // second row.
+  const { mutate: resendInvitation, isPending: resendPending } =
+    useInviteMember(authClient, {
+      onSuccess: () => toast.success(organizationLocalization.invitationResent)
+    })
+
   const roleLabel = roles?.[invitation.role] ?? invitation.role
 
   const statusLabel =
@@ -52,9 +67,11 @@ export function OrganizationInvitationRow({
       invitation.status as keyof typeof organizationLocalization
     ] ?? invitation.status
 
-  if (cancelPermissionPending) {
+  if (cancelPermissionPending || invitePermissionPending) {
     return <OrganizationInvitationRowSkeleton />
   }
+
+  const isPending = invitation.status === "pending"
 
   return (
     <TableRow>
@@ -79,8 +96,30 @@ export function OrganizationInvitationRow({
       </TableCell>
 
       <TableCell className="text-end">
-        {cancelInvitationPermission?.success &&
-          invitation.status === "pending" && (
+        <div className="flex justify-end gap-2">
+          {inviteMemberPermission?.success && isPending && (
+            <Button
+              size="icon"
+              variant="outline"
+              className="size-8"
+              disabled={resendPending}
+              onClick={() =>
+                resendInvitation({
+                  email: invitation.email,
+                  organizationId: invitation.organizationId,
+                  role: invitation.role as Parameters<
+                    typeof resendInvitation
+                  >[0]["role"],
+                  resend: true
+                })
+              }
+              aria-label={organizationLocalization.resendInvitation}
+            >
+              {resendPending ? <Spinner /> : <Send />}
+            </Button>
+          )}
+
+          {cancelInvitationPermission?.success && isPending && (
             <Button
               size="icon"
               variant="outline"
@@ -92,6 +131,7 @@ export function OrganizationInvitationRow({
               {cancelPending ? <Spinner /> : <X />}
             </Button>
           )}
+        </div>
       </TableCell>
     </TableRow>
   )

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-invitation-row.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-invitation-row.tsx
@@ -4,10 +4,12 @@ import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organi
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
   useCancelInvitation,
-  useHasPermission
+  useHasPermission,
+  useInviteMember
 } from "@better-auth-ui/react/plugins/organization"
 import type { Invitation } from "better-auth/client"
-import { X } from "lucide-react"
+import { Send, X } from "lucide-react"
+import { toast } from "sonner"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -45,6 +47,19 @@ export function OrganizationInvitationRow({
   const { mutate: cancelInvitation, isPending: cancelPending } =
     useCancelInvitation(authClient)
 
+  const { data: inviteMemberPermission, isPending: invitePermissionPending } =
+    useHasPermission(authClient, {
+      permissions: { invitation: ["create"] }
+    })
+
+  // Better Auth treats a re-invite as a resend: it extends the existing
+  // invitation's expiry and sends the email again rather than creating a
+  // second row.
+  const { mutate: resendInvitation, isPending: resendPending } =
+    useInviteMember(authClient, {
+      onSuccess: () => toast.success(organizationLocalization.invitationResent)
+    })
+
   const roleLabel = roles?.[invitation.role] ?? invitation.role
 
   const statusLabel =
@@ -52,9 +67,11 @@ export function OrganizationInvitationRow({
       invitation.status as keyof typeof organizationLocalization
     ] ?? invitation.status
 
-  if (cancelPermissionPending) {
+  if (cancelPermissionPending || invitePermissionPending) {
     return <OrganizationInvitationRowSkeleton />
   }
+
+  const isPending = invitation.status === "pending"
 
   return (
     <TableRow>
@@ -79,8 +96,30 @@ export function OrganizationInvitationRow({
       </TableCell>
 
       <TableCell className="text-end">
-        {cancelInvitationPermission?.success &&
-          invitation.status === "pending" && (
+        <div className="flex justify-end gap-2">
+          {inviteMemberPermission?.success && isPending && (
+            <Button
+              size="icon"
+              variant="outline"
+              className="size-8"
+              disabled={resendPending}
+              onClick={() =>
+                resendInvitation({
+                  email: invitation.email,
+                  organizationId: invitation.organizationId,
+                  role: invitation.role as Parameters<
+                    typeof resendInvitation
+                  >[0]["role"],
+                  resend: true
+                })
+              }
+              aria-label={organizationLocalization.resendInvitation}
+            >
+              {resendPending ? <Spinner /> : <Send />}
+            </Button>
+          )}
+
+          {cancelInvitationPermission?.success && isPending && (
             <Button
               size="icon"
               variant="outline"
@@ -92,6 +131,7 @@ export function OrganizationInvitationRow({
               {cancelPending ? <Spinner /> : <X />}
             </Button>
           )}
+        </div>
       </TableCell>
     </TableRow>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-invitation-row.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-invitation-row.tsx
@@ -18,7 +18,7 @@ type OrganizationInvitation = {
   createdAt?: Date | string | null
   email?: string | null
   id: string
-  organizationId?: string | null
+  organizationId: string
   role?: string | null
   status?: string | null
 }
@@ -112,7 +112,7 @@ export function OrganizationInvitationRow(
               onClick={() =>
                 resendInvitation.mutate({
                   email: props.invitation.email ?? "",
-                  organizationId: props.invitation.organizationId ?? undefined,
+                  organizationId: props.invitation.organizationId,
                   resend: true,
                   role: (props.invitation.role ?? "member") as Parameters<
                     typeof resendInvitation.mutate

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-invitation-row.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-invitation-row.tsx
@@ -1,20 +1,24 @@
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
-import { useAuth } from "@better-auth-ui/solid"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import {
   useCancelInvitation,
-  useHasPermission
+  useHasPermission,
+  useInviteMember
 } from "@better-auth-ui/solid/plugins/organization"
-import { X } from "lucide-solid"
+import { Send, X } from "lucide-solid"
 import { Show } from "solid-js"
+import { toast } from "solid-sonner"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Spinner } from "@/components/ui/spinner"
 import { TableCell, TableRow } from "@/components/ui/table"
+import { organizationPlugin } from "@/lib/auth/organization-plugin"
 
 type OrganizationInvitation = {
   createdAt?: Date | string | null
   email?: string | null
   id: string
+  organizationId?: string | null
   role?: string | null
   status?: string | null
 }
@@ -62,10 +66,22 @@ export function OrganizationInvitationRow(
   props: OrganizationInvitationRowProps
 ) {
   const auth = useAuth<OrganizationAuthClient>()
+  const config = useAuthPlugin(organizationPlugin)
   const permission = useHasPermission(auth.authClient, () => ({
     permissions: { invitation: ["cancel"] }
   }))
+  const invitePermission = useHasPermission(auth.authClient, () => ({
+    permissions: { invitation: ["create"] }
+  }))
   const cancelInvitation = useCancelInvitation(auth.authClient)
+
+  // Better Auth treats a re-invite as a resend: it extends the existing
+  // invitation's expiry and sends the email again rather than creating a
+  // second row.
+  const resendInvitation = useInviteMember(auth.authClient, () => ({
+    onSuccess: () => toast.success(config.localization.invitationResent)
+  }))
+  const isPending = () => props.invitation.status === "pending"
   const roleLabel = () =>
     props.roles[props.invitation.role ?? ""] ??
     formatRole(props.invitation.role)
@@ -88,31 +104,56 @@ export function OrganizationInvitationRow(
         </Badge>
       </TableCell>
       <TableCell class="text-end">
-        <Show
-          when={
-            permission.data?.success && props.invitation.status === "pending"
-          }
-        >
-          <Button
-            aria-label="Cancel invitation"
-            disabled={cancelInvitation.isPending}
-            onClick={() =>
-              cancelInvitation.mutate({
-                invitationId: props.invitation.id
-              })
-            }
-            size="icon-sm"
-            type="button"
-            variant="outline"
-          >
-            <Show
-              when={cancelInvitation.isPending}
-              fallback={<X class="size-4 text-destructive" />}
+        <div class="flex justify-end gap-2">
+          <Show when={invitePermission.data?.success && isPending()}>
+            <Button
+              aria-label={config.localization.resendInvitation}
+              disabled={resendInvitation.isPending}
+              onClick={() =>
+                resendInvitation.mutate({
+                  email: props.invitation.email ?? "",
+                  organizationId: props.invitation.organizationId ?? undefined,
+                  resend: true,
+                  role: (props.invitation.role ?? "member") as Parameters<
+                    typeof resendInvitation.mutate
+                  >[0]["role"]
+                })
+              }
+              size="icon-sm"
+              type="button"
+              variant="outline"
             >
-              <Spinner class="text-destructive" />
-            </Show>
-          </Button>
-        </Show>
+              <Show
+                when={resendInvitation.isPending}
+                fallback={<Send class="size-4" />}
+              >
+                <Spinner />
+              </Show>
+            </Button>
+          </Show>
+
+          <Show when={permission.data?.success && isPending()}>
+            <Button
+              aria-label={config.localization.cancelInvitation}
+              disabled={cancelInvitation.isPending}
+              onClick={() =>
+                cancelInvitation.mutate({
+                  invitationId: props.invitation.id
+                })
+              }
+              size="icon-sm"
+              type="button"
+              variant="outline"
+            >
+              <Show
+                when={cancelInvitation.isPending}
+                fallback={<X class="size-4 text-destructive" />}
+              >
+                <Spinner class="text-destructive" />
+              </Show>
+            </Button>
+          </Show>
+        </div>
       </TableCell>
     </TableRow>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-invitations.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-invitations.tsx
@@ -95,6 +95,7 @@ type OrganizationInvitation = {
   createdAt?: Date | string | null
   email?: string | null
   id: string
+  organizationId: string
   role?: string | null
   status?: string | null
 }

--- a/examples/start-solid-zaidan-example/tests/auth-route.test.ts
+++ b/examples/start-solid-zaidan-example/tests/auth-route.test.ts
@@ -3548,6 +3548,9 @@ describe("Solid auth route component selection", () => {
     )
     expect(organizationInvitationRow).toContain("resendInvitation.mutate")
     expect(organizationInvitationRow).toContain("resend: true")
+    expect(organizationInvitationRow).toContain(
+      "organizationId: props.invitation.organizationId"
+    )
     expect(organizationInvitationRow).toContain("Badge")
     expect(organizationInvitationRow).toContain("Spinner")
     expect(organizationInvitationRowSkeleton).toContain("TableRow")

--- a/examples/start-solid-zaidan-example/tests/auth-route.test.ts
+++ b/examples/start-solid-zaidan-example/tests/auth-route.test.ts
@@ -3544,8 +3544,10 @@ describe("Solid auth route component selection", () => {
       "disabled={cancelInvitation.isPending}"
     )
     expect(organizationInvitationRow).toContain(
-      'aria-label="Cancel invitation"'
+      "config.localization.cancelInvitation"
     )
+    expect(organizationInvitationRow).toContain("resendInvitation.mutate")
+    expect(organizationInvitationRow).toContain("resend: true")
     expect(organizationInvitationRow).toContain("Badge")
     expect(organizationInvitationRow).toContain("Spinner")
     expect(organizationInvitationRowSkeleton).toContain("TableRow")

--- a/packages/core/src/plugins/organization/organization-localization.ts
+++ b/packages/core/src/plugins/organization/organization-localization.ts
@@ -35,6 +35,8 @@ export const organizationLocalization = {
     "Permanently delete this organization and all of its data. All members will lose access and this cannot be undone.",
   /** @remarks `"Invitations"` */
   invitations: "Invitations",
+  /** @remarks `"Invitation resent"` */
+  invitationResent: "Invitation resent",
   /** @remarks `"Invitation unavailable"` */
   invitationUnavailable: "Invitation unavailable",
   /** @remarks `"This invitation is invalid, expired, or has already been handled."` */
@@ -115,6 +117,8 @@ export const organizationLocalization = {
   /** @remarks `"Are you sure you want to remove this member from the organization? They will lose access immediately."` */
   removeMemberWarning:
     "Are you sure you want to remove this member from the organization? They will lose access immediately.",
+  /** @remarks `"Resend invitation"` */
+  resendInvitation: "Resend invitation",
   /** @remarks `"Role"` */
   role: "Role",
   /** @remarks `"Search..."` */

--- a/packages/heroui/src/components/auth/organization/organization-invitation-row.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-invitation-row.tsx
@@ -2,10 +2,11 @@ import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organi
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
   useCancelInvitation,
-  useHasPermission
+  useHasPermission,
+  useInviteMember
 } from "@better-auth-ui/react/plugins/organization"
-import { Xmark } from "@gravity-ui/icons"
-import { Button, Chip, Spinner, Table } from "@heroui/react"
+import { PaperPlane, Xmark } from "@gravity-ui/icons"
+import { Button, Chip, Spinner, Table, toast } from "@heroui/react"
 
 import type { Invitation } from "better-auth/client"
 
@@ -33,6 +34,19 @@ export function OrganizationInvitationTableRow({
   const { mutate: cancelInvitation, isPending: cancelPending } =
     useCancelInvitation(authClient as OrganizationAuthClient)
 
+  const { data: inviteMemberPermission, isPending: invitePermissionPending } =
+    useHasPermission(authClient as OrganizationAuthClient, {
+      permissions: { invitation: ["create"] }
+    })
+
+  // Better Auth treats a re-invite as a resend: it extends the existing
+  // invitation's expiry and sends the email again rather than creating a
+  // second row.
+  const { mutate: resendInvitation, isPending: resendPending } =
+    useInviteMember(authClient as OrganizationAuthClient, {
+      onSuccess: () => toast.success(organizationLocalization.invitationResent)
+    })
+
   const roleLabel = roles?.[invitation.role] ?? invitation.role
 
   const statusLabel =
@@ -47,9 +61,11 @@ export function OrganizationInvitationTableRow({
           ? "danger"
           : "default"
 
-  if (cancelPermissionPending) {
+  if (cancelPermissionPending || invitePermissionPending) {
     return <OrganizationInvitationRowSkeleton />
   }
+
+  const isPending = invitation.status === "pending"
 
   return (
     <Table.Row>
@@ -73,8 +89,34 @@ export function OrganizationInvitationTableRow({
       </Table.Cell>
 
       <Table.Cell className="text-end">
-        {cancelInvitationPermission?.success &&
-          invitation.status === "pending" && (
+        <div className="flex justify-end gap-2">
+          {inviteMemberPermission?.success && isPending && (
+            <Button
+              isIconOnly
+              size="sm"
+              variant="tertiary"
+              isPending={resendPending}
+              onPress={() =>
+                resendInvitation({
+                  email: invitation.email,
+                  organizationId: invitation.organizationId,
+                  role: invitation.role as Parameters<
+                    typeof resendInvitation
+                  >[0]["role"],
+                  resend: true
+                })
+              }
+              aria-label={organizationLocalization.resendInvitation}
+            >
+              {resendPending ? (
+                <Spinner color="current" size="sm" />
+              ) : (
+                <PaperPlane />
+              )}
+            </Button>
+          )}
+
+          {cancelInvitationPermission?.success && isPending && (
             <Button
               isIconOnly
               size="sm"
@@ -90,6 +132,7 @@ export function OrganizationInvitationTableRow({
               )}
             </Button>
           )}
+        </div>
       </Table.Cell>
     </Table.Row>
   )


### PR DESCRIPTION
Stacked on #490.

## Problem

When an invitation expired or landed in spam, the only thing an admin could do from the UI was cancel it and start over. Better Auth has supported resending since forever, we just never surfaced it.

## What changed

Each pending invitation row gets a resend action next to cancel. It calls `inviteMember` with `resend: true`, which Better Auth handles on a dedicated branch in `crud-invites.ts`: it finds the existing pending invitation, extends `expiresAt`, and re-sends the email. It does not create a second invitation, and it does not touch the role or team.

The action is gated on `invitation: ["create"]`, matching what the endpoint checks. That is deliberately a different permission from cancel's `invitation: ["cancel"]`, so a role with only cancel rights sees only the cancel button.

`organizationId` is passed explicitly from the invitation record rather than leaning on the active-organization fallback in `useInviteMember`.

## New localization keys

- `resendInvitation` — "Resend invitation"
- `invitationResent` — "Invitation resent"

## Coverage

shadcn (Radix + Base UI), HeroUI, and Solid/Zaidan.

While wiring this up, the Solid row moved off its hardcoded English `aria-label`s onto the organization plugin's localization, which is what every other Solid organization component already does.

## Tests

The Solid registry parity test now asserts against the localization reference and the `resend: true` payload rather than a hardcoded label string.

`nx run-many -t typecheck` and `nx run-many -t test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to resend pending organization invitations directly from invitation rows.
  * Resending extends the invitation expiry and sends another email without creating a duplicate.
  * Resend actions are available only with the required invitation permission and include loading and success feedback.
  * Added localized text for resend actions and confirmation messages.

* **Documentation**
  * Updated organization invitation documentation to cover resend, cancel, role, and status-filter actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->