### PR TITLE
feat(billing): add provider adapters

### DIFF
--- a/apps/docs/content/docs/heroui/plugins/billing.mdx
+++ b/apps/docs/content/docs/heroui/plugins/billing.mdx
@@ -7,7 +7,7 @@ description: Add provider-neutral pricing, subscriptions, checkout, seats, usage
 import { Callout } from "fumadocs-ui/components/callout"
 import { Step, Steps } from "fumadocs-ui/components/steps"
 
-The billing plugin adds a complete billing tab to personal or organization settings. Its components use a generic `BillingAdapter`, so the UI does not depend on provider-specific objects. BAUI includes adapters for Better Auth's Stripe and Polar plugins.
+The billing plugin adds a complete billing tab to personal or organization settings. Its components use a generic `BillingAdapter`, so the UI does not depend on provider-specific objects. BAUI includes adapters for Stripe, Polar, Autumn, Creem, Dodo Payments, and Commet.
 
 The billing view includes pricing plans, checkout, subscription status, portal access, cancellation, restoration, seats, and metered usage.
 
@@ -17,7 +17,9 @@ The billing view includes pricing plans, checkout, subscription status, portal a
 <Step>
 ### Configure billing in Better Auth
 
-Install and configure the [Better Auth Stripe plugin](https://www.better-auth.com/docs/beta/plugins/stripe) or the [Better Auth Polar plugin](https://www.better-auth.com/docs/plugins/polar). Add its client plugin to your Better Auth client and apply its database schema.
+Configure one of Better Auth's supported billing plugins. Add its client plugin and apply its database schema.
+
+See the provider guides for [Stripe](https://www.better-auth.com/docs/beta/plugins/stripe), [Polar](https://www.better-auth.com/docs/plugins/polar), [Autumn](https://www.better-auth.com/docs/plugins/autumn), [Creem](https://www.better-auth.com/docs/plugins/creem), [Dodo Payments](https://docs.dodopayments.com/developer-resources/better-auth-adaptor), and [Commet](https://www.better-auth.com/docs/plugins/commet).
 
 </Step>
 <Step>
@@ -110,6 +112,70 @@ export const billingAdapter = createPolarBillingAdapter(authClient, {
 
 Polar handles cancellation, restoration, and seat changes in its customer portal. Its adapter marks those direct actions as unsupported, so BAUI shows a manage-billing action instead. Stripe uses Better Auth's subscription endpoints.
 
+## Other bundled adapters
+
+| Adapter | Checkout and state | Direct actions | Scope |
+| --- | --- | --- | --- |
+| Stripe | Better Auth subscription API | Cancel, restore, seats | User and explicit organization |
+| Polar | Checkout, subscriptions, usage | Portal fallback | User and explicit organization |
+| Autumn | Attach, customer subscriptions, balances | Cancel, restore, optional license seats | User |
+| Creem | Checkout and active subscription | Cancel | User |
+| Dodo Payments | Checkout session and subscription list | Portal fallback | User |
+| Commet | Portal and current subscription | Cancel, optional feature usage and seats | User |
+
+```ts title="lib/billing.ts"
+import {
+  createAutumnBillingAdapter,
+  createCommetBillingAdapter,
+  createCreemBillingAdapter,
+  createDodoPaymentsBillingAdapter
+} from "@better-auth-ui/core/plugins/billing"
+import { createAutumnClient } from "autumn-js/react"
+
+const urls = {
+  successUrl: "/settings/billing?checkout=success",
+  cancelUrl: "/settings/billing?checkout=canceled",
+  returnUrl: "/settings/billing"
+}
+
+const autumnClient = createAutumnClient({
+  pathPrefix: "/api/auth/autumn",
+  includeCredentials: true
+})
+
+export const autumnAdapter = createAutumnBillingAdapter(autumnClient, {
+  plans,
+  seatLicensePlans: { pro: "team-seat" },
+  ...urls
+})
+
+export const creemAdapter = createCreemBillingAdapter(authClient, {
+  plans,
+  products: { pro: "prod_creem_pro" },
+  ...urls
+})
+
+export const dodoAdapter = createDodoPaymentsBillingAdapter(authClient, {
+  plans,
+  products: { pro: { type: "slug", value: "pro" } },
+  ...urls
+})
+
+export const commetAdapter = createCommetBillingAdapter(authClient, {
+  plans,
+  planIds: { pro: "commet-plan-id" },
+  usage: true,
+  seatFeatureCode: "members",
+  ...urls
+})
+```
+
+Enable the matching provider sub-plugins. Dodo needs checkout and portal. Commet needs portal and subscriptions, plus features or seats when you enable those adapter options.
+
+<Callout type="warn" title="User-only provider clients">
+Autumn, Creem, Dodo Payments, and Commet resolve the signed-in customer. Their browser APIs do not accept an explicit organization ID. Their adapters declare `scopes.organization: false`. `billingPlugin` rejects an organization billing configuration instead of reading active organization state.
+</Callout>
+
 ## Custom adapter
 
 Implement `BillingAdapter` to connect another billing service. The adapter receives an explicit user or organization scope for every operation.
@@ -119,6 +185,7 @@ import type { BillingAdapter } from "@better-auth-ui/core/plugins/billing"
 
 export const billingAdapter: BillingAdapter = {
   id: "custom",
+  scopes: { user: true, organization: true },
   supports: { cancel: true, restore: true, seats: true },
   listPlans: async (scope, signal) => billingApi.listPlans(scope, signal),
   getState: async (scope, signal) => billingApi.getState(scope, signal),

--- a/apps/docs/content/docs/shadcn/plugins/billing.mdx
+++ b/apps/docs/content/docs/shadcn/plugins/billing.mdx
@@ -7,7 +7,7 @@ description: Add pricing, subscriptions, checkout, seats, usage, and billing man
 import { Callout } from "fumadocs-ui/components/callout"
 import { Step, Steps } from "fumadocs-ui/components/steps"
 
-The billing plugin adds a complete billing tab to personal or organization settings. Every component reads a provider-neutral `BillingAdapter`. BAUI includes adapters for Better Auth's Stripe and Polar plugins, and you can implement the same interface for another billing service.
+The billing plugin adds a complete billing tab to personal or organization settings. Every component reads a provider-neutral `BillingAdapter`. BAUI includes adapters for Stripe, Polar, Autumn, Creem, Dodo Payments, and Commet.
 
 The UI includes:
 
@@ -26,7 +26,9 @@ The UI includes:
 <Step>
 ### Configure a Better Auth billing plugin
 
-Use the [Better Auth Stripe plugin](https://www.better-auth.com/docs/beta/plugins/stripe) or the [Better Auth Polar plugin](https://www.better-auth.com/docs/plugins/polar) on the server and client. Apply the plugin's database schema before you open the billing page.
+Configure one of Better Auth's supported billing plugins on the server and client. Apply its database schema before you open the billing page.
+
+See the provider guides for [Stripe](https://www.better-auth.com/docs/beta/plugins/stripe), [Polar](https://www.better-auth.com/docs/plugins/polar), [Autumn](https://www.better-auth.com/docs/plugins/autumn), [Creem](https://www.better-auth.com/docs/plugins/creem), [Dodo Payments](https://docs.dodopayments.com/developer-resources/better-auth-adaptor), and [Commet](https://www.better-auth.com/docs/plugins/commet).
 
 </Step>
 <Step>
@@ -128,6 +130,72 @@ export const billingAdapter = createPolarBillingAdapter(authClient, {
 
 Polar handles cancellation, restoration, and seat changes in its customer portal. Its adapter marks those direct actions as unsupported, so BAUI shows a manage-billing action instead. Stripe performs the actions through Better Auth's subscription endpoints.
 
+## Other bundled adapters
+
+Each adapter reflects the official client API. It does not claim support for actions that the provider handles in its portal.
+
+| Adapter | Checkout and state | Direct actions | Scope |
+| --- | --- | --- | --- |
+| Stripe | Better Auth subscription API | Cancel, restore, seats | User and explicit organization |
+| Polar | Checkout, subscriptions, usage | Portal fallback | User and explicit organization |
+| Autumn | Attach, customer subscriptions, balances | Cancel, restore, optional license seats | User |
+| Creem | Checkout and active subscription | Cancel | User |
+| Dodo Payments | Checkout session and subscription list | Portal fallback | User |
+| Commet | Portal and current subscription | Cancel, optional feature usage and seats | User |
+
+```ts title="lib/billing.ts"
+import {
+  createAutumnBillingAdapter,
+  createCommetBillingAdapter,
+  createCreemBillingAdapter,
+  createDodoPaymentsBillingAdapter
+} from "@better-auth-ui/core/plugins/billing"
+import { createAutumnClient } from "autumn-js/react"
+
+const urls = {
+  successUrl: "/settings/billing?checkout=success",
+  cancelUrl: "/settings/billing?checkout=canceled",
+  returnUrl: "/settings/billing"
+}
+
+const autumnClient = createAutumnClient({
+  pathPrefix: "/api/auth/autumn",
+  includeCredentials: true
+})
+
+export const autumnAdapter = createAutumnBillingAdapter(autumnClient, {
+  plans,
+  seatLicensePlans: { pro: "team-seat" },
+  ...urls
+})
+
+export const creemAdapter = createCreemBillingAdapter(authClient, {
+  plans,
+  products: { pro: "prod_creem_pro" },
+  ...urls
+})
+
+export const dodoAdapter = createDodoPaymentsBillingAdapter(authClient, {
+  plans,
+  products: { pro: { type: "slug", value: "pro" } },
+  ...urls
+})
+
+export const commetAdapter = createCommetBillingAdapter(authClient, {
+  plans,
+  planIds: { pro: "commet-plan-id" },
+  usage: true,
+  seatFeatureCode: "members",
+  ...urls
+})
+```
+
+Enable the matching provider sub-plugins. Dodo needs checkout and portal. Commet needs portal and subscriptions, plus features or seats when you enable those adapter options.
+
+<Callout type="warn" title="User-only provider clients">
+Autumn, Creem, Dodo Payments, and Commet resolve the signed-in customer. Their browser APIs do not accept an explicit organization ID. Their adapters declare `scopes.organization: false`. `billingPlugin` rejects an organization billing configuration instead of reading active organization state.
+</Callout>
+
 ## Custom adapters
 
 Implement `BillingAdapter` when you use another provider. Keep provider SDK objects inside the adapter and return only BAUI's generic plan, subscription, usage, and action types.
@@ -137,6 +205,7 @@ import type { BillingAdapter } from "@better-auth-ui/core/plugins/billing"
 
 export const billingAdapter: BillingAdapter = {
   id: "custom",
+  scopes: { user: true, organization: true },
   supports: { cancel: true, restore: true, seats: true },
   listPlans: async (scope, signal) => billingApi.listPlans(scope, signal),
   getState: async (scope, signal) => billingApi.getState(scope, signal),

--- a/apps/docs/content/docs/zaidan/plugins/billing.mdx
+++ b/apps/docs/content/docs/zaidan/plugins/billing.mdx
@@ -7,7 +7,7 @@ description: Add plans, subscriptions, checkout, seats, and usage to Solid/Zaida
 import { Callout } from 'fumadocs-ui/components/callout'
 import { Step, Steps } from 'fumadocs-ui/components/steps'
 
-The billing plugin adds a billing tab to personal or organization settings. Every view reads a provider-neutral `BillingAdapter`, so the same UI works against Stripe, Polar, or anything else you write an adapter for.
+The billing plugin adds a billing tab to personal or organization settings. Every view reads a provider-neutral `BillingAdapter`. BAUI includes adapters for Stripe, Polar, Autumn, Creem, Dodo Payments, and Commet.
 
 The UI covers:
 
@@ -25,7 +25,9 @@ The UI covers:
 <Step>
 ### Configure a Better Auth billing plugin
 
-Use the [Better Auth Stripe plugin](https://www.better-auth.com/docs/beta/plugins/stripe) or the [Better Auth Polar plugin](https://www.better-auth.com/docs/plugins/polar) on the server and client, and apply its schema before opening the billing page.
+Configure one of Better Auth's supported billing plugins on the server and client. Apply its schema before you open the billing page.
+
+See the provider guides for [Stripe](https://www.better-auth.com/docs/beta/plugins/stripe), [Polar](https://www.better-auth.com/docs/plugins/polar), [Autumn](https://www.better-auth.com/docs/plugins/autumn), [Creem](https://www.better-auth.com/docs/plugins/creem), [Dodo Payments](https://docs.dodopayments.com/developer-resources/better-auth-adaptor), and [Commet](https://www.better-auth.com/docs/plugins/commet).
 
 </Step>
 <Step>
@@ -39,7 +41,7 @@ npx shadcn@latest add https://better-auth-ui.com/r/solid/billing.json
 <Step>
 ### Register the plugin
 
-Build an adapter and hand it to the plugin. BAUI ships `createStripeBillingAdapter` and `createPolarBillingAdapter`.
+Build an adapter and hand it to the plugin.
 
 ```tsx title="src/components/providers.tsx"
 import { createStripeBillingAdapter } from "@better-auth-ui/core/plugins/billing" // [!code highlight]
@@ -47,7 +49,12 @@ import { AuthProvider } from "@/components/auth/auth-provider"
 import { billingPlugin } from "@/lib/auth/billing-plugin" // [!code highlight]
 import { authClient } from "@/lib/auth-client"
 
-const billingAdapter = createStripeBillingAdapter(authClient) // [!code highlight]
+const billingAdapter = createStripeBillingAdapter(authClient, {
+  plans,
+  successUrl: "/settings/billing?checkout=success",
+  cancelUrl: "/settings/billing?checkout=canceled",
+  returnUrl: "/settings/billing"
+}) // [!code highlight]
 
 export function Providers(props: { children?: JSX.Element }) {
   return (
@@ -68,6 +75,23 @@ export function Providers(props: { children?: JSX.Element }) {
 
 </Step>
 </Steps>
+
+## Bundled adapters
+
+| Adapter | Checkout and state | Direct actions | Scope |
+| --- | --- | --- | --- |
+| Stripe | Better Auth subscription API | Cancel, restore, seats | User and explicit organization |
+| Polar | Checkout, subscriptions, usage | Portal fallback | User and explicit organization |
+| Autumn | Attach, customer subscriptions, balances | Cancel, restore, optional license seats | User |
+| Creem | Checkout and active subscription | Cancel | User |
+| Dodo Payments | Checkout session and subscription list | Portal fallback | User |
+| Commet | Portal and current subscription | Cancel, optional feature usage and seats | User |
+
+The factories are `createStripeBillingAdapter`, `createPolarBillingAdapter`, `createAutumnBillingAdapter`, `createCreemBillingAdapter`, `createDodoPaymentsBillingAdapter`, and `createCommetBillingAdapter`. They use the same `BillingPlan` list and work with both React and Solid billing hooks.
+
+<Callout type="warn" title="User-only provider clients">
+Autumn, Creem, Dodo Payments, and Commet resolve the signed-in customer. Their browser APIs do not accept an explicit organization ID. Their adapters declare `scopes.organization: false`. `billingPlugin` rejects an organization billing configuration instead of reading active organization state.
+</Callout>
 
 <Callout type="info">
   The adapter's `supports` flags decide which controls render. A provider that cannot restore a canceled subscription does not show the restore button.

--- a/bun.lock
+++ b/bun.lock
@@ -401,9 +401,14 @@
         "@better-auth/passkey": "1.7.0",
         "@better-auth/sso": "1.7.0",
         "@better-auth/stripe": "1.7.0",
+        "@commet/better-auth": "8.1.0",
+        "@commet/node": "9.1.0",
+        "@creem_io/better-auth": "1.1.4",
+        "@dodopayments/better-auth": "1.6.5",
         "@mikkelscheike/email-provider-links": "5.2.1",
         "@polar-sh/better-auth": "1.7.0",
         "@tanstack/query-core": "^5.101.2",
+        "autumn-js": "1.2.53",
         "better-auth": "1.7.0",
         "vitest": "^4.1.9",
       },
@@ -414,9 +419,13 @@
         "@better-auth/passkey": ">=1.7.0",
         "@better-auth/sso": ">=1.7.0",
         "@better-auth/stripe": ">=1.7.0",
+        "@commet/better-auth": ">=8.1.0",
+        "@creem_io/better-auth": ">=1.1.4",
+        "@dodopayments/better-auth": ">=1.6.5",
         "@mikkelscheike/email-provider-links": ">=5.2.1",
         "@polar-sh/better-auth": ">=1.7.0",
         "@tanstack/query-core": ">=5.101.2",
+        "autumn-js": ">=1.2.53",
         "better-auth": ">=1.7.0",
       },
       "optionalPeers": [
@@ -425,7 +434,11 @@
         "@better-auth/passkey",
         "@better-auth/sso",
         "@better-auth/stripe",
+        "@commet/better-auth",
+        "@creem_io/better-auth",
+        "@dodopayments/better-auth",
         "@polar-sh/better-auth",
+        "autumn-js",
       ],
     },
     "packages/heroui": {
@@ -822,15 +835,27 @@
 
     "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260801.1", "", { "os": "win32", "cpu": "x64" }, "sha512-2oQz+Ksu4ji6e/+ZoYX+tWQEcxAii2p7l+iR8kx48W1llMalaufAsmVxTlk+3/vrM7D3/2c0iK448e0UQTcIMg=="],
 
+    "@commet/better-auth": ["@commet/better-auth@8.1.0", "", { "peerDependencies": { "@commet/node": ">=9.1.0 <10.0.0", "better-auth": ">=1.5.6", "better-call": ">=1.3.2", "zod": ">=3.24.2" } }, "sha512-ceBiW3vVuzCJll78igeFeoJijMxgO9Exyk4X9i0gfweCCf3X+g9NHRgb4lO6reahYaYP3OHpwh7YCoMmHnFk0Q=="],
+
+    "@commet/node": ["@commet/node@9.1.0", "", { "peerDependencies": { "typescript": ">=5.0.0" } }, "sha512-Xpmsrmi17qtBCC1/A0Q8omh6EVjhFJpWgcjshXBITxzR0XQsxjQUqb/J6NV1vpRov9bqNYRbXeWb4xEa6fhEsg=="],
+
     "@corvu/calendar": ["@corvu/calendar@0.1.2", "", { "dependencies": { "@corvu/utils": "~0.4.2" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-Vbdns1iNNI0WTIwDZS7m9pHWtr/YTz7yrisXhHUCfl4mxDvb9W8MMmun651wiEjhL7+OrcNbbl2kTOmYSFIf4g=="],
 
     "@corvu/otp-field": ["@corvu/otp-field@0.1.4", "", { "dependencies": { "@corvu/utils": "~0.4.2" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-3eG7OoUt6CfVqGujIYfqImdrhGR/s4DpKr5ZQT10zzw3nawIlcwVpqoHTam0v4cgv+NXXvl6I8DoA3J+WgW2YA=="],
 
     "@corvu/utils": ["@corvu/utils@0.4.2", "", { "dependencies": { "@floating-ui/dom": "^1.6.11" }, "peerDependencies": { "solid-js": "^1.8" } }, "sha512-Ox2kYyxy7NoXdKWdHeDEjZxClwzO4SKM8plAaVwmAJPxHMqA0rLOoAsa+hBDwRLpctf+ZRnAd/ykguuJidnaTA=="],
 
+    "@creem_io/better-auth": ["@creem_io/better-auth@1.1.4", "", { "dependencies": { "@creem_io/webhook-types": "^1.0.0", "creem": "^1.6.0" }, "peerDependencies": { "better-auth": "^1.3.34", "zod": "^3.23.8 || ^4" } }, "sha512-sGp2SJ28LI+0yr9EyFd7hPVCczdSx6K2yTBmkB4MdNzmEsPumBqEfn/MX7HNazVTQ3xEVyyDAicnz4XKrTOX3g=="],
+
+    "@creem_io/webhook-types": ["@creem_io/webhook-types@1.0.0", "", {}, "sha512-LZUgFG+UNb+SkVAz/TngdGDgwfE1mxzX1tlcRmwfA94h/SH5nv0Qtg25GO+JTXyMsMAu5pD596HpezAo3WtJcQ=="],
+
     "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
 
     "@date-fns/tz": ["@date-fns/tz@1.5.0", "", {}, "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg=="],
+
+    "@dodopayments/better-auth": ["@dodopayments/better-auth@1.6.5", "", { "dependencies": { "@dodopayments/core": "^0.3.14" }, "peerDependencies": { "better-auth": "^1.4.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-4PhRByCrCQuEQq1wluJ0MS2b5k6LGjcTmKDofFxt/Kb7Hhg53hOFpfurjzOkKdLqumht4WeXWWnucAA6O0ZXqA=="],
+
+    "@dodopayments/core": ["@dodopayments/core@0.3.14", "", { "dependencies": { "dodopayments": "^2.46.0", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-x7gC2d3cY2PkPWHYDU2AKCZk5xgKDMJG5A0dj8m+9+3B7gLtprE3eoDnvPz2zVSccQVvvCd2nQfARjY3EIfwBQ=="],
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.75.1", "", { "dependencies": { "@dotenvx/primitives": "^0.8.0", "commander": "^11.1.0", "conf": "^10.2.0", "dotenv": "^17.2.1", "enquirer": "^2.4.1", "env-paths": "^2.2.1", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "open": "^8.4.2", "picomatch": "^4.0.4", "systeminformation": "^5.22.11", "undici": "^7.11.0", "which": "^4.0.0", "yocto-spinner": "^1.1.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-/BITOC9dmS/edY2zQwZNicQ059O6RKabtQfyEafV0nGtfYRNHYy1DIPiYVcov40+tob9hfmBnbR963dS+EQ1DQ=="],
 
@@ -1822,7 +1847,7 @@
 
     "@zkochan/js-yaml": ["@zkochan/js-yaml@0.0.7", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ=="],
 
-    "accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
 
@@ -1871,6 +1896,8 @@
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
     "atomically": ["atomically@2.1.1", "", { "dependencies": { "stubborn-fs": "^2.0.0", "when-exit": "^2.1.4" } }, "sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ=="],
+
+    "autumn-js": ["autumn-js@1.2.53", "", { "dependencies": { "query-string": "^9.2.2", "rou3": "^0.6.1", "zod": "^4.0.0" }, "peerDependencies": { "better-auth": "^1.6.0", "better-call": "^1.0.12", "express": "^5.2.1", "hono": "^4.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "react": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["better-auth", "better-call", "express", "hono", "next", "react"] }, "sha512-4P+bXo1jn2uXqd5R/wEi7O/3pUNzdHGKTlaPY1/jiey7gWJocpZ63lF+g0MUYy5KcRfdRUPCbk84WF3mp0tTKw=="],
 
     "axios": ["axios@1.18.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g=="],
 
@@ -2014,7 +2041,7 @@
 
     "confbox": ["confbox@0.2.4", "", {}, "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ=="],
 
-    "content-disposition": ["content-disposition@0.5.2", "", {}, "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA=="],
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
@@ -2031,6 +2058,8 @@
     "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cosmiconfig": ["cosmiconfig@9.0.2", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg=="],
+
+    "creem": ["creem@1.6.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.26.0", "jsonpath-rfc9535": "1.1.0", "zod": "^3.25.0 || ^4.0.0" }, "bin": { "mcp": "bin/mcp-server.js" } }, "sha512-1dwtrqJ5wWgBVL+0eIqHS4IN99tJeWHa1hbr4AQUNe3r/Zjo0W1/xXvZbhS9TwPNRgsP1gDIsTRQrRHRjG4wzw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -2055,6 +2084,8 @@
     "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
+    "decode-uri-component": ["decode-uri-component@0.5.0", "", {}, "sha512-1BiQVoK8C9gUbQU6NzAtO/tkz2qOFpEObMWpcFvhx4fYnj4Oc5yzaJN/LD36ihkVUdXyh5ZekzX+yM+ty/SrPg=="],
 
     "dedent": ["dedent@1.7.2", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA=="],
 
@@ -2091,6 +2122,8 @@
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "docs": ["docs@workspace:apps/docs"],
+
+    "dodopayments": ["dodopayments@2.47.0", "", { "dependencies": { "standardwebhooks": "^1.0.0" }, "bin": { "dodopayments": "bin/cli" } }, "sha512-4lmI7/NDJjJOmy2jGJaowt3/heXx01IDwPkiuuHqifcdi4+nFg1d1vrlcE8ULw4r+TO+TA1ZPFyaHxSm8hbjvQ=="],
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
@@ -2229,6 +2262,8 @@
     "figures": ["figures@3.2.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "filter-obj": ["filter-obj@5.1.0", "", {}, "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng=="],
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
@@ -2441,6 +2476,8 @@
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
+
+    "jsonpath-rfc9535": ["jsonpath-rfc9535@1.1.0", "", {}, "sha512-Bj8ldGo67FNvj5nNsxGN7frkUcHZWqszNkfBOvfxOM1+WUa5J0PiGaflroTKOjGo2JQhOC1DZUaTv4tGzBaQLQ=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
@@ -2834,11 +2871,13 @@
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
+    "query-string": ["query-string@9.5.0", "", { "dependencies": { "decode-uri-component": "^0.5.0", "filter-obj": "^5.1.0", "split-on-first": "^3.0.0" } }, "sha512-YlJmwNyi0RGYjlxYcuDncMsxFU7YyutbuI7gTm8ySxIGBlwx5yiBCOD5ig9ZNoHkawk/1Dey0N5mEfcUybMVAA=="],
+
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "radix-ui": ["radix-ui@1.6.7", "", { "dependencies": { "@radix-ui/primitive": "1.1.7", "@radix-ui/react-accessible-icon": "1.1.15", "@radix-ui/react-accordion": "1.2.20", "@radix-ui/react-alert-dialog": "1.1.23", "@radix-ui/react-arrow": "1.1.15", "@radix-ui/react-aspect-ratio": "1.1.15", "@radix-ui/react-avatar": "1.2.6", "@radix-ui/react-checkbox": "1.3.11", "@radix-ui/react-collapsible": "1.1.20", "@radix-ui/react-collection": "1.1.15", "@radix-ui/react-compose-refs": "1.1.5", "@radix-ui/react-context": "1.2.2", "@radix-ui/react-context-menu": "2.3.7", "@radix-ui/react-dialog": "1.1.23", "@radix-ui/react-direction": "1.1.4", "@radix-ui/react-dismissable-layer": "1.1.19", "@radix-ui/react-dropdown-menu": "2.1.24", "@radix-ui/react-focus-guards": "1.1.6", "@radix-ui/react-focus-scope": "1.1.16", "@radix-ui/react-form": "0.1.16", "@radix-ui/react-hover-card": "1.1.23", "@radix-ui/react-label": "2.1.15", "@radix-ui/react-menu": "2.1.24", "@radix-ui/react-menubar": "1.1.24", "@radix-ui/react-navigation-menu": "1.2.22", "@radix-ui/react-one-time-password-field": "0.1.16", "@radix-ui/react-password-toggle-field": "0.1.11", "@radix-ui/react-popover": "1.1.23", "@radix-ui/react-popper": "1.3.7", "@radix-ui/react-portal": "1.1.17", "@radix-ui/react-presence": "1.1.10", "@radix-ui/react-primitive": "2.1.10", "@radix-ui/react-progress": "1.1.16", "@radix-ui/react-radio-group": "1.4.7", "@radix-ui/react-roving-focus": "1.1.19", "@radix-ui/react-scroll-area": "1.2.18", "@radix-ui/react-select": "2.3.7", "@radix-ui/react-separator": "1.1.15", "@radix-ui/react-slider": "1.4.7", "@radix-ui/react-slot": "1.3.3", "@radix-ui/react-switch": "1.3.7", "@radix-ui/react-tabs": "1.1.21", "@radix-ui/react-toast": "1.2.23", "@radix-ui/react-toggle": "1.1.18", "@radix-ui/react-toggle-group": "1.1.19", "@radix-ui/react-toolbar": "1.1.19", "@radix-ui/react-tooltip": "1.2.16", "@radix-ui/react-use-callback-ref": "1.1.4", "@radix-ui/react-use-controllable-state": "1.2.6", "@radix-ui/react-use-effect-event": "0.0.5", "@radix-ui/react-use-escape-keydown": "1.1.5", "@radix-ui/react-use-is-hydrated": "0.1.3", "@radix-ui/react-use-layout-effect": "1.1.4", "@radix-ui/react-use-size": "1.1.4", "@radix-ui/react-visually-hidden": "1.2.11" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-QBdhh1arIEUvPC0dQ5+nwWAxt7+N+oP/9jPwjJkGFoSk/sqxg32gJtSXGtFh8frAIcS6oC9cx2Q+7KYCQLOAeA=="],
 
-    "range-parser": ["range-parser@1.2.0", "", {}, "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A=="],
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
@@ -2944,7 +2983,7 @@
 
     "rolldown": ["rolldown@1.2.3", "", { "dependencies": { "@oxc-project/types": "=0.143.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.2.3", "@rolldown/binding-darwin-arm64": "1.2.3", "@rolldown/binding-darwin-x64": "1.2.3", "@rolldown/binding-freebsd-x64": "1.2.3", "@rolldown/binding-linux-arm-gnueabihf": "1.2.3", "@rolldown/binding-linux-arm64-gnu": "1.2.3", "@rolldown/binding-linux-arm64-musl": "1.2.3", "@rolldown/binding-linux-ppc64-gnu": "1.2.3", "@rolldown/binding-linux-s390x-gnu": "1.2.3", "@rolldown/binding-linux-x64-gnu": "1.2.3", "@rolldown/binding-linux-x64-musl": "1.2.3", "@rolldown/binding-openharmony-arm64": "1.2.3", "@rolldown/binding-win32-arm64-msvc": "1.2.3", "@rolldown/binding-win32-x64-msvc": "1.2.3" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A=="],
 
-    "rou3": ["rou3@0.9.2", "", {}, "sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ=="],
+    "rou3": ["rou3@0.6.3", "", {}, "sha512-1HSG1ENTj7Kkm5muMnXuzzfdDOf7CFnbSYFA+H3Fp/rB9lOCxCPgy1jlZxTKyFoC5jJay8Mmc+VbPLYRjzYLrA=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
@@ -3037,6 +3076,8 @@
     "source-map-support": ["source-map-support@0.5.19", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "split-on-first": ["split-on-first@3.0.0", "", {}, "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA=="],
 
     "srvx": ["srvx@0.11.22", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ=="],
 
@@ -3530,7 +3571,9 @@
 
     "@types/ws/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
-    "accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "babel-dead-code-elimination/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
@@ -3545,6 +3588,8 @@
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "better-call/@better-auth/utils": ["@better-auth/utils@0.5.0", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-BL8W4EfIZFwlu0r54m3v1ztjDhu6dDe/amLTm0xybmbZaNgYUqhD3SjpAsnq0q8YD6/ki4iwIgxJNLP/N3TxiA=="],
+
+    "better-call/rou3": ["rou3@0.9.2", "", {}, "sha512-3SOzvaAg8rkHrXtRjpCvCvbyO5to9oOO27Z/XqHEYXfMRVSw/qMIVdmaOk9W2lcRLtR6dlqTjo9hDeJk70QBYQ=="],
 
     "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
@@ -3576,6 +3621,8 @@
 
     "engine.io/@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
+    "engine.io/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
+
     "estree-util-to-js/source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
     "execa/figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
@@ -3584,13 +3631,7 @@
 
     "execa/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
-    "express/accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
-    "express/content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
-
     "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
-    "express/range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
 
     "fumadocs-core/shiki": ["shiki@4.4.2", "", { "dependencies": { "@shikijs/core": "4.4.2", "@shikijs/engine-javascript": "4.4.2", "@shikijs/engine-oniguruma": "4.4.2", "@shikijs/langs": "4.4.2", "@shikijs/themes": "4.4.2", "@shikijs/types": "4.4.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5" } }, "sha512-P8F/dFhRevaw2uSdeIYlq/5SXZNY85DPtmXQ947gD1Zj2JqO5AkNvVVBar0Me9JkFx3uzVud/qOtP5ek9NEQGA=="],
 
@@ -3662,17 +3703,19 @@
 
     "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
-    "send/range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
-
     "serve/chalk": ["chalk@5.0.1", "", {}, "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="],
 
     "serve-handler/bytes": ["bytes@3.0.0", "", {}, "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw=="],
+
+    "serve-handler/content-disposition": ["content-disposition@0.5.2", "", {}, "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA=="],
 
     "serve-handler/mime-types": ["mime-types@2.1.18", "", { "dependencies": { "mime-db": "~1.33.0" } }, "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ=="],
 
     "serve-handler/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "serve-handler/path-to-regexp": ["path-to-regexp@3.3.0", "", {}, "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw=="],
+
+    "serve-handler/range-parser": ["range-parser@1.2.0", "", {}, "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A=="],
 
     "shadcn/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
@@ -3689,6 +3732,8 @@
     "shiki/@shikijs/core": ["@shikijs/core@4.3.1", "", { "dependencies": { "@shikijs/primitive": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA=="],
 
     "shiki/@shikijs/types": ["@shikijs/types@4.3.1", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g=="],
+
+    "socket.io/accepts": ["accepts@1.3.8", "", { "dependencies": { "mime-types": "~2.1.34", "negotiator": "0.6.3" } }, "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw=="],
 
     "storybook/@testing-library/jest-dom": ["@testing-library/jest-dom@6.9.1", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA=="],
 
@@ -3956,6 +4001,8 @@
 
     "@tanstack/router-plugin/unplugin/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
+    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "babel-plugin-const-enum/@babel/traverse/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
     "babel-plugin-macros/cosmiconfig/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
@@ -4032,11 +4079,11 @@
 
     "drizzle-kit/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "engine.io/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
+
     "execa/figures/is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
 
     "execa/npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
-
-    "express/accepts/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
@@ -4151,6 +4198,8 @@
     "shadcn/ts-morph/@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
 
     "shiki/@shikijs/core/@shikijs/primitive": ["@shikijs/primitive@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A=="],
+
+    "socket.io/accepts/negotiator": ["negotiator@0.6.3", "", {}, "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="],
 
     "storybook/@vitest/expect/@vitest/utils": ["@vitest/utils@3.2.4", "", { "dependencies": { "@vitest/pretty-format": "3.2.4", "loupe": "^3.1.4", "tinyrainbow": "^2.0.0" } }, "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -179,9 +179,14 @@
     "@better-auth/passkey": "1.7.0",
     "@better-auth/sso": "1.7.0",
     "@better-auth/stripe": "1.7.0",
+    "@commet/better-auth": "8.1.0",
+    "@commet/node": "9.1.0",
+    "@creem_io/better-auth": "1.1.4",
+    "@dodopayments/better-auth": "1.6.5",
     "@mikkelscheike/email-provider-links": "5.2.1",
     "@polar-sh/better-auth": "1.7.0",
     "@tanstack/query-core": "^5.101.2",
+    "autumn-js": "1.2.53",
     "better-auth": "1.7.0",
     "vitest": "^4.1.9"
   },
@@ -192,9 +197,13 @@
     "@better-auth/passkey": ">=1.7.0",
     "@better-auth/sso": ">=1.7.0",
     "@better-auth/stripe": ">=1.7.0",
+    "@commet/better-auth": ">=8.1.0",
+    "@creem_io/better-auth": ">=1.1.4",
+    "@dodopayments/better-auth": ">=1.6.5",
     "@mikkelscheike/email-provider-links": ">=5.2.1",
     "@polar-sh/better-auth": ">=1.7.0",
     "@tanstack/query-core": ">=5.101.2",
+    "autumn-js": ">=1.2.53",
     "better-auth": ">=1.7.0"
   },
   "peerDependenciesMeta": {
@@ -213,7 +222,19 @@
     "@better-auth/stripe": {
       "optional": true
     },
+    "@commet/better-auth": {
+      "optional": true
+    },
+    "@creem_io/better-auth": {
+      "optional": true
+    },
+    "@dodopayments/better-auth": {
+      "optional": true
+    },
     "@polar-sh/better-auth": {
+      "optional": true
+    },
+    "autumn-js": {
       "optional": true
     }
   },

--- a/packages/core/src/plugins/billing/billing-adapter.ts
+++ b/packages/core/src/plugins/billing/billing-adapter.ts
@@ -77,10 +77,17 @@ export type BillingCapabilities = {
   seats: boolean
 }
 
+export type BillingScopeCapabilities = {
+  user: boolean
+  organization: boolean
+}
+
 /** Provider-neutral billing operations consumed by every BAUI billing view. */
 export interface BillingAdapter {
   readonly id: string
   readonly supports: BillingCapabilities
+  /** Billing scopes supported by the provider client. Omit for custom adapters. */
+  readonly scopes?: BillingScopeCapabilities
   listPlans(scope: BillingScope, signal?: AbortSignal): Promise<BillingPlan[]>
   getState(scope: BillingScope, signal?: AbortSignal): Promise<BillingState>
   checkout(

--- a/packages/core/src/plugins/billing/billing-plugin.ts
+++ b/packages/core/src/plugins/billing/billing-plugin.ts
@@ -26,13 +26,27 @@ export type BillingPluginOptions = {
 
 export const billingPlugin = createAuthPlugin(
   "billing",
-  (options: BillingPluginOptions) => ({
-    adapter: options.adapter,
-    localization: { ...billingLocalization, ...options.localization },
-    user: options.user ?? true,
-    organization: options.organization ?? false,
-    viewPaths: {
-      settings: { billing: options.path ?? "billing" }
+  (options: BillingPluginOptions) => {
+    const user = options.user ?? true
+    const organization = options.organization ?? false
+
+    if (user && options.adapter.scopes?.user === false) {
+      throw new Error(`${options.adapter.id} does not support user billing.`)
     }
-  })
+    if (organization && options.adapter.scopes?.organization === false) {
+      throw new Error(
+        `${options.adapter.id} does not support explicit organization billing.`
+      )
+    }
+
+    return {
+      adapter: options.adapter,
+      localization: { ...billingLocalization, ...options.localization },
+      user,
+      organization,
+      viewPaths: {
+        settings: { billing: options.path ?? "billing" }
+      }
+    }
+  }
 )

--- a/packages/core/src/plugins/billing/vendor-adapters.ts
+++ b/packages/core/src/plugins/billing/vendor-adapters.ts
@@ -1,5 +1,9 @@
 import type { stripeClient } from "@better-auth/stripe/client"
+import type { commetClient } from "@commet/better-auth/client"
+import type { creemClient } from "@creem_io/better-auth/client"
+import type { dodopaymentsClient } from "@dodopayments/better-auth/client"
 import type { polarClient } from "@polar-sh/better-auth/client"
+import type { IAutumnClient } from "autumn-js/react"
 import type { AuthClient } from "../../lib/auth-client"
 import type {
   BillingActionResult,
@@ -20,6 +24,23 @@ export type PolarBillingClient = AuthClient<{
   plugins: [ReturnType<typeof polarClient>]
 }>
 
+export type AutumnBillingClient = Pick<
+  IAutumnClient,
+  "getOrCreateCustomer" | "attach" | "updateSubscription" | "openCustomerPortal"
+>
+
+export type CreemBillingClient = AuthClient<{
+  plugins: [ReturnType<typeof creemClient>]
+}>
+
+export type DodoPaymentsBillingClient = AuthClient<{
+  plugins: [ReturnType<typeof dodopaymentsClient>]
+}>
+
+export type CommetBillingClient = AuthClient<{
+  plugins: [ReturnType<typeof commetClient>]
+}>
+
 export type VendorBillingAdapterOptions = {
   plans: BillingPlan[]
   successUrl: string
@@ -33,6 +54,33 @@ export type PolarBillingAdapterOptions = VendorBillingAdapterOptions & {
     string,
     { type: "slug"; value: string } | { type: "product"; value: string }
   >
+}
+
+export type ProductBillingAdapterOptions = VendorBillingAdapterOptions & {
+  /** Provider product ID for each BAUI plan ID. */
+  products?: Record<string, string>
+}
+
+export type DodoPaymentsBillingAdapterOptions = VendorBillingAdapterOptions & {
+  /** Dodo product or configured slug for each BAUI plan ID. */
+  products?: Record<
+    string,
+    { type: "slug"; value: string } | { type: "product"; value: string }
+  >
+}
+
+export type AutumnBillingAdapterOptions = VendorBillingAdapterOptions & {
+  /** Autumn license plan used for seat quantity on each BAUI plan. */
+  seatLicensePlans?: Record<string, string>
+}
+
+export type CommetBillingAdapterOptions = VendorBillingAdapterOptions & {
+  /** Commet plan ID for each BAUI plan ID. */
+  planIds?: Record<string, string>
+  /** Commet seat feature updated by BAUI's seat editor. */
+  seatFeatureCode?: string
+  /** Read metered feature access into BAUI usage rows. @default false */
+  usage?: boolean
 }
 
 type RecordValue = Record<string, unknown>
@@ -75,6 +123,8 @@ const dateValue = (value: unknown) => {
 
 const statusValue = (value: unknown): BillingSubscriptionStatus => {
   const status = stringValue(value)
+  if (status === "cancelled") return "canceled"
+  if (status === "scheduled_cancel") return "active"
   return status === "active" ||
     status === "trialing" ||
     status === "past_due" ||
@@ -97,26 +147,48 @@ const intervalValue = (value: unknown) => {
 
 const mapSubscription = (value: unknown): BillingSubscription | undefined => {
   const subscription = record(value)
-  const id = stringValue(subscription?.id)
+  const id =
+    stringValue(subscription?.id) ??
+    stringValue(subscription?.subscriptionId) ??
+    stringValue(subscription?.subscription_id) ??
+    stringValue(subscription?.creemSubscriptionId)
   if (!subscription || !id) return undefined
   const product = record(subscription.product)
+  const plan = record(subscription.plan)
+  const price = record(subscription.price) ?? record(plan?.price)
+  const currentPeriod = record(subscription.currentPeriod)
+  const canceledAt =
+    subscription.canceledAt ??
+    subscription.canceled_at ??
+    subscription.cancelledAt ??
+    subscription.cancelled_at
 
   return {
     id,
     planId:
+      stringValue(subscription.planId) ??
       stringValue(subscription.plan) ??
       stringValue(subscription.productId) ??
       stringValue(subscription.product_id) ??
       stringValue(product?.id) ??
+      stringValue(plan?.id) ??
       "unknown",
-    planName: stringValue(subscription.planName) ?? stringValue(product?.name),
+    planName:
+      stringValue(subscription.planName) ??
+      stringValue(product?.name) ??
+      stringValue(plan?.name) ??
+      stringValue(subscription.name),
     priceId:
-      stringValue(subscription.priceId) ?? stringValue(subscription.price_id),
+      stringValue(subscription.priceId) ??
+      stringValue(subscription.price_id) ??
+      stringValue(price?.id),
     interval:
       intervalValue(
         subscription.interval ??
           subscription.billingInterval ??
-          subscription.recurringInterval
+          subscription.recurringInterval ??
+          subscription.recurring_interval ??
+          price?.interval
       ) ??
       (typeof subscription.annual === "boolean"
         ? subscription.annual
@@ -125,13 +197,28 @@ const mapSubscription = (value: unknown): BillingSubscription | undefined => {
         : undefined),
     status: statusValue(subscription.status),
     currentPeriodEnd: dateValue(
-      subscription.currentPeriodEnd ?? subscription.current_period_end
+      subscription.currentPeriodEnd ??
+        subscription.current_period_end ??
+        subscription.currentPeriodEndDate ??
+        subscription.current_period_end_date ??
+        subscription.periodEnd ??
+        subscription.period_end ??
+        subscription.nextBillingDate ??
+        subscription.next_billing_date ??
+        currentPeriod?.end
     ),
     cancelAtPeriodEnd: Boolean(
-      subscription.cancelAtPeriodEnd ?? subscription.cancel_at_period_end
+      subscription.cancelAtPeriodEnd ??
+        subscription.cancel_at_period_end ??
+        subscription.cancelAtNextBillingDate ??
+        subscription.cancel_at_next_billing_date ??
+        subscription.status === "scheduled_cancel"
     ),
-    canceledAt: dateValue(subscription.canceledAt ?? subscription.canceled_at),
-    seats: numberValue(subscription.seats) ?? numberValue(subscription.quantity)
+    canceledAt: dateValue(canceledAt),
+    seats:
+      numberValue(subscription.seats) ??
+      numberValue(subscription.quantity) ??
+      numberValue(subscription.units)
   }
 }
 
@@ -166,7 +253,65 @@ const mapUsage = (value: unknown): BillingUsage | undefined => {
 
 const actionResult = (result: unknown): BillingActionResult => {
   const value = record(unwrap(result))
-  return { url: stringValue(value?.url ?? value?.customerPortalUrl) }
+  return {
+    url: stringValue(
+      value?.url ??
+        value?.paymentUrl ??
+        value?.redirectUrl ??
+        value?.redirect_url ??
+        value?.customerPortalUrl
+    )
+  }
+}
+
+const userOnlyScope = (scope: BillingScope, provider: string) => {
+  if (scope.type === "organization") {
+    throw new Error(
+      `${provider} does not accept an explicit organization ID in its Better Auth client API.`
+    )
+  }
+}
+
+const resolvePlanId = (
+  providerPlanId: string,
+  products: Record<string, string> | undefined
+) =>
+  Object.entries(products ?? {}).find(
+    ([, productId]) => productId === providerPlanId
+  )?.[0] ?? providerPlanId
+
+const mapAutumnUsage = (customer: RecordValue): BillingUsage[] =>
+  Object.entries(record(customer.balances) ?? {}).map(([id, value]) => {
+    const balance = record(value)
+    const feature = record(balance?.feature)
+    const unlimited = balance?.unlimited === true
+
+    return {
+      id,
+      label: stringValue(feature?.name) ?? id,
+      used: numberValue(balance?.usage) ?? 0,
+      limit: unlimited ? undefined : numberValue(balance?.granted),
+      unit: stringValue(feature?.displayName) ?? stringValue(feature?.name)
+    }
+  })
+
+const mapCommetUsage = (value: unknown): BillingUsage | undefined => {
+  const feature = record(value)
+  const consumption = record(feature?.consumption)
+  const code = stringValue(feature?.code)
+  const used = numberValue(consumption?.unitsUsed)
+  if (!code || used === undefined) return undefined
+
+  return {
+    id: code,
+    label: stringValue(feature?.name) ?? code,
+    used,
+    limit:
+      consumption?.unlimited === true
+        ? undefined
+        : numberValue(consumption?.includedUnits),
+    unit: stringValue(feature?.unitName)
+  }
 }
 
 const scopeParams = (scope: BillingScope) => ({
@@ -363,6 +508,301 @@ export function createPolarBillingAdapter(
     /** Polar completes seat changes in its customer portal. */
     async updateSeats(scope) {
       return portal(scope)
+    }
+  }
+}
+
+export function createAutumnBillingAdapter(
+  client: AutumnBillingClient,
+  options: AutumnBillingAdapterOptions
+): BillingAdapter {
+  const getState = async (
+    scope: BillingScope,
+    _signal?: AbortSignal
+  ): Promise<BillingState> => {
+    userOnlyScope(scope, "Autumn")
+    const customer = record(
+      await client.getOrCreateCustomer({
+        expand: ["subscriptions.plan", "balances.feature"]
+      })
+    )
+    const subscription = (
+      Array.isArray(customer?.subscriptions) ? customer.subscriptions : []
+    )
+      .map(mapSubscription)
+      .find(Boolean)
+
+    return {
+      subscription,
+      usage: customer ? mapAutumnUsage(customer) : []
+    }
+  }
+
+  const updateSubscription = async (
+    scope: BillingScope,
+    input: Parameters<AutumnBillingClient["updateSubscription"]>[0]
+  ) => {
+    userOnlyScope(scope, "Autumn")
+    return actionResult(await client.updateSubscription(input))
+  }
+
+  return {
+    id: "autumn",
+    scopes: { user: true, organization: false },
+    supports: {
+      cancel: true,
+      restore: true,
+      seats: Boolean(options.seatLicensePlans)
+    },
+    async listPlans(scope) {
+      userOnlyScope(scope, "Autumn")
+      return options.plans
+    },
+    getState,
+    async checkout(scope, input) {
+      userOnlyScope(scope, "Autumn")
+      const seatLicensePlan = options.seatLicensePlans?.[input.planId]
+      return actionResult(
+        await client.attach({
+          planId: input.planId,
+          successUrl: options.successUrl,
+          redirectMode: "always",
+          ...(seatLicensePlan && input.seats
+            ? {
+                licenseQuantities: [
+                  { licensePlanId: seatLicensePlan, quantity: input.seats }
+                ]
+              }
+            : {})
+        })
+      )
+    },
+    async openPortal(scope) {
+      userOnlyScope(scope, "Autumn")
+      return actionResult(
+        await client.openCustomerPortal({
+          returnUrl: options.returnUrl
+        })
+      )
+    },
+    cancel: (scope, subscriptionId) =>
+      updateSubscription(scope, {
+        subscriptionId,
+        cancelAction: "cancel_end_of_cycle"
+      }),
+    restore: (scope, subscriptionId) =>
+      updateSubscription(scope, {
+        subscriptionId,
+        cancelAction: "uncancel"
+      }),
+    async updateSeats(scope, subscriptionId, seats) {
+      const state = await getState(scope)
+      const planId = state.subscription?.planId
+      const licensePlanId = planId
+        ? options.seatLicensePlans?.[planId]
+        : undefined
+      if (!licensePlanId) {
+        throw new Error("The Autumn seat license plan is unavailable.")
+      }
+      return updateSubscription(scope, {
+        subscriptionId,
+        licenseQuantities: [{ licensePlanId, quantity: seats }]
+      })
+    }
+  }
+}
+
+export function createCreemBillingAdapter(
+  client: CreemBillingClient,
+  options: ProductBillingAdapterOptions
+): BillingAdapter {
+  const portal = async (scope: BillingScope) => {
+    userOnlyScope(scope, "Creem")
+    return actionResult(await client.creem.createPortal())
+  }
+
+  return {
+    id: "creem",
+    scopes: { user: true, organization: false },
+    supports: { cancel: true, restore: false, seats: false },
+    async listPlans(scope) {
+      userOnlyScope(scope, "Creem")
+      return options.plans
+    },
+    async getState(scope): Promise<BillingState> {
+      userOnlyScope(scope, "Creem")
+      const access = record(unwrap(await client.creem.hasAccessGranted()))
+      const subscription = mapSubscription(access?.subscription)
+      const normalizedSubscription = subscription
+        ? {
+            ...subscription,
+            planId: resolvePlanId(subscription.planId, options.products)
+          }
+        : undefined
+
+      return { subscription: normalizedSubscription, usage: [] }
+    },
+    async checkout(scope, input) {
+      userOnlyScope(scope, "Creem")
+      return actionResult(
+        await client.creem.createCheckout({
+          productId: options.products?.[input.planId] ?? input.planId,
+          ...(input.seats ? { units: input.seats } : {}),
+          successUrl: options.successUrl
+        })
+      )
+    },
+    openPortal: portal,
+    async cancel(scope, subscriptionId) {
+      userOnlyScope(scope, "Creem")
+      return actionResult(
+        await client.creem.cancelSubscription({ id: subscriptionId })
+      )
+    },
+    /** Creem completes restoration in its customer portal. */
+    restore: portal,
+    /** Creem completes unit changes in its customer portal. */
+    updateSeats: portal
+  }
+}
+
+export function createDodoPaymentsBillingAdapter(
+  client: DodoPaymentsBillingClient,
+  options: DodoPaymentsBillingAdapterOptions
+): BillingAdapter {
+  const portal = async (scope: BillingScope) => {
+    userOnlyScope(scope, "Dodo Payments")
+    return actionResult(await client.dodopayments.customer.portal())
+  }
+
+  return {
+    id: "dodo-payments",
+    scopes: { user: true, organization: false },
+    supports: { cancel: false, restore: false, seats: false },
+    async listPlans(scope) {
+      userOnlyScope(scope, "Dodo Payments")
+      return options.plans
+    },
+    async getState(scope, signal): Promise<BillingState> {
+      userOnlyScope(scope, "Dodo Payments")
+      const subscriptions = items(
+        await client.dodopayments.customer.subscriptions.list({
+          query: { limit: 100, page: 1 },
+          fetchOptions: { signal, throw: true }
+        })
+      )
+      const subscription = subscriptions.map(mapSubscription).find(Boolean)
+      if (!subscription) return { usage: [] }
+
+      const providerPlanId = subscription.planId
+      const planId =
+        Object.entries(options.products ?? {}).find(
+          ([, product]) => product.value === providerPlanId
+        )?.[0] ?? providerPlanId
+      return { subscription: { ...subscription, planId }, usage: [] }
+    },
+    async checkout(scope, input) {
+      userOnlyScope(scope, "Dodo Payments")
+      const product = options.products?.[input.planId]
+      return actionResult(
+        await client.dodopayments.checkoutSession({
+          ...(product?.type === "product"
+            ? {
+                product_cart: [
+                  {
+                    product_id: product.value,
+                    quantity: input.seats ?? 1
+                  }
+                ]
+              }
+            : { slug: product?.value ?? input.planId }),
+          referenceId:
+            scope.type === "user" ? scope.userId : scope.organizationId
+        })
+      )
+    },
+    openPortal: portal,
+    /** Dodo Payments completes cancellation in its customer portal. */
+    cancel: portal,
+    /** Dodo Payments completes restoration in its customer portal. */
+    restore: portal,
+    /** Dodo Payments completes quantity changes in its customer portal. */
+    updateSeats: portal
+  }
+}
+
+export function createCommetBillingAdapter(
+  client: CommetBillingClient,
+  options: CommetBillingAdapterOptions
+): BillingAdapter {
+  const portal = async (scope: BillingScope) => {
+    userOnlyScope(scope, "Commet")
+    return actionResult(await client.customer.portal())
+  }
+
+  return {
+    id: "commet",
+    scopes: { user: true, organization: false },
+    supports: {
+      cancel: true,
+      restore: false,
+      seats: Boolean(options.seatFeatureCode)
+    },
+    async listPlans(scope) {
+      userOnlyScope(scope, "Commet")
+      return options.plans
+    },
+    async getState(scope, signal): Promise<BillingState> {
+      userOnlyScope(scope, "Commet")
+      const [subscriptionResult, featuresResult, seatsResult] =
+        await Promise.all([
+          client.subscription.get({ signal, throw: true }),
+          options.usage
+            ? client.features.list({ signal, throw: true })
+            : undefined,
+          options.seatFeatureCode
+            ? client.seats.list({ signal, throw: true })
+            : undefined
+        ])
+      const subscription = mapSubscription(unwrap(subscriptionResult))
+      const seat = options.seatFeatureCode
+        ? record(record(unwrap(seatsResult))?.[options.seatFeatureCode])
+        : undefined
+      const normalizedSubscription = subscription
+        ? {
+            ...subscription,
+            planId: resolvePlanId(subscription.planId, options.planIds),
+            seats: numberValue(seat?.current) ?? subscription.seats
+          }
+        : undefined
+      const usage = options.usage
+        ? items(featuresResult)
+            .map(mapCommetUsage)
+            .filter((value): value is BillingUsage => Boolean(value))
+        : []
+
+      return { subscription: normalizedSubscription, usage }
+    },
+    /** Commet starts plan changes in its customer portal. */
+    checkout: portal,
+    openPortal: portal,
+    async cancel(scope) {
+      userOnlyScope(scope, "Commet")
+      return actionResult(
+        await client.subscription.cancel({ immediate: false }, { throw: true })
+      )
+    },
+    /** Commet completes restoration in its customer portal. */
+    restore: portal,
+    async updateSeats(scope, _subscriptionId, seats) {
+      userOnlyScope(scope, "Commet")
+      if (!options.seatFeatureCode) return portal(scope)
+      return actionResult(
+        await client.seats.set(
+          { featureCode: options.seatFeatureCode, count: seats },
+          { throw: true }
+        )
+      )
     }
   }
 }

--- a/packages/core/tests/billing-plugin.test.ts
+++ b/packages/core/tests/billing-plugin.test.ts
@@ -6,6 +6,10 @@ import {
   billingPlugin,
   billingQueryKeys,
   billingScopeKey,
+  createAutumnBillingAdapter,
+  createCommetBillingAdapter,
+  createCreemBillingAdapter,
+  createDodoPaymentsBillingAdapter,
   createPolarBillingAdapter,
   createStripeBillingAdapter,
   followBillingAction
@@ -49,6 +53,20 @@ describe("billingPlugin", () => {
       organization: true,
       viewPaths: { settings: { billing: "plan" } }
     })
+  })
+
+  it("rejects provider scope configurations that cannot be fulfilled", () => {
+    const adapter = {
+      id: "user-only",
+      scopes: { user: true, organization: false }
+    } as never
+
+    expect(() => billingPlugin({ adapter, organization: true })).toThrow(
+      "user-only does not support explicit organization billing"
+    )
+    expect(() =>
+      billingPlugin({ adapter, user: true, organization: false })
+    ).not.toThrow()
   })
 
   it("keeps user and explicit organization cache scopes separate", () => {
@@ -376,5 +394,286 @@ describe("vendor billing adapters", () => {
       url: "/portal"
     })
     expect(portal).toHaveBeenCalledTimes(3)
+  })
+
+  it("maps Autumn subscriptions and balances and preserves seat licenses", async () => {
+    const getOrCreateCustomer = vi.fn(async () => ({
+      subscriptions: [
+        {
+          id: "autumn-sub",
+          planId: "pro",
+          status: "active",
+          currentPeriodEnd: 1_800_000_000_000,
+          quantity: 4
+        }
+      ],
+      balances: {
+        messages: {
+          usage: 25,
+          granted: 100,
+          unlimited: false,
+          feature: { name: "Messages" }
+        }
+      }
+    }))
+    const attach = vi.fn(async () => ({ paymentUrl: "/autumn-checkout" }))
+    const updateSubscription = vi.fn(async () => ({ paymentUrl: null }))
+    const adapter = createAutumnBillingAdapter(
+      {
+        getOrCreateCustomer,
+        attach,
+        updateSubscription,
+        openCustomerPortal: vi.fn(async () => ({
+          customerId: "user-1",
+          url: "/autumn-portal"
+        }))
+      } as never,
+      {
+        plans: [...plans],
+        seatLicensePlans: { pro: "team-seat" },
+        successUrl: "/success",
+        cancelUrl: "/cancel",
+        returnUrl: "/settings/billing"
+      }
+    )
+
+    const state = await adapter.getState(userScope)
+    const checkout = await adapter.checkout(userScope, {
+      planId: "pro",
+      priceId: "pro-month",
+      seats: 5
+    })
+    await adapter.cancel(userScope, "autumn-sub")
+    await adapter.restore(userScope, "autumn-sub")
+    await adapter.updateSeats(userScope, "autumn-sub", 8)
+
+    expect(state).toMatchObject({
+      subscription: { id: "autumn-sub", planId: "pro", seats: 4 },
+      usage: [{ id: "messages", label: "Messages", used: 25, limit: 100 }]
+    })
+    expect(checkout).toEqual({ url: "/autumn-checkout" })
+    expect(attach).toHaveBeenCalledWith(
+      expect.objectContaining({
+        planId: "pro",
+        licenseQuantities: [{ licensePlanId: "team-seat", quantity: 5 }]
+      })
+    )
+    expect(updateSubscription).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ cancelAction: "cancel_end_of_cycle" })
+    )
+    expect(updateSubscription).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ cancelAction: "uncancel" })
+    )
+    expect(updateSubscription).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        licenseQuantities: [{ licensePlanId: "team-seat", quantity: 8 }]
+      })
+    )
+    expect(adapter.scopes).toEqual({ user: true, organization: false })
+  })
+
+  it("connects Creem checkout, subscription state, cancellation, and portal", async () => {
+    const createCheckout = vi.fn(async () => ({
+      data: { url: "/creem-checkout" }
+    }))
+    const cancelSubscription = vi.fn(async () => ({
+      data: { success: true }
+    }))
+    const adapter = createCreemBillingAdapter(
+      {
+        creem: {
+          createCheckout,
+          createPortal: vi.fn(async () => ({ data: { url: "/creem-portal" } })),
+          cancelSubscription,
+          hasAccessGranted: vi.fn(async () => ({
+            data: {
+              subscription: {
+                id: "creem-sub",
+                productId: "creem-pro",
+                status: "active",
+                periodEnd: "2027-01-01T00:00:00.000Z"
+              }
+            }
+          }))
+        }
+      } as never,
+      {
+        plans: [...plans],
+        products: { pro: "creem-pro" },
+        successUrl: "/success",
+        cancelUrl: "/cancel",
+        returnUrl: "/settings/billing"
+      }
+    )
+
+    const state = await adapter.getState(userScope)
+    const checkout = await adapter.checkout(userScope, {
+      planId: "pro",
+      priceId: "pro-month",
+      seats: 3
+    })
+    await adapter.cancel(userScope, "creem-sub")
+
+    expect(state.subscription).toMatchObject({
+      id: "creem-sub",
+      planId: "pro",
+      status: "active"
+    })
+    expect(checkout).toEqual({ url: "/creem-checkout" })
+    expect(createCheckout).toHaveBeenCalledWith(
+      expect.objectContaining({ productId: "creem-pro", units: 3 })
+    )
+    expect(cancelSubscription).toHaveBeenCalledWith({ id: "creem-sub" })
+  })
+
+  it("uses Dodo checkout sessions and maps customer subscriptions", async () => {
+    const checkoutSession = vi.fn(async () => ({
+      data: { url: "/dodo-checkout" }
+    }))
+    const subscriptions = vi.fn(async () => ({
+      data: {
+        items: [
+          {
+            subscription_id: "dodo-sub",
+            product_id: "dodo-pro",
+            status: "active",
+            quantity: 6,
+            next_billing_date: "2027-01-01T00:00:00.000Z"
+          }
+        ]
+      }
+    }))
+    const adapter = createDodoPaymentsBillingAdapter(
+      {
+        dodopayments: {
+          checkoutSession,
+          customer: {
+            portal: vi.fn(async () => ({ data: { url: "/dodo-portal" } })),
+            subscriptions: { list: subscriptions }
+          }
+        }
+      } as never,
+      {
+        plans: [...plans],
+        products: { pro: { type: "product", value: "dodo-pro" } },
+        successUrl: "/success",
+        cancelUrl: "/cancel",
+        returnUrl: "/settings/billing"
+      }
+    )
+
+    const state = await adapter.getState(userScope)
+    const checkout = await adapter.checkout(userScope, {
+      planId: "pro",
+      priceId: "pro-month",
+      seats: 6
+    })
+
+    expect(state.subscription).toMatchObject({
+      id: "dodo-sub",
+      planId: "pro",
+      seats: 6
+    })
+    expect(checkout).toEqual({ url: "/dodo-checkout" })
+    expect(checkoutSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        product_cart: [{ product_id: "dodo-pro", quantity: 6 }],
+        referenceId: "user-1"
+      })
+    )
+  })
+
+  it("maps Commet subscription, usage, and seat state", async () => {
+    const cancel = vi.fn(async () => ({ data: { status: "active" } }))
+    const setSeats = vi.fn(async () => ({ data: { current: 9 } }))
+    const adapter = createCommetBillingAdapter(
+      {
+        customer: {
+          portal: vi.fn(async () => ({ url: "/commet-portal", redirect: true }))
+        },
+        subscription: {
+          get: vi.fn(async () => ({
+            data: {
+              id: "commet-sub",
+              plan: { id: "commet-pro", name: "Pro" },
+              status: "active",
+              billingInterval: "monthly",
+              currentPeriod: { end: "2027-01-01T00:00:00.000Z" }
+            }
+          })),
+          cancel
+        },
+        features: {
+          list: vi.fn(async () => ({
+            data: [
+              {
+                code: "api-calls",
+                name: "API calls",
+                unitName: "request",
+                consumption: {
+                  model: "metered",
+                  unitsUsed: 40,
+                  includedUnits: 100,
+                  unlimited: false
+                }
+              }
+            ]
+          }))
+        },
+        seats: {
+          list: vi.fn(async () => ({ data: { members: { current: 5 } } })),
+          set: setSeats
+        }
+      } as never,
+      {
+        plans: [...plans],
+        planIds: { pro: "commet-pro" },
+        seatFeatureCode: "members",
+        usage: true,
+        successUrl: "/success",
+        cancelUrl: "/cancel",
+        returnUrl: "/settings/billing"
+      }
+    )
+
+    const state = await adapter.getState(userScope)
+    const checkout = await adapter.checkout(userScope, {
+      planId: "pro",
+      priceId: "pro-month"
+    })
+    await adapter.cancel(userScope, "commet-sub")
+    await adapter.updateSeats(userScope, "commet-sub", 9)
+
+    expect(state).toMatchObject({
+      subscription: {
+        id: "commet-sub",
+        planId: "pro",
+        interval: "month",
+        seats: 5
+      },
+      usage: [{ id: "api-calls", used: 40, limit: 100 }]
+    })
+    expect(checkout).toEqual({ url: "/commet-portal" })
+    expect(cancel).toHaveBeenCalledWith({ immediate: false }, { throw: true })
+    expect(setSeats).toHaveBeenCalledWith(
+      { featureCode: "members", count: 9 },
+      { throw: true }
+    )
+  })
+
+  it("fails before calling user-only provider APIs for organization scope", async () => {
+    const adapter = createCreemBillingAdapter({} as never, {
+      plans: [...plans],
+      successUrl: "/success",
+      cancelUrl: "/cancel",
+      returnUrl: "/settings/billing"
+    })
+
+    await expect(adapter.listPlans(organizationScope)).rejects.toThrow(
+      "Creem does not accept an explicit organization ID"
+    )
   })
 })


### PR DESCRIPTION
## Summary

- add first-party Autumn, Creem, Dodo Payments, and Commet billing adapters
- normalize provider subscriptions, usage, checkout, portal, cancellation, restoration, and seat capabilities
- add optional peer dependencies and setup documentation for shadcn, HeroUI, and Zaidan
- reject organization billing for provider clients that cannot accept an explicit organization ID

Stripe and Polar retain explicit user and organization scopes. The four new provider clients are intentionally user-scoped so BAUI never relies on active-organization state.

## Validation

- 34 core test files and 269 tests
- typechecks for core, React, Solid, HeroUI, shadcn source, Base UI, Zaidan, and docs
- core build and both registry builds
- Biome and project lint

This is PR 5 of 5 in native GitHub stack #502 and depends on #500.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>