### PR TITLE
feat(organization): paginate members on the server

### DIFF
--- a/apps/docs/content/docs/heroui/plugins/organization.mdx
+++ b/apps/docs/content/docs/heroui/plugins/organization.mdx
@@ -3,6 +3,7 @@ title: Organization
 description: Add multi-tenant organization management with members, invitations, and roles to your authentication UI.
 ---
 
+import { Callout } from 'fumadocs-ui/components/callout'
 import { Step, Steps } from 'fumadocs-ui/components/steps'
 import { Tab, Tabs, TabsList, TabsTrigger } from 'fumadocs-ui/components/tabs'
 
@@ -793,6 +794,42 @@ Searchable, sortable, filter-by-role table of the active organization's members 
 ```
 
 <auto-type-table path="../../../../../../packages/heroui/src/components/auth/organization/organization-members.tsx" name="OrganizationMembersProps" />
+
+### Paginating members
+
+By default `<OrganizationMembers />` asks for the whole list and filters it in
+the browser. That is fine for a handful of members and quietly wrong for a
+large organization: `list-members` caps its response at 100 rows (or your
+`membershipLimit`) and says nothing about the rest, so members past that point
+simply never appear.
+
+Pass `pageSize` to move paging onto the server:
+
+```tsx
+<OrganizationMembers pageSize={20} />
+```
+
+In paged mode the component sends `limit` and `offset`, applies the role filter
+server-side through `filterField`/`filterValue`, sorts by role through
+`sortBy`/`sortDirection`, and reads the row count from the endpoint's `total`.
+
+Two controls step aside in paged mode, because `list-members` cannot honour
+them across pages:
+
+- **The search box.** The endpoint has no search parameter. Name and email live
+  on the joined user row, which it does not query.
+- **Sorting by member.** Same reason: it can only sort columns on the member
+  row itself.
+
+The signed-in user's own role comes from `getActiveMemberRole` rather than from
+scanning the loaded page, since they may well be on a different one. That is
+exposed as `useActiveMemberRole` if you need it yourself.
+
+<Callout>
+`list-invitations` and `list-sessions` take no pagination parameters at all, so
+those lists stay client-side until Better Auth adds them. `list-api-keys` does
+support `limit` and `offset`; wiring it up is a separate change.
+</Callout>
 
 ### `<OrganizationInvitations />`
 

--- a/apps/docs/content/docs/shadcn/plugins/organization.mdx
+++ b/apps/docs/content/docs/shadcn/plugins/organization.mdx
@@ -3,6 +3,7 @@ title: Organization
 description: Add multi-tenant organization management with members, invitations, and roles to your authentication UI.
 ---
 
+import { Callout } from 'fumadocs-ui/components/callout'
 import { Step, Steps } from 'fumadocs-ui/components/steps'
 import { Tab, Tabs, TabsList, TabsTrigger } from 'fumadocs-ui/components/tabs'
 
@@ -829,6 +830,42 @@ Searchable, sortable, filter-by-role table of the active organization's members 
 ```
 
 <auto-type-table path="../../../../../../examples/start-shadcn-example/src/components/auth/organization/organization-members.tsx" name="OrganizationMembersProps" />
+
+### Paginating members
+
+By default `<OrganizationMembers />` asks for the whole list and filters it in
+the browser. That is fine for a handful of members and quietly wrong for a
+large organization: `list-members` caps its response at 100 rows (or your
+`membershipLimit`) and says nothing about the rest, so members past that point
+simply never appear.
+
+Pass `pageSize` to move paging onto the server:
+
+```tsx
+<OrganizationMembers pageSize={20} />
+```
+
+In paged mode the component sends `limit` and `offset`, applies the role filter
+server-side through `filterField`/`filterValue`, sorts by role through
+`sortBy`/`sortDirection`, and reads the row count from the endpoint's `total`.
+
+Two controls step aside in paged mode, because `list-members` cannot honour
+them across pages:
+
+- **The search box.** The endpoint has no search parameter. Name and email live
+  on the joined user row, which it does not query.
+- **Sorting by member.** Same reason: it can only sort columns on the member
+  row itself.
+
+The signed-in user's own role comes from `getActiveMemberRole` rather than from
+scanning the loaded page, since they may well be on a different one. That is
+exposed as `useActiveMemberRole` if you need it yourself.
+
+<Callout>
+`list-invitations` and `list-sessions` take no pagination parameters at all, so
+those lists stay client-side until Better Auth adds them. `list-api-keys` does
+support `limit` and `offset`; wiring it up is a separate change.
+</Callout>
 
 ### `<OrganizationInvitations />`
 

--- a/apps/docs/content/docs/zaidan/plugins/organization.mdx
+++ b/apps/docs/content/docs/zaidan/plugins/organization.mdx
@@ -3,6 +3,7 @@ title: Organization
 description: Add multi-tenant organization management with members, invitations, and roles to your Solid/Zaidan auth UI.
 ---
 
+import { Callout } from 'fumadocs-ui/components/callout'
 import { Step, Steps } from 'fumadocs-ui/components/steps'
 
 The organization plugin adds multi-tenant organization management to your Solid/Zaidan authentication UI. Users can create, switch between, and manage organizations with members, invitations, and roles.
@@ -644,6 +645,42 @@ Searchable, sortable, filter-by-role table of the active organization's members 
 ```
 
 <auto-type-table path="../../../../../../examples/start-solid-zaidan-example/src/components/auth/organization/organization-members.tsx" name="OrganizationMembersProps" />
+
+### Paginating members
+
+By default `<OrganizationMembers />` asks for the whole list and filters it in
+the browser. That is fine for a handful of members and quietly wrong for a
+large organization: `list-members` caps its response at 100 rows (or your
+`membershipLimit`) and says nothing about the rest, so members past that point
+simply never appear.
+
+Pass `pageSize` to move paging onto the server:
+
+```tsx
+<OrganizationMembers pageSize={20} />
+```
+
+In paged mode the component sends `limit` and `offset`, applies the role filter
+server-side through `filterField`/`filterValue`, sorts by role through
+`sortBy`/`sortDirection`, and reads the row count from the endpoint's `total`.
+
+Two controls step aside in paged mode, because `list-members` cannot honour
+them across pages:
+
+- **The search box.** The endpoint has no search parameter. Name and email live
+  on the joined user row, which it does not query.
+- **Sorting by member.** Same reason: it can only sort columns on the member
+  row itself.
+
+The signed-in user's own role comes from `getActiveMemberRole` rather than from
+scanning the loaded page, since they may well be on a different one. That is
+exposed as `useActiveMemberRole` if you need it yourself.
+
+<Callout>
+`list-invitations` and `list-sessions` take no pagination parameters at all, so
+those lists stay client-side until Better Auth adds them. `list-api-keys` does
+support `limit` and `offset`; wiring it up is a separate change.
+</Callout>
 
 ### `<OrganizationInvitations />`
 

--- a/apps/docs/src/components/auth/organization/organization-members.tsx
+++ b/apps/docs/src/components/auth/organization/organization-members.tsx
@@ -4,15 +4,22 @@ import {
   hasMemberRole,
   type OrganizationAuthClient
 } from "@better-auth-ui/core/plugins/organization"
-import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
+  useActiveMemberRole,
   useActiveOrganization,
   useHasPermission,
   useListOrganizationMembers
 } from "@better-auth-ui/react/plugins/organization"
 import type { Member } from "better-auth/client"
 import { ChevronUp, Filter, Search, X } from "lucide-react"
-import { type ComponentProps, type ReactNode, useMemo, useState } from "react"
+import {
+  type ComponentProps,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useState
+} from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button, buttonVariants } from "@/components/ui/button"
@@ -52,6 +59,15 @@ type SortDescriptor = {
 /** Props for the `OrganizationMembers` component. */
 export type OrganizationMembersProps = {
   className?: string
+  /**
+   * Rows per page. Setting it moves paging, role filtering, and role sorting
+   * onto the server, which is what large organizations want: without it the
+   * endpoint caps the response at 100 members with no indication.
+   *
+   * Leave it unset to keep the whole list in memory and filter it in the
+   * browser.
+   */
+  pageSize?: number
 }
 
 /**
@@ -59,6 +75,7 @@ export type OrganizationMembersProps = {
  */
 export function OrganizationMembers({
   className,
+  pageSize,
   ...props
 }: OrganizationMembersProps & ComponentProps<"div">) {
   const { authClient } = useAuth<OrganizationAuthClient>()
@@ -68,11 +85,47 @@ export function OrganizationMembers({
     roles
   } = useAuthPlugin(organizationPlugin)
 
-  const { data: session } = useSession(authClient)
   const { data: activeOrganization, isPending: activeOrganizationPending } =
     useActiveOrganization(authClient)
+
+  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>()
+  const [roleFilter, setRoleFilter] = useState("all")
+  const [search, setSearch] = useState("")
+  const [page, setPage] = useState(0)
+
+  const paged = pageSize !== undefined
+
   const { data: membersData, isPending: membersPending } =
-    useListOrganizationMembers(authClient)
+    useListOrganizationMembers(authClient, {
+      query: paged
+        ? {
+            limit: pageSize,
+            offset: page * pageSize,
+            ...(roleFilter === "all"
+              ? {}
+              : {
+                  filterField: "role",
+                  filterValue: roleFilter,
+                  // Roles are stored comma-joined, so an exact match would
+                  // drop anyone holding more than one.
+                  filterOperator: "contains" as const
+                }),
+            ...(sortDescriptor?.column === "role"
+              ? {
+                  sortBy: "role",
+                  sortDirection:
+                    sortDescriptor.direction === "descending"
+                      ? ("desc" as const)
+                      : ("asc" as const)
+                }
+              : {})
+          }
+        : undefined
+    })
+
+  // The signed-in user need not be on the loaded page, so their own role comes
+  // from a dedicated endpoint rather than from the member list.
+  const { data: activeMemberRole } = useActiveMemberRole(authClient)
 
   const { isPending: updatePermissionPending } = useHasPermission(authClient, {
     permissions: { member: ["update"] }
@@ -87,20 +140,22 @@ export function OrganizationMembers({
     updatePermissionPending ||
     deletePermissionPending
 
-  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>()
-  const [roleFilter, setRoleFilter] = useState("all")
-  const [search, setSearch] = useState("")
-
   const filteredMembers = useMemo(() => {
+    // The server already applied the role filter when paging, and it has no
+    // parameter for name or email search, so both stay here only in the
+    // unpaged mode where the whole list is present.
+    if (paged) return membersData?.members
+
     return membersData?.members.filter(
       (member) =>
         (roleFilter === "all" || hasMemberRole(member.role, roleFilter)) &&
         (member.user.name.toLowerCase().includes(search.toLowerCase()) ||
           member.user.email.toLowerCase().includes(search.toLowerCase()))
     )
-  }, [search, membersData?.members, roleFilter])
+  }, [paged, search, membersData?.members, roleFilter])
 
   const sortedMembers = useMemo(() => {
+    if (paged) return filteredMembers
     if (!sortDescriptor) return filteredMembers
     if (!filteredMembers) return filteredMembers
 
@@ -118,17 +173,26 @@ export function OrganizationMembers({
 
       return cmp
     })
-  }, [sortDescriptor, filteredMembers])
+  }, [paged, sortDescriptor, filteredMembers])
 
   const [inviteOpen, setInviteOpen] = useState(false)
 
-  const isOwner = membersData?.members.some(
-    (member) =>
-      hasMemberRole(member.role, "owner") && member.userId === session?.user.id
-  )
+  const isOwner = hasMemberRole(activeMemberRole?.role, "owner")
+
+  const total = membersData?.total ?? membersData?.members.length ?? 0
+
   const atMembershipLimit =
-    membershipLimit !== undefined &&
-    (membersData?.members.length ?? 0) >= membershipLimit
+    membershipLimit !== undefined && total >= membershipLimit
+
+  // Any change to what the server is being asked for invalidates the cursor.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resets on query change
+  useEffect(() => {
+    setPage(0)
+  }, [roleFilter, sortDescriptor, activeOrganization?.id])
+
+  const pageStart = page * (pageSize ?? 0)
+  const pageEnd = pageStart + (sortedMembers?.length ?? 0)
+  const hasNextPage = pageEnd < total
 
   function toggleSort(column: string) {
     setSortDescriptor((current) => {
@@ -161,20 +225,24 @@ export function OrganizationMembers({
 
       <div className="flex flex-col gap-4">
         <div className="flex items-center gap-3">
-          <InputGroup className="min-w-0 sm:w-[220px]">
-            <InputGroupInput
-              type="search"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              aria-label={organizationLocalization.search}
-              placeholder={organizationLocalization.search}
-              disabled={isPending}
-            />
+          {/* list-members has no search parameter, so a search box would
+              only ever filter the page in front of you. */}
+          {!paged && (
+            <InputGroup className="min-w-0 sm:w-[220px]">
+              <InputGroupInput
+                type="search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                aria-label={organizationLocalization.search}
+                placeholder={organizationLocalization.search}
+                disabled={isPending}
+              />
 
-            <InputGroupAddon>
-              <Search className="text-muted-foreground" />
-            </InputGroupAddon>
-          </InputGroup>
+              <InputGroupAddon>
+                <Search className="text-muted-foreground" />
+              </InputGroupAddon>
+            </InputGroup>
+          )}
 
           <DropdownMenu>
             <DropdownMenuTrigger
@@ -228,16 +296,22 @@ export function OrganizationMembers({
           <Table aria-label={organizationLocalization.members}>
             <TableHeader>
               <TableRow>
-                <SortableTableHead
-                  sortDirection={
-                    sortDescriptor?.column === "user"
-                      ? sortDescriptor.direction
-                      : undefined
-                  }
-                  onClick={() => toggleSort("user")}
-                >
-                  {organizationLocalization.member}
-                </SortableTableHead>
+                {/* Name and email live on the joined user row, which
+                    list-members cannot sort by. */}
+                {paged ? (
+                  <TableHead>{organizationLocalization.member}</TableHead>
+                ) : (
+                  <SortableTableHead
+                    sortDirection={
+                      sortDescriptor?.column === "user"
+                        ? sortDescriptor.direction
+                        : undefined
+                    }
+                    onClick={() => toggleSort("user")}
+                  >
+                    {organizationLocalization.member}
+                  </SortableTableHead>
+                )}
 
                 <SortableTableHead
                   sortDirection={
@@ -273,6 +347,37 @@ export function OrganizationMembers({
             </TableBody>
           </Table>
         </Card>
+
+        {paged && total > 0 && (
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-muted-foreground text-sm tabular-nums">
+              {organizationLocalization.paginationRange
+                .replace("{{from}}", String(pageStart + 1))
+                .replace("{{to}}", String(pageEnd))
+                .replace("{{total}}", String(total))}
+            </p>
+
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isPending || page === 0}
+                onClick={() => setPage((current) => Math.max(0, current - 1))}
+              >
+                {organizationLocalization.previousPage}
+              </Button>
+
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isPending || !hasNextPage}
+                onClick={() => setPage((current) => current + 1)}
+              >
+                {organizationLocalization.nextPage}
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
 
       <InviteMemberDialog open={inviteOpen} onOpenChange={setInviteOpen} />

--- a/apps/docs/src/components/auth/organization/organization-members.tsx
+++ b/apps/docs/src/components/auth/organization/organization-members.tsx
@@ -60,7 +60,8 @@ type SortDescriptor = {
 export type OrganizationMembersProps = {
   className?: string
   /**
-   * Rows per page. Setting it moves paging, role filtering, and role sorting
+   * Number of rows per page. This value must be a positive integer. Setting it
+   * moves paging, role filtering, and role sorting
    * onto the server, which is what large organizations want: without it the
    * endpoint caps the response at 100 members with no indication.
    *
@@ -68,6 +69,17 @@ export type OrganizationMembersProps = {
    * browser.
    */
   pageSize?: number
+}
+
+function validatePageSize(pageSize?: number) {
+  if (
+    pageSize !== undefined &&
+    (!Number.isInteger(pageSize) || pageSize <= 0)
+  ) {
+    throw new RangeError("pageSize must be a positive integer")
+  }
+
+  return pageSize
 }
 
 /**
@@ -78,6 +90,7 @@ export function OrganizationMembers({
   pageSize,
   ...props
 }: OrganizationMembersProps & ComponentProps<"div">) {
+  const validatedPageSize = validatePageSize(pageSize)
   const { authClient } = useAuth<OrganizationAuthClient>()
   const {
     localization: organizationLocalization,
@@ -93,14 +106,14 @@ export function OrganizationMembers({
   const [search, setSearch] = useState("")
   const [page, setPage] = useState(0)
 
-  const paged = pageSize !== undefined
+  const paged = validatedPageSize !== undefined
 
   const { data: membersData, isPending: membersPending } =
     useListOrganizationMembers(authClient, {
       query: paged
         ? {
-            limit: pageSize,
-            offset: page * pageSize,
+            limit: validatedPageSize,
+            offset: page * validatedPageSize,
             ...(roleFilter === "all"
               ? {}
               : {
@@ -190,7 +203,7 @@ export function OrganizationMembers({
     setPage(0)
   }, [roleFilter, sortDescriptor, activeOrganization?.id])
 
-  const pageStart = page * (pageSize ?? 0)
+  const pageStart = page * (validatedPageSize ?? 0)
   const pageEnd = pageStart + (sortedMembers?.length ?? 0)
   const hasNextPage = pageEnd < total
 

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-members.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-members.tsx
@@ -4,15 +4,22 @@ import {
   hasMemberRole,
   type OrganizationAuthClient
 } from "@better-auth-ui/core/plugins/organization"
-import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
+  useActiveMemberRole,
   useActiveOrganization,
   useHasPermission,
   useListOrganizationMembers
 } from "@better-auth-ui/react/plugins/organization"
 import type { Member } from "better-auth/client"
 import { ChevronUp, Filter, Search, X } from "lucide-react"
-import { type ComponentProps, type ReactNode, useMemo, useState } from "react"
+import {
+  type ComponentProps,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useState
+} from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button, buttonVariants } from "@/components/ui/button"
@@ -52,6 +59,15 @@ type SortDescriptor = {
 /** Props for the `OrganizationMembers` component. */
 export type OrganizationMembersProps = {
   className?: string
+  /**
+   * Rows per page. Setting it moves paging, role filtering, and role sorting
+   * onto the server, which is what large organizations want: without it the
+   * endpoint caps the response at 100 members with no indication.
+   *
+   * Leave it unset to keep the whole list in memory and filter it in the
+   * browser.
+   */
+  pageSize?: number
 }
 
 /**
@@ -59,6 +75,7 @@ export type OrganizationMembersProps = {
  */
 export function OrganizationMembers({
   className,
+  pageSize,
   ...props
 }: OrganizationMembersProps & ComponentProps<"div">) {
   const { authClient } = useAuth<OrganizationAuthClient>()
@@ -68,11 +85,47 @@ export function OrganizationMembers({
     roles
   } = useAuthPlugin(organizationPlugin)
 
-  const { data: session } = useSession(authClient)
   const { data: activeOrganization, isPending: activeOrganizationPending } =
     useActiveOrganization(authClient)
+
+  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>()
+  const [roleFilter, setRoleFilter] = useState("all")
+  const [search, setSearch] = useState("")
+  const [page, setPage] = useState(0)
+
+  const paged = pageSize !== undefined
+
   const { data: membersData, isPending: membersPending } =
-    useListOrganizationMembers(authClient)
+    useListOrganizationMembers(authClient, {
+      query: paged
+        ? {
+            limit: pageSize,
+            offset: page * pageSize,
+            ...(roleFilter === "all"
+              ? {}
+              : {
+                  filterField: "role",
+                  filterValue: roleFilter,
+                  // Roles are stored comma-joined, so an exact match would
+                  // drop anyone holding more than one.
+                  filterOperator: "contains" as const
+                }),
+            ...(sortDescriptor?.column === "role"
+              ? {
+                  sortBy: "role",
+                  sortDirection:
+                    sortDescriptor.direction === "descending"
+                      ? ("desc" as const)
+                      : ("asc" as const)
+                }
+              : {})
+          }
+        : undefined
+    })
+
+  // The signed-in user need not be on the loaded page, so their own role comes
+  // from a dedicated endpoint rather than from the member list.
+  const { data: activeMemberRole } = useActiveMemberRole(authClient)
 
   const { isPending: updatePermissionPending } = useHasPermission(authClient, {
     permissions: { member: ["update"] }
@@ -87,20 +140,22 @@ export function OrganizationMembers({
     updatePermissionPending ||
     deletePermissionPending
 
-  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>()
-  const [roleFilter, setRoleFilter] = useState("all")
-  const [search, setSearch] = useState("")
-
   const filteredMembers = useMemo(() => {
+    // The server already applied the role filter when paging, and it has no
+    // parameter for name or email search, so both stay here only in the
+    // unpaged mode where the whole list is present.
+    if (paged) return membersData?.members
+
     return membersData?.members.filter(
       (member) =>
         (roleFilter === "all" || hasMemberRole(member.role, roleFilter)) &&
         (member.user.name.toLowerCase().includes(search.toLowerCase()) ||
           member.user.email.toLowerCase().includes(search.toLowerCase()))
     )
-  }, [search, membersData?.members, roleFilter])
+  }, [paged, search, membersData?.members, roleFilter])
 
   const sortedMembers = useMemo(() => {
+    if (paged) return filteredMembers
     if (!sortDescriptor) return filteredMembers
     if (!filteredMembers) return filteredMembers
 
@@ -118,17 +173,26 @@ export function OrganizationMembers({
 
       return cmp
     })
-  }, [sortDescriptor, filteredMembers])
+  }, [paged, sortDescriptor, filteredMembers])
 
   const [inviteOpen, setInviteOpen] = useState(false)
 
-  const isOwner = membersData?.members.some(
-    (member) =>
-      hasMemberRole(member.role, "owner") && member.userId === session?.user.id
-  )
+  const isOwner = hasMemberRole(activeMemberRole?.role, "owner")
+
+  const total = membersData?.total ?? membersData?.members.length ?? 0
+
   const atMembershipLimit =
-    membershipLimit !== undefined &&
-    (membersData?.members.length ?? 0) >= membershipLimit
+    membershipLimit !== undefined && total >= membershipLimit
+
+  // Any change to what the server is being asked for invalidates the cursor.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resets on query change
+  useEffect(() => {
+    setPage(0)
+  }, [roleFilter, sortDescriptor, activeOrganization?.id])
+
+  const pageStart = page * (pageSize ?? 0)
+  const pageEnd = pageStart + (sortedMembers?.length ?? 0)
+  const hasNextPage = pageEnd < total
 
   function toggleSort(column: string) {
     setSortDescriptor((current) => {
@@ -161,20 +225,24 @@ export function OrganizationMembers({
 
       <div className="flex flex-col gap-4">
         <div className="flex items-center gap-3">
-          <InputGroup className="min-w-0 sm:w-[220px]">
-            <InputGroupInput
-              type="search"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              aria-label={organizationLocalization.search}
-              placeholder={organizationLocalization.search}
-              disabled={isPending}
-            />
+          {/* list-members has no search parameter, so a search box would
+              only ever filter the page in front of you. */}
+          {!paged && (
+            <InputGroup className="min-w-0 sm:w-[220px]">
+              <InputGroupInput
+                type="search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                aria-label={organizationLocalization.search}
+                placeholder={organizationLocalization.search}
+                disabled={isPending}
+              />
 
-            <InputGroupAddon>
-              <Search className="text-muted-foreground" />
-            </InputGroupAddon>
-          </InputGroup>
+              <InputGroupAddon>
+                <Search className="text-muted-foreground" />
+              </InputGroupAddon>
+            </InputGroup>
+          )}
 
           <DropdownMenu>
             <DropdownMenuTrigger
@@ -228,16 +296,22 @@ export function OrganizationMembers({
           <Table aria-label={organizationLocalization.members}>
             <TableHeader>
               <TableRow>
-                <SortableTableHead
-                  sortDirection={
-                    sortDescriptor?.column === "user"
-                      ? sortDescriptor.direction
-                      : undefined
-                  }
-                  onClick={() => toggleSort("user")}
-                >
-                  {organizationLocalization.member}
-                </SortableTableHead>
+                {/* Name and email live on the joined user row, which
+                    list-members cannot sort by. */}
+                {paged ? (
+                  <TableHead>{organizationLocalization.member}</TableHead>
+                ) : (
+                  <SortableTableHead
+                    sortDirection={
+                      sortDescriptor?.column === "user"
+                        ? sortDescriptor.direction
+                        : undefined
+                    }
+                    onClick={() => toggleSort("user")}
+                  >
+                    {organizationLocalization.member}
+                  </SortableTableHead>
+                )}
 
                 <SortableTableHead
                   sortDirection={
@@ -273,6 +347,37 @@ export function OrganizationMembers({
             </TableBody>
           </Table>
         </Card>
+
+        {paged && total > 0 && (
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-muted-foreground text-sm tabular-nums">
+              {organizationLocalization.paginationRange
+                .replace("{{from}}", String(pageStart + 1))
+                .replace("{{to}}", String(pageEnd))
+                .replace("{{total}}", String(total))}
+            </p>
+
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isPending || page === 0}
+                onClick={() => setPage((current) => Math.max(0, current - 1))}
+              >
+                {organizationLocalization.previousPage}
+              </Button>
+
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isPending || !hasNextPage}
+                onClick={() => setPage((current) => current + 1)}
+              >
+                {organizationLocalization.nextPage}
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
 
       <InviteMemberDialog open={inviteOpen} onOpenChange={setInviteOpen} />

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-members.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-members.tsx
@@ -60,7 +60,8 @@ type SortDescriptor = {
 export type OrganizationMembersProps = {
   className?: string
   /**
-   * Rows per page. Setting it moves paging, role filtering, and role sorting
+   * Number of rows per page. This value must be a positive integer. Setting it
+   * moves paging, role filtering, and role sorting
    * onto the server, which is what large organizations want: without it the
    * endpoint caps the response at 100 members with no indication.
    *
@@ -68,6 +69,17 @@ export type OrganizationMembersProps = {
    * browser.
    */
   pageSize?: number
+}
+
+function validatePageSize(pageSize?: number) {
+  if (
+    pageSize !== undefined &&
+    (!Number.isInteger(pageSize) || pageSize <= 0)
+  ) {
+    throw new RangeError("pageSize must be a positive integer")
+  }
+
+  return pageSize
 }
 
 /**
@@ -78,6 +90,7 @@ export function OrganizationMembers({
   pageSize,
   ...props
 }: OrganizationMembersProps & ComponentProps<"div">) {
+  const validatedPageSize = validatePageSize(pageSize)
   const { authClient } = useAuth<OrganizationAuthClient>()
   const {
     localization: organizationLocalization,
@@ -93,14 +106,14 @@ export function OrganizationMembers({
   const [search, setSearch] = useState("")
   const [page, setPage] = useState(0)
 
-  const paged = pageSize !== undefined
+  const paged = validatedPageSize !== undefined
 
   const { data: membersData, isPending: membersPending } =
     useListOrganizationMembers(authClient, {
       query: paged
         ? {
-            limit: pageSize,
-            offset: page * pageSize,
+            limit: validatedPageSize,
+            offset: page * validatedPageSize,
             ...(roleFilter === "all"
               ? {}
               : {
@@ -190,7 +203,7 @@ export function OrganizationMembers({
     setPage(0)
   }, [roleFilter, sortDescriptor, activeOrganization?.id])
 
-  const pageStart = page * (pageSize ?? 0)
+  const pageStart = page * (validatedPageSize ?? 0)
   const pageEnd = pageStart + (sortedMembers?.length ?? 0)
   const hasNextPage = pageEnd < total
 

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-members.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-members.tsx
@@ -4,15 +4,22 @@ import {
   hasMemberRole,
   type OrganizationAuthClient
 } from "@better-auth-ui/core/plugins/organization"
-import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
+  useActiveMemberRole,
   useActiveOrganization,
   useHasPermission,
   useListOrganizationMembers
 } from "@better-auth-ui/react/plugins/organization"
 import type { Member } from "better-auth/client"
 import { ChevronUp, Filter, Search, X } from "lucide-react"
-import { type ComponentProps, type ReactNode, useMemo, useState } from "react"
+import {
+  type ComponentProps,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useState
+} from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button, buttonVariants } from "@/components/ui/button"
@@ -52,6 +59,15 @@ type SortDescriptor = {
 /** Props for the `OrganizationMembers` component. */
 export type OrganizationMembersProps = {
   className?: string
+  /**
+   * Rows per page. Setting it moves paging, role filtering, and role sorting
+   * onto the server, which is what large organizations want: without it the
+   * endpoint caps the response at 100 members with no indication.
+   *
+   * Leave it unset to keep the whole list in memory and filter it in the
+   * browser.
+   */
+  pageSize?: number
 }
 
 /**
@@ -59,6 +75,7 @@ export type OrganizationMembersProps = {
  */
 export function OrganizationMembers({
   className,
+  pageSize,
   ...props
 }: OrganizationMembersProps & ComponentProps<"div">) {
   const { authClient } = useAuth<OrganizationAuthClient>()
@@ -68,11 +85,47 @@ export function OrganizationMembers({
     roles
   } = useAuthPlugin(organizationPlugin)
 
-  const { data: session } = useSession(authClient)
   const { data: activeOrganization, isPending: activeOrganizationPending } =
     useActiveOrganization(authClient)
+
+  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>()
+  const [roleFilter, setRoleFilter] = useState("all")
+  const [search, setSearch] = useState("")
+  const [page, setPage] = useState(0)
+
+  const paged = pageSize !== undefined
+
   const { data: membersData, isPending: membersPending } =
-    useListOrganizationMembers(authClient)
+    useListOrganizationMembers(authClient, {
+      query: paged
+        ? {
+            limit: pageSize,
+            offset: page * pageSize,
+            ...(roleFilter === "all"
+              ? {}
+              : {
+                  filterField: "role",
+                  filterValue: roleFilter,
+                  // Roles are stored comma-joined, so an exact match would
+                  // drop anyone holding more than one.
+                  filterOperator: "contains" as const
+                }),
+            ...(sortDescriptor?.column === "role"
+              ? {
+                  sortBy: "role",
+                  sortDirection:
+                    sortDescriptor.direction === "descending"
+                      ? ("desc" as const)
+                      : ("asc" as const)
+                }
+              : {})
+          }
+        : undefined
+    })
+
+  // The signed-in user need not be on the loaded page, so their own role comes
+  // from a dedicated endpoint rather than from the member list.
+  const { data: activeMemberRole } = useActiveMemberRole(authClient)
 
   const { isPending: updatePermissionPending } = useHasPermission(authClient, {
     permissions: { member: ["update"] }
@@ -87,20 +140,22 @@ export function OrganizationMembers({
     updatePermissionPending ||
     deletePermissionPending
 
-  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>()
-  const [roleFilter, setRoleFilter] = useState("all")
-  const [search, setSearch] = useState("")
-
   const filteredMembers = useMemo(() => {
+    // The server already applied the role filter when paging, and it has no
+    // parameter for name or email search, so both stay here only in the
+    // unpaged mode where the whole list is present.
+    if (paged) return membersData?.members
+
     return membersData?.members.filter(
       (member) =>
         (roleFilter === "all" || hasMemberRole(member.role, roleFilter)) &&
         (member.user.name.toLowerCase().includes(search.toLowerCase()) ||
           member.user.email.toLowerCase().includes(search.toLowerCase()))
     )
-  }, [search, membersData?.members, roleFilter])
+  }, [paged, search, membersData?.members, roleFilter])
 
   const sortedMembers = useMemo(() => {
+    if (paged) return filteredMembers
     if (!sortDescriptor) return filteredMembers
     if (!filteredMembers) return filteredMembers
 
@@ -118,17 +173,26 @@ export function OrganizationMembers({
 
       return cmp
     })
-  }, [sortDescriptor, filteredMembers])
+  }, [paged, sortDescriptor, filteredMembers])
 
   const [inviteOpen, setInviteOpen] = useState(false)
 
-  const isOwner = membersData?.members.some(
-    (member) =>
-      hasMemberRole(member.role, "owner") && member.userId === session?.user.id
-  )
+  const isOwner = hasMemberRole(activeMemberRole?.role, "owner")
+
+  const total = membersData?.total ?? membersData?.members.length ?? 0
+
   const atMembershipLimit =
-    membershipLimit !== undefined &&
-    (membersData?.members.length ?? 0) >= membershipLimit
+    membershipLimit !== undefined && total >= membershipLimit
+
+  // Any change to what the server is being asked for invalidates the cursor.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resets on query change
+  useEffect(() => {
+    setPage(0)
+  }, [roleFilter, sortDescriptor, activeOrganization?.id])
+
+  const pageStart = page * (pageSize ?? 0)
+  const pageEnd = pageStart + (sortedMembers?.length ?? 0)
+  const hasNextPage = pageEnd < total
 
   function toggleSort(column: string) {
     setSortDescriptor((current) => {
@@ -161,20 +225,24 @@ export function OrganizationMembers({
 
       <div className="flex flex-col gap-4">
         <div className="flex items-center gap-3">
-          <InputGroup className="min-w-0 sm:w-[220px]">
-            <InputGroupInput
-              type="search"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              aria-label={organizationLocalization.search}
-              placeholder={organizationLocalization.search}
-              disabled={isPending}
-            />
+          {/* list-members has no search parameter, so a search box would
+              only ever filter the page in front of you. */}
+          {!paged && (
+            <InputGroup className="min-w-0 sm:w-[220px]">
+              <InputGroupInput
+                type="search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                aria-label={organizationLocalization.search}
+                placeholder={organizationLocalization.search}
+                disabled={isPending}
+              />
 
-            <InputGroupAddon>
-              <Search className="text-muted-foreground" />
-            </InputGroupAddon>
-          </InputGroup>
+              <InputGroupAddon>
+                <Search className="text-muted-foreground" />
+              </InputGroupAddon>
+            </InputGroup>
+          )}
 
           <DropdownMenu>
             <DropdownMenuTrigger
@@ -228,16 +296,22 @@ export function OrganizationMembers({
           <Table aria-label={organizationLocalization.members}>
             <TableHeader>
               <TableRow>
-                <SortableTableHead
-                  sortDirection={
-                    sortDescriptor?.column === "user"
-                      ? sortDescriptor.direction
-                      : undefined
-                  }
-                  onClick={() => toggleSort("user")}
-                >
-                  {organizationLocalization.member}
-                </SortableTableHead>
+                {/* Name and email live on the joined user row, which
+                    list-members cannot sort by. */}
+                {paged ? (
+                  <TableHead>{organizationLocalization.member}</TableHead>
+                ) : (
+                  <SortableTableHead
+                    sortDirection={
+                      sortDescriptor?.column === "user"
+                        ? sortDescriptor.direction
+                        : undefined
+                    }
+                    onClick={() => toggleSort("user")}
+                  >
+                    {organizationLocalization.member}
+                  </SortableTableHead>
+                )}
 
                 <SortableTableHead
                   sortDirection={
@@ -273,6 +347,37 @@ export function OrganizationMembers({
             </TableBody>
           </Table>
         </Card>
+
+        {paged && total > 0 && (
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-muted-foreground text-sm tabular-nums">
+              {organizationLocalization.paginationRange
+                .replace("{{from}}", String(pageStart + 1))
+                .replace("{{to}}", String(pageEnd))
+                .replace("{{total}}", String(total))}
+            </p>
+
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isPending || page === 0}
+                onClick={() => setPage((current) => Math.max(0, current - 1))}
+              >
+                {organizationLocalization.previousPage}
+              </Button>
+
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isPending || !hasNextPage}
+                onClick={() => setPage((current) => current + 1)}
+              >
+                {organizationLocalization.nextPage}
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
 
       <InviteMemberDialog open={inviteOpen} onOpenChange={setInviteOpen} />

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-members.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-members.tsx
@@ -60,7 +60,8 @@ type SortDescriptor = {
 export type OrganizationMembersProps = {
   className?: string
   /**
-   * Rows per page. Setting it moves paging, role filtering, and role sorting
+   * Number of rows per page. This value must be a positive integer. Setting it
+   * moves paging, role filtering, and role sorting
    * onto the server, which is what large organizations want: without it the
    * endpoint caps the response at 100 members with no indication.
    *
@@ -68,6 +69,17 @@ export type OrganizationMembersProps = {
    * browser.
    */
   pageSize?: number
+}
+
+function validatePageSize(pageSize?: number) {
+  if (
+    pageSize !== undefined &&
+    (!Number.isInteger(pageSize) || pageSize <= 0)
+  ) {
+    throw new RangeError("pageSize must be a positive integer")
+  }
+
+  return pageSize
 }
 
 /**
@@ -78,6 +90,7 @@ export function OrganizationMembers({
   pageSize,
   ...props
 }: OrganizationMembersProps & ComponentProps<"div">) {
+  const validatedPageSize = validatePageSize(pageSize)
   const { authClient } = useAuth<OrganizationAuthClient>()
   const {
     localization: organizationLocalization,
@@ -93,14 +106,14 @@ export function OrganizationMembers({
   const [search, setSearch] = useState("")
   const [page, setPage] = useState(0)
 
-  const paged = pageSize !== undefined
+  const paged = validatedPageSize !== undefined
 
   const { data: membersData, isPending: membersPending } =
     useListOrganizationMembers(authClient, {
       query: paged
         ? {
-            limit: pageSize,
-            offset: page * pageSize,
+            limit: validatedPageSize,
+            offset: page * validatedPageSize,
             ...(roleFilter === "all"
               ? {}
               : {
@@ -190,7 +203,7 @@ export function OrganizationMembers({
     setPage(0)
   }, [roleFilter, sortDescriptor, activeOrganization?.id])
 
-  const pageStart = page * (pageSize ?? 0)
+  const pageStart = page * (validatedPageSize ?? 0)
   const pageEnd = pageStart + (sortedMembers?.length ?? 0)
   const hasNextPage = pageEnd < total
 

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-members.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-members.tsx
@@ -4,15 +4,22 @@ import {
   hasMemberRole,
   type OrganizationAuthClient
 } from "@better-auth-ui/core/plugins/organization"
-import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
+  useActiveMemberRole,
   useActiveOrganization,
   useHasPermission,
   useListOrganizationMembers
 } from "@better-auth-ui/react/plugins/organization"
 import type { Member } from "better-auth/client"
 import { ChevronUp, Filter, Search, X } from "lucide-react"
-import { type ComponentProps, type ReactNode, useMemo, useState } from "react"
+import {
+  type ComponentProps,
+  type ReactNode,
+  useEffect,
+  useMemo,
+  useState
+} from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button, buttonVariants } from "@/components/ui/button"
@@ -52,6 +59,15 @@ type SortDescriptor = {
 /** Props for the `OrganizationMembers` component. */
 export type OrganizationMembersProps = {
   className?: string
+  /**
+   * Rows per page. Setting it moves paging, role filtering, and role sorting
+   * onto the server, which is what large organizations want: without it the
+   * endpoint caps the response at 100 members with no indication.
+   *
+   * Leave it unset to keep the whole list in memory and filter it in the
+   * browser.
+   */
+  pageSize?: number
 }
 
 /**
@@ -59,6 +75,7 @@ export type OrganizationMembersProps = {
  */
 export function OrganizationMembers({
   className,
+  pageSize,
   ...props
 }: OrganizationMembersProps & ComponentProps<"div">) {
   const { authClient } = useAuth<OrganizationAuthClient>()
@@ -68,11 +85,47 @@ export function OrganizationMembers({
     roles
   } = useAuthPlugin(organizationPlugin)
 
-  const { data: session } = useSession(authClient)
   const { data: activeOrganization, isPending: activeOrganizationPending } =
     useActiveOrganization(authClient)
+
+  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>()
+  const [roleFilter, setRoleFilter] = useState("all")
+  const [search, setSearch] = useState("")
+  const [page, setPage] = useState(0)
+
+  const paged = pageSize !== undefined
+
   const { data: membersData, isPending: membersPending } =
-    useListOrganizationMembers(authClient)
+    useListOrganizationMembers(authClient, {
+      query: paged
+        ? {
+            limit: pageSize,
+            offset: page * pageSize,
+            ...(roleFilter === "all"
+              ? {}
+              : {
+                  filterField: "role",
+                  filterValue: roleFilter,
+                  // Roles are stored comma-joined, so an exact match would
+                  // drop anyone holding more than one.
+                  filterOperator: "contains" as const
+                }),
+            ...(sortDescriptor?.column === "role"
+              ? {
+                  sortBy: "role",
+                  sortDirection:
+                    sortDescriptor.direction === "descending"
+                      ? ("desc" as const)
+                      : ("asc" as const)
+                }
+              : {})
+          }
+        : undefined
+    })
+
+  // The signed-in user need not be on the loaded page, so their own role comes
+  // from a dedicated endpoint rather than from the member list.
+  const { data: activeMemberRole } = useActiveMemberRole(authClient)
 
   const { isPending: updatePermissionPending } = useHasPermission(authClient, {
     permissions: { member: ["update"] }
@@ -87,20 +140,22 @@ export function OrganizationMembers({
     updatePermissionPending ||
     deletePermissionPending
 
-  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>()
-  const [roleFilter, setRoleFilter] = useState("all")
-  const [search, setSearch] = useState("")
-
   const filteredMembers = useMemo(() => {
+    // The server already applied the role filter when paging, and it has no
+    // parameter for name or email search, so both stay here only in the
+    // unpaged mode where the whole list is present.
+    if (paged) return membersData?.members
+
     return membersData?.members.filter(
       (member) =>
         (roleFilter === "all" || hasMemberRole(member.role, roleFilter)) &&
         (member.user.name.toLowerCase().includes(search.toLowerCase()) ||
           member.user.email.toLowerCase().includes(search.toLowerCase()))
     )
-  }, [search, membersData?.members, roleFilter])
+  }, [paged, search, membersData?.members, roleFilter])
 
   const sortedMembers = useMemo(() => {
+    if (paged) return filteredMembers
     if (!sortDescriptor) return filteredMembers
     if (!filteredMembers) return filteredMembers
 
@@ -118,17 +173,26 @@ export function OrganizationMembers({
 
       return cmp
     })
-  }, [sortDescriptor, filteredMembers])
+  }, [paged, sortDescriptor, filteredMembers])
 
   const [inviteOpen, setInviteOpen] = useState(false)
 
-  const isOwner = membersData?.members.some(
-    (member) =>
-      hasMemberRole(member.role, "owner") && member.userId === session?.user.id
-  )
+  const isOwner = hasMemberRole(activeMemberRole?.role, "owner")
+
+  const total = membersData?.total ?? membersData?.members.length ?? 0
+
   const atMembershipLimit =
-    membershipLimit !== undefined &&
-    (membersData?.members.length ?? 0) >= membershipLimit
+    membershipLimit !== undefined && total >= membershipLimit
+
+  // Any change to what the server is being asked for invalidates the cursor.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resets on query change
+  useEffect(() => {
+    setPage(0)
+  }, [roleFilter, sortDescriptor, activeOrganization?.id])
+
+  const pageStart = page * (pageSize ?? 0)
+  const pageEnd = pageStart + (sortedMembers?.length ?? 0)
+  const hasNextPage = pageEnd < total
 
   function toggleSort(column: string) {
     setSortDescriptor((current) => {
@@ -161,20 +225,24 @@ export function OrganizationMembers({
 
       <div className="flex flex-col gap-4">
         <div className="flex items-center gap-3">
-          <InputGroup className="min-w-0 sm:w-[220px]">
-            <InputGroupInput
-              type="search"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              aria-label={organizationLocalization.search}
-              placeholder={organizationLocalization.search}
-              disabled={isPending}
-            />
+          {/* list-members has no search parameter, so a search box would
+              only ever filter the page in front of you. */}
+          {!paged && (
+            <InputGroup className="min-w-0 sm:w-[220px]">
+              <InputGroupInput
+                type="search"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                aria-label={organizationLocalization.search}
+                placeholder={organizationLocalization.search}
+                disabled={isPending}
+              />
 
-            <InputGroupAddon>
-              <Search className="text-muted-foreground" />
-            </InputGroupAddon>
-          </InputGroup>
+              <InputGroupAddon>
+                <Search className="text-muted-foreground" />
+              </InputGroupAddon>
+            </InputGroup>
+          )}
 
           <DropdownMenu>
             <DropdownMenuTrigger
@@ -228,16 +296,22 @@ export function OrganizationMembers({
           <Table aria-label={organizationLocalization.members}>
             <TableHeader>
               <TableRow>
-                <SortableTableHead
-                  sortDirection={
-                    sortDescriptor?.column === "user"
-                      ? sortDescriptor.direction
-                      : undefined
-                  }
-                  onClick={() => toggleSort("user")}
-                >
-                  {organizationLocalization.member}
-                </SortableTableHead>
+                {/* Name and email live on the joined user row, which
+                    list-members cannot sort by. */}
+                {paged ? (
+                  <TableHead>{organizationLocalization.member}</TableHead>
+                ) : (
+                  <SortableTableHead
+                    sortDirection={
+                      sortDescriptor?.column === "user"
+                        ? sortDescriptor.direction
+                        : undefined
+                    }
+                    onClick={() => toggleSort("user")}
+                  >
+                    {organizationLocalization.member}
+                  </SortableTableHead>
+                )}
 
                 <SortableTableHead
                   sortDirection={
@@ -273,6 +347,37 @@ export function OrganizationMembers({
             </TableBody>
           </Table>
         </Card>
+
+        {paged && total > 0 && (
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-muted-foreground text-sm tabular-nums">
+              {organizationLocalization.paginationRange
+                .replace("{{from}}", String(pageStart + 1))
+                .replace("{{to}}", String(pageEnd))
+                .replace("{{total}}", String(total))}
+            </p>
+
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isPending || page === 0}
+                onClick={() => setPage((current) => Math.max(0, current - 1))}
+              >
+                {organizationLocalization.previousPage}
+              </Button>
+
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={isPending || !hasNextPage}
+                onClick={() => setPage((current) => current + 1)}
+              >
+                {organizationLocalization.nextPage}
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
 
       <InviteMemberDialog open={inviteOpen} onOpenChange={setInviteOpen} />

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-members.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-members.tsx
@@ -60,7 +60,8 @@ type SortDescriptor = {
 export type OrganizationMembersProps = {
   className?: string
   /**
-   * Rows per page. Setting it moves paging, role filtering, and role sorting
+   * Number of rows per page. This value must be a positive integer. Setting it
+   * moves paging, role filtering, and role sorting
    * onto the server, which is what large organizations want: without it the
    * endpoint caps the response at 100 members with no indication.
    *
@@ -68,6 +69,17 @@ export type OrganizationMembersProps = {
    * browser.
    */
   pageSize?: number
+}
+
+function validatePageSize(pageSize?: number) {
+  if (
+    pageSize !== undefined &&
+    (!Number.isInteger(pageSize) || pageSize <= 0)
+  ) {
+    throw new RangeError("pageSize must be a positive integer")
+  }
+
+  return pageSize
 }
 
 /**
@@ -78,6 +90,7 @@ export function OrganizationMembers({
   pageSize,
   ...props
 }: OrganizationMembersProps & ComponentProps<"div">) {
+  const validatedPageSize = validatePageSize(pageSize)
   const { authClient } = useAuth<OrganizationAuthClient>()
   const {
     localization: organizationLocalization,
@@ -93,14 +106,14 @@ export function OrganizationMembers({
   const [search, setSearch] = useState("")
   const [page, setPage] = useState(0)
 
-  const paged = pageSize !== undefined
+  const paged = validatedPageSize !== undefined
 
   const { data: membersData, isPending: membersPending } =
     useListOrganizationMembers(authClient, {
       query: paged
         ? {
-            limit: pageSize,
-            offset: page * pageSize,
+            limit: validatedPageSize,
+            offset: page * validatedPageSize,
             ...(roleFilter === "all"
               ? {}
               : {
@@ -190,7 +203,7 @@ export function OrganizationMembers({
     setPage(0)
   }, [roleFilter, sortDescriptor, activeOrganization?.id])
 
-  const pageStart = page * (pageSize ?? 0)
+  const pageStart = page * (validatedPageSize ?? 0)
   const pageEnd = pageStart + (sortedMembers?.length ?? 0)
   const hasNextPage = pageEnd < total
 

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-members.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-members.tsx
@@ -3,10 +3,21 @@ import {
   type OrganizationAuthClient,
   type OrganizationLocalization
 } from "@better-auth-ui/core/plugins/organization"
-import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/solid"
-import { useListOrganizationMembers } from "@better-auth-ui/solid/plugins/organization"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
+import {
+  useActiveMemberRole,
+  useListOrganizationMembers
+} from "@better-auth-ui/solid/plugins/organization"
 import { ChevronUp, Filter, Search, X } from "lucide-solid"
-import { createMemo, createSignal, For, type JSX, Show } from "solid-js"
+import {
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  type JSX,
+  on,
+  Show
+} from "solid-js"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
@@ -38,6 +49,15 @@ import { OrganizationMemberRowSkeleton } from "./organization-member-row-skeleto
 
 export type OrganizationMembersProps = {
   class?: string
+  /**
+   * Rows per page. Setting it moves paging, role filtering, and role sorting
+   * onto the server, which is what large organizations want: without it the
+   * endpoint caps the response at 100 members with no indication.
+   *
+   * Leave it unset to keep the whole list in memory and filter it in the
+   * browser.
+   */
+  pageSize?: number
 }
 
 type OrganizationMember = {
@@ -78,7 +98,10 @@ const fallbackLocalization = {
   role: "Role",
   member: "Member",
   admin: "Admin",
-  owner: "Owner"
+  owner: "Owner",
+  previousPage: "Previous page",
+  nextPage: "Next page",
+  paginationRange: "{{from}}–{{to}} of {{total}}"
 } satisfies Pick<
   OrganizationLocalization,
   | "changeMemberRole"
@@ -96,6 +119,9 @@ const fallbackLocalization = {
   | "member"
   | "admin"
   | "owner"
+  | "previousPage"
+  | "nextPage"
+  | "paginationRange"
 >
 
 const fallbackRoles: RoleMap = {
@@ -143,8 +169,45 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
     column: "name",
     direction: "ascending"
   })
-  const session = useSession(auth.authClient)
-  const members = useListOrganizationMembers(auth.authClient)
+  const [page, setPage] = createSignal(0)
+  const paged = () => props.pageSize !== undefined
+
+  const members = useListOrganizationMembers(auth.authClient, () => {
+    const size = props.pageSize
+
+    if (size === undefined) return {}
+
+    const descriptor = sortDescriptor()
+
+    return {
+      query: {
+        limit: size,
+        offset: page() * size,
+        ...(memberRoleFilter() === "all"
+          ? {}
+          : {
+              filterField: "role",
+              filterValue: memberRoleFilter(),
+              // Roles are stored comma-joined, so an exact match would drop
+              // anyone holding more than one.
+              filterOperator: "contains" as const
+            }),
+        ...(descriptor.column === "role"
+          ? {
+              sortBy: "role",
+              sortDirection:
+                descriptor.direction === "descending"
+                  ? ("desc" as const)
+                  : ("asc" as const)
+            }
+          : {})
+      }
+    }
+  })
+
+  // The signed-in user need not be on the loaded page, so their own role comes
+  // from a dedicated endpoint rather than from the member list.
+  const activeMemberRole = useActiveMemberRole(auth.authClient)
   const memberRows = () => (members.data?.members ?? []) as OrganizationMember[]
   const organizationPluginConfig = () =>
     auth.plugins.find((plugin) => plugin.id === organizationPlugin.id) as
@@ -164,6 +227,9 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
             | "all"
             | "role"
             | "member"
+            | "previousPage"
+            | "nextPage"
+            | "paginationRange"
           >
           roles?: RoleMap
         }
@@ -176,8 +242,13 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
   const selectedRoleLabel = () =>
     roles()[memberRoleFilter()] ?? memberRoleFilter()
   const normalizedMemberSearch = () => memberSearch().trim().toLowerCase()
-  const filteredMemberRows = () =>
-    memberRows().filter((member) => {
+  const filteredMemberRows = () => {
+    // The server already applied the role filter when paging, and it has no
+    // parameter for name or email search, so both stay here only in the
+    // unpaged mode where the whole list is present.
+    if (paged()) return memberRows()
+
+    return memberRows().filter((member) => {
       const roleMatches =
         memberRoleFilter() === "all" ||
         hasMemberRole(member.role, memberRoleFilter())
@@ -196,6 +267,7 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
 
       return roleMatches && searchableMember.includes(search)
     })
+  }
   const sortMembers = (
     first: OrganizationMember,
     second: OrganizationMember
@@ -220,7 +292,8 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
       ? comparison * -1
       : comparison
   }
-  const sortedMemberRows = () => [...filteredMemberRows()].sort(sortMembers)
+  const sortedMemberRows = () =>
+    paged() ? filteredMemberRows() : [...filteredMemberRows()].sort(sortMembers)
   const toggleSort = (column: MemberSort) => {
     setMemberSort(column)
     setSortDescriptor((current) => {
@@ -235,12 +308,21 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
       }
     })
   }
-  const isOwner = () =>
-    memberRows().some(
-      (member) =>
-        hasMemberRole(member.role, "owner") &&
-        member.userId === session.data?.user.id
+  const isOwner = () => hasMemberRole(activeMemberRole.data?.role, "owner")
+
+  const total = () => members.data?.total ?? memberRows().length
+  const pageStart = () => page() * (props.pageSize ?? 0)
+  const pageEnd = () => pageStart() + sortedMemberRows().length
+  const hasNextPage = () => pageEnd() < total()
+
+  // Any change to what the server is being asked for invalidates the cursor.
+  createEffect(
+    on(
+      () => [memberRoleFilter(), sortDescriptor().column] as const,
+      () => setPage(0),
+      { defer: true }
     )
+  )
 
   return (
     <div class={cn("flex flex-col gap-3", props.class)}>
@@ -250,7 +332,7 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
           class="shrink-0"
           disabled={
             config.membershipLimit !== undefined &&
-            memberRows().length >= config.membershipLimit
+            total() >= config.membershipLimit
           }
           onClick={() => setInviteOpen(true)}
           size="sm"
@@ -281,18 +363,24 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
           }
         >
           <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
-            <InputGroup class="min-w-0 sm:w-[220px]">
-              <InputGroupAddon>
-                <Search class="size-4 text-muted-foreground" />
-              </InputGroupAddon>
-              <InputGroupInput
-                aria-label={localization().search}
-                onInput={(event) => setMemberSearch(event.currentTarget.value)}
-                placeholder={localization().search}
-                type="search"
-                value={memberSearch()}
-              />
-            </InputGroup>
+            {/* list-members has no search parameter, so a search box would
+                only ever filter the page in front of you. */}
+            <Show when={!paged()}>
+              <InputGroup class="min-w-0 sm:w-[220px]">
+                <InputGroupAddon>
+                  <Search class="size-4 text-muted-foreground" />
+                </InputGroupAddon>
+                <InputGroupInput
+                  aria-label={localization().search}
+                  onInput={(event) =>
+                    setMemberSearch(event.currentTarget.value)
+                  }
+                  placeholder={localization().search}
+                  type="search"
+                  value={memberSearch()}
+                />
+              </InputGroup>
+            </Show>
             <DropdownMenu>
               <DropdownMenuTrigger
                 as={Button}
@@ -344,16 +432,23 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
             <Table aria-label="Members">
               <TableHeader>
                 <TableRow>
-                  <SortableTableHead
-                    onClick={() => toggleSort("name")}
-                    sortDirection={
-                      sortDescriptor().column === "name"
-                        ? sortDescriptor().direction
-                        : undefined
-                    }
+                  {/* Name and email live on the joined user row, which
+                      list-members cannot sort by. */}
+                  <Show
+                    when={!paged()}
+                    fallback={<TableHead>{localization().member}</TableHead>}
                   >
-                    {localization().member}
-                  </SortableTableHead>
+                    <SortableTableHead
+                      onClick={() => toggleSort("name")}
+                      sortDirection={
+                        sortDescriptor().column === "name"
+                          ? sortDescriptor().direction
+                          : undefined
+                      }
+                    >
+                      {localization().member}
+                    </SortableTableHead>
+                  </Show>
                   <SortableTableHead
                     onClick={() => toggleSort("role")}
                     sortDirection={
@@ -395,6 +490,39 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
               </TableBody>
             </Table>
           </Card>
+
+          <Show when={paged() && total() > 0}>
+            <div class="flex items-center justify-between gap-3">
+              <p class="text-muted-foreground text-sm tabular-nums">
+                {localization()
+                  .paginationRange.replace("{{from}}", String(pageStart() + 1))
+                  .replace("{{to}}", String(pageEnd()))
+                  .replace("{{total}}", String(total()))}
+              </p>
+
+              <div class="flex gap-2">
+                <Button
+                  disabled={page() === 0}
+                  onClick={() => setPage((current) => Math.max(0, current - 1))}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  {localization().previousPage}
+                </Button>
+
+                <Button
+                  disabled={!hasNextPage()}
+                  onClick={() => setPage((current) => current + 1)}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  {localization().nextPage}
+                </Button>
+              </div>
+            </div>
+          </Show>
         </Show>
       </Show>
       <InviteMemberDialog open={inviteOpen()} onOpenChange={setInviteOpen} />

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-members.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-members.tsx
@@ -49,8 +49,11 @@ import { OrganizationMemberRowSkeleton } from "./organization-member-row-skeleto
 
 export type OrganizationMembersProps = {
   class?: string
+  /** Organization to query. The current organization is used when omitted. */
+  organizationId?: string
   /**
-   * Rows per page. Setting it moves paging, role filtering, and role sorting
+   * Number of rows per page. This value must be a positive integer. Setting it
+   * moves paging, role filtering, and role sorting
    * onto the server, which is what large organizations want: without it the
    * endpoint caps the response at 100 members with no indication.
    *
@@ -58,6 +61,17 @@ export type OrganizationMembersProps = {
    * browser.
    */
   pageSize?: number
+}
+
+function validatePageSize(pageSize?: number) {
+  if (
+    pageSize !== undefined &&
+    (!Number.isInteger(pageSize) || pageSize <= 0)
+  ) {
+    throw new RangeError("pageSize must be a positive integer")
+  }
+
+  return pageSize
 }
 
 type OrganizationMember = {
@@ -170,10 +184,11 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
     direction: "ascending"
   })
   const [page, setPage] = createSignal(0)
-  const paged = () => props.pageSize !== undefined
+  const pageSize = () => validatePageSize(props.pageSize)
+  const paged = () => pageSize() !== undefined
 
   const members = useListOrganizationMembers(auth.authClient, () => {
-    const size = props.pageSize
+    const size = pageSize()
 
     if (size === undefined) return {}
 
@@ -183,6 +198,7 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
       query: {
         limit: size,
         offset: page() * size,
+        organizationId: props.organizationId,
         ...(memberRoleFilter() === "all"
           ? {}
           : {
@@ -311,14 +327,20 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
   const isOwner = () => hasMemberRole(activeMemberRole.data?.role, "owner")
 
   const total = () => members.data?.total ?? memberRows().length
-  const pageStart = () => page() * (props.pageSize ?? 0)
+  const pageStart = () => page() * (pageSize() ?? 0)
   const pageEnd = () => pageStart() + sortedMemberRows().length
   const hasNextPage = () => pageEnd() < total()
 
   // Any change to what the server is being asked for invalidates the cursor.
   createEffect(
     on(
-      () => [memberRoleFilter(), sortDescriptor().column] as const,
+      () =>
+        [
+          memberRoleFilter(),
+          sortDescriptor().column,
+          sortDescriptor().direction,
+          props.organizationId
+        ] as const,
       () => setPage(0),
       { defer: true }
     )

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-people.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-people.tsx
@@ -4,12 +4,14 @@ import { OrganizationMembers } from "./organization-members"
 
 export type OrganizationPeopleProps = {
   class?: string
+  /** Organization to query. The current organization is used when omitted. */
+  organizationId?: string
 }
 
 export function OrganizationPeople(props: OrganizationPeopleProps) {
   return (
     <div class={cn("grid gap-4 md:gap-6", props.class)}>
-      <OrganizationMembers />
+      <OrganizationMembers organizationId={props.organizationId} />
       <OrganizationInvitations />
     </div>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization.tsx
@@ -93,7 +93,7 @@ export function Organization(props: OrganizationProps) {
               value={config.viewPaths.organization.people}
               tabIndex={-1}
             >
-              <OrganizationPeople />
+              <OrganizationPeople organizationId={currentOrganization().id} />
             </TabsContent>
             <Show when={config.teams}>
               <TabsContent

--- a/packages/core/src/plugins/organization/active-member-role-query.ts
+++ b/packages/core/src/plugins/organization/active-member-role-query.ts
@@ -1,0 +1,84 @@
+import {
+  type QueryClient,
+  type QueryOptions,
+  skipToken
+} from "@tanstack/query-core"
+import type { InferData } from "../../lib/auth-client"
+import { createAuthQueryFetchOptions } from "../../lib/auth-query-retry"
+import type { OrganizationAuthClient } from "./organization-auth-client"
+import { organizationQueryKeys } from "./organization-query-keys"
+
+export type ActiveMemberRoleData<
+  TAuthClient extends OrganizationAuthClient = OrganizationAuthClient
+> = InferData<TAuthClient["organization"]["getActiveMemberRole"]>
+
+export type ActiveMemberRoleParams<
+  TAuthClient extends OrganizationAuthClient = OrganizationAuthClient
+> = Parameters<TAuthClient["organization"]["getActiveMemberRole"]>[0]
+
+export type ActiveMemberRoleOptions<
+  TAuthClient extends OrganizationAuthClient = OrganizationAuthClient
+> = Omit<QueryOptions<ActiveMemberRoleData<TAuthClient>>, "queryKey"> &
+  ActiveMemberRoleParams<TAuthClient>
+
+/**
+ * Query options factory for the signed-in user's own role in an organization.
+ *
+ * Prefer this over scanning `listMembers` for the current user: once the
+ * member list is paginated, the signed-in user may not be on the page that
+ * happens to be loaded.
+ *
+ * @param authClient - The Better Auth organization client.
+ * @param userId - The current signed-in user's ID. Used for cache partitioning.
+ * @param params - Parameters forwarded to `authClient.organization.getActiveMemberRole`.
+ */
+export function activeMemberRoleOptions<
+  TAuthClient extends OrganizationAuthClient
+>(
+  authClient: TAuthClient,
+  userId?: string,
+  params?: ActiveMemberRoleParams<TAuthClient>
+) {
+  type TData = ActiveMemberRoleData<TAuthClient>
+  const queryKey = organizationQueryKeys.members.activeRole(
+    userId,
+    params?.query
+  )
+  const query = params?.query as
+    | { organizationId?: string; organizationSlug?: string }
+    | undefined
+
+  return {
+    queryKey,
+    queryFn:
+      userId && (query?.organizationId || query?.organizationSlug)
+        ? ({ signal }) =>
+            authClient.organization.getActiveMemberRole({
+              ...params,
+              fetchOptions: createAuthQueryFetchOptions(
+                params?.fetchOptions,
+                signal
+              )
+            }) as Promise<TData>
+        : skipToken
+  } satisfies QueryOptions
+}
+
+/**
+ * Get the signed-in user's organization role from the cache, fetching if needed.
+ */
+export const ensureActiveMemberRole = <
+  TAuthClient extends OrganizationAuthClient
+>(
+  queryClient: QueryClient,
+  authClient: TAuthClient,
+  userId: string,
+  options?: ActiveMemberRoleOptions<TAuthClient>
+) => {
+  const { fetchOptions, query, ...queryOptions } = options ?? {}
+
+  return queryClient.ensureQueryData({
+    ...activeMemberRoleOptions(authClient, userId, { query, fetchOptions }),
+    ...queryOptions
+  })
+}

--- a/packages/core/src/plugins/organization/index.ts
+++ b/packages/core/src/plugins/organization/index.ts
@@ -1,4 +1,5 @@
 export * from "./accept-invitation-mutation"
+export * from "./active-member-role-query"
 export * from "./active-organization-query"
 export * from "./cancel-invitation-mutation"
 export * from "./check-slug-mutation"

--- a/packages/core/src/plugins/organization/organization-localization.ts
+++ b/packages/core/src/plugins/organization/organization-localization.ts
@@ -104,10 +104,16 @@ export const organizationLocalization = {
   owner: "Owner",
   /** @remarks `"Pending"` */
   pending: "Pending",
+  /** @remarks `"Next page"` */
+  nextPage: "Next page",
   /** @remarks `"Personal account"` */
   personalAccount: "Personal account",
+  /** @remarks `"Previous page"` */
+  previousPage: "Previous page",
   /** @remarks `"Rejected"` */
   rejected: "Rejected",
+  /** @remarks `"{{from}}–{{to}} of {{total}}"` */
+  paginationRange: "{{from}}–{{to}} of {{total}}",
   /** @remarks `"Return"` */
   return: "Return",
   /** @remarks `"Reject invitation"` */

--- a/packages/core/src/plugins/organization/organization-query-keys.ts
+++ b/packages/core/src/plugins/organization/organization-query-keys.ts
@@ -46,7 +46,17 @@ export const organizationQueryKeys = {
     lists: (userId: string | undefined) =>
       [...organizationQueryKeys.members.all(userId), "list"] as const,
     list: <TQuery = undefined>(userId: string | undefined, query?: TQuery) =>
-      [...organizationQueryKeys.members.lists(userId), query ?? null] as const
+      [...organizationQueryKeys.members.lists(userId), query ?? null] as const,
+    /** The signed-in user's own role within an organization. */
+    activeRole: <TQuery = undefined>(
+      userId: string | undefined,
+      query?: TQuery
+    ) =>
+      [
+        ...organizationQueryKeys.members.all(userId),
+        "activeRole",
+        query ?? null
+      ] as const
   },
 
   invitations: {

--- a/packages/core/tests/active-member-role-query.test.ts
+++ b/packages/core/tests/active-member-role-query.test.ts
@@ -1,0 +1,53 @@
+import { skipToken } from "@tanstack/query-core"
+import { describe, expect, it, vi } from "vitest"
+import { activeMemberRoleOptions } from "../src/plugins/organization/active-member-role-query"
+
+const createAuthClient = () => ({
+  organization: {
+    getActiveMemberRole: vi.fn(async () => ({ role: "owner" }))
+  }
+})
+
+describe("activeMemberRoleOptions", () => {
+  it("waits until it knows which organization to ask about", () => {
+    const authClient = createAuthClient() as never
+
+    // Firing without an organization would resolve against whatever the
+    // session happens to consider active, which is not what the caller asked.
+    expect(activeMemberRoleOptions(authClient, "user-1").queryFn).toBe(
+      skipToken
+    )
+    expect(
+      activeMemberRoleOptions(authClient, undefined, {
+        query: { organizationId: "org-1" }
+      } as never).queryFn
+    ).toBe(skipToken)
+  })
+
+  it("accepts either an id or a slug", () => {
+    const authClient = createAuthClient() as never
+
+    for (const query of [
+      { organizationId: "org-1" },
+      { organizationSlug: "acme" }
+    ]) {
+      expect(
+        activeMemberRoleOptions(authClient, "user-1", { query } as never)
+          .queryFn
+      ).not.toBe(skipToken)
+    }
+  })
+
+  it("partitions the cache by user and by organization", () => {
+    const authClient = createAuthClient() as never
+    const forOrg = (organizationId: string, userId: string) =>
+      JSON.stringify(
+        activeMemberRoleOptions(authClient, userId, {
+          query: { organizationId }
+        } as never).queryKey
+      )
+
+    expect(forOrg("org-1", "user-1")).not.toBe(forOrg("org-2", "user-1"))
+    expect(forOrg("org-1", "user-1")).not.toBe(forOrg("org-1", "user-2"))
+  })
+})

--- a/packages/heroui/src/components/auth/organization/organization-members.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-members.tsx
@@ -2,8 +2,9 @@ import {
   hasMemberRole,
   type OrganizationAuthClient
 } from "@better-auth-ui/core/plugins/organization"
-import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
+  useActiveMemberRole,
   useActiveOrganization,
   useHasPermission,
   useListOrganizationMembers
@@ -20,7 +21,7 @@ import {
   Table
 } from "@heroui/react"
 import type { Member } from "better-auth/client"
-import { type ComponentProps, useMemo, useState } from "react"
+import { type ComponentProps, useEffect, useMemo, useState } from "react"
 
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
 import { InviteMemberDialog } from "./invite-member-dialog"
@@ -30,6 +31,15 @@ import { OrganizationMemberRowSkeleton } from "./organization-member-row-skeleto
 /** Props for the {@link OrganizationMembers} component. */
 export type OrganizationMembersProps = {
   className?: string
+  /**
+   * Rows per page. Setting it moves paging, role filtering, and role sorting
+   * onto the server, which is what large organizations want: without it the
+   * endpoint caps the response at 100 members with no indication.
+   *
+   * Leave it unset to keep the whole list in memory and filter it in the
+   * browser.
+   */
+  pageSize?: number
 }
 
 /**
@@ -37,6 +47,7 @@ export type OrganizationMembersProps = {
  */
 export function OrganizationMembers({
   className,
+  pageSize,
   ...props
 }: OrganizationMembersProps & ComponentProps<"div">) {
   const { authClient } = useAuth()
@@ -46,11 +57,49 @@ export function OrganizationMembers({
     roles
   } = useAuthPlugin(organizationPlugin)
 
-  const { data: session } = useSession(authClient)
   const { data: activeOrganization, isPending: activeOrganizationPending } =
     useActiveOrganization(authClient as OrganizationAuthClient)
+
+  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>()
+  const [roleFilter, setRoleFilter] = useState("all")
+  const [search, setSearch] = useState("")
+  const [page, setPage] = useState(0)
+
+  const paged = pageSize !== undefined
+
   const { data: membersData, isPending: membersPending } =
-    useListOrganizationMembers(authClient as OrganizationAuthClient)
+    useListOrganizationMembers(authClient as OrganizationAuthClient, {
+      query: paged
+        ? {
+            limit: pageSize,
+            offset: page * pageSize,
+            ...(roleFilter === "all"
+              ? {}
+              : {
+                  filterField: "role",
+                  filterValue: roleFilter,
+                  // Roles are stored comma-joined, so an exact match would
+                  // drop anyone holding more than one.
+                  filterOperator: "contains" as const
+                }),
+            ...(sortDescriptor?.column === "role"
+              ? {
+                  sortBy: "role",
+                  sortDirection:
+                    sortDescriptor.direction === "descending"
+                      ? ("desc" as const)
+                      : ("asc" as const)
+                }
+              : {})
+          }
+        : undefined
+    })
+
+  // The signed-in user need not be on the loaded page, so their own role comes
+  // from a dedicated endpoint rather than from the member list.
+  const { data: activeMemberRole } = useActiveMemberRole(
+    authClient as OrganizationAuthClient
+  )
 
   const { isPending: updatePermissionPending } = useHasPermission(
     authClient as OrganizationAuthClient,
@@ -67,20 +116,22 @@ export function OrganizationMembers({
     updatePermissionPending ||
     deletePermissionPending
 
-  const [sortDescriptor, setSortDescriptor] = useState<SortDescriptor>()
-  const [roleFilter, setRoleFilter] = useState("all")
-  const [search, setSearch] = useState("")
-
   const filteredMembers = useMemo(() => {
+    // The server already applied the role filter when paging, and it has no
+    // parameter for name or email search, so both stay here only in the
+    // unpaged mode where the whole list is present.
+    if (paged) return membersData?.members
+
     return membersData?.members.filter(
       (member) =>
         (roleFilter === "all" || hasMemberRole(member.role, roleFilter)) &&
         (member.user.name.toLowerCase().includes(search.toLowerCase()) ||
           member.user.email.toLowerCase().includes(search.toLowerCase()))
     )
-  }, [search, membersData?.members, roleFilter])
+  }, [paged, search, membersData?.members, roleFilter])
 
   const sortedMembers = useMemo(() => {
+    if (paged) return filteredMembers
     if (!sortDescriptor) return filteredMembers
     if (!filteredMembers) return filteredMembers
 
@@ -98,17 +149,26 @@ export function OrganizationMembers({
 
       return cmp
     })
-  }, [sortDescriptor, filteredMembers])
+  }, [paged, sortDescriptor, filteredMembers])
 
   const [inviteOpen, setInviteOpen] = useState(false)
-  const membershipLimitReached =
-    membershipLimit !== undefined &&
-    (membersData?.members.length ?? 0) >= membershipLimit
 
-  const isOwner = membersData?.members.some(
-    (member) =>
-      hasMemberRole(member.role, "owner") && member.userId === session?.user.id
-  )
+  const total = membersData?.total ?? membersData?.members.length ?? 0
+
+  const membershipLimitReached =
+    membershipLimit !== undefined && total >= membershipLimit
+
+  const isOwner = hasMemberRole(activeMemberRole?.role, "owner")
+
+  // Any change to what the server is being asked for invalidates the cursor.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: resets on query change
+  useEffect(() => {
+    setPage(0)
+  }, [roleFilter, sortDescriptor, activeOrganization?.id])
+
+  const pageStart = page * (pageSize ?? 0)
+  const pageEnd = pageStart + (sortedMembers?.length ?? 0)
+  const hasNextPage = pageEnd < total
 
   return (
     <div className={cn("flex flex-col gap-3", className)} {...props}>
@@ -129,24 +189,28 @@ export function OrganizationMembers({
 
       <div className="flex flex-col gap-4">
         <div className="flex items-center gap-3">
-          <SearchField
-            className="min-w-0"
-            aria-label={organizationLocalization.search}
-            value={search}
-            onChange={setSearch}
-            isDisabled={isPending}
-          >
-            <SearchField.Group>
-              <SearchField.SearchIcon />
+          {/* list-members has no search parameter, so a search box would
+              only ever filter the page in front of you. */}
+          {!paged && (
+            <SearchField
+              className="min-w-0"
+              aria-label={organizationLocalization.search}
+              value={search}
+              onChange={setSearch}
+              isDisabled={isPending}
+            >
+              <SearchField.Group>
+                <SearchField.SearchIcon />
 
-              <SearchField.Input
-                placeholder={organizationLocalization.search}
-                className="sm:w-[200px]"
-              />
+                <SearchField.Input
+                  placeholder={organizationLocalization.search}
+                  className="sm:w-[200px]"
+                />
 
-              <SearchField.ClearButton />
-            </SearchField.Group>
-          </SearchField>
+                <SearchField.ClearButton />
+              </SearchField.Group>
+            </SearchField>
+          )}
 
           <Dropdown>
             <Button size="sm" variant="secondary" isDisabled={isPending}>
@@ -218,7 +282,9 @@ export function OrganizationMembers({
               }}
             >
               <Table.Header>
-                <Table.Column allowsSorting isRowHeader id="user">
+                {/* Name and email live on the joined user row, which
+                    list-members cannot sort by. */}
+                <Table.Column allowsSorting={!paged} isRowHeader id="user">
                   {({ sortDirection }) => (
                     <Table.SortableColumnHeader sortDirection={sortDirection}>
                       {organizationLocalization.member}
@@ -257,6 +323,37 @@ export function OrganizationMembers({
             </Table.Content>
           </Table.ScrollContainer>
         </Table>
+
+        {paged && total > 0 && (
+          <div className="flex items-center justify-between gap-3">
+            <p className="text-muted text-sm tabular-nums">
+              {organizationLocalization.paginationRange
+                .replace("{{from}}", String(pageStart + 1))
+                .replace("{{to}}", String(pageEnd))
+                .replace("{{total}}", String(total))}
+            </p>
+
+            <div className="flex gap-2">
+              <Button
+                size="sm"
+                variant="secondary"
+                isDisabled={isPending || page === 0}
+                onPress={() => setPage((current) => Math.max(0, current - 1))}
+              >
+                {organizationLocalization.previousPage}
+              </Button>
+
+              <Button
+                size="sm"
+                variant="secondary"
+                isDisabled={isPending || !hasNextPage}
+                onPress={() => setPage((current) => current + 1)}
+              >
+                {organizationLocalization.nextPage}
+              </Button>
+            </div>
+          </div>
+        )}
       </div>
 
       <InviteMemberDialog isOpen={inviteOpen} onOpenChange={setInviteOpen} />

--- a/packages/heroui/src/components/auth/organization/organization-members.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-members.tsx
@@ -32,7 +32,8 @@ import { OrganizationMemberRowSkeleton } from "./organization-member-row-skeleto
 export type OrganizationMembersProps = {
   className?: string
   /**
-   * Rows per page. Setting it moves paging, role filtering, and role sorting
+   * Number of rows per page. This value must be a positive integer. Setting it
+   * moves paging, role filtering, and role sorting
    * onto the server, which is what large organizations want: without it the
    * endpoint caps the response at 100 members with no indication.
    *
@@ -40,6 +41,17 @@ export type OrganizationMembersProps = {
    * browser.
    */
   pageSize?: number
+}
+
+function validatePageSize(pageSize?: number) {
+  if (
+    pageSize !== undefined &&
+    (!Number.isInteger(pageSize) || pageSize <= 0)
+  ) {
+    throw new RangeError("pageSize must be a positive integer")
+  }
+
+  return pageSize
 }
 
 /**
@@ -50,6 +62,7 @@ export function OrganizationMembers({
   pageSize,
   ...props
 }: OrganizationMembersProps & ComponentProps<"div">) {
+  const validatedPageSize = validatePageSize(pageSize)
   const { authClient } = useAuth()
   const {
     localization: organizationLocalization,
@@ -65,14 +78,14 @@ export function OrganizationMembers({
   const [search, setSearch] = useState("")
   const [page, setPage] = useState(0)
 
-  const paged = pageSize !== undefined
+  const paged = validatedPageSize !== undefined
 
   const { data: membersData, isPending: membersPending } =
     useListOrganizationMembers(authClient as OrganizationAuthClient, {
       query: paged
         ? {
-            limit: pageSize,
-            offset: page * pageSize,
+            limit: validatedPageSize,
+            offset: page * validatedPageSize,
             ...(roleFilter === "all"
               ? {}
               : {
@@ -166,7 +179,7 @@ export function OrganizationMembers({
     setPage(0)
   }, [roleFilter, sortDescriptor, activeOrganization?.id])
 
-  const pageStart = page * (pageSize ?? 0)
+  const pageStart = page * (validatedPageSize ?? 0)
   const pageEnd = pageStart + (sortedMembers?.length ?? 0)
   const hasNextPage = pageEnd < total
 

--- a/packages/react/src/plugins/organization/hooks/queries/index.ts
+++ b/packages/react/src/plugins/organization/hooks/queries/index.ts
@@ -1,3 +1,4 @@
+export * from "./use-active-member-role"
 export * from "./use-active-organization"
 export * from "./use-full-organization"
 export * from "./use-has-permission"

--- a/packages/react/src/plugins/organization/hooks/queries/use-active-member-role.ts
+++ b/packages/react/src/plugins/organization/hooks/queries/use-active-member-role.ts
@@ -1,0 +1,64 @@
+import {
+  type ActiveMemberRoleData,
+  type ActiveMemberRoleParams,
+  activeMemberRoleOptions,
+  type OrganizationAuthClient
+} from "@better-auth-ui/core/plugins/organization"
+import {
+  type QueryClient,
+  type UseQueryOptions,
+  useQuery
+} from "@tanstack/react-query"
+import { useSession } from "../../../../hooks/queries/use-session"
+import { useActiveOrganization } from "./use-active-organization"
+
+/**
+ * Options for `useActiveMemberRole`, combining React Query options with core
+ * query parameters.
+ */
+export type UseActiveMemberRoleOptions<
+  TAuthClient extends OrganizationAuthClient = OrganizationAuthClient
+> = Omit<UseQueryOptions<ActiveMemberRoleData<TAuthClient>>, "queryKey"> &
+  ActiveMemberRoleParams<TAuthClient>
+
+/**
+ * React query hook for the signed-in user's own role in an organization.
+ *
+ * Prefer this over scanning `useListOrganizationMembers` for the current user:
+ * with a paginated member list the signed-in user may not be on the loaded
+ * page.
+ *
+ * @param authClient - The Better Auth client.
+ * @param options - Core query parameters and React Query options.
+ * @param queryClient - Optional React Query client override.
+ */
+export function useActiveMemberRole<TAuthClient extends OrganizationAuthClient>(
+  authClient: TAuthClient,
+  options: UseActiveMemberRoleOptions<TAuthClient> = {},
+  queryClient?: QueryClient
+) {
+  const { data: session } = useSession(authClient, undefined, queryClient)
+  const userId = session?.user.id
+
+  const { query, fetchOptions, ...queryOptions } = options
+
+  const { data: activeOrganization } = useActiveOrganization(
+    authClient,
+    undefined,
+    queryClient
+  )
+
+  return useQuery(
+    {
+      ...activeMemberRoleOptions(authClient, userId, {
+        query: {
+          ...query,
+          organizationId: query?.organizationId ?? activeOrganization?.id
+        },
+        fetchOptions
+      }),
+      ...queryOptions
+    },
+    queryClient
+  )
+}

--- a/packages/solid/src/plugins/organization/hooks/queries/index.ts
+++ b/packages/solid/src/plugins/organization/hooks/queries/index.ts
@@ -1,3 +1,4 @@
+export * from "./use-active-member-role"
 export * from "./use-active-organization"
 export * from "./use-full-organization"
 export * from "./use-has-permission"

--- a/packages/solid/src/plugins/organization/hooks/queries/use-active-member-role.ts
+++ b/packages/solid/src/plugins/organization/hooks/queries/use-active-member-role.ts
@@ -1,0 +1,65 @@
+import {
+  type ActiveMemberRoleData,
+  type ActiveMemberRoleParams,
+  activeMemberRoleOptions,
+  type OrganizationAuthClient
+} from "@better-auth-ui/core/plugins/organization"
+import {
+  type QueryClient,
+  type QueryOptions,
+  useQuery
+} from "@tanstack/solid-query"
+import type { Accessor } from "solid-js"
+import { useSession } from "../../../../hooks/queries/use-session"
+import { useActiveOrganization } from "./use-active-organization"
+
+/**
+ * Reactive options accessor for `useActiveMemberRole`, combining Solid Query
+ * options with core query parameters.
+ */
+export type UseActiveMemberRoleOptions<
+  TAuthClient extends OrganizationAuthClient = OrganizationAuthClient
+> = Accessor<
+  Omit<QueryOptions<ActiveMemberRoleData<TAuthClient>>, "queryKey"> &
+    ActiveMemberRoleParams<TAuthClient>
+>
+
+/**
+ * Solid query hook for the signed-in user's own role in an organization.
+ *
+ * Prefer this over scanning `useListOrganizationMembers` for the current user:
+ * with a paginated member list the signed-in user may not be on the loaded
+ * page.
+ *
+ * @param authClient - The Better Auth client.
+ * @param options - Reactive core query parameters and Solid Query options.
+ * @param queryClient - Optional Solid Query client accessor override.
+ */
+export function useActiveMemberRole<TAuthClient extends OrganizationAuthClient>(
+  authClient: TAuthClient,
+  options?: UseActiveMemberRoleOptions<TAuthClient>,
+  queryClient?: Accessor<QueryClient>
+) {
+  const session = useSession(authClient, undefined, queryClient)
+  const activeOrganization = useActiveOrganization(
+    authClient,
+    undefined,
+    queryClient
+  )
+
+  return useQuery(() => {
+    const userId = session.data?.user.id
+    const { query, fetchOptions, initialData, ...queryOptions } =
+      options?.() ?? {}
+    const organizationId = query?.organizationId ?? activeOrganization.data?.id
+
+    return {
+      ...activeMemberRoleOptions(authClient, userId, {
+        query: { ...query, organizationId },
+        fetchOptions
+      }),
+      ...queryOptions,
+      initialData: initialData as undefined
+    }
+  }, queryClient)
+}


### PR DESCRIPTION
Stacked on #492.

## Problem

`<OrganizationMembers />` fetched the whole member list and filtered it in a `useMemo`. That is not just slow for a large organization, it is **wrong**:

```js
// better-auth/dist/plugins/organization/adapter.mjs
limit: data.limit || (typeof options?.membershipLimit === "number" ? options.membershipLimit : 100) || 100,
```

With no `limit`, the endpoint caps at 100 rows and reports nothing about the remainder. Member 101 simply never appeared, and the UI gave no hint that anything was missing.

## What changed

`pageSize` is a new opt-in prop:

```tsx
<OrganizationMembers pageSize={20} />
```

In paged mode the component:

- sends `limit` and `offset`
- applies the role filter server-side via `filterField` / `filterValue`, using the `contains` operator (roles are stored comma-joined, so `eq` would drop anyone holding more than one)
- sorts by role via `sortBy` / `sortDirection`
- reads the row count from the endpoint's `total` and renders a range plus prev/next

Leaving `pageSize` unset keeps today's behaviour byte for byte.

## Two controls step aside when paged

Neither can be honoured across pages, so rather than pretend:

- **Search box.** `list-members` has no search parameter. Name and email live on the joined `user` row, which the endpoint does not query.
- **Sorting by member.** Same reason.

Both are documented with the reason, since this is a Better Auth endpoint gap rather than ours.

## Owner detection had to move

The old check scanned the loaded members for the signed-in user:

```ts
membersData?.members.some((m) => m.role === "owner" && m.userId === session?.user.id)
```

Under pagination that user may be on another page, which would silently strip their owner-only actions. This adds `activeMemberRoleOptions` to core and `useActiveMemberRole` to both framework packages, backed by Better Auth's existing `getActiveMemberRole`. It is exported, so consumers can use it too.

## Correcting the scope

I originally said the same shape applied to invitations, API keys, and sessions. Checking the schemas: `list-invitations` and `list-sessions` accept **no** pagination parameters, so those genuinely cannot be paged today. `list-api-keys` does accept `limit`/`offset`/`sortBy`/`sortDirection`; that is a separate change rather than something I have folded in here.

## Coverage

shadcn (Radix + Base UI), HeroUI, Solid/Zaidan.

## Tests

`packages/core/tests/active-member-role-query.test.ts` covers the skipToken guards (no user, no organization), accepting either an id or a slug, and cache partitioning by both user and organization.

`nx run-many -t typecheck` and `nx run-many -t test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional server-side pagination for organization members, including page controls, totals, role filtering, and role sorting.
  * Added active-member-role retrieval for React and Solid integrations.
  * Added localized pagination labels and range text.

* **Documentation**
  * Documented pagination setup, filtering and sorting behavior, active-role handling, and current limitations across supported examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->