### PR TITLE
feat(organization): support model-specific fields

### DIFF
--- a/apps/docs/content/docs/heroui/plugins/organization.mdx
+++ b/apps/docs/content/docs/heroui/plugins/organization.mdx
@@ -1050,6 +1050,34 @@ Set `syncSession` when an application still reads `session.activeTeamId`. This o
 
 The `useListUserTeams` and `useSetActiveTeam` hooks are also available for custom controls. Always pass `organizationId` to both APIs.
 
-Use `organizationLimit`, `membershipLimit`, and `invitationLimit` to disable actions when a configured limit is reached. Use `allowOrganizationCreation: false` to hide creation controls. Use `additionalFields` to add custom inputs to organization creation and profile forms.
+### Model-specific fields
+
+Configure fields by the Better Auth model that stores them. The names and types must match the `schema` fields in the server organization plugin.
+
+```tsx
+organizationPlugin({
+  modelFields: {
+    organization: [
+      { name: "billingCode", type: "string", label: "Billing code" }
+    ],
+    member: [
+      { name: "title", type: "string", label: "Job title" }
+    ],
+    invitation: [
+      { name: "department", type: "string", label: "Department" }
+    ],
+    team: [
+      { name: "description", type: "string", inputType: "textarea", label: "Description" }
+    ],
+    role: [
+      { name: "color", type: "string", label: "Color" }
+    ]
+  }
+})
+```
+
+Organization fields appear in creation and profile forms. Invitation, team, and role fields appear in their create and edit workflows. Member fields appear as read-only details because Better Auth does not provide browser client endpoints for creating or editing a member model directly.
+
+Use `organizationLimit`, `membershipLimit`, and `invitationLimit` to disable actions when a configured limit is reached. Use `allowOrganizationCreation: false` to hide creation controls.
 
 Plugins can add an organization settings tab through `organizationTabs`. Each tab receives `organizationId` and `organizationSlug` for the active organization.

--- a/apps/docs/content/docs/shadcn/plugins/organization.mdx
+++ b/apps/docs/content/docs/shadcn/plugins/organization.mdx
@@ -1084,6 +1084,34 @@ Set `syncSession` when an application still reads `session.activeTeamId`. This o
 
 The `useListUserTeams` and `useSetActiveTeam` hooks are also available for custom controls. Always pass `organizationId` to both APIs.
 
-Use `organizationLimit`, `membershipLimit`, and `invitationLimit` to disable actions when a configured limit is reached. Use `allowOrganizationCreation: false` to hide creation controls. Use `additionalFields` to add custom inputs to organization creation and profile forms.
+### Model-specific fields
+
+Configure fields by the Better Auth model that stores them. The names and types must match the `schema` fields in the server organization plugin.
+
+```tsx
+organizationPlugin({
+  modelFields: {
+    organization: [
+      { name: "billingCode", type: "string", label: "Billing code" }
+    ],
+    member: [
+      { name: "title", type: "string", label: "Job title" }
+    ],
+    invitation: [
+      { name: "department", type: "string", label: "Department" }
+    ],
+    team: [
+      { name: "description", type: "string", inputType: "textarea", label: "Description" }
+    ],
+    role: [
+      { name: "color", type: "string", label: "Color" }
+    ]
+  }
+})
+```
+
+Organization fields appear in creation and profile forms. Invitation, team, and role fields appear in their create and edit workflows. Member fields appear as read-only details because Better Auth does not provide browser client endpoints for creating or editing a member model directly.
+
+Use `organizationLimit`, `membershipLimit`, and `invitationLimit` to disable actions when a configured limit is reached. Use `allowOrganizationCreation: false` to hide creation controls.
 
 Plugins can add an organization settings tab through `organizationTabs`. Each tab receives `organizationId` and `organizationSlug` for the active organization.

--- a/apps/docs/content/docs/zaidan/plugins/organization.mdx
+++ b/apps/docs/content/docs/zaidan/plugins/organization.mdx
@@ -907,6 +907,34 @@ Set `syncSession` when an application still reads `session.activeTeamId`. This o
 
 The `useListUserTeams` and `useSetActiveTeam` hooks are also available for custom controls. Always pass `organizationId` to both APIs.
 
-Use `organizationLimit`, `membershipLimit`, and `invitationLimit` to disable actions when a configured limit is reached. Use `allowOrganizationCreation: false` to hide creation controls. Use `additionalFields` to add custom inputs to organization creation and profile forms.
+### Model-specific fields
+
+Configure fields by the Better Auth model that stores them. The names and types must match the `schema` fields in the server organization plugin.
+
+```tsx
+organizationPlugin({
+  modelFields: {
+    organization: [
+      { name: "billingCode", type: "string", label: "Billing code" }
+    ],
+    member: [
+      { name: "title", type: "string", label: "Job title" }
+    ],
+    invitation: [
+      { name: "department", type: "string", label: "Department" }
+    ],
+    team: [
+      { name: "description", type: "string", inputType: "textarea", label: "Description" }
+    ],
+    role: [
+      { name: "color", type: "string", label: "Color" }
+    ]
+  }
+})
+```
+
+Organization fields appear in creation and profile forms. Invitation, team, and role fields appear in their create and edit workflows. Member fields appear as read-only details because Better Auth does not provide browser client endpoints for creating or editing a member model directly.
+
+Use `organizationLimit`, `membershipLimit`, and `invitationLimit` to disable actions when a configured limit is reached. Use `allowOrganizationCreation: false` to hide creation controls.
 
 Plugins can add an organization settings tab through `organizationTabs`. Each tab receives `organizationId` and `organizationSlug` for the active organization.

--- a/apps/docs/src/components/auth/organization/invite-member-dialog.tsx
+++ b/apps/docs/src/components/auth/organization/invite-member-dialog.tsx
@@ -153,7 +153,13 @@ export function InviteMemberDialog({
     if (!activeOrganizationId || !isRoleValid || atInvitationLimit) return
 
     const formData = new FormData(e.currentTarget)
-    const email = formData.get("email") as string
+    const invitationEmail = (formData.get("email") as string).trim()
+    const invitationRoles = [...selectedRoles] as Parameters<
+      typeof inviteMember
+    >[0]["role"]
+    const selectedTeamId = teams.data?.some((team) => team.id === teamId)
+      ? teamId
+      : undefined
 
     setIsSubmitting(true)
     let invitationValues: Record<string, unknown>
@@ -168,17 +174,13 @@ export function InviteMemberDialog({
       return
     }
 
-    const selectedTeamId = teams.data?.some((team) => team.id === teamId)
-      ? teamId
-      : undefined
-
     inviteMember(
       {
-        email: email.trim(),
+        ...invitationValues,
+        email: invitationEmail,
         organizationId: activeOrganizationId,
-        role: selectedRoles as Parameters<typeof inviteMember>[0]["role"],
-        teamId: selectedTeamId,
-        ...invitationValues
+        role: invitationRoles,
+        teamId: selectedTeamId
       },
       { onSettled: () => setIsSubmitting(false) }
     )

--- a/apps/docs/src/components/auth/organization/invite-member-dialog.tsx
+++ b/apps/docs/src/components/auth/organization/invite-member-dialog.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { parseAdditionalFieldValues } from "@better-auth-ui/core"
 import {
   mergeOrganizationRoleLabels,
   type OrganizationAuthClient
@@ -21,6 +22,7 @@ import {
   useState
 } from "react"
 import { toast } from "sonner"
+import { AdditionalField } from "@/components/auth/additional-field"
 import { Button, buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
@@ -68,6 +70,7 @@ export function InviteMemberDialog({
 }: InviteMemberDialogProps) {
   const { authClient, localization } = useAuth<OrganizationAuthClient>()
   const {
+    modelFields: { invitation: invitationFields },
     dynamicAccessControl,
     invitationLimit,
     localization: organizationLocalization,
@@ -95,6 +98,7 @@ export function InviteMemberDialog({
   })
   const [teamId, setTeamId] = useState("")
   const [emailError, setEmailError] = useState<string>()
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const activeOrganizationId = activeOrganization?.id
   const previousOrganizationId = useRef(activeOrganizationId)
 
@@ -143,24 +147,41 @@ export function InviteMemberDialog({
     )
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
 
     if (!activeOrganizationId || !isRoleValid || atInvitationLimit) return
 
-    const formData = new FormData(e.target as HTMLFormElement)
+    const formData = new FormData(e.currentTarget)
     const email = formData.get("email") as string
+
+    setIsSubmitting(true)
+    let invitationValues: Record<string, unknown>
+    try {
+      invitationValues = await parseAdditionalFieldValues(
+        invitationFields,
+        formData
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsSubmitting(false)
+      return
+    }
 
     const selectedTeamId = teams.data?.some((team) => team.id === teamId)
       ? teamId
       : undefined
 
-    inviteMember({
-      email: email.trim(),
-      organizationId: activeOrganizationId,
-      role: selectedRoles as Parameters<typeof inviteMember>[0]["role"],
-      teamId: selectedTeamId
-    })
+    inviteMember(
+      {
+        email: email.trim(),
+        organizationId: activeOrganizationId,
+        role: selectedRoles as Parameters<typeof inviteMember>[0]["role"],
+        teamId: selectedTeamId,
+        ...invitationValues
+      },
+      { onSettled: () => setIsSubmitting(false) }
+    )
   }
 
   const atInvitationLimit =
@@ -285,12 +306,22 @@ export function InviteMemberDialog({
                 </Select>
               </Field>
             )}
+
+            {invitationFields.map((field) => (
+              <AdditionalField
+                key={field.name}
+                field={field}
+                name={field.name}
+                isPending={isInviting || isSubmitting}
+                optionalLabel={localization.settings.optional}
+              />
+            ))}
           </div>
 
           <DialogFooter>
             <DialogClose
               className={buttonVariants({ variant: "outline" })}
-              disabled={isInviting}
+              disabled={isInviting || isSubmitting}
               type="button"
             >
               {localization.settings.cancel}
@@ -298,9 +329,11 @@ export function InviteMemberDialog({
 
             <Button
               type="submit"
-              disabled={isInviting || !isRoleValid || atInvitationLimit}
+              disabled={
+                isInviting || isSubmitting || !isRoleValid || atInvitationLimit
+              }
             >
-              {isInviting && <Spinner />}
+              {(isInviting || isSubmitting) && <Spinner />}
 
               {organizationLocalization.inviteMember}
             </Button>

--- a/apps/docs/src/components/auth/organization/organization-invitation-row.tsx
+++ b/apps/docs/src/components/auth/organization/organization-invitation-row.tsx
@@ -126,12 +126,6 @@ export function OrganizationInvitationRow({
               disabled={resendPending}
               onClick={() =>
                 resendInvitation({
-                  email: invitation.email,
-                  organizationId: invitation.organizationId,
-                  role: invitation.role as Parameters<
-                    typeof resendInvitation
-                  >[0]["role"],
-                  resend: true,
                   ...Object.fromEntries(
                     invitationFields.flatMap((field) => {
                       const value = (
@@ -139,7 +133,13 @@ export function OrganizationInvitationRow({
                       )[field.name]
                       return value === undefined ? [] : [[field.name, value]]
                     })
-                  )
+                  ),
+                  email: invitation.email,
+                  organizationId: invitation.organizationId,
+                  role: invitation.role as Parameters<
+                    typeof resendInvitation
+                  >[0]["role"],
+                  resend: true
                 })
               }
               aria-label={organizationLocalization.resendInvitation}

--- a/apps/docs/src/components/auth/organization/organization-invitation-row.tsx
+++ b/apps/docs/src/components/auth/organization/organization-invitation-row.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { formatAdditionalFieldValue } from "@better-auth-ui/core"
 import {
   memberRoleLabels,
   type OrganizationAuthClient
@@ -37,8 +38,11 @@ export function OrganizationInvitationRow({
   invitation
 }: OrganizationInvitationRowProps) {
   const { authClient } = useAuth<OrganizationAuthClient>()
-  const { localization: organizationLocalization, roles } =
-    useAuthPlugin(organizationPlugin)
+  const {
+    modelFields: { invitation: invitationFields },
+    localization: organizationLocalization,
+    roles
+  } = useAuthPlugin(organizationPlugin)
 
   const {
     data: cancelInvitationPermission,
@@ -78,7 +82,21 @@ export function OrganizationInvitationRow({
 
   return (
     <TableRow>
-      <TableCell className="font-medium text-sm">{invitation.email}</TableCell>
+      <TableCell>
+        <div className="flex flex-col gap-1">
+          <span className="font-medium text-sm">{invitation.email}</span>
+          {invitationFields.map((field) => {
+            const value = formatAdditionalFieldValue(
+              (invitation as unknown as Record<string, unknown>)[field.name]
+            )
+            return value ? (
+              <span className="text-xs text-muted-foreground" key={field.name}>
+                {field.label}: {value}
+              </span>
+            ) : null
+          })}
+        </div>
+      </TableCell>
 
       <TableCell className="text-muted-foreground text-xs tabular-nums whitespace-nowrap">
         {new Date(invitation.createdAt).toLocaleString(undefined, {
@@ -113,7 +131,15 @@ export function OrganizationInvitationRow({
                   role: invitation.role as Parameters<
                     typeof resendInvitation
                   >[0]["role"],
-                  resend: true
+                  resend: true,
+                  ...Object.fromEntries(
+                    invitationFields.flatMap((field) => {
+                      const value = (
+                        invitation as unknown as Record<string, unknown>
+                      )[field.name]
+                      return value === undefined ? [] : [[field.name, value]]
+                    })
+                  )
                 })
               }
               aria-label={organizationLocalization.resendInvitation}

--- a/apps/docs/src/components/auth/organization/organization-member-row.tsx
+++ b/apps/docs/src/components/auth/organization/organization-member-row.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { formatAdditionalFieldValue } from "@better-auth-ui/core"
 import {
   memberRoleLabels,
   mergeOrganizationRoleLabels,
@@ -46,6 +47,7 @@ export function OrganizationMemberRow({
 }: OrganizationMemberRowProps) {
   const { authClient } = useAuth<OrganizationAuthClient>()
   const {
+    modelFields: { member: memberFields },
     dynamicAccessControl,
     localization: organizationLocalization,
     roles
@@ -112,7 +114,19 @@ export function OrganizationMemberRow({
   return (
     <TableRow>
       <TableCell>
-        <UserView user={member.user} />
+        <div className="flex flex-col gap-1">
+          <UserView user={member.user} />
+          {memberFields.map((field) => {
+            const value = formatAdditionalFieldValue(
+              (member as unknown as Record<string, unknown>)[field.name]
+            )
+            return value ? (
+              <span className="text-xs text-muted-foreground" key={field.name}>
+                {field.label}: {value}
+              </span>
+            ) : null
+          })}
+        </div>
       </TableCell>
 
       <TableCell>{roleLabel}</TableCell>

--- a/apps/docs/src/components/auth/organization/organization-roles.tsx
+++ b/apps/docs/src/components/auth/organization/organization-roles.tsx
@@ -1,5 +1,10 @@
 "use client"
 
+import {
+  type AdditionalFields,
+  fieldsWithModelValues,
+  parseAdditionalFieldValues
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
@@ -37,11 +42,13 @@ import {
   TableRow
 } from "@/components/ui/table"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
+import { AdditionalField } from "../additional-field"
 
 type Role = {
   id: string
   role: string
   permission: Record<string, string[]>
+  [key: string]: unknown
 }
 
 export function OrganizationRoles({
@@ -50,7 +57,7 @@ export function OrganizationRoles({
   organizationId: string
 }) {
   const { authClient } = useAuth<OrganizationAuthClient>()
-  const { dynamicAccessControl, localization } =
+  const { dynamicAccessControl, localization, modelFields } =
     useAuthPlugin(organizationPlugin)
   const roles = useListRoles(authClient, {
     query: { organizationId },
@@ -147,6 +154,7 @@ export function OrganizationRoles({
         open={editingRole !== undefined}
         role={editingRole ?? undefined}
         registry={dynamicAccessControl?.permissions ?? {}}
+        roleFields={modelFields.role}
         onOpenChange={(open) => !open && setEditingRole(undefined)}
       />
     </div>
@@ -239,19 +247,22 @@ function RoleDialog({
   open,
   organizationId,
   registry,
-  role
+  role,
+  roleFields
 }: {
   onOpenChange: (open: boolean) => void
   open: boolean
   organizationId: string
   registry: Record<string, { label?: string; actions: Record<string, string> }>
   role?: Role
+  roleFields: AdditionalFields
 }) {
   const { authClient, localization: authLocalization } =
     useAuth<OrganizationAuthClient>()
   const { localization } = useAuthPlugin(organizationPlugin)
   const [name, setName] = useState("")
   const [permission, setPermission] = useState<Record<string, string[]>>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const createRole = useCreateRole(authClient, organizationId, {
     onSuccess: () => {
       toast.success(localization.roleCreated)
@@ -271,23 +282,44 @@ function RoleDialog({
     setPermission(role?.permission ?? {})
   }, [open, role])
 
-  function submit(event: FormEvent<HTMLFormElement>) {
+  async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const roleName = name.trim()
     if (!roleName) return
 
-    if (role) {
-      updateRole.mutate({
-        organizationId,
-        roleId: role.id,
-        data: { roleName, permission }
-      })
-    } else {
-      createRole.mutate({ organizationId, role: roleName, permission })
+    setIsSubmitting(true)
+    try {
+      const additionalFields = await parseAdditionalFieldValues(
+        roleFields,
+        new FormData(event.currentTarget)
+      )
+      if (role) {
+        updateRole.mutate(
+          {
+            organizationId,
+            roleId: role.id,
+            data: { ...additionalFields, roleName, permission }
+          },
+          { onSettled: () => setIsSubmitting(false) }
+        )
+      } else {
+        createRole.mutate(
+          {
+            organizationId,
+            role: roleName,
+            permission,
+            additionalFields
+          },
+          { onSettled: () => setIsSubmitting(false) }
+        )
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsSubmitting(false)
     }
   }
 
-  const pending = createRole.isPending || updateRole.isPending
+  const pending = createRole.isPending || updateRole.isPending || isSubmitting
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -315,6 +347,16 @@ function RoleDialog({
               required
             />
           </Field>
+
+          {fieldsWithModelValues(roleFields, role ?? {}).map((field) => (
+            <AdditionalField
+              key={field.name}
+              field={field}
+              name={field.name}
+              isPending={pending}
+              optionalLabel={authLocalization.settings.optional}
+            />
+          ))}
 
           <fieldset className="flex flex-col gap-4">
             <legend className="text-sm font-medium">

--- a/apps/docs/src/components/auth/organization/organization-teams.tsx
+++ b/apps/docs/src/components/auth/organization/organization-teams.tsx
@@ -1,5 +1,10 @@
 "use client"
 
+import {
+  type AdditionalFields,
+  fieldsWithModelValues,
+  parseAdditionalFieldValues
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
@@ -28,11 +33,13 @@ import {
 } from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
+import { AdditionalField } from "../additional-field"
 
 export function OrganizationTeams() {
-  const { authClient } = useAuth<OrganizationAuthClient>()
+  const { authClient, localization: authLocalization } =
+    useAuth<OrganizationAuthClient>()
   const { data: activeOrganization } = useActiveOrganization(authClient)
-  const { localization } = useAuthPlugin(organizationPlugin)
+  const { localization, modelFields } = useAuthPlugin(organizationPlugin)
   const teams = useListTeams(authClient, {
     query: { organizationId: activeOrganization?.id }
   })
@@ -41,13 +48,31 @@ export function OrganizationTeams() {
     onSuccess: () => toast.success(localization.teamCreated)
   })
 
-  function handleCreate(event: FormEvent<HTMLFormElement>) {
+  const [isCreatingFields, setIsCreatingFields] = useState(false)
+
+  async function handleCreate(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const form = event.currentTarget
     const name = String(new FormData(form).get("name") ?? "").trim()
     if (!name || !activeOrganization) return
-    createTeam.mutate({ name, organizationId: activeOrganization.id })
-    form.reset()
+
+    setIsCreatingFields(true)
+    try {
+      const values = await parseAdditionalFieldValues(
+        modelFields.team,
+        new FormData(form)
+      )
+      createTeam.mutate(
+        { ...values, name, organizationId: activeOrganization.id },
+        {
+          onSuccess: () => form.reset(),
+          onSettled: () => setIsCreatingFields(false)
+        }
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsCreatingFields(false)
+    }
   }
 
   return (
@@ -59,12 +84,28 @@ export function OrganizationTeams() {
             {localization.teamsDescription}
           </p>
         </div>
-        <form className="flex items-end gap-2" onSubmit={handleCreate}>
+        <form
+          className="grid w-full gap-3 sm:max-w-xl sm:grid-cols-2"
+          onSubmit={handleCreate}
+        >
           <Field>
             <FieldLabel htmlFor="new-team-name">{localization.name}</FieldLabel>
             <Input id="new-team-name" name="name" required />
           </Field>
-          <Button type="submit" disabled={createTeam.isPending}>
+          {modelFields.team.map((field) => (
+            <AdditionalField
+              key={field.name}
+              field={field}
+              name={field.name}
+              isPending={createTeam.isPending || isCreatingFields}
+              optionalLabel={authLocalization.settings.optional}
+            />
+          ))}
+          <Button
+            className="self-end"
+            type="submit"
+            disabled={createTeam.isPending || isCreatingFields}
+          >
             {createTeam.isPending && <Spinner />}
             {localization.createTeam}
           </Button>
@@ -79,6 +120,7 @@ export function OrganizationTeams() {
             organizationId={activeOrganization?.id ?? ""}
             organizationMembers={members.data?.members ?? []}
             team={team}
+            teamFields={modelFields.team}
           />
         ))
       ) : (
@@ -98,14 +140,16 @@ export function OrganizationTeams() {
 function TeamCard({
   organizationId,
   organizationMembers,
-  team
+  team,
+  teamFields
 }: {
   organizationId: string
   organizationMembers: Array<{
     userId: string
     user: { name: string; email: string }
   }>
-  team: { id: string; name: string }
+  team: { id: string; name: string; [key: string]: unknown }
+  teamFields: AdditionalFields
 }) {
   const { authClient, localization: authLocalization } =
     useAuth<OrganizationAuthClient>()
@@ -116,6 +160,7 @@ function TeamCard({
   const updateTeam = useUpdateTeam(authClient)
   const removeTeam = useRemoveTeam(authClient)
   const [name, setName] = useState(team.name)
+  const [isUpdatingFields, setIsUpdatingFields] = useState(false)
   const [userId, setUserId] = useState("")
   const addMember = useAddTeamMember(authClient, {
     onSuccess: () => setUserId("")
@@ -123,10 +168,34 @@ function TeamCard({
   const removeMember = useRemoveTeamMember(authClient)
   const memberIds = new Set(teamMembers.data?.map((member) => member.userId))
 
+  const handleUpdate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setIsUpdatingFields(true)
+    try {
+      const values = await parseAdditionalFieldValues(
+        teamFields,
+        new FormData(event.currentTarget)
+      )
+      updateTeam.mutate(
+        {
+          teamId: team.id,
+          data: { ...values, name, organizationId }
+        },
+        { onSettled: () => setIsUpdatingFields(false) }
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsUpdatingFields(false)
+    }
+  }
+
   return (
     <Card>
       <CardContent className="flex flex-col gap-4 pt-6">
-        <div className="flex flex-col items-end gap-2 sm:flex-row">
+        <form
+          className="grid items-end gap-3 sm:grid-cols-2"
+          onSubmit={handleUpdate}
+        >
           <Field className="flex-1">
             <FieldLabel htmlFor={`team-name-${team.id}`}>
               {localization.name}
@@ -137,19 +206,24 @@ function TeamCard({
               onChange={(event) => setName(event.target.value)}
             />
           </Field>
+          {fieldsWithModelValues(teamFields, team).map((field) => (
+            <AdditionalField
+              key={field.name}
+              field={field}
+              name={field.name}
+              isPending={updateTeam.isPending || isUpdatingFields}
+              optionalLabel={authLocalization.settings.optional}
+            />
+          ))}
           <Button
-            disabled={updateTeam.isPending}
+            type="submit"
+            disabled={updateTeam.isPending || isUpdatingFields}
             variant="outline"
-            onClick={() =>
-              updateTeam.mutate({
-                teamId: team.id,
-                data: { name, organizationId }
-              })
-            }
           >
             {authLocalization.settings.saveChanges}
           </Button>
           <Button
+            type="button"
             disabled={removeTeam.isPending}
             variant="destructive"
             onClick={() => {
@@ -159,7 +233,7 @@ function TeamCard({
           >
             {localization.deleteTeam}
           </Button>
-        </div>
+        </form>
         <div className="flex items-end gap-2">
           <Field className="flex-1">
             <FieldLabel>{localization.addTeamMember}</FieldLabel>

--- a/examples/next-shadcn-example/src/components/auth/organization/invite-member-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/invite-member-dialog.tsx
@@ -153,7 +153,13 @@ export function InviteMemberDialog({
     if (!activeOrganizationId || !isRoleValid || atInvitationLimit) return
 
     const formData = new FormData(e.currentTarget)
-    const email = formData.get("email") as string
+    const invitationEmail = (formData.get("email") as string).trim()
+    const invitationRoles = [...selectedRoles] as Parameters<
+      typeof inviteMember
+    >[0]["role"]
+    const selectedTeamId = teams.data?.some((team) => team.id === teamId)
+      ? teamId
+      : undefined
 
     setIsSubmitting(true)
     let invitationValues: Record<string, unknown>
@@ -168,17 +174,13 @@ export function InviteMemberDialog({
       return
     }
 
-    const selectedTeamId = teams.data?.some((team) => team.id === teamId)
-      ? teamId
-      : undefined
-
     inviteMember(
       {
-        email: email.trim(),
+        ...invitationValues,
+        email: invitationEmail,
         organizationId: activeOrganizationId,
-        role: selectedRoles as Parameters<typeof inviteMember>[0]["role"],
-        teamId: selectedTeamId,
-        ...invitationValues
+        role: invitationRoles,
+        teamId: selectedTeamId
       },
       { onSettled: () => setIsSubmitting(false) }
     )

--- a/examples/next-shadcn-example/src/components/auth/organization/invite-member-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/invite-member-dialog.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { parseAdditionalFieldValues } from "@better-auth-ui/core"
 import {
   mergeOrganizationRoleLabels,
   type OrganizationAuthClient
@@ -21,6 +22,7 @@ import {
   useState
 } from "react"
 import { toast } from "sonner"
+import { AdditionalField } from "@/components/auth/additional-field"
 import { Button, buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
@@ -68,6 +70,7 @@ export function InviteMemberDialog({
 }: InviteMemberDialogProps) {
   const { authClient, localization } = useAuth<OrganizationAuthClient>()
   const {
+    modelFields: { invitation: invitationFields },
     dynamicAccessControl,
     invitationLimit,
     localization: organizationLocalization,
@@ -95,6 +98,7 @@ export function InviteMemberDialog({
   })
   const [teamId, setTeamId] = useState("")
   const [emailError, setEmailError] = useState<string>()
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const activeOrganizationId = activeOrganization?.id
   const previousOrganizationId = useRef(activeOrganizationId)
 
@@ -143,24 +147,41 @@ export function InviteMemberDialog({
     )
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
 
     if (!activeOrganizationId || !isRoleValid || atInvitationLimit) return
 
-    const formData = new FormData(e.target as HTMLFormElement)
+    const formData = new FormData(e.currentTarget)
     const email = formData.get("email") as string
+
+    setIsSubmitting(true)
+    let invitationValues: Record<string, unknown>
+    try {
+      invitationValues = await parseAdditionalFieldValues(
+        invitationFields,
+        formData
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsSubmitting(false)
+      return
+    }
 
     const selectedTeamId = teams.data?.some((team) => team.id === teamId)
       ? teamId
       : undefined
 
-    inviteMember({
-      email: email.trim(),
-      organizationId: activeOrganizationId,
-      role: selectedRoles as Parameters<typeof inviteMember>[0]["role"],
-      teamId: selectedTeamId
-    })
+    inviteMember(
+      {
+        email: email.trim(),
+        organizationId: activeOrganizationId,
+        role: selectedRoles as Parameters<typeof inviteMember>[0]["role"],
+        teamId: selectedTeamId,
+        ...invitationValues
+      },
+      { onSettled: () => setIsSubmitting(false) }
+    )
   }
 
   const atInvitationLimit =
@@ -285,12 +306,22 @@ export function InviteMemberDialog({
                 </Select>
               </Field>
             )}
+
+            {invitationFields.map((field) => (
+              <AdditionalField
+                key={field.name}
+                field={field}
+                name={field.name}
+                isPending={isInviting || isSubmitting}
+                optionalLabel={localization.settings.optional}
+              />
+            ))}
           </div>
 
           <DialogFooter>
             <DialogClose
               className={buttonVariants({ variant: "outline" })}
-              disabled={isInviting}
+              disabled={isInviting || isSubmitting}
               type="button"
             >
               {localization.settings.cancel}
@@ -298,9 +329,11 @@ export function InviteMemberDialog({
 
             <Button
               type="submit"
-              disabled={isInviting || !isRoleValid || atInvitationLimit}
+              disabled={
+                isInviting || isSubmitting || !isRoleValid || atInvitationLimit
+              }
             >
-              {isInviting && <Spinner />}
+              {(isInviting || isSubmitting) && <Spinner />}
 
               {organizationLocalization.inviteMember}
             </Button>

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-invitation-row.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-invitation-row.tsx
@@ -126,12 +126,6 @@ export function OrganizationInvitationRow({
               disabled={resendPending}
               onClick={() =>
                 resendInvitation({
-                  email: invitation.email,
-                  organizationId: invitation.organizationId,
-                  role: invitation.role as Parameters<
-                    typeof resendInvitation
-                  >[0]["role"],
-                  resend: true,
                   ...Object.fromEntries(
                     invitationFields.flatMap((field) => {
                       const value = (
@@ -139,7 +133,13 @@ export function OrganizationInvitationRow({
                       )[field.name]
                       return value === undefined ? [] : [[field.name, value]]
                     })
-                  )
+                  ),
+                  email: invitation.email,
+                  organizationId: invitation.organizationId,
+                  role: invitation.role as Parameters<
+                    typeof resendInvitation
+                  >[0]["role"],
+                  resend: true
                 })
               }
               aria-label={organizationLocalization.resendInvitation}

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-invitation-row.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-invitation-row.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { formatAdditionalFieldValue } from "@better-auth-ui/core"
 import {
   memberRoleLabels,
   type OrganizationAuthClient
@@ -37,8 +38,11 @@ export function OrganizationInvitationRow({
   invitation
 }: OrganizationInvitationRowProps) {
   const { authClient } = useAuth<OrganizationAuthClient>()
-  const { localization: organizationLocalization, roles } =
-    useAuthPlugin(organizationPlugin)
+  const {
+    modelFields: { invitation: invitationFields },
+    localization: organizationLocalization,
+    roles
+  } = useAuthPlugin(organizationPlugin)
 
   const {
     data: cancelInvitationPermission,
@@ -78,7 +82,21 @@ export function OrganizationInvitationRow({
 
   return (
     <TableRow>
-      <TableCell className="font-medium text-sm">{invitation.email}</TableCell>
+      <TableCell>
+        <div className="flex flex-col gap-1">
+          <span className="font-medium text-sm">{invitation.email}</span>
+          {invitationFields.map((field) => {
+            const value = formatAdditionalFieldValue(
+              (invitation as unknown as Record<string, unknown>)[field.name]
+            )
+            return value ? (
+              <span className="text-xs text-muted-foreground" key={field.name}>
+                {field.label}: {value}
+              </span>
+            ) : null
+          })}
+        </div>
+      </TableCell>
 
       <TableCell className="text-muted-foreground text-xs tabular-nums whitespace-nowrap">
         {new Date(invitation.createdAt).toLocaleString(undefined, {
@@ -113,7 +131,15 @@ export function OrganizationInvitationRow({
                   role: invitation.role as Parameters<
                     typeof resendInvitation
                   >[0]["role"],
-                  resend: true
+                  resend: true,
+                  ...Object.fromEntries(
+                    invitationFields.flatMap((field) => {
+                      const value = (
+                        invitation as unknown as Record<string, unknown>
+                      )[field.name]
+                      return value === undefined ? [] : [[field.name, value]]
+                    })
+                  )
                 })
               }
               aria-label={organizationLocalization.resendInvitation}

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-member-row.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-member-row.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { formatAdditionalFieldValue } from "@better-auth-ui/core"
 import {
   memberRoleLabels,
   mergeOrganizationRoleLabels,
@@ -46,6 +47,7 @@ export function OrganizationMemberRow({
 }: OrganizationMemberRowProps) {
   const { authClient } = useAuth<OrganizationAuthClient>()
   const {
+    modelFields: { member: memberFields },
     dynamicAccessControl,
     localization: organizationLocalization,
     roles
@@ -112,7 +114,19 @@ export function OrganizationMemberRow({
   return (
     <TableRow>
       <TableCell>
-        <UserView user={member.user} />
+        <div className="flex flex-col gap-1">
+          <UserView user={member.user} />
+          {memberFields.map((field) => {
+            const value = formatAdditionalFieldValue(
+              (member as unknown as Record<string, unknown>)[field.name]
+            )
+            return value ? (
+              <span className="text-xs text-muted-foreground" key={field.name}>
+                {field.label}: {value}
+              </span>
+            ) : null
+          })}
+        </div>
       </TableCell>
 
       <TableCell>{roleLabel}</TableCell>

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-roles.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-roles.tsx
@@ -1,5 +1,10 @@
 "use client"
 
+import {
+  type AdditionalFields,
+  fieldsWithModelValues,
+  parseAdditionalFieldValues
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
@@ -37,11 +42,13 @@ import {
   TableRow
 } from "@/components/ui/table"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
+import { AdditionalField } from "../additional-field"
 
 type Role = {
   id: string
   role: string
   permission: Record<string, string[]>
+  [key: string]: unknown
 }
 
 export function OrganizationRoles({
@@ -50,7 +57,7 @@ export function OrganizationRoles({
   organizationId: string
 }) {
   const { authClient } = useAuth<OrganizationAuthClient>()
-  const { dynamicAccessControl, localization } =
+  const { dynamicAccessControl, localization, modelFields } =
     useAuthPlugin(organizationPlugin)
   const roles = useListRoles(authClient, {
     query: { organizationId },
@@ -147,6 +154,7 @@ export function OrganizationRoles({
         open={editingRole !== undefined}
         role={editingRole ?? undefined}
         registry={dynamicAccessControl?.permissions ?? {}}
+        roleFields={modelFields.role}
         onOpenChange={(open) => !open && setEditingRole(undefined)}
       />
     </div>
@@ -239,19 +247,22 @@ function RoleDialog({
   open,
   organizationId,
   registry,
-  role
+  role,
+  roleFields
 }: {
   onOpenChange: (open: boolean) => void
   open: boolean
   organizationId: string
   registry: Record<string, { label?: string; actions: Record<string, string> }>
   role?: Role
+  roleFields: AdditionalFields
 }) {
   const { authClient, localization: authLocalization } =
     useAuth<OrganizationAuthClient>()
   const { localization } = useAuthPlugin(organizationPlugin)
   const [name, setName] = useState("")
   const [permission, setPermission] = useState<Record<string, string[]>>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const createRole = useCreateRole(authClient, organizationId, {
     onSuccess: () => {
       toast.success(localization.roleCreated)
@@ -271,23 +282,44 @@ function RoleDialog({
     setPermission(role?.permission ?? {})
   }, [open, role])
 
-  function submit(event: FormEvent<HTMLFormElement>) {
+  async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const roleName = name.trim()
     if (!roleName) return
 
-    if (role) {
-      updateRole.mutate({
-        organizationId,
-        roleId: role.id,
-        data: { roleName, permission }
-      })
-    } else {
-      createRole.mutate({ organizationId, role: roleName, permission })
+    setIsSubmitting(true)
+    try {
+      const additionalFields = await parseAdditionalFieldValues(
+        roleFields,
+        new FormData(event.currentTarget)
+      )
+      if (role) {
+        updateRole.mutate(
+          {
+            organizationId,
+            roleId: role.id,
+            data: { ...additionalFields, roleName, permission }
+          },
+          { onSettled: () => setIsSubmitting(false) }
+        )
+      } else {
+        createRole.mutate(
+          {
+            organizationId,
+            role: roleName,
+            permission,
+            additionalFields
+          },
+          { onSettled: () => setIsSubmitting(false) }
+        )
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsSubmitting(false)
     }
   }
 
-  const pending = createRole.isPending || updateRole.isPending
+  const pending = createRole.isPending || updateRole.isPending || isSubmitting
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -315,6 +347,16 @@ function RoleDialog({
               required
             />
           </Field>
+
+          {fieldsWithModelValues(roleFields, role ?? {}).map((field) => (
+            <AdditionalField
+              key={field.name}
+              field={field}
+              name={field.name}
+              isPending={pending}
+              optionalLabel={authLocalization.settings.optional}
+            />
+          ))}
 
           <fieldset className="flex flex-col gap-4">
             <legend className="text-sm font-medium">

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-teams.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-teams.tsx
@@ -1,5 +1,10 @@
 "use client"
 
+import {
+  type AdditionalFields,
+  fieldsWithModelValues,
+  parseAdditionalFieldValues
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
@@ -28,11 +33,13 @@ import {
 } from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
+import { AdditionalField } from "../additional-field"
 
 export function OrganizationTeams() {
-  const { authClient } = useAuth<OrganizationAuthClient>()
+  const { authClient, localization: authLocalization } =
+    useAuth<OrganizationAuthClient>()
   const { data: activeOrganization } = useActiveOrganization(authClient)
-  const { localization } = useAuthPlugin(organizationPlugin)
+  const { localization, modelFields } = useAuthPlugin(organizationPlugin)
   const teams = useListTeams(authClient, {
     query: { organizationId: activeOrganization?.id }
   })
@@ -41,13 +48,31 @@ export function OrganizationTeams() {
     onSuccess: () => toast.success(localization.teamCreated)
   })
 
-  function handleCreate(event: FormEvent<HTMLFormElement>) {
+  const [isCreatingFields, setIsCreatingFields] = useState(false)
+
+  async function handleCreate(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const form = event.currentTarget
     const name = String(new FormData(form).get("name") ?? "").trim()
     if (!name || !activeOrganization) return
-    createTeam.mutate({ name, organizationId: activeOrganization.id })
-    form.reset()
+
+    setIsCreatingFields(true)
+    try {
+      const values = await parseAdditionalFieldValues(
+        modelFields.team,
+        new FormData(form)
+      )
+      createTeam.mutate(
+        { ...values, name, organizationId: activeOrganization.id },
+        {
+          onSuccess: () => form.reset(),
+          onSettled: () => setIsCreatingFields(false)
+        }
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsCreatingFields(false)
+    }
   }
 
   return (
@@ -59,12 +84,28 @@ export function OrganizationTeams() {
             {localization.teamsDescription}
           </p>
         </div>
-        <form className="flex items-end gap-2" onSubmit={handleCreate}>
+        <form
+          className="grid w-full gap-3 sm:max-w-xl sm:grid-cols-2"
+          onSubmit={handleCreate}
+        >
           <Field>
             <FieldLabel htmlFor="new-team-name">{localization.name}</FieldLabel>
             <Input id="new-team-name" name="name" required />
           </Field>
-          <Button type="submit" disabled={createTeam.isPending}>
+          {modelFields.team.map((field) => (
+            <AdditionalField
+              key={field.name}
+              field={field}
+              name={field.name}
+              isPending={createTeam.isPending || isCreatingFields}
+              optionalLabel={authLocalization.settings.optional}
+            />
+          ))}
+          <Button
+            className="self-end"
+            type="submit"
+            disabled={createTeam.isPending || isCreatingFields}
+          >
             {createTeam.isPending && <Spinner />}
             {localization.createTeam}
           </Button>
@@ -79,6 +120,7 @@ export function OrganizationTeams() {
             organizationId={activeOrganization?.id ?? ""}
             organizationMembers={members.data?.members ?? []}
             team={team}
+            teamFields={modelFields.team}
           />
         ))
       ) : (
@@ -98,14 +140,16 @@ export function OrganizationTeams() {
 function TeamCard({
   organizationId,
   organizationMembers,
-  team
+  team,
+  teamFields
 }: {
   organizationId: string
   organizationMembers: Array<{
     userId: string
     user: { name: string; email: string }
   }>
-  team: { id: string; name: string }
+  team: { id: string; name: string; [key: string]: unknown }
+  teamFields: AdditionalFields
 }) {
   const { authClient, localization: authLocalization } =
     useAuth<OrganizationAuthClient>()
@@ -116,6 +160,7 @@ function TeamCard({
   const updateTeam = useUpdateTeam(authClient)
   const removeTeam = useRemoveTeam(authClient)
   const [name, setName] = useState(team.name)
+  const [isUpdatingFields, setIsUpdatingFields] = useState(false)
   const [userId, setUserId] = useState("")
   const addMember = useAddTeamMember(authClient, {
     onSuccess: () => setUserId("")
@@ -123,10 +168,34 @@ function TeamCard({
   const removeMember = useRemoveTeamMember(authClient)
   const memberIds = new Set(teamMembers.data?.map((member) => member.userId))
 
+  const handleUpdate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setIsUpdatingFields(true)
+    try {
+      const values = await parseAdditionalFieldValues(
+        teamFields,
+        new FormData(event.currentTarget)
+      )
+      updateTeam.mutate(
+        {
+          teamId: team.id,
+          data: { ...values, name, organizationId }
+        },
+        { onSettled: () => setIsUpdatingFields(false) }
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsUpdatingFields(false)
+    }
+  }
+
   return (
     <Card>
       <CardContent className="flex flex-col gap-4 pt-6">
-        <div className="flex flex-col items-end gap-2 sm:flex-row">
+        <form
+          className="grid items-end gap-3 sm:grid-cols-2"
+          onSubmit={handleUpdate}
+        >
           <Field className="flex-1">
             <FieldLabel htmlFor={`team-name-${team.id}`}>
               {localization.name}
@@ -137,19 +206,24 @@ function TeamCard({
               onChange={(event) => setName(event.target.value)}
             />
           </Field>
+          {fieldsWithModelValues(teamFields, team).map((field) => (
+            <AdditionalField
+              key={field.name}
+              field={field}
+              name={field.name}
+              isPending={updateTeam.isPending || isUpdatingFields}
+              optionalLabel={authLocalization.settings.optional}
+            />
+          ))}
           <Button
-            disabled={updateTeam.isPending}
+            type="submit"
+            disabled={updateTeam.isPending || isUpdatingFields}
             variant="outline"
-            onClick={() =>
-              updateTeam.mutate({
-                teamId: team.id,
-                data: { name, organizationId }
-              })
-            }
           >
             {authLocalization.settings.saveChanges}
           </Button>
           <Button
+            type="button"
             disabled={removeTeam.isPending}
             variant="destructive"
             onClick={() => {
@@ -159,7 +233,7 @@ function TeamCard({
           >
             {localization.deleteTeam}
           </Button>
-        </div>
+        </form>
         <div className="flex items-end gap-2">
           <Field className="flex-1">
             <FieldLabel>{localization.addTeamMember}</FieldLabel>

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/invite-member-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/invite-member-dialog.tsx
@@ -1,15 +1,26 @@
 "use client"
 
-import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
+import { parseAdditionalFieldValues } from "@better-auth-ui/core"
+import {
+  mergeOrganizationRoleLabels,
+  type OrganizationAuthClient
+} from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
   useActiveOrganization,
   useInviteMember,
   useListOrganizationInvitations,
+  useListRoles,
   useListTeams
 } from "@better-auth-ui/react/plugins/organization"
 import { ChevronDown, UserPlus } from "lucide-react"
-import { type SyntheticEvent, useEffect, useRef, useState } from "react"
+import {
+  type SyntheticEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react"
 import { toast } from "sonner"
 import { Button, buttonVariants } from "@/components/ui/button"
 import {
@@ -40,6 +51,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
+import { AdditionalField } from "../additional-field"
 
 /** Props for the `InviteMemberDialog` component. */
 export type InviteMemberDialogProps = {
@@ -59,8 +71,10 @@ export function InviteMemberDialog({
 }: InviteMemberDialogProps) {
   const { authClient, localization } = useAuth<OrganizationAuthClient>()
   const {
+    dynamicAccessControl,
     invitationLimit,
     localization: organizationLocalization,
+    modelFields: { invitation: invitationFields },
     roles,
     teams: teamsEnabled
   } = useAuthPlugin(organizationPlugin)
@@ -70,16 +84,25 @@ export function InviteMemberDialog({
     enabled: teamsEnabled
   })
   const invitations = useListOrganizationInvitations(authClient)
+  const dynamicRoles = useListRoles(authClient, {
+    query: { organizationId: activeOrganization?.id },
+    enabled: dynamicAccessControl?.enabled === true
+  })
+  const assignableRoles = useMemo(
+    () => mergeOrganizationRoleLabels(roles, dynamicRoles.data),
+    [dynamicRoles.data, roles]
+  )
 
   const [selectedRoles, setSelectedRoles] = useState(() => {
-    const fallback = pickDefaultRole(Object.keys(roles))
+    const fallback = pickDefaultRole(Object.keys(assignableRoles))
     return fallback ? [fallback] : []
   })
   const [teamId, setTeamId] = useState("")
   const [emailError, setEmailError] = useState<string>()
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const activeOrganizationId = activeOrganization?.id
   const previousOrganizationId = useRef(activeOrganizationId)
-  const roleItems = Object.entries(roles).map(([value, label]) => ({
+  const roleItems = Object.entries(assignableRoles).map(([value, label]) => ({
     label,
     value
   }))
@@ -88,7 +111,7 @@ export function InviteMemberDialog({
 
   useEffect(() => {
     setSelectedRoles((current) => {
-      const keys = Object.keys(roles)
+      const keys = Object.keys(assignableRoles)
       const kept = current.filter((entry) => keys.includes(entry))
 
       if (kept.length > 0) return kept
@@ -96,7 +119,7 @@ export function InviteMemberDialog({
       const fallback = pickDefaultRole(keys)
       return fallback ? [fallback] : []
     })
-  }, [roles])
+  }, [assignableRoles])
 
   useEffect(() => {
     const organizationChanged =
@@ -120,7 +143,7 @@ export function InviteMemberDialog({
   const isRoleValid = selectedRoles.length > 0
 
   const roleSummary = selectedRoles
-    .map((entry) => roles[entry] ?? entry)
+    .map((entry) => assignableRoles[entry] ?? entry)
     .join(", ")
 
   const toggleRole = (role: string) => {
@@ -131,23 +154,40 @@ export function InviteMemberDialog({
     )
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
 
-    if (!isRoleValid || atInvitationLimit) return
+    if (!activeOrganizationId || !isRoleValid || atInvitationLimit) return
 
-    const formData = new FormData(e.target as HTMLFormElement)
+    const formData = new FormData(e.currentTarget)
     const email = formData.get("email") as string
+    setIsSubmitting(true)
+    let invitationValues: Record<string, unknown>
+    try {
+      invitationValues = await parseAdditionalFieldValues(
+        invitationFields,
+        formData
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsSubmitting(false)
+      return
+    }
 
     const selectedTeamId = teams.data?.some((team) => team.id === teamId)
       ? teamId
       : undefined
 
-    inviteMember({
-      email: email.trim(),
-      role: selectedRoles as Parameters<typeof inviteMember>[0]["role"],
-      teamId: selectedTeamId
-    })
+    inviteMember(
+      {
+        email: email.trim(),
+        organizationId: activeOrganizationId,
+        role: selectedRoles as Parameters<typeof inviteMember>[0]["role"],
+        teamId: selectedTeamId,
+        ...invitationValues
+      },
+      { onSettled: () => setIsSubmitting(false) }
+    )
   }
 
   const atInvitationLimit =
@@ -183,7 +223,7 @@ export function InviteMemberDialog({
                 autoFocus
                 required
                 placeholder={localization.auth.email}
-                disabled={isInviting}
+                disabled={isInviting || isSubmitting}
                 onChange={() => setEmailError(undefined)}
                 onInvalid={(e) => {
                   e.preventDefault()
@@ -207,7 +247,7 @@ export function InviteMemberDialog({
               <DropdownMenu>
                 <DropdownMenuTrigger
                   id="invite-member-role"
-                  disabled={isInviting}
+                  disabled={isInviting || isSubmitting}
                   className={cn(
                     buttonVariants({ variant: "outline" }),
                     "w-full justify-between font-normal"
@@ -249,7 +289,7 @@ export function InviteMemberDialog({
                   items={teamItems}
                   value={teamId}
                   onValueChange={(value) => setTeamId(value ?? "")}
-                  disabled={isInviting}
+                  disabled={isInviting || isSubmitting}
                 >
                   <SelectTrigger id="invite-member-team" className="w-full">
                     <SelectValue
@@ -268,12 +308,21 @@ export function InviteMemberDialog({
                 </Select>
               </Field>
             )}
+            {invitationFields.map((field) => (
+              <AdditionalField
+                key={field.name}
+                field={field}
+                name={field.name}
+                isPending={isInviting || isSubmitting}
+                optionalLabel={localization.settings.optional}
+              />
+            ))}
           </div>
 
           <DialogFooter>
             <DialogClose
               className={buttonVariants({ variant: "outline" })}
-              disabled={isInviting}
+              disabled={isInviting || isSubmitting}
               type="button"
             >
               {localization.settings.cancel}
@@ -281,9 +330,11 @@ export function InviteMemberDialog({
 
             <Button
               type="submit"
-              disabled={isInviting || !isRoleValid || atInvitationLimit}
+              disabled={
+                isInviting || isSubmitting || !isRoleValid || atInvitationLimit
+              }
             >
-              {isInviting && <Spinner />}
+              {(isInviting || isSubmitting) && <Spinner />}
 
               {organizationLocalization.inviteMember}
             </Button>

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/invite-member-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/invite-member-dialog.tsx
@@ -160,7 +160,13 @@ export function InviteMemberDialog({
     if (!activeOrganizationId || !isRoleValid || atInvitationLimit) return
 
     const formData = new FormData(e.currentTarget)
-    const email = formData.get("email") as string
+    const invitationEmail = (formData.get("email") as string).trim()
+    const invitationRoles = [...selectedRoles] as Parameters<
+      typeof inviteMember
+    >[0]["role"]
+    const selectedTeamId = teams.data?.some((team) => team.id === teamId)
+      ? teamId
+      : undefined
     setIsSubmitting(true)
     let invitationValues: Record<string, unknown>
     try {
@@ -174,17 +180,13 @@ export function InviteMemberDialog({
       return
     }
 
-    const selectedTeamId = teams.data?.some((team) => team.id === teamId)
-      ? teamId
-      : undefined
-
     inviteMember(
       {
-        email: email.trim(),
+        ...invitationValues,
+        email: invitationEmail,
         organizationId: activeOrganizationId,
-        role: selectedRoles as Parameters<typeof inviteMember>[0]["role"],
-        teamId: selectedTeamId,
-        ...invitationValues
+        role: invitationRoles,
+        teamId: selectedTeamId
       },
       { onSettled: () => setIsSubmitting(false) }
     )

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-invitation-row.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-invitation-row.tsx
@@ -126,12 +126,6 @@ export function OrganizationInvitationRow({
               disabled={resendPending}
               onClick={() =>
                 resendInvitation({
-                  email: invitation.email,
-                  organizationId: invitation.organizationId,
-                  role: invitation.role as Parameters<
-                    typeof resendInvitation
-                  >[0]["role"],
-                  resend: true,
                   ...Object.fromEntries(
                     invitationFields.flatMap((field) => {
                       const value = (
@@ -139,7 +133,13 @@ export function OrganizationInvitationRow({
                       )[field.name]
                       return value === undefined ? [] : [[field.name, value]]
                     })
-                  )
+                  ),
+                  email: invitation.email,
+                  organizationId: invitation.organizationId,
+                  role: invitation.role as Parameters<
+                    typeof resendInvitation
+                  >[0]["role"],
+                  resend: true
                 })
               }
               aria-label={organizationLocalization.resendInvitation}

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-invitation-row.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-invitation-row.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { formatAdditionalFieldValue } from "@better-auth-ui/core"
 import {
   memberRoleLabels,
   type OrganizationAuthClient
@@ -37,8 +38,11 @@ export function OrganizationInvitationRow({
   invitation
 }: OrganizationInvitationRowProps) {
   const { authClient } = useAuth<OrganizationAuthClient>()
-  const { localization: organizationLocalization, roles } =
-    useAuthPlugin(organizationPlugin)
+  const {
+    modelFields: { invitation: invitationFields },
+    localization: organizationLocalization,
+    roles
+  } = useAuthPlugin(organizationPlugin)
 
   const {
     data: cancelInvitationPermission,
@@ -78,7 +82,21 @@ export function OrganizationInvitationRow({
 
   return (
     <TableRow>
-      <TableCell className="font-medium text-sm">{invitation.email}</TableCell>
+      <TableCell>
+        <div className="flex flex-col gap-1">
+          <span className="font-medium text-sm">{invitation.email}</span>
+          {invitationFields.map((field) => {
+            const value = formatAdditionalFieldValue(
+              (invitation as unknown as Record<string, unknown>)[field.name]
+            )
+            return value ? (
+              <span className="text-xs text-muted-foreground" key={field.name}>
+                {field.label}: {value}
+              </span>
+            ) : null
+          })}
+        </div>
+      </TableCell>
 
       <TableCell className="text-muted-foreground text-xs tabular-nums whitespace-nowrap">
         {new Date(invitation.createdAt).toLocaleString(undefined, {
@@ -113,7 +131,15 @@ export function OrganizationInvitationRow({
                   role: invitation.role as Parameters<
                     typeof resendInvitation
                   >[0]["role"],
-                  resend: true
+                  resend: true,
+                  ...Object.fromEntries(
+                    invitationFields.flatMap((field) => {
+                      const value = (
+                        invitation as unknown as Record<string, unknown>
+                      )[field.name]
+                      return value === undefined ? [] : [[field.name, value]]
+                    })
+                  )
                 })
               }
               aria-label={organizationLocalization.resendInvitation}

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-member-row.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-member-row.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { formatAdditionalFieldValue } from "@better-auth-ui/core"
 import {
   memberRoleLabels,
   mergeOrganizationRoleLabels,
@@ -46,6 +47,7 @@ export function OrganizationMemberRow({
 }: OrganizationMemberRowProps) {
   const { authClient } = useAuth<OrganizationAuthClient>()
   const {
+    modelFields: { member: memberFields },
     dynamicAccessControl,
     localization: organizationLocalization,
     roles
@@ -112,7 +114,19 @@ export function OrganizationMemberRow({
   return (
     <TableRow>
       <TableCell>
-        <UserView user={member.user} />
+        <div className="flex flex-col gap-1">
+          <UserView user={member.user} />
+          {memberFields.map((field) => {
+            const value = formatAdditionalFieldValue(
+              (member as unknown as Record<string, unknown>)[field.name]
+            )
+            return value ? (
+              <span className="text-xs text-muted-foreground" key={field.name}>
+                {field.label}: {value}
+              </span>
+            ) : null
+          })}
+        </div>
       </TableCell>
 
       <TableCell>{roleLabel}</TableCell>

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-roles.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-roles.tsx
@@ -1,5 +1,10 @@
 "use client"
 
+import {
+  type AdditionalFields,
+  fieldsWithModelValues,
+  parseAdditionalFieldValues
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
@@ -37,11 +42,13 @@ import {
   TableRow
 } from "@/components/ui/table"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
+import { AdditionalField } from "../additional-field"
 
 type Role = {
   id: string
   role: string
   permission: Record<string, string[]>
+  [key: string]: unknown
 }
 
 export function OrganizationRoles({
@@ -50,7 +57,7 @@ export function OrganizationRoles({
   organizationId: string
 }) {
   const { authClient } = useAuth<OrganizationAuthClient>()
-  const { dynamicAccessControl, localization } =
+  const { dynamicAccessControl, localization, modelFields } =
     useAuthPlugin(organizationPlugin)
   const roles = useListRoles(authClient, {
     query: { organizationId },
@@ -147,6 +154,7 @@ export function OrganizationRoles({
         open={editingRole !== undefined}
         role={editingRole ?? undefined}
         registry={dynamicAccessControl?.permissions ?? {}}
+        roleFields={modelFields.role}
         onOpenChange={(open) => !open && setEditingRole(undefined)}
       />
     </div>
@@ -239,19 +247,22 @@ function RoleDialog({
   open,
   organizationId,
   registry,
-  role
+  role,
+  roleFields
 }: {
   onOpenChange: (open: boolean) => void
   open: boolean
   organizationId: string
   registry: Record<string, { label?: string; actions: Record<string, string> }>
   role?: Role
+  roleFields: AdditionalFields
 }) {
   const { authClient, localization: authLocalization } =
     useAuth<OrganizationAuthClient>()
   const { localization } = useAuthPlugin(organizationPlugin)
   const [name, setName] = useState("")
   const [permission, setPermission] = useState<Record<string, string[]>>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const createRole = useCreateRole(authClient, organizationId, {
     onSuccess: () => {
       toast.success(localization.roleCreated)
@@ -271,23 +282,44 @@ function RoleDialog({
     setPermission(role?.permission ?? {})
   }, [open, role])
 
-  function submit(event: FormEvent<HTMLFormElement>) {
+  async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const roleName = name.trim()
     if (!roleName) return
 
-    if (role) {
-      updateRole.mutate({
-        organizationId,
-        roleId: role.id,
-        data: { roleName, permission }
-      })
-    } else {
-      createRole.mutate({ organizationId, role: roleName, permission })
+    setIsSubmitting(true)
+    try {
+      const additionalFields = await parseAdditionalFieldValues(
+        roleFields,
+        new FormData(event.currentTarget)
+      )
+      if (role) {
+        updateRole.mutate(
+          {
+            organizationId,
+            roleId: role.id,
+            data: { ...additionalFields, roleName, permission }
+          },
+          { onSettled: () => setIsSubmitting(false) }
+        )
+      } else {
+        createRole.mutate(
+          {
+            organizationId,
+            role: roleName,
+            permission,
+            additionalFields
+          },
+          { onSettled: () => setIsSubmitting(false) }
+        )
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsSubmitting(false)
     }
   }
 
-  const pending = createRole.isPending || updateRole.isPending
+  const pending = createRole.isPending || updateRole.isPending || isSubmitting
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -315,6 +347,16 @@ function RoleDialog({
               required
             />
           </Field>
+
+          {fieldsWithModelValues(roleFields, role ?? {}).map((field) => (
+            <AdditionalField
+              key={field.name}
+              field={field}
+              name={field.name}
+              isPending={pending}
+              optionalLabel={authLocalization.settings.optional}
+            />
+          ))}
 
           <fieldset className="flex flex-col gap-4">
             <legend className="text-sm font-medium">

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-teams.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-teams.tsx
@@ -1,5 +1,10 @@
 "use client"
 
+import {
+  type AdditionalFields,
+  fieldsWithModelValues,
+  parseAdditionalFieldValues
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
@@ -29,11 +34,13 @@ import {
 } from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
+import { AdditionalField } from "../additional-field"
 
 export function OrganizationTeams() {
-  const { authClient } = useAuth<OrganizationAuthClient>()
+  const { authClient, localization: authLocalization } =
+    useAuth<OrganizationAuthClient>()
   const { data: activeOrganization } = useActiveOrganization(authClient)
-  const { localization } = useAuthPlugin(organizationPlugin)
+  const { localization, modelFields } = useAuthPlugin(organizationPlugin)
   const teams = useListTeams(authClient, {
     query: { organizationId: activeOrganization?.id }
   })
@@ -42,13 +49,30 @@ export function OrganizationTeams() {
     onSuccess: () => toast.success(localization.teamCreated)
   })
 
-  function handleCreate(event: FormEvent<HTMLFormElement>) {
+  const [isCreatingFields, setIsCreatingFields] = useState(false)
+
+  async function handleCreate(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const form = event.currentTarget
     const name = String(new FormData(form).get("name") ?? "").trim()
     if (!name || !activeOrganization) return
-    createTeam.mutate({ name, organizationId: activeOrganization.id })
-    form.reset()
+    setIsCreatingFields(true)
+    try {
+      const values = await parseAdditionalFieldValues(
+        modelFields.team,
+        new FormData(form)
+      )
+      createTeam.mutate(
+        { ...values, name, organizationId: activeOrganization.id },
+        {
+          onSuccess: () => form.reset(),
+          onSettled: () => setIsCreatingFields(false)
+        }
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsCreatingFields(false)
+    }
   }
 
   return (
@@ -60,13 +84,29 @@ export function OrganizationTeams() {
             {localization.teamsDescription}
           </p>
         </div>
-        <form className="flex items-end gap-2" onSubmit={handleCreate}>
+        <form
+          className="grid w-full gap-3 sm:max-w-xl sm:grid-cols-2"
+          onSubmit={handleCreate}
+        >
           <Field>
             <FieldLabel htmlFor="new-team-name">{localization.name}</FieldLabel>
             <Input id="new-team-name" name="name" required />
           </Field>
-          <Button type="submit" disabled={createTeam.isPending}>
-            {createTeam.isPending && <Spinner />}
+          {modelFields.team.map((field) => (
+            <AdditionalField
+              key={field.name}
+              field={field}
+              name={field.name}
+              isPending={createTeam.isPending || isCreatingFields}
+              optionalLabel={authLocalization.settings.optional}
+            />
+          ))}
+          <Button
+            className="self-end"
+            type="submit"
+            disabled={createTeam.isPending || isCreatingFields}
+          >
+            {(createTeam.isPending || isCreatingFields) && <Spinner />}
             {localization.createTeam}
           </Button>
         </form>
@@ -80,6 +120,7 @@ export function OrganizationTeams() {
             organizationId={activeOrganization?.id ?? ""}
             organizationMembers={members.data?.members ?? []}
             team={team}
+            teamFields={modelFields.team}
           />
         ))
       ) : (
@@ -99,14 +140,16 @@ export function OrganizationTeams() {
 function TeamCard({
   organizationId,
   organizationMembers,
-  team
+  team,
+  teamFields
 }: {
   organizationId: string
   organizationMembers: Array<{
     userId: string
     user: { name: string; email: string }
   }>
-  team: { id: string; name: string }
+  team: { id: string; name: string; [key: string]: unknown }
+  teamFields: AdditionalFields
 }) {
   const { authClient, localization: authLocalization } =
     useAuth<OrganizationAuthClient>()
@@ -117,6 +160,7 @@ function TeamCard({
   const updateTeam = useUpdateTeam(authClient)
   const removeTeam = useRemoveTeam(authClient)
   const [name, setName] = useState(team.name)
+  const [isUpdatingFields, setIsUpdatingFields] = useState(false)
   const [userId, setUserId] = useState("")
   const addMember = useAddTeamMember(authClient, {
     onSuccess: () => setUserId("")
@@ -129,11 +173,34 @@ function TeamCard({
       label: member.user.name || member.user.email,
       value: member.userId
     }))
+  const handleUpdate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setIsUpdatingFields(true)
+    try {
+      const values = await parseAdditionalFieldValues(
+        teamFields,
+        new FormData(event.currentTarget)
+      )
+      updateTeam.mutate(
+        {
+          teamId: team.id,
+          data: { ...values, name, organizationId }
+        },
+        { onSettled: () => setIsUpdatingFields(false) }
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsUpdatingFields(false)
+    }
+  }
 
   return (
     <Card>
       <CardContent className="flex flex-col gap-4 pt-6">
-        <div className="flex flex-col items-end gap-2 sm:flex-row">
+        <form
+          className="grid items-end gap-3 sm:grid-cols-2"
+          onSubmit={handleUpdate}
+        >
           <Field className="flex-1">
             <FieldLabel htmlFor={`team-name-${team.id}`}>
               {localization.name}
@@ -144,19 +211,24 @@ function TeamCard({
               onChange={(event) => setName(event.target.value)}
             />
           </Field>
+          {fieldsWithModelValues(teamFields, team).map((field) => (
+            <AdditionalField
+              key={field.name}
+              field={field}
+              name={field.name}
+              isPending={updateTeam.isPending || isUpdatingFields}
+              optionalLabel={authLocalization.settings.optional}
+            />
+          ))}
           <Button
-            disabled={updateTeam.isPending}
+            type="submit"
+            disabled={updateTeam.isPending || isUpdatingFields}
             variant="outline"
-            onClick={() =>
-              updateTeam.mutate({
-                teamId: team.id,
-                data: { name, organizationId }
-              })
-            }
           >
             {authLocalization.settings.saveChanges}
           </Button>
           <Button
+            type="button"
             disabled={removeTeam.isPending}
             variant="destructive"
             onClick={() => {
@@ -166,7 +238,7 @@ function TeamCard({
           >
             {localization.deleteTeam}
           </Button>
-        </div>
+        </form>
         <div className="flex items-end gap-2">
           <Field className="flex-1">
             <FieldLabel>{localization.addTeamMember}</FieldLabel>

--- a/examples/start-shadcn-example/src/components/auth/organization/invite-member-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/invite-member-dialog.tsx
@@ -153,7 +153,13 @@ export function InviteMemberDialog({
     if (!activeOrganizationId || !isRoleValid || atInvitationLimit) return
 
     const formData = new FormData(e.currentTarget)
-    const email = formData.get("email") as string
+    const invitationEmail = (formData.get("email") as string).trim()
+    const invitationRoles = [...selectedRoles] as Parameters<
+      typeof inviteMember
+    >[0]["role"]
+    const selectedTeamId = teams.data?.some((team) => team.id === teamId)
+      ? teamId
+      : undefined
 
     setIsSubmitting(true)
     let invitationValues: Record<string, unknown>
@@ -168,17 +174,13 @@ export function InviteMemberDialog({
       return
     }
 
-    const selectedTeamId = teams.data?.some((team) => team.id === teamId)
-      ? teamId
-      : undefined
-
     inviteMember(
       {
-        email: email.trim(),
+        ...invitationValues,
+        email: invitationEmail,
         organizationId: activeOrganizationId,
-        role: selectedRoles as Parameters<typeof inviteMember>[0]["role"],
-        teamId: selectedTeamId,
-        ...invitationValues
+        role: invitationRoles,
+        teamId: selectedTeamId
       },
       { onSettled: () => setIsSubmitting(false) }
     )

--- a/examples/start-shadcn-example/src/components/auth/organization/invite-member-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/invite-member-dialog.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { parseAdditionalFieldValues } from "@better-auth-ui/core"
 import {
   mergeOrganizationRoleLabels,
   type OrganizationAuthClient
@@ -21,6 +22,7 @@ import {
   useState
 } from "react"
 import { toast } from "sonner"
+import { AdditionalField } from "@/components/auth/additional-field"
 import { Button, buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
@@ -68,6 +70,7 @@ export function InviteMemberDialog({
 }: InviteMemberDialogProps) {
   const { authClient, localization } = useAuth<OrganizationAuthClient>()
   const {
+    modelFields: { invitation: invitationFields },
     dynamicAccessControl,
     invitationLimit,
     localization: organizationLocalization,
@@ -95,6 +98,7 @@ export function InviteMemberDialog({
   })
   const [teamId, setTeamId] = useState("")
   const [emailError, setEmailError] = useState<string>()
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const activeOrganizationId = activeOrganization?.id
   const previousOrganizationId = useRef(activeOrganizationId)
 
@@ -143,24 +147,41 @@ export function InviteMemberDialog({
     )
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
 
     if (!activeOrganizationId || !isRoleValid || atInvitationLimit) return
 
-    const formData = new FormData(e.target as HTMLFormElement)
+    const formData = new FormData(e.currentTarget)
     const email = formData.get("email") as string
+
+    setIsSubmitting(true)
+    let invitationValues: Record<string, unknown>
+    try {
+      invitationValues = await parseAdditionalFieldValues(
+        invitationFields,
+        formData
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsSubmitting(false)
+      return
+    }
 
     const selectedTeamId = teams.data?.some((team) => team.id === teamId)
       ? teamId
       : undefined
 
-    inviteMember({
-      email: email.trim(),
-      organizationId: activeOrganizationId,
-      role: selectedRoles as Parameters<typeof inviteMember>[0]["role"],
-      teamId: selectedTeamId
-    })
+    inviteMember(
+      {
+        email: email.trim(),
+        organizationId: activeOrganizationId,
+        role: selectedRoles as Parameters<typeof inviteMember>[0]["role"],
+        teamId: selectedTeamId,
+        ...invitationValues
+      },
+      { onSettled: () => setIsSubmitting(false) }
+    )
   }
 
   const atInvitationLimit =
@@ -285,12 +306,22 @@ export function InviteMemberDialog({
                 </Select>
               </Field>
             )}
+
+            {invitationFields.map((field) => (
+              <AdditionalField
+                key={field.name}
+                field={field}
+                name={field.name}
+                isPending={isInviting || isSubmitting}
+                optionalLabel={localization.settings.optional}
+              />
+            ))}
           </div>
 
           <DialogFooter>
             <DialogClose
               className={buttonVariants({ variant: "outline" })}
-              disabled={isInviting}
+              disabled={isInviting || isSubmitting}
               type="button"
             >
               {localization.settings.cancel}
@@ -298,9 +329,11 @@ export function InviteMemberDialog({
 
             <Button
               type="submit"
-              disabled={isInviting || !isRoleValid || atInvitationLimit}
+              disabled={
+                isInviting || isSubmitting || !isRoleValid || atInvitationLimit
+              }
             >
-              {isInviting && <Spinner />}
+              {(isInviting || isSubmitting) && <Spinner />}
 
               {organizationLocalization.inviteMember}
             </Button>

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-invitation-row.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-invitation-row.tsx
@@ -126,12 +126,6 @@ export function OrganizationInvitationRow({
               disabled={resendPending}
               onClick={() =>
                 resendInvitation({
-                  email: invitation.email,
-                  organizationId: invitation.organizationId,
-                  role: invitation.role as Parameters<
-                    typeof resendInvitation
-                  >[0]["role"],
-                  resend: true,
                   ...Object.fromEntries(
                     invitationFields.flatMap((field) => {
                       const value = (
@@ -139,7 +133,13 @@ export function OrganizationInvitationRow({
                       )[field.name]
                       return value === undefined ? [] : [[field.name, value]]
                     })
-                  )
+                  ),
+                  email: invitation.email,
+                  organizationId: invitation.organizationId,
+                  role: invitation.role as Parameters<
+                    typeof resendInvitation
+                  >[0]["role"],
+                  resend: true
                 })
               }
               aria-label={organizationLocalization.resendInvitation}

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-invitation-row.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-invitation-row.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { formatAdditionalFieldValue } from "@better-auth-ui/core"
 import {
   memberRoleLabels,
   type OrganizationAuthClient
@@ -37,8 +38,11 @@ export function OrganizationInvitationRow({
   invitation
 }: OrganizationInvitationRowProps) {
   const { authClient } = useAuth<OrganizationAuthClient>()
-  const { localization: organizationLocalization, roles } =
-    useAuthPlugin(organizationPlugin)
+  const {
+    modelFields: { invitation: invitationFields },
+    localization: organizationLocalization,
+    roles
+  } = useAuthPlugin(organizationPlugin)
 
   const {
     data: cancelInvitationPermission,
@@ -78,7 +82,21 @@ export function OrganizationInvitationRow({
 
   return (
     <TableRow>
-      <TableCell className="font-medium text-sm">{invitation.email}</TableCell>
+      <TableCell>
+        <div className="flex flex-col gap-1">
+          <span className="font-medium text-sm">{invitation.email}</span>
+          {invitationFields.map((field) => {
+            const value = formatAdditionalFieldValue(
+              (invitation as unknown as Record<string, unknown>)[field.name]
+            )
+            return value ? (
+              <span className="text-xs text-muted-foreground" key={field.name}>
+                {field.label}: {value}
+              </span>
+            ) : null
+          })}
+        </div>
+      </TableCell>
 
       <TableCell className="text-muted-foreground text-xs tabular-nums whitespace-nowrap">
         {new Date(invitation.createdAt).toLocaleString(undefined, {
@@ -113,7 +131,15 @@ export function OrganizationInvitationRow({
                   role: invitation.role as Parameters<
                     typeof resendInvitation
                   >[0]["role"],
-                  resend: true
+                  resend: true,
+                  ...Object.fromEntries(
+                    invitationFields.flatMap((field) => {
+                      const value = (
+                        invitation as unknown as Record<string, unknown>
+                      )[field.name]
+                      return value === undefined ? [] : [[field.name, value]]
+                    })
+                  )
                 })
               }
               aria-label={organizationLocalization.resendInvitation}

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-member-row.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-member-row.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { formatAdditionalFieldValue } from "@better-auth-ui/core"
 import {
   memberRoleLabels,
   mergeOrganizationRoleLabels,
@@ -46,6 +47,7 @@ export function OrganizationMemberRow({
 }: OrganizationMemberRowProps) {
   const { authClient } = useAuth<OrganizationAuthClient>()
   const {
+    modelFields: { member: memberFields },
     dynamicAccessControl,
     localization: organizationLocalization,
     roles
@@ -112,7 +114,19 @@ export function OrganizationMemberRow({
   return (
     <TableRow>
       <TableCell>
-        <UserView user={member.user} />
+        <div className="flex flex-col gap-1">
+          <UserView user={member.user} />
+          {memberFields.map((field) => {
+            const value = formatAdditionalFieldValue(
+              (member as unknown as Record<string, unknown>)[field.name]
+            )
+            return value ? (
+              <span className="text-xs text-muted-foreground" key={field.name}>
+                {field.label}: {value}
+              </span>
+            ) : null
+          })}
+        </div>
       </TableCell>
 
       <TableCell>{roleLabel}</TableCell>

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-roles.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-roles.tsx
@@ -1,5 +1,10 @@
 "use client"
 
+import {
+  type AdditionalFields,
+  fieldsWithModelValues,
+  parseAdditionalFieldValues
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
@@ -37,11 +42,13 @@ import {
   TableRow
 } from "@/components/ui/table"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
+import { AdditionalField } from "../additional-field"
 
 type Role = {
   id: string
   role: string
   permission: Record<string, string[]>
+  [key: string]: unknown
 }
 
 export function OrganizationRoles({
@@ -50,7 +57,7 @@ export function OrganizationRoles({
   organizationId: string
 }) {
   const { authClient } = useAuth<OrganizationAuthClient>()
-  const { dynamicAccessControl, localization } =
+  const { dynamicAccessControl, localization, modelFields } =
     useAuthPlugin(organizationPlugin)
   const roles = useListRoles(authClient, {
     query: { organizationId },
@@ -147,6 +154,7 @@ export function OrganizationRoles({
         open={editingRole !== undefined}
         role={editingRole ?? undefined}
         registry={dynamicAccessControl?.permissions ?? {}}
+        roleFields={modelFields.role}
         onOpenChange={(open) => !open && setEditingRole(undefined)}
       />
     </div>
@@ -239,19 +247,22 @@ function RoleDialog({
   open,
   organizationId,
   registry,
-  role
+  role,
+  roleFields
 }: {
   onOpenChange: (open: boolean) => void
   open: boolean
   organizationId: string
   registry: Record<string, { label?: string; actions: Record<string, string> }>
   role?: Role
+  roleFields: AdditionalFields
 }) {
   const { authClient, localization: authLocalization } =
     useAuth<OrganizationAuthClient>()
   const { localization } = useAuthPlugin(organizationPlugin)
   const [name, setName] = useState("")
   const [permission, setPermission] = useState<Record<string, string[]>>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const createRole = useCreateRole(authClient, organizationId, {
     onSuccess: () => {
       toast.success(localization.roleCreated)
@@ -271,23 +282,44 @@ function RoleDialog({
     setPermission(role?.permission ?? {})
   }, [open, role])
 
-  function submit(event: FormEvent<HTMLFormElement>) {
+  async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const roleName = name.trim()
     if (!roleName) return
 
-    if (role) {
-      updateRole.mutate({
-        organizationId,
-        roleId: role.id,
-        data: { roleName, permission }
-      })
-    } else {
-      createRole.mutate({ organizationId, role: roleName, permission })
+    setIsSubmitting(true)
+    try {
+      const additionalFields = await parseAdditionalFieldValues(
+        roleFields,
+        new FormData(event.currentTarget)
+      )
+      if (role) {
+        updateRole.mutate(
+          {
+            organizationId,
+            roleId: role.id,
+            data: { ...additionalFields, roleName, permission }
+          },
+          { onSettled: () => setIsSubmitting(false) }
+        )
+      } else {
+        createRole.mutate(
+          {
+            organizationId,
+            role: roleName,
+            permission,
+            additionalFields
+          },
+          { onSettled: () => setIsSubmitting(false) }
+        )
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsSubmitting(false)
     }
   }
 
-  const pending = createRole.isPending || updateRole.isPending
+  const pending = createRole.isPending || updateRole.isPending || isSubmitting
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -315,6 +347,16 @@ function RoleDialog({
               required
             />
           </Field>
+
+          {fieldsWithModelValues(roleFields, role ?? {}).map((field) => (
+            <AdditionalField
+              key={field.name}
+              field={field}
+              name={field.name}
+              isPending={pending}
+              optionalLabel={authLocalization.settings.optional}
+            />
+          ))}
 
           <fieldset className="flex flex-col gap-4">
             <legend className="text-sm font-medium">

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-teams.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-teams.tsx
@@ -1,5 +1,10 @@
 "use client"
 
+import {
+  type AdditionalFields,
+  fieldsWithModelValues,
+  parseAdditionalFieldValues
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
@@ -28,11 +33,13 @@ import {
 } from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
+import { AdditionalField } from "../additional-field"
 
 export function OrganizationTeams() {
-  const { authClient } = useAuth<OrganizationAuthClient>()
+  const { authClient, localization: authLocalization } =
+    useAuth<OrganizationAuthClient>()
   const { data: activeOrganization } = useActiveOrganization(authClient)
-  const { localization } = useAuthPlugin(organizationPlugin)
+  const { localization, modelFields } = useAuthPlugin(organizationPlugin)
   const teams = useListTeams(authClient, {
     query: { organizationId: activeOrganization?.id }
   })
@@ -41,13 +48,31 @@ export function OrganizationTeams() {
     onSuccess: () => toast.success(localization.teamCreated)
   })
 
-  function handleCreate(event: FormEvent<HTMLFormElement>) {
+  const [isCreatingFields, setIsCreatingFields] = useState(false)
+
+  async function handleCreate(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
     const form = event.currentTarget
     const name = String(new FormData(form).get("name") ?? "").trim()
     if (!name || !activeOrganization) return
-    createTeam.mutate({ name, organizationId: activeOrganization.id })
-    form.reset()
+
+    setIsCreatingFields(true)
+    try {
+      const values = await parseAdditionalFieldValues(
+        modelFields.team,
+        new FormData(form)
+      )
+      createTeam.mutate(
+        { ...values, name, organizationId: activeOrganization.id },
+        {
+          onSuccess: () => form.reset(),
+          onSettled: () => setIsCreatingFields(false)
+        }
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsCreatingFields(false)
+    }
   }
 
   return (
@@ -59,12 +84,28 @@ export function OrganizationTeams() {
             {localization.teamsDescription}
           </p>
         </div>
-        <form className="flex items-end gap-2" onSubmit={handleCreate}>
+        <form
+          className="grid w-full gap-3 sm:max-w-xl sm:grid-cols-2"
+          onSubmit={handleCreate}
+        >
           <Field>
             <FieldLabel htmlFor="new-team-name">{localization.name}</FieldLabel>
             <Input id="new-team-name" name="name" required />
           </Field>
-          <Button type="submit" disabled={createTeam.isPending}>
+          {modelFields.team.map((field) => (
+            <AdditionalField
+              key={field.name}
+              field={field}
+              name={field.name}
+              isPending={createTeam.isPending || isCreatingFields}
+              optionalLabel={authLocalization.settings.optional}
+            />
+          ))}
+          <Button
+            className="self-end"
+            type="submit"
+            disabled={createTeam.isPending || isCreatingFields}
+          >
             {createTeam.isPending && <Spinner />}
             {localization.createTeam}
           </Button>
@@ -79,6 +120,7 @@ export function OrganizationTeams() {
             organizationId={activeOrganization?.id ?? ""}
             organizationMembers={members.data?.members ?? []}
             team={team}
+            teamFields={modelFields.team}
           />
         ))
       ) : (
@@ -98,14 +140,16 @@ export function OrganizationTeams() {
 function TeamCard({
   organizationId,
   organizationMembers,
-  team
+  team,
+  teamFields
 }: {
   organizationId: string
   organizationMembers: Array<{
     userId: string
     user: { name: string; email: string }
   }>
-  team: { id: string; name: string }
+  team: { id: string; name: string; [key: string]: unknown }
+  teamFields: AdditionalFields
 }) {
   const { authClient, localization: authLocalization } =
     useAuth<OrganizationAuthClient>()
@@ -116,6 +160,7 @@ function TeamCard({
   const updateTeam = useUpdateTeam(authClient)
   const removeTeam = useRemoveTeam(authClient)
   const [name, setName] = useState(team.name)
+  const [isUpdatingFields, setIsUpdatingFields] = useState(false)
   const [userId, setUserId] = useState("")
   const addMember = useAddTeamMember(authClient, {
     onSuccess: () => setUserId("")
@@ -123,10 +168,34 @@ function TeamCard({
   const removeMember = useRemoveTeamMember(authClient)
   const memberIds = new Set(teamMembers.data?.map((member) => member.userId))
 
+  const handleUpdate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setIsUpdatingFields(true)
+    try {
+      const values = await parseAdditionalFieldValues(
+        teamFields,
+        new FormData(event.currentTarget)
+      )
+      updateTeam.mutate(
+        {
+          teamId: team.id,
+          data: { ...values, name, organizationId }
+        },
+        { onSettled: () => setIsUpdatingFields(false) }
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsUpdatingFields(false)
+    }
+  }
+
   return (
     <Card>
       <CardContent className="flex flex-col gap-4 pt-6">
-        <div className="flex flex-col items-end gap-2 sm:flex-row">
+        <form
+          className="grid items-end gap-3 sm:grid-cols-2"
+          onSubmit={handleUpdate}
+        >
           <Field className="flex-1">
             <FieldLabel htmlFor={`team-name-${team.id}`}>
               {localization.name}
@@ -137,19 +206,24 @@ function TeamCard({
               onChange={(event) => setName(event.target.value)}
             />
           </Field>
+          {fieldsWithModelValues(teamFields, team).map((field) => (
+            <AdditionalField
+              key={field.name}
+              field={field}
+              name={field.name}
+              isPending={updateTeam.isPending || isUpdatingFields}
+              optionalLabel={authLocalization.settings.optional}
+            />
+          ))}
           <Button
-            disabled={updateTeam.isPending}
+            type="submit"
+            disabled={updateTeam.isPending || isUpdatingFields}
             variant="outline"
-            onClick={() =>
-              updateTeam.mutate({
-                teamId: team.id,
-                data: { name, organizationId }
-              })
-            }
           >
             {authLocalization.settings.saveChanges}
           </Button>
           <Button
+            type="button"
             disabled={removeTeam.isPending}
             variant="destructive"
             onClick={() => {
@@ -159,7 +233,7 @@ function TeamCard({
           >
             {localization.deleteTeam}
           </Button>
-        </div>
+        </form>
         <div className="flex items-end gap-2">
           <Field className="flex-1">
             <FieldLabel>{localization.addTeamMember}</FieldLabel>

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/invite-member-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/invite-member-dialog.tsx
@@ -113,7 +113,20 @@ export function InviteMemberDialog(props: InviteMemberDialogProps) {
       (invitations.data?.filter((invitation) => invitation.status === "pending")
         .length ?? 0) >= config.invitationLimit
 
-    if (!email().trim() || selectedRoles().length === 0 || atInvitationLimit)
+    const organizationId = activeOrganization.data?.id
+    const invitationEmail = email().trim()
+    const invitationRoles = [...selectedRoles()] as InviteMemberParams["role"]
+    const currentTeamId = teamId()
+    const selectedTeamId = teams.data?.some((team) => team.id === currentTeamId)
+      ? currentTeamId
+      : undefined
+
+    if (
+      !organizationId ||
+      !invitationEmail ||
+      invitationRoles.length === 0 ||
+      atInvitationLimit
+    )
       return
 
     const formData = new FormData(event.currentTarget as HTMLFormElement)
@@ -130,16 +143,12 @@ export function InviteMemberDialog(props: InviteMemberDialogProps) {
       return
     }
 
-    const selectedTeamId = teams.data?.some((team) => team.id === teamId())
-      ? teamId()
-      : undefined
-
     const payload = {
-      email: email().trim(),
-      organizationId: activeOrganization.data?.id,
+      ...invitationValues,
+      email: invitationEmail,
+      organizationId,
       teamId: selectedTeamId,
-      role: selectedRoles() as InviteMemberParams["role"],
-      ...invitationValues
+      role: invitationRoles
     } satisfies InviteMemberParams
 
     inviteMember.mutate(payload, { onSettled: () => setIsSubmitting(false) })

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/invite-member-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/invite-member-dialog.tsx
@@ -1,3 +1,4 @@
+import { parseAdditionalFieldValues } from "@better-auth-ui/core"
 import type {
   InviteMemberParams,
   OrganizationAuthClient
@@ -28,6 +29,7 @@ import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { NativeSelect, NativeSelectOption } from "@/components/ui/native-select"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
+import { AdditionalField } from "../additional-field"
 
 export type InviteMemberDialogProps = {
   open: boolean
@@ -72,6 +74,7 @@ export function InviteMemberDialog(props: InviteMemberDialogProps) {
       return next.length > 0 ? next : current
     })
   const [teamId, setTeamId] = createSignal("")
+  const [isSubmitting, setIsSubmitting] = createSignal(false)
   const inviteMember = useInviteMember(auth.authClient, () => ({
     onSuccess: () => {
       props.onOpenChange(false)
@@ -102,7 +105,7 @@ export function InviteMemberDialog(props: InviteMemberDialogProps) {
     )
   )
 
-  const handleSubmit = (event: SubmitEvent) => {
+  const handleSubmit = async (event: SubmitEvent) => {
     event.preventDefault()
 
     const atInvitationLimit =
@@ -113,6 +116,20 @@ export function InviteMemberDialog(props: InviteMemberDialogProps) {
     if (!email().trim() || selectedRoles().length === 0 || atInvitationLimit)
       return
 
+    const formData = new FormData(event.currentTarget as HTMLFormElement)
+    setIsSubmitting(true)
+    let invitationValues: Record<string, unknown>
+    try {
+      invitationValues = await parseAdditionalFieldValues(
+        config.modelFields.invitation,
+        formData
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsSubmitting(false)
+      return
+    }
+
     const selectedTeamId = teams.data?.some((team) => team.id === teamId())
       ? teamId()
       : undefined
@@ -121,10 +138,11 @@ export function InviteMemberDialog(props: InviteMemberDialogProps) {
       email: email().trim(),
       organizationId: activeOrganization.data?.id,
       teamId: selectedTeamId,
-      role: selectedRoles() as InviteMemberParams["role"]
+      role: selectedRoles() as InviteMemberParams["role"],
+      ...invitationValues
     } satisfies InviteMemberParams
 
-    inviteMember.mutate(payload)
+    inviteMember.mutate(payload, { onSettled: () => setIsSubmitting(false) })
   }
 
   return (
@@ -203,10 +221,21 @@ export function InviteMemberDialog(props: InviteMemberDialogProps) {
             </Field>
           </Show>
 
+          <For each={config.modelFields.invitation}>
+            {(field) => (
+              <AdditionalField
+                field={field}
+                isPending={inviteMember.isPending || isSubmitting()}
+                name={field.name}
+                optionalLabel={auth.localization.settings.optional}
+              />
+            )}
+          </For>
+
           <DialogFooter>
             <DialogClose
               as={Button}
-              disabled={inviteMember.isPending}
+              disabled={inviteMember.isPending || isSubmitting()}
               type="button"
               variant="outline"
             >
@@ -215,6 +244,7 @@ export function InviteMemberDialog(props: InviteMemberDialogProps) {
             <Button
               disabled={
                 inviteMember.isPending ||
+                isSubmitting() ||
                 !email().trim() ||
                 selectedRoles().length === 0 ||
                 (config.invitationLimit !== undefined &&

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-invitation-row.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-invitation-row.tsx
@@ -132,18 +132,18 @@ export function OrganizationInvitationRow(
               disabled={resendInvitation.isPending}
               onClick={() =>
                 resendInvitation.mutate({
-                  email: props.invitation.email ?? "",
-                  organizationId: props.invitation.organizationId,
-                  resend: true,
-                  role: (props.invitation.role ?? "member") as Parameters<
-                    typeof resendInvitation.mutate
-                  >[0]["role"],
                   ...Object.fromEntries(
                     config.modelFields.invitation.flatMap((field) => {
                       const value = props.invitation[field.name]
                       return value === undefined ? [] : [[field.name, value]]
                     })
-                  )
+                  ),
+                  email: props.invitation.email ?? "",
+                  organizationId: props.invitation.organizationId,
+                  resend: true,
+                  role: (props.invitation.role ?? "member") as Parameters<
+                    typeof resendInvitation.mutate
+                  >[0]["role"]
                 })
               }
               size="icon-sm"

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-invitation-row.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-invitation-row.tsx
@@ -1,3 +1,4 @@
+import { formatAdditionalFieldValue } from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import {
@@ -6,7 +7,7 @@ import {
   useInviteMember
 } from "@better-auth-ui/solid/plugins/organization"
 import { Send, X } from "lucide-solid"
-import { Show } from "solid-js"
+import { For, Show } from "solid-js"
 import { toast } from "solid-sonner"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -21,6 +22,7 @@ type OrganizationInvitation = {
   organizationId: string
   role?: string | null
   status?: string | null
+  [key: string]: unknown
 }
 
 type RoleMap = Record<string, string>
@@ -91,8 +93,27 @@ export function OrganizationInvitationRow(
 
   return (
     <TableRow>
-      <TableCell class="font-medium">
-        {props.invitation.email ?? "Invitation"}
+      <TableCell>
+        <div class="flex flex-col gap-1">
+          <span class="font-medium">
+            {props.invitation.email ?? "Invitation"}
+          </span>
+          <For each={config.modelFields.invitation}>
+            {(field) => {
+              const value = () =>
+                formatAdditionalFieldValue(props.invitation[field.name])
+              return (
+                <Show when={value()}>
+                  {(resolved) => (
+                    <span class="text-muted-foreground text-xs">
+                      {field.label}: {resolved()}
+                    </span>
+                  )}
+                </Show>
+              )
+            }}
+          </For>
+        </div>
       </TableCell>
       <TableCell class="whitespace-nowrap text-muted-foreground text-xs tabular-nums">
         {formatInvitationDate(props.invitation.createdAt)}
@@ -116,7 +137,13 @@ export function OrganizationInvitationRow(
                   resend: true,
                   role: (props.invitation.role ?? "member") as Parameters<
                     typeof resendInvitation.mutate
-                  >[0]["role"]
+                  >[0]["role"],
+                  ...Object.fromEntries(
+                    config.modelFields.invitation.flatMap((field) => {
+                      const value = props.invitation[field.name]
+                      return value === undefined ? [] : [[field.name, value]]
+                    })
+                  )
                 })
               }
               size="icon-sm"

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-member-row.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-member-row.tsx
@@ -1,3 +1,4 @@
+import { formatAdditionalFieldValue } from "@better-auth-ui/core"
 import {
   type LeaveOrganizationParams,
   memberRoleLabels,
@@ -7,7 +8,7 @@ import {
   type RemoveMemberParams,
   type UpdateMemberRoleParams
 } from "@better-auth-ui/core/plugins/organization"
-import { useAuth, useSession } from "@better-auth-ui/solid"
+import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/solid"
 import {
   useActiveOrganization,
   useHasPermission,
@@ -48,6 +49,7 @@ type OrganizationMember = {
     image?: string | null
     name?: string | null
   } | null
+  [key: string]: unknown
 }
 
 type RoleMap = Record<string, string>
@@ -191,6 +193,7 @@ function LeaveOrganizationDialog(props: {
 
 export function OrganizationMemberRow(props: OrganizationMemberRowProps) {
   const auth = useAuth<OrganizationAuthClient>()
+  const config = useAuthPlugin(organizationPlugin)
   const [removeOpen, setRemoveOpen] = createSignal(false)
   const [leaveOpen, setLeaveOpen] = createSignal(false)
   const session = useSession(auth.authClient)
@@ -233,11 +236,28 @@ export function OrganizationMemberRow(props: OrganizationMemberRowProps) {
   return (
     <TableRow>
       <TableCell>
-        <UserView
-          image={user()?.image}
-          label={user()?.name ?? user()?.email ?? "Member"}
-          secondaryLabel={user()?.email}
-        />
+        <div class="flex flex-col gap-1">
+          <UserView
+            image={user()?.image}
+            label={user()?.name ?? user()?.email ?? "Member"}
+            secondaryLabel={user()?.email}
+          />
+          <For each={config.modelFields.member}>
+            {(field) => {
+              const value = () =>
+                formatAdditionalFieldValue(props.member[field.name])
+              return (
+                <Show when={value()}>
+                  {(resolved) => (
+                    <span class="text-muted-foreground text-xs">
+                      {field.label}: {resolved()}
+                    </span>
+                  )}
+                </Show>
+              )
+            }}
+          </For>
+        </div>
       </TableCell>
       <TableCell class="text-sm">
         {memberRoleLabels(props.member.role, props.roles).join(", ") ||

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-roles.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-roles.tsx
@@ -1,3 +1,8 @@
+import {
+  type AdditionalFields,
+  fieldsWithModelValues,
+  parseAdditionalFieldValues
+} from "@better-auth-ui/core"
 import type {
   OrganizationAuthClient,
   OrganizationPermissionRegistry
@@ -36,11 +41,13 @@ import {
   TableRow
 } from "@/components/ui/table"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
+import { AdditionalField } from "../additional-field"
 
 type Role = {
   id: string
   role: string
   permission: Record<string, string[]>
+  [key: string]: unknown
 }
 
 export function OrganizationRoles(props: { organizationId: string }) {
@@ -152,6 +159,7 @@ export function OrganizationRoles(props: { organizationId: string }) {
         organizationId={props.organizationId}
         registry={config.dynamicAccessControl?.permissions ?? {}}
         role={editingRole() ?? undefined}
+        roleFields={config.modelFields.role}
       />
     </div>
   )
@@ -236,11 +244,13 @@ function RoleDialog(props: {
   organizationId: string
   registry: OrganizationPermissionRegistry
   role?: Role
+  roleFields: AdditionalFields
 }) {
   const auth = useAuth<OrganizationAuthClient>()
   const config = useAuthPlugin(organizationPlugin)
   const [name, setName] = createSignal("")
   const [permission, setPermission] = createSignal<Record<string, string[]>>({})
+  const [isSubmitting, setIsSubmitting] = createSignal(false)
   const createRole = useCreateRole(
     auth.authClient,
     () => props.organizationId,
@@ -268,27 +278,45 @@ function RoleDialog(props: {
     setPermission(props.role?.permission ?? {})
   })
 
-  const submit = (event: SubmitEvent) => {
+  const submit = async (event: SubmitEvent) => {
     event.preventDefault()
     const roleName = name().trim()
     if (!roleName) return
 
-    if (props.role) {
-      updateRole.mutate({
-        organizationId: props.organizationId,
-        roleId: props.role.id,
-        data: { roleName, permission: permission() }
-      })
-    } else {
-      createRole.mutate({
-        organizationId: props.organizationId,
-        role: roleName,
-        permission: permission()
-      })
+    setIsSubmitting(true)
+    try {
+      const additionalFields = await parseAdditionalFieldValues(
+        props.roleFields,
+        new FormData(event.currentTarget as HTMLFormElement)
+      )
+      if (props.role) {
+        updateRole.mutate(
+          {
+            organizationId: props.organizationId,
+            roleId: props.role.id,
+            data: { ...additionalFields, roleName, permission: permission() }
+          },
+          { onSettled: () => setIsSubmitting(false) }
+        )
+      } else {
+        createRole.mutate(
+          {
+            organizationId: props.organizationId,
+            role: roleName,
+            permission: permission(),
+            additionalFields
+          },
+          { onSettled: () => setIsSubmitting(false) }
+        )
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsSubmitting(false)
     }
   }
 
-  const pending = () => createRole.isPending || updateRole.isPending
+  const pending = () =>
+    createRole.isPending || updateRole.isPending || isSubmitting()
 
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
@@ -318,6 +346,17 @@ function RoleDialog(props: {
               value={name()}
             />
           </Field>
+
+          <For each={fieldsWithModelValues(props.roleFields, props.role ?? {})}>
+            {(field) => (
+              <AdditionalField
+                field={field}
+                isPending={pending()}
+                name={field.name}
+                optionalLabel={auth.localization.settings.optional}
+              />
+            )}
+          </For>
 
           <fieldset class="flex flex-col gap-4">
             <legend class="text-sm font-medium">

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-teams.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-teams.tsx
@@ -1,3 +1,8 @@
+import {
+  type AdditionalFields,
+  fieldsWithModelValues,
+  parseAdditionalFieldValues
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import {
@@ -25,6 +30,7 @@ import {
   SelectValue
 } from "@/components/ui/select"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
+import { AdditionalField } from "../additional-field"
 
 type MemberOption = { id: string; label: string }
 
@@ -39,14 +45,31 @@ export function OrganizationTeams() {
   const createTeam = useCreateTeam(auth.authClient, () => ({
     onSuccess: () => toast.success(config.localization.teamCreated)
   }))
+  const [isCreatingFields, setIsCreatingFields] = createSignal(false)
 
-  function handleCreate(event: SubmitEvent) {
+  async function handleCreate(event: SubmitEvent) {
     event.preventDefault()
     const form = event.currentTarget as HTMLFormElement
     const name = String(new FormData(form).get("name") ?? "").trim()
     if (!name || !activeOrganization.data) return
-    createTeam.mutate({ name, organizationId: activeOrganization.data.id })
-    form.reset()
+
+    setIsCreatingFields(true)
+    try {
+      const values = await parseAdditionalFieldValues(
+        config.modelFields.team,
+        new FormData(form)
+      )
+      createTeam.mutate(
+        { ...values, name, organizationId: activeOrganization.data.id },
+        {
+          onSuccess: () => form.reset(),
+          onSettled: () => setIsCreatingFields(false)
+        }
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsCreatingFields(false)
+    }
   }
 
   return (
@@ -58,14 +81,31 @@ export function OrganizationTeams() {
             {config.localization.teamsDescription}
           </p>
         </div>
-        <form class="flex items-end gap-2" onSubmit={handleCreate}>
+        <form
+          class="grid w-full gap-3 sm:max-w-xl sm:grid-cols-2"
+          onSubmit={handleCreate}
+        >
           <Field>
             <FieldLabel for="new-team-name">
               {config.localization.name}
             </FieldLabel>
             <Input id="new-team-name" name="name" required />
           </Field>
-          <Button type="submit" disabled={createTeam.isPending}>
+          <For each={config.modelFields.team}>
+            {(field) => (
+              <AdditionalField
+                field={field}
+                isPending={createTeam.isPending || isCreatingFields()}
+                name={field.name}
+                optionalLabel={auth.localization.settings.optional}
+              />
+            )}
+          </For>
+          <Button
+            class="self-end"
+            type="submit"
+            disabled={createTeam.isPending || isCreatingFields()}
+          >
             {config.localization.createTeam}
           </Button>
         </form>
@@ -89,6 +129,7 @@ export function OrganizationTeams() {
               organizationId={activeOrganization.data?.id ?? ""}
               organizationMembers={members.data?.members ?? []}
               team={team}
+              teamFields={config.modelFields.team}
             />
           )}
         </For>
@@ -104,6 +145,7 @@ function TeamCard(props: {
     user: { name: string; email: string }
   }>
   team: { id: string; name: string }
+  teamFields: AdditionalFields
 }) {
   const auth = useAuth<OrganizationAuthClient>()
   const config = useAuthPlugin(organizationPlugin)
@@ -113,6 +155,7 @@ function TeamCard(props: {
   const updateTeam = useUpdateTeam(auth.authClient)
   const removeTeam = useRemoveTeam(auth.authClient)
   const [name, setName] = createSignal(props.team.name)
+  const [isUpdatingFields, setIsUpdatingFields] = createSignal(false)
   const [selectedMember, setSelectedMember] = createSignal<MemberOption>()
   const addMember = useAddTeamMember(auth.authClient, () => ({
     onSuccess: () => setSelectedMember(undefined)
@@ -128,10 +171,38 @@ function TeamCard(props: {
       }))
   }
 
+  const handleUpdate = async (event: SubmitEvent) => {
+    event.preventDefault()
+    setIsUpdatingFields(true)
+    try {
+      const values = await parseAdditionalFieldValues(
+        props.teamFields,
+        new FormData(event.currentTarget as HTMLFormElement)
+      )
+      updateTeam.mutate(
+        {
+          teamId: props.team.id,
+          data: {
+            ...values,
+            name: name(),
+            organizationId: props.organizationId
+          }
+        },
+        { onSettled: () => setIsUpdatingFields(false) }
+      )
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error))
+      setIsUpdatingFields(false)
+    }
+  }
+
   return (
     <Card>
       <CardContent class="flex flex-col gap-4">
-        <div class="flex flex-col items-end gap-2 sm:flex-row">
+        <form
+          class="grid items-end gap-3 sm:grid-cols-2"
+          onSubmit={handleUpdate}
+        >
           <Field class="flex-1">
             <FieldLabel for={`team-name-${props.team.id}`}>
               {config.localization.name}
@@ -142,19 +213,30 @@ function TeamCard(props: {
               onInput={(event) => setName(event.currentTarget.value)}
             />
           </Field>
+          <For
+            each={fieldsWithModelValues(
+              props.teamFields,
+              props.team as Record<string, unknown>
+            )}
+          >
+            {(field) => (
+              <AdditionalField
+                field={field}
+                isPending={updateTeam.isPending || isUpdatingFields()}
+                name={field.name}
+                optionalLabel={auth.localization.settings.optional}
+              />
+            )}
+          </For>
           <Button
-            disabled={updateTeam.isPending}
+            type="submit"
+            disabled={updateTeam.isPending || isUpdatingFields()}
             variant="outline"
-            onClick={() =>
-              updateTeam.mutate({
-                teamId: props.team.id,
-                data: { name: name(), organizationId: props.organizationId }
-              })
-            }
           >
             {auth.localization.settings.saveChanges}
           </Button>
           <Button
+            type="button"
             disabled={removeTeam.isPending}
             variant="destructive"
             onClick={() => {
@@ -167,7 +249,7 @@ function TeamCard(props: {
           >
             {config.localization.deleteTeam}
           </Button>
-        </div>
+        </form>
         <div class="flex items-end gap-2">
           <Field class="flex-1">
             <FieldLabel>{config.localization.addTeamMember}</FieldLabel>

--- a/packages/core/src/config/additional-fields-config.ts
+++ b/packages/core/src/config/additional-fields-config.ts
@@ -163,6 +163,69 @@ export function parseAdditionalFieldValue(
   return raw
 }
 
+/** Parse and validate a model's configured fields from submitted form data. */
+export async function parseAdditionalFieldValues(
+  fields: AdditionalFields,
+  formData: FormData
+): Promise<Record<string, AdditionalFieldValue | null>> {
+  const values: Record<string, AdditionalFieldValue | null> = {}
+
+  for (const field of fields) {
+    if (field.readOnly) continue
+
+    const value = parseAdditionalFieldValue(
+      field,
+      formData.get(field.name) as string | null
+    )
+    await field.validate?.(value)
+    if (value !== undefined) values[field.name] = value
+  }
+
+  return values
+}
+
+/** Seed field defaults from a Better Auth model returned by a query. */
+export function fieldsWithModelValues(
+  fields: AdditionalFields,
+  model: Record<string, unknown>
+): AdditionalFields {
+  return fields.map((field) => {
+    const value = model[field.name]
+
+    if (
+      value !== null &&
+      typeof value !== "string" &&
+      typeof value !== "number" &&
+      typeof value !== "boolean" &&
+      !(value instanceof Date)
+    ) {
+      return field
+    }
+
+    return { ...field, defaultValue: value }
+  })
+}
+
+/** Format a persisted additional-field value for compact read-only display. */
+export function formatAdditionalFieldValue(value: unknown): string | undefined {
+  if (value === null || value === undefined || value === "") return undefined
+  if (value instanceof Date) return value.toLocaleString()
+  if (typeof value === "string") {
+    const parsed = new Date(value)
+    if (
+      /^\d{4}-\d{2}-\d{2}(T|$)/.test(value) &&
+      !Number.isNaN(parsed.getTime())
+    ) {
+      return parsed.toLocaleString()
+    }
+    return value
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value)
+  }
+  return undefined
+}
+
 /** Resolve the effective `inputType`, defaulting based on `field.type`. */
 export function resolveInputType(
   field: AdditionalField

--- a/packages/core/src/config/additional-fields-config.ts
+++ b/packages/core/src/config/additional-fields-config.ts
@@ -211,11 +211,18 @@ export function formatAdditionalFieldValue(value: unknown): string | undefined {
   if (value === null || value === undefined || value === "") return undefined
   if (value instanceof Date) return value.toLocaleString()
   if (typeof value === "string") {
+    const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+    if (dateOnly) {
+      const [, year, month, day] = dateOnly
+      return new Date(
+        Number(year),
+        Number(month) - 1,
+        Number(day)
+      ).toLocaleString()
+    }
+
     const parsed = new Date(value)
-    if (
-      /^\d{4}-\d{2}-\d{2}(T|$)/.test(value) &&
-      !Number.isNaN(parsed.getTime())
-    ) {
+    if (/^\d{4}-\d{2}-\d{2}T/.test(value) && !Number.isNaN(parsed.getTime())) {
       return parsed.toLocaleString()
     }
     return value

--- a/packages/core/src/plugins/organization/organization-plugin.ts
+++ b/packages/core/src/plugins/organization/organization-plugin.ts
@@ -93,8 +93,6 @@ export type OrganizationPluginOptions = {
     enabled?: boolean
     /** Resources and actions available in the role permission matrix. */
     permissions: OrganizationPermissionRegistry
-    /** Additional fields rendered when a dynamic role is created or edited. */
-    additionalFields?: AdditionalFields
   }
   slug?: string | null
   /**
@@ -104,6 +102,11 @@ export type OrganizationPluginOptions = {
   slugPrefix?: string
   /** Additional organization fields rendered during creation and profile editing. */
   additionalFields?: AdditionalFields
+  /**
+   * Additional fields grouped by the Better Auth organization model that
+   * owns them. `organization` overrides the legacy `additionalFields` array.
+   */
+  modelFields?: OrganizationAdditionalFields
   /** Maximum organizations the current user can create. */
   organizationLimit?: number
   /** Maximum members per organization. */
@@ -114,6 +117,19 @@ export type OrganizationPluginOptions = {
   allowOrganizationCreation?: boolean
   /** Enable Better Auth team management controls. @default false */
   teams?: boolean
+}
+
+export type OrganizationAdditionalFields = {
+  /** Fields rendered during organization creation and profile editing. */
+  organization?: AdditionalFields
+  /** Read-only member details returned by Better Auth member queries. */
+  member?: AdditionalFields
+  /** Fields rendered when an invitation is created. */
+  invitation?: AdditionalFields
+  /** Fields rendered when a team is created or edited. */
+  team?: AdditionalFields
+  /** Fields rendered when a dynamic organization role is created or edited. */
+  role?: AdditionalFields
 }
 
 export type OrganizationPermissionResource = {
@@ -158,13 +174,20 @@ export const organizationPlugin = createAuthPlugin(
         }),
         ...options.additionalRoles
       },
-      additionalFields: options.additionalFields ?? [],
+      additionalFields:
+        options.modelFields?.organization ?? options.additionalFields ?? [],
+      modelFields: {
+        organization:
+          options.modelFields?.organization ?? options.additionalFields ?? [],
+        member: options.modelFields?.member ?? [],
+        invitation: options.modelFields?.invitation ?? [],
+        team: options.modelFields?.team ?? [],
+        role: options.modelFields?.role ?? []
+      },
       dynamicAccessControl: options.dynamicAccessControl
         ? {
             enabled: options.dynamicAccessControl.enabled ?? true,
-            permissions: options.dynamicAccessControl.permissions,
-            additionalFields:
-              options.dynamicAccessControl.additionalFields ?? []
+            permissions: options.dynamicAccessControl.permissions
           }
         : undefined,
       organizationLimit: resolvePolicyLimit(options.organizationLimit),

--- a/packages/core/tests/additional-fields-config.test.ts
+++ b/packages/core/tests/additional-fields-config.test.ts
@@ -1,8 +1,10 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import {
   type AdditionalField,
+  fieldsWithModelValues,
   parseAdditionalFieldValue,
+  parseAdditionalFieldValues,
   resolveInputType
 } from "../src/config/additional-fields-config"
 
@@ -13,6 +15,36 @@ const baseField = (overrides: Partial<AdditionalField>): AdditionalField =>
     type: "string",
     ...overrides
   }) as AdditionalField
+
+describe("model field helpers", () => {
+  it("parses writable values, validates them, and omits read-only fields", async () => {
+    const validate = vi.fn()
+    const fields = [
+      baseField({ name: "title", validate }),
+      baseField({ name: "level", type: "number" }),
+      baseField({ name: "internal", readOnly: true })
+    ]
+    const formData = new FormData()
+    formData.set("title", "Engineer")
+    formData.set("level", "4")
+    formData.set("internal", "secret")
+
+    await expect(parseAdditionalFieldValues(fields, formData)).resolves.toEqual(
+      { title: "Engineer", level: 4 }
+    )
+    expect(validate).toHaveBeenCalledWith("Engineer")
+  })
+
+  it("seeds edit fields without mutating the configured fields", () => {
+    const fields = [baseField({ name: "color", defaultValue: "blue" })]
+
+    expect(fieldsWithModelValues(fields, { color: "green" })[0]).toMatchObject({
+      name: "color",
+      defaultValue: "green"
+    })
+    expect(fields[0]?.defaultValue).toBe("blue")
+  })
+})
 
 describe("parseAdditionalFieldValue", () => {
   describe("string", () => {

--- a/packages/core/tests/additional-fields-config.test.ts
+++ b/packages/core/tests/additional-fields-config.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest"
 import {
   type AdditionalField,
   fieldsWithModelValues,
+  formatAdditionalFieldValue,
   parseAdditionalFieldValue,
   parseAdditionalFieldValues,
   resolveInputType
@@ -43,6 +44,20 @@ describe("model field helpers", () => {
       defaultValue: "green"
     })
     expect(fields[0]?.defaultValue).toBe("blue")
+  })
+
+  it("formats date-only values as local calendar dates", () => {
+    const previousTimezone = process.env.TZ
+    process.env.TZ = "America/Los_Angeles"
+
+    try {
+      expect(formatAdditionalFieldValue("2024-06-15")).toBe(
+        new Date(2024, 5, 15).toLocaleString()
+      )
+    } finally {
+      if (previousTimezone === undefined) delete process.env.TZ
+      else process.env.TZ = previousTimezone
+    }
   })
 })
 

--- a/packages/core/tests/organization-plugin.test.ts
+++ b/packages/core/tests/organization-plugin.test.ts
@@ -38,9 +38,15 @@ describe("organizationPlugin", () => {
 
     expect(
       organizationPlugin({
-        dynamicAccessControl: { permissions, additionalFields }
+        dynamicAccessControl: { permissions },
+        modelFields: { role: additionalFields }
       }).dynamicAccessControl
-    ).toEqual({ enabled: true, permissions, additionalFields })
+    ).toEqual({ enabled: true, permissions })
+
+    expect(
+      organizationPlugin({ modelFields: { role: additionalFields } })
+        .modelFields.role
+    ).toEqual(additionalFields)
   })
 
   it("exposes team and policy controls", () => {
@@ -48,7 +54,7 @@ describe("organizationPlugin", () => {
       { name: "billingCode", label: "Billing code", type: "string" as const }
     ]
     const plugin = organizationPlugin({
-      additionalFields,
+      modelFields: { organization: additionalFields },
       allowOrganizationCreation: false,
       invitationLimit: 5,
       membershipLimit: 20,
@@ -58,6 +64,13 @@ describe("organizationPlugin", () => {
 
     expect(plugin).toMatchObject({
       additionalFields,
+      modelFields: {
+        organization: additionalFields,
+        member: [],
+        invitation: [],
+        team: [],
+        role: []
+      },
       allowOrganizationCreation: false,
       invitationLimit: 5,
       membershipLimit: 20,

--- a/packages/heroui/src/components/auth/organization/invite-member-dialog.tsx
+++ b/packages/heroui/src/components/auth/organization/invite-member-dialog.tsx
@@ -1,3 +1,4 @@
+import { parseAdditionalFieldValues } from "@better-auth-ui/core"
 import {
   mergeOrganizationRoleLabels,
   type OrganizationAuthClient
@@ -34,6 +35,7 @@ import {
 } from "react"
 
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
+import { AdditionalField } from "../additional-field"
 
 /** Props for the {@link InviteMemberDialog} component. */
 export type InviteMemberDialogProps = {
@@ -57,6 +59,7 @@ export function InviteMemberDialog({
 }: InviteMemberDialogProps) {
   const { authClient, localization } = useAuth()
   const {
+    modelFields: { invitation: invitationFields },
     dynamicAccessControl,
     invitationLimit,
     localization: organizationLocalization,
@@ -85,6 +88,7 @@ export function InviteMemberDialog({
     (invitations.data?.filter((invitation) => invitation.status === "pending")
       .length ?? 0) >= invitationLimit
   const [teamIds, setTeamIds] = useState<string[]>([])
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const activeOrganizationId = activeOrganization?.id
   const previousOrganizationId = useRef(activeOrganizationId)
 
@@ -125,25 +129,42 @@ export function InviteMemberDialog({
 
   const isRoleValid = selectedRoles.length > 0
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
+  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
     e.preventDefault()
 
     if (!activeOrganizationId || !isRoleValid || invitationLimitReached) return
 
-    const formData = new FormData(e.target as HTMLFormElement)
+    const formData = new FormData(e.currentTarget)
     const email = formData.get("email") as string
+
+    setIsSubmitting(true)
+    let invitationValues: Record<string, unknown>
+    try {
+      invitationValues = await parseAdditionalFieldValues(
+        invitationFields,
+        formData
+      )
+    } catch (error) {
+      toast.danger(error instanceof Error ? error.message : String(error))
+      setIsSubmitting(false)
+      return
+    }
 
     const availableTeamIds = new Set(teams.data?.map((team) => team.id))
     const selectedTeamIds = teamIds.filter((teamId) =>
       availableTeamIds.has(teamId)
     )
 
-    inviteMember({
-      email: email.trim(),
-      organizationId: activeOrganizationId,
-      role: selectedRoles as Parameters<typeof inviteMember>[0]["role"],
-      ...(selectedTeamIds.length ? { teamId: selectedTeamIds } : {})
-    })
+    inviteMember(
+      {
+        email: email.trim(),
+        organizationId: activeOrganizationId,
+        role: selectedRoles as Parameters<typeof inviteMember>[0]["role"],
+        ...(selectedTeamIds.length ? { teamId: selectedTeamIds } : {}),
+        ...invitationValues
+      },
+      { onSettled: () => setIsSubmitting(false) }
+    )
   }
 
   return (
@@ -177,7 +198,7 @@ export function InviteMemberDialog({
                 id="email"
                 name="email"
                 type="email"
-                isDisabled={isInviting}
+                isDisabled={isInviting || isSubmitting}
                 validate={(value) => {
                   if (!value) return localization.auth.fieldRequired
                   if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
@@ -208,7 +229,7 @@ export function InviteMemberDialog({
 
                   setSelectedRoles(next)
                 }}
-                isDisabled={isInviting}
+                isDisabled={isInviting || isSubmitting}
                 variant="secondary"
                 fullWidth
               >
@@ -255,19 +276,34 @@ export function InviteMemberDialog({
                   </div>
                 </div>
               )}
+              {invitationFields.map((field) => (
+                <AdditionalField
+                  key={field.name}
+                  field={field}
+                  name={field.name}
+                  isPending={isInviting || isSubmitting}
+                  optionalLabel={localization.settings.optional}
+                />
+              ))}
             </AlertDialog.Body>
 
             <AlertDialog.Footer>
-              <Button slot="close" variant="tertiary" isDisabled={isInviting}>
+              <Button
+                slot="close"
+                variant="tertiary"
+                isDisabled={isInviting || isSubmitting}
+              >
                 {localization.settings.cancel}
               </Button>
 
               <Button
                 type="submit"
-                isPending={isInviting}
+                isPending={isInviting || isSubmitting}
                 isDisabled={!isRoleValid || invitationLimitReached}
               >
-                {isInviting && <Spinner color="current" size="sm" />}
+                {(isInviting || isSubmitting) && (
+                  <Spinner color="current" size="sm" />
+                )}
 
                 {organizationLocalization.inviteMember}
               </Button>

--- a/packages/heroui/src/components/auth/organization/invite-member-dialog.tsx
+++ b/packages/heroui/src/components/auth/organization/invite-member-dialog.tsx
@@ -135,7 +135,14 @@ export function InviteMemberDialog({
     if (!activeOrganizationId || !isRoleValid || invitationLimitReached) return
 
     const formData = new FormData(e.currentTarget)
-    const email = formData.get("email") as string
+    const invitationEmail = (formData.get("email") as string).trim()
+    const invitationRoles = [...selectedRoles] as Parameters<
+      typeof inviteMember
+    >[0]["role"]
+    const availableTeamIds = new Set(teams.data?.map((team) => team.id))
+    const selectedTeamIds = teamIds.filter((teamId) =>
+      availableTeamIds.has(teamId)
+    )
 
     setIsSubmitting(true)
     let invitationValues: Record<string, unknown>
@@ -150,18 +157,13 @@ export function InviteMemberDialog({
       return
     }
 
-    const availableTeamIds = new Set(teams.data?.map((team) => team.id))
-    const selectedTeamIds = teamIds.filter((teamId) =>
-      availableTeamIds.has(teamId)
-    )
-
     inviteMember(
       {
-        email: email.trim(),
+        ...invitationValues,
+        email: invitationEmail,
         organizationId: activeOrganizationId,
-        role: selectedRoles as Parameters<typeof inviteMember>[0]["role"],
-        ...(selectedTeamIds.length ? { teamId: selectedTeamIds } : {}),
-        ...invitationValues
+        role: invitationRoles,
+        ...(selectedTeamIds.length ? { teamId: selectedTeamIds } : {})
       },
       { onSettled: () => setIsSubmitting(false) }
     )

--- a/packages/heroui/src/components/auth/organization/organization-invitation-row.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-invitation-row.tsx
@@ -117,12 +117,6 @@ export function OrganizationInvitationTableRow({
               isPending={resendPending}
               onPress={() =>
                 resendInvitation({
-                  email: invitation.email,
-                  organizationId: invitation.organizationId,
-                  role: invitation.role as Parameters<
-                    typeof resendInvitation
-                  >[0]["role"],
-                  resend: true,
                   ...Object.fromEntries(
                     invitationFields.flatMap((field) => {
                       const value = (
@@ -130,7 +124,13 @@ export function OrganizationInvitationTableRow({
                       )[field.name]
                       return value === undefined ? [] : [[field.name, value]]
                     })
-                  )
+                  ),
+                  email: invitation.email,
+                  organizationId: invitation.organizationId,
+                  role: invitation.role as Parameters<
+                    typeof resendInvitation
+                  >[0]["role"],
+                  resend: true
                 })
               }
               aria-label={organizationLocalization.resendInvitation}

--- a/packages/heroui/src/components/auth/organization/organization-invitation-row.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-invitation-row.tsx
@@ -1,3 +1,4 @@
+import { formatAdditionalFieldValue } from "@better-auth-ui/core"
 import {
   memberRoleLabels,
   type OrganizationAuthClient
@@ -24,8 +25,11 @@ export function OrganizationInvitationTableRow({
   invitation
 }: OrganizationInvitationTableRowProps) {
   const { authClient } = useAuth()
-  const { localization: organizationLocalization, roles } =
-    useAuthPlugin(organizationPlugin)
+  const {
+    modelFields: { invitation: invitationFields },
+    localization: organizationLocalization,
+    roles
+  } = useAuthPlugin(organizationPlugin)
 
   const {
     data: cancelInvitationPermission,
@@ -72,8 +76,20 @@ export function OrganizationInvitationTableRow({
 
   return (
     <Table.Row>
-      <Table.Cell className="font-medium text-sm">
-        {invitation.email}
+      <Table.Cell>
+        <div className="flex flex-col gap-1">
+          <span className="font-medium text-sm">{invitation.email}</span>
+          {invitationFields.map((field) => {
+            const value = formatAdditionalFieldValue(
+              (invitation as unknown as Record<string, unknown>)[field.name]
+            )
+            return value ? (
+              <span className="text-muted text-xs" key={field.name}>
+                {field.label}: {value}
+              </span>
+            ) : null
+          })}
+        </div>
       </Table.Cell>
 
       <Table.Cell className="text-muted text-xs tabular-nums whitespace-nowrap">
@@ -106,7 +122,15 @@ export function OrganizationInvitationTableRow({
                   role: invitation.role as Parameters<
                     typeof resendInvitation
                   >[0]["role"],
-                  resend: true
+                  resend: true,
+                  ...Object.fromEntries(
+                    invitationFields.flatMap((field) => {
+                      const value = (
+                        invitation as unknown as Record<string, unknown>
+                      )[field.name]
+                      return value === undefined ? [] : [[field.name, value]]
+                    })
+                  )
                 })
               }
               aria-label={organizationLocalization.resendInvitation}

--- a/packages/heroui/src/components/auth/organization/organization-member-row.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-member-row.tsx
@@ -1,3 +1,4 @@
+import { formatAdditionalFieldValue } from "@better-auth-ui/core"
 import {
   memberRoleLabels,
   mergeOrganizationRoleLabels,
@@ -34,6 +35,7 @@ export function OrganizationMemberRow({
 }: OrganizationMemberRowProps) {
   const { authClient } = useAuth()
   const {
+    modelFields: { member: memberFields },
     dynamicAccessControl,
     localization: organizationLocalization,
     roles
@@ -85,7 +87,19 @@ export function OrganizationMemberRow({
   return (
     <Table.Row>
       <Table.Cell>
-        <UserView user={member.user} />
+        <div className="flex flex-col gap-1">
+          <UserView user={member.user} />
+          {memberFields.map((field) => {
+            const value = formatAdditionalFieldValue(
+              (member as unknown as Record<string, unknown>)[field.name]
+            )
+            return value ? (
+              <span className="text-muted text-xs" key={field.name}>
+                {field.label}: {value}
+              </span>
+            ) : null
+          })}
+        </div>
       </Table.Cell>
 
       <Table.Cell>{roleLabel}</Table.Cell>

--- a/packages/heroui/src/components/auth/organization/organization-roles.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-roles.tsx
@@ -1,3 +1,8 @@
+import {
+  type AdditionalFields,
+  fieldsWithModelValues,
+  parseAdditionalFieldValues
+} from "@better-auth-ui/core"
 import type {
   OrganizationAuthClient,
   OrganizationPermissionRegistry
@@ -27,11 +32,13 @@ import {
 } from "@heroui/react"
 import { type FormEvent, useEffect, useState } from "react"
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
+import { AdditionalField } from "../additional-field"
 
 type Role = {
   id: string
   role: string
   permission: Record<string, string[]>
+  [key: string]: unknown
 }
 
 export function OrganizationRoles({
@@ -41,7 +48,7 @@ export function OrganizationRoles({
 }) {
   const { authClient } = useAuth()
   const client = authClient as OrganizationAuthClient
-  const { dynamicAccessControl, localization } =
+  const { dynamicAccessControl, localization, modelFields } =
     useAuthPlugin(organizationPlugin)
   const roles = useListRoles(client, {
     query: { organizationId },
@@ -134,6 +141,7 @@ export function OrganizationRoles({
         onOpenChange={(open) => !open && setEditingRole(undefined)}
         organizationId={organizationId}
         registry={dynamicAccessControl?.permissions ?? {}}
+        roleFields={modelFields.role}
         role={editingRole ?? undefined}
       />
     </div>
@@ -226,19 +234,22 @@ function RoleDialog({
   onOpenChange,
   organizationId,
   registry,
-  role
+  role,
+  roleFields
 }: {
   isOpen: boolean
   onOpenChange: (open: boolean) => void
   organizationId: string
   registry: OrganizationPermissionRegistry
   role?: Role
+  roleFields: AdditionalFields
 }) {
   const { authClient, localization: authLocalization } = useAuth()
   const client = authClient as OrganizationAuthClient
   const { localization } = useAuthPlugin(organizationPlugin)
   const [name, setName] = useState("")
   const [permission, setPermission] = useState<Record<string, string[]>>({})
+  const [isSubmitting, setIsSubmitting] = useState(false)
   const createRole = useCreateRole(client, organizationId, {
     onSuccess: () => {
       toast.success(localization.roleCreated)
@@ -258,23 +269,44 @@ function RoleDialog({
     setPermission(role?.permission ?? {})
   }, [isOpen, role])
 
-  const submit = (event: FormEvent<HTMLFormElement>) => {
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const roleName = name.trim()
     if (!roleName) return
 
-    if (role) {
-      updateRole.mutate({
-        organizationId,
-        roleId: role.id,
-        data: { roleName, permission }
-      })
-    } else {
-      createRole.mutate({ organizationId, role: roleName, permission })
+    setIsSubmitting(true)
+    try {
+      const additionalFields = await parseAdditionalFieldValues(
+        roleFields,
+        new FormData(event.currentTarget)
+      )
+      if (role) {
+        updateRole.mutate(
+          {
+            organizationId,
+            roleId: role.id,
+            data: { ...additionalFields, roleName, permission }
+          },
+          { onSettled: () => setIsSubmitting(false) }
+        )
+      } else {
+        createRole.mutate(
+          {
+            organizationId,
+            role: roleName,
+            permission,
+            additionalFields
+          },
+          { onSettled: () => setIsSubmitting(false) }
+        )
+      }
+    } catch (error) {
+      toast.danger(error instanceof Error ? error.message : String(error))
+      setIsSubmitting(false)
     }
   }
 
-  const pending = createRole.isPending || updateRole.isPending
+  const pending = createRole.isPending || updateRole.isPending || isSubmitting
 
   return (
     <AlertDialog.Backdrop isOpen={isOpen} onOpenChange={onOpenChange}>
@@ -300,6 +332,15 @@ function RoleDialog({
                   variant="secondary"
                 />
               </TextField>
+              {fieldsWithModelValues(roleFields, role ?? {}).map((field) => (
+                <AdditionalField
+                  key={field.name}
+                  field={field}
+                  name={field.name}
+                  isPending={pending}
+                  optionalLabel={authLocalization.settings.optional}
+                />
+              ))}
               <fieldset className="flex flex-col gap-4">
                 <legend className="mb-3 text-sm font-medium">
                   {localization.permissions}

--- a/packages/heroui/src/components/auth/organization/organization-teams.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-teams.tsx
@@ -1,3 +1,8 @@
+import {
+  type AdditionalFields,
+  fieldsWithModelValues,
+  parseAdditionalFieldValues
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
@@ -25,13 +30,15 @@ import {
 } from "@heroui/react"
 import { type FormEvent, useState } from "react"
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
+import { AdditionalField } from "../additional-field"
 
 export function OrganizationTeams() {
-  const { authClient } = useAuth()
+  const { authClient, localization } = useAuth()
   const { data: activeOrganization } = useActiveOrganization(
     authClient as OrganizationAuthClient
   )
-  const { localization: labels } = useAuthPlugin(organizationPlugin)
+  const { localization: labels, modelFields } =
+    useAuthPlugin(organizationPlugin)
   const client = authClient as OrganizationAuthClient
   const teams = useListTeams(client, {
     query: { organizationId: activeOrganization?.id }
@@ -40,28 +47,63 @@ export function OrganizationTeams() {
   const createTeam = useCreateTeam(client, {
     onSuccess: () => toast.success(labels.teamCreated)
   })
-  const submit = (event: FormEvent<HTMLFormElement>) => {
+  const [isCreatingFields, setIsCreatingFields] = useState(false)
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const name = String(
       new FormData(event.currentTarget).get("name") ?? ""
     ).trim()
-    if (name && activeOrganization) {
-      createTeam.mutate({ name, organizationId: activeOrganization.id })
+    if (!name || !activeOrganization) return
+
+    setIsCreatingFields(true)
+    try {
+      const values = await parseAdditionalFieldValues(
+        modelFields.team,
+        new FormData(event.currentTarget)
+      )
+      const form = event.currentTarget
+      createTeam.mutate(
+        { ...values, name, organizationId: activeOrganization.id },
+        {
+          onSuccess: () => form.reset(),
+          onSettled: () => setIsCreatingFields(false)
+        }
+      )
+    } catch (error) {
+      toast.danger(error instanceof Error ? error.message : String(error))
+      setIsCreatingFields(false)
     }
-    event.currentTarget.reset()
   }
 
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-end justify-between gap-3">
         <h2 className="text-sm font-semibold">{labels.teams}</h2>
-        <Form className="flex items-end gap-2" onSubmit={submit}>
+        <Form
+          className="grid w-full gap-3 sm:max-w-xl sm:grid-cols-2"
+          onSubmit={submit}
+        >
           <TextField name="name" isDisabled={createTeam.isPending}>
             <Label>{labels.name}</Label>
             <Input variant="secondary" required />
           </TextField>
-          <Button type="submit" isPending={createTeam.isPending}>
-            {createTeam.isPending && <Spinner color="current" size="sm" />}
+          {modelFields.team.map((field) => (
+            <AdditionalField
+              key={field.name}
+              field={field}
+              name={field.name}
+              isPending={createTeam.isPending || isCreatingFields}
+              optionalLabel={localization.settings.optional}
+            />
+          ))}
+          <Button
+            className="self-end"
+            type="submit"
+            isPending={createTeam.isPending || isCreatingFields}
+          >
+            {(createTeam.isPending || isCreatingFields) && (
+              <Spinner color="current" size="sm" />
+            )}
             {labels.createTeam}
           </Button>
         </Form>
@@ -75,6 +117,7 @@ export function OrganizationTeams() {
             team={team}
             organizationId={activeOrganization?.id ?? ""}
             organizationMembers={members.data?.members ?? []}
+            teamFields={modelFields.team}
           />
         ))
       ) : (
@@ -92,20 +135,23 @@ export function OrganizationTeams() {
 function TeamCard({
   team,
   organizationId,
-  organizationMembers
+  organizationMembers,
+  teamFields
 }: {
-  team: { id: string; name: string }
+  team: { id: string; name: string; [key: string]: unknown }
   organizationId: string
   organizationMembers: Array<{
     userId: string
     user: { name: string; email: string }
   }>
+  teamFields: AdditionalFields
 }) {
   const { authClient, localization } = useAuth()
   const { localization: labels } = useAuthPlugin(organizationPlugin)
   const client = authClient as OrganizationAuthClient
   const teamMembers = useListTeamMembers(client, { query: { teamId: team.id } })
   const [name, setName] = useState(team.name)
+  const [isUpdatingFields, setIsUpdatingFields] = useState(false)
   const [userId, setUserId] = useState<string>()
   const updateTeam = useUpdateTeam(client)
   const removeTeam = useRemoveTeam(client)
@@ -114,11 +160,34 @@ function TeamCard({
   })
   const removeMember = useRemoveTeamMember(client)
   const memberIds = new Set(teamMembers.data?.map((member) => member.userId))
+  const submitUpdate = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setIsUpdatingFields(true)
+    try {
+      const values = await parseAdditionalFieldValues(
+        teamFields,
+        new FormData(event.currentTarget)
+      )
+      updateTeam.mutate(
+        {
+          teamId: team.id,
+          data: { ...values, name, organizationId }
+        },
+        { onSettled: () => setIsUpdatingFields(false) }
+      )
+    } catch (error) {
+      toast.danger(error instanceof Error ? error.message : String(error))
+      setIsUpdatingFields(false)
+    }
+  }
 
   return (
     <Card>
       <Card.Content className="gap-4">
-        <div className="flex items-end gap-2">
+        <Form
+          className="grid items-end gap-3 sm:grid-cols-2"
+          onSubmit={submitUpdate}
+        >
           <TextField className="flex-1">
             <Label>{labels.name}</Label>
             <Input
@@ -127,18 +196,24 @@ function TeamCard({
               variant="secondary"
             />
           </TextField>
+          {fieldsWithModelValues(teamFields, team).map((field) => (
+            <AdditionalField
+              key={field.name}
+              field={field}
+              name={field.name}
+              isPending={updateTeam.isPending || isUpdatingFields}
+              optionalLabel={localization.settings.optional}
+            />
+          ))}
           <Button
+            type="submit"
             variant="outline"
-            onPress={() =>
-              updateTeam.mutate({
-                teamId: team.id,
-                data: { name, organizationId }
-              })
-            }
+            isDisabled={updateTeam.isPending || isUpdatingFields}
           >
             {localization.settings.saveChanges}
           </Button>
           <Button
+            type="button"
             variant="danger-soft"
             onPress={() =>
               removeTeam.mutate({ teamId: team.id, organizationId })
@@ -146,7 +221,7 @@ function TeamCard({
           >
             {labels.deleteTeam}
           </Button>
-        </div>
+        </Form>
         <div className="flex items-end gap-2">
           <Select
             className="flex-1"


### PR DESCRIPTION
## Summary

- add field groups for organization, member, invitation, team, and dynamic-role models
- reuse the existing additional-field renderer and validation flow across every UI package
- include model fields in create, edit, and invitation mutation payloads
- preserve the legacy organization-only additionalFields configuration

## Validation

- core unit tests
- package typechecks
- registry builds
- Biome and project lint

This is PR 3 of 5 in native GitHub stack #502 and depends on #498.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable model-specific fields for organizations, members, invitations, teams, and roles.
  - Custom fields now appear in relevant create, edit, invitation, profile, and read-only views.
  - Invitation resending preserves configured field values.
  - Added validation, formatted value display, and support for field types such as textareas.
  - Forms provide loading states, disable controls during submission, and show validation errors.

- **Documentation**
  - Updated organization plugin guidance with model field configuration and workflow details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->