### PR TITLE
feat(phone-number): add international input

### DIFF
--- a/apps/docs/content/docs/heroui/plugins/phone-number.mdx
+++ b/apps/docs/content/docs/heroui/plugins/phone-number.mdx
@@ -7,7 +7,7 @@ description: Add phone verification-code and password sign-in, recovery, and ver
 import { Callout } from "fumadocs-ui/components/callout"
 import { Step, Steps } from "fumadocs-ui/components/steps"
 
-The HeroUI phone-number plugin contributes a phone sign-in route, password recovery views, and a verified phone-number card for account settings.
+The HeroUI phone-number plugin contributes a phone sign-in route, password recovery views, and a verified phone-number card for account settings. Its country selector formats national input as the user types, validates it, and sends an E.164 number to Better Auth.
 
 ## Setup
 
@@ -35,7 +35,7 @@ export const auth = betterAuth({
 })
 ```
 
-Normalize phone numbers on the server, preferably to E.164. Do not log codes in production. Better Auth recommends dispatching the SMS without waiting for the provider response.
+Keep server-side validation as a trust boundary even though the UI normalizes numbers to E.164. Do not log codes in production. Better Auth recommends dispatching the SMS without waiting for the provider response.
 
 </Step>
 <Step>
@@ -106,6 +106,8 @@ const validAuthPaths = new Set([
 | `passwordReset` | `false` | `sendPasswordResetOTP` |
 | `changePhoneNumber` | `true` | `sendOTP` |
 | `otpLength` | `6` | Must match Better Auth `otpLength` |
+
+Use `defaultCountry`, `countries`, and `locale` to control the selector. Supply an `adapter` when your application needs different formatting or validation rules.
 
 When password sign-in reports `PHONE_NUMBER_NOT_VERIFIED`, the UI switches to the code step. Better Auth sends that verification code automatically.
 

--- a/apps/docs/content/docs/shadcn/plugins/phone-number.mdx
+++ b/apps/docs/content/docs/shadcn/plugins/phone-number.mdx
@@ -7,10 +7,10 @@ description: Add phone verification-code and password sign-in, recovery, and ver
 import { Callout } from "fumadocs-ui/components/callout"
 import { Step, Steps } from "fumadocs-ui/components/steps"
 
-The phone-number plugin adds a dedicated `/auth/phone-number` view. It supports passwordless verification codes, phone number and password sign-in, password recovery, and a verified phone-number card in account settings.
+The phone-number plugin adds a dedicated `/auth/phone-number` view. It supports passwordless verification codes, phone number and password sign-in, password recovery, and a verified phone-number card in account settings. Its country selector formats national input as the user types, validates it, and sends an E.164 number to Better Auth.
 
 <Callout type="warn">
-Treat phone numbers as normalized identifiers. Validate and convert them to one canonical format, usually E.164, before sending an SMS. The UI intentionally accepts international input and leaves provider-specific parsing to your server.
+Keep server-side phone validation as a trust boundary. The UI sends E.164 numbers, but clients can bypass UI validation.
 </Callout>
 
 ## Setup
@@ -117,6 +117,8 @@ Use `validAuthPaths` in the route guard that renders `<Auth path={path} />`.
 | `passwordReset` | `false` | `sendPasswordResetOTP` |
 | `changePhoneNumber` | `true` | `sendOTP`. Verification uses `updatePhoneNumber: true` |
 | `otpLength` | `6` | Must match Better Auth `otpLength` |
+
+Use `defaultCountry`, `countries`, and `locale` to control the selector. Supply an `adapter` when your application needs different formatting or validation rules.
 
 When both sign-in modes are enabled, the form lets users switch between a code and a password. If password sign-in returns `PHONE_NUMBER_NOT_VERIFIED`, it moves directly to the code step because Better Auth has already started verification.
 

--- a/apps/docs/content/docs/zaidan/plugins/phone-number.mdx
+++ b/apps/docs/content/docs/zaidan/plugins/phone-number.mdx
@@ -7,7 +7,7 @@ description: Add phone verification-code and password sign-in to Solid and Zaida
 import { Callout } from "fumadocs-ui/components/callout"
 import { Step, Steps } from "fumadocs-ui/components/steps"
 
-The Solid/Zaidan registry item adds phone verification-code and password sign-in, phone password recovery, and verified phone-number management.
+The Solid/Zaidan registry item adds phone verification-code and password sign-in, phone password recovery, and verified phone-number management. Its country selector formats national input as the user types, validates it, and sends an E.164 number to Better Auth.
 
 ## Setup
 
@@ -35,7 +35,7 @@ export const auth = betterAuth({
 })
 ```
 
-Normalize numbers on the server and do not log codes in production.
+Keep server-side validation as a trust boundary even though the UI normalizes numbers to E.164. Do not log codes in production.
 
 </Step>
 <Step>
@@ -109,6 +109,8 @@ const validAuthPathSegments = new Set([
 | `passwordReset` | `false` | `sendPasswordResetOTP` |
 | `changePhoneNumber` | `true` | `sendOTP` |
 | `otpLength` | `6` | Must match Better Auth `otpLength` |
+
+Use `defaultCountry`, `countries`, and `locale` to control the selector. Supply an `adapter` when your application needs different formatting or validation rules.
 
 <Callout type="warn">
 Passwordless phone verification bypasses Better Auth 2FA. Phone number and password sign-in still follows the configured second-factor flow.

--- a/apps/docs/src/components/auth/phone-number/change-phone-number.tsx
+++ b/apps/docs/src/components/auth/phone-number/change-phone-number.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import {
   useAuth,
   useAuthPlugin,
@@ -16,18 +19,13 @@ import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
+import { FieldDescription } from "@/components/ui/field"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
 import { OtpField } from "../otp-field"
+import { InternationalPhoneField } from "./international-phone-field"
 import { RemovePhoneNumberDialog } from "./remove-phone-number-dialog"
 
 type PhoneNumberUser = {
@@ -41,19 +39,32 @@ export type ChangePhoneNumberProps = {
 /** Add, replace, or remove the authenticated user's verified phone number. */
 export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
   const { authClient } = useAuth()
-  const { localization, otpLength } = useAuthPlugin(phoneNumberPlugin)
+  const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
+    localization,
+    otpLength
+  } = useAuthPlugin(phoneNumberPlugin)
   const phoneClient = authClient as PhoneNumberAuthClient
   const { data: session } = useSession(phoneClient)
   const currentPhoneNumber =
     (session?.user as PhoneNumberUser | undefined)?.phoneNumber ?? ""
-  const [phoneNumber, setPhoneNumber] = useState("")
+  const [phoneNumber, setPhoneNumber] = useState(() =>
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
   const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
   const [fieldError, setFieldError] = useState<string>()
 
   useEffect(() => {
-    if (session) setPhoneNumber(currentPhoneNumber)
-  }, [currentPhoneNumber, session])
+    if (session) {
+      setPhoneNumber(
+        createPhoneNumberValue(currentPhoneNumber, defaultCountry, adapter)
+      )
+    }
+  }, [adapter, currentPhoneNumber, defaultCountry, session])
 
   const { mutate: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
     phoneClient,
@@ -74,7 +85,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
     phoneClient,
     {
       onSuccess: () => {
-        setPhoneNumber("")
+        setPhoneNumber(createPhoneNumberValue("", defaultCountry, adapter))
         toast.success(localization.phoneNumberRemoved)
       }
     }
@@ -83,12 +94,16 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
 
   const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault()
+    if (!phoneNumber.e164) {
+      setFieldError(localization.invalidPhoneNumber)
+      return
+    }
     if (!codeSent) {
-      sendOtp({ phoneNumber })
+      sendOtp({ phoneNumber: phoneNumber.e164 })
       return
     }
 
-    verify({ phoneNumber, code, updatePhoneNumber: true })
+    verify({ phoneNumber: phoneNumber.e164, code, updatePhoneNumber: true })
   }
   const removePhoneNumber = () =>
     updateUser({
@@ -108,7 +123,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                 <FieldDescription>
                   {localization.codeSentTo.replace(
                     "{{phoneNumber}}",
-                    phoneNumber
+                    phoneNumber.display
                   )}
                 </FieldDescription>
                 <OtpField
@@ -121,39 +136,24 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                   onChange={setCode}
                 />
               </>
+            ) : session ? (
+              <InternationalPhoneField
+                adapter={adapter}
+                countryCodes={countries}
+                countryLabel={localization.country}
+                disabled={isPending}
+                error={fieldError}
+                locale={locale}
+                phoneLabel={localization.phoneNumber}
+                placeholder={localization.phoneNumberPlaceholder}
+                value={phoneNumber}
+                onChange={(value) => {
+                  setPhoneNumber(value)
+                  setFieldError(undefined)
+                }}
+              />
             ) : (
-              <Field data-invalid={Boolean(fieldError)}>
-                <FieldLabel htmlFor="settingsPhoneNumber">
-                  {localization.phoneNumber}
-                </FieldLabel>
-                {session ? (
-                  <Input
-                    id="settingsPhoneNumber"
-                    name="phoneNumber"
-                    type="tel"
-                    autoComplete="tel"
-                    inputMode="tel"
-                    value={phoneNumber}
-                    placeholder={localization.phoneNumberPlaceholder}
-                    required
-                    disabled={isPending}
-                    onChange={(event) => {
-                      setPhoneNumber(event.target.value)
-                      setFieldError(undefined)
-                    }}
-                    onInvalid={(event) => {
-                      event.preventDefault()
-                      setFieldError(event.currentTarget.validationMessage)
-                    }}
-                    aria-invalid={Boolean(fieldError)}
-                  />
-                ) : (
-                  <Skeleton>
-                    <Input className="invisible" />
-                  </Skeleton>
-                )}
-                <FieldError>{fieldError}</FieldError>
-              </Field>
+              <Skeleton className="h-14 w-full" />
             )}
           </CardContent>
           <CardFooter className="gap-3">
@@ -166,7 +166,13 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                 onClick={() => {
                   setCode("")
                   setCodeSent(false)
-                  setPhoneNumber(currentPhoneNumber)
+                  setPhoneNumber(
+                    createPhoneNumberValue(
+                      currentPhoneNumber,
+                      defaultCountry,
+                      adapter
+                    )
+                  )
                 }}
               >
                 {localization.cancel}

--- a/apps/docs/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/apps/docs/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -1,23 +1,20 @@
 "use client"
 
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import { useAuth, useAuthPlugin, useFetchOptions } from "@better-auth-ui/react"
 import { useRequestPhoneNumberPasswordReset } from "@better-auth-ui/react/plugins/phone-number"
 import { type SyntheticEvent, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldGroup,
-  FieldLabel
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
+import { FieldDescription, FieldGroup } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { InternationalPhoneField } from "./international-phone-field"
 
 export const PHONE_NUMBER_RESET_STORAGE_KEY =
   "better-auth-ui.phone-number-reset"
@@ -32,9 +29,18 @@ export function ForgotPhoneNumberPassword({
 }: ForgotPhoneNumberPasswordProps) {
   const { authClient, basePaths, localization, navigate, plugins, Link } =
     useAuth()
-  const { localization: phoneLocalization, viewPaths: phoneNumberViewPaths } =
-    useAuthPlugin(phoneNumberPlugin)
+  const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
+    localization: phoneLocalization,
+    viewPaths: phoneNumberViewPaths
+  } = useAuthPlugin(phoneNumberPlugin)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
+  const [phoneNumber, setPhoneNumber] = useState(() =>
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
   const [fieldError, setFieldError] = useState<string>()
   const { mutate: requestReset, isPending } =
     useRequestPhoneNumberPasswordReset(authClient as PhoneNumberAuthClient, {
@@ -52,9 +58,12 @@ export function ForgotPhoneNumberPassword({
 
   const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault()
-    const formData = new FormData(event.currentTarget)
+    if (!phoneNumber.e164) {
+      setFieldError(phoneLocalization.invalidPhoneNumber)
+      return
+    }
     requestReset({
-      phoneNumber: String(formData.get("phoneNumber") ?? ""),
+      phoneNumber: phoneNumber.e164,
       fetchOptions
     })
   }
@@ -69,28 +78,21 @@ export function ForgotPhoneNumberPassword({
       <CardContent>
         <form onSubmit={handleSubmit}>
           <FieldGroup>
-            <Field data-invalid={Boolean(fieldError)}>
-              <FieldLabel htmlFor="resetPhoneNumber">
-                {phoneLocalization.phoneNumber}
-              </FieldLabel>
-              <Input
-                id="resetPhoneNumber"
-                name="phoneNumber"
-                type="tel"
-                autoComplete="tel"
-                inputMode="tel"
-                placeholder={phoneLocalization.phoneNumberPlaceholder}
-                required
-                disabled={isPending}
-                onChange={() => setFieldError(undefined)}
-                onInvalid={(event) => {
-                  event.preventDefault()
-                  setFieldError(event.currentTarget.validationMessage)
-                }}
-                aria-invalid={Boolean(fieldError)}
-              />
-              <FieldError>{fieldError}</FieldError>
-            </Field>
+            <InternationalPhoneField
+              adapter={adapter}
+              countryCodes={countries}
+              countryLabel={phoneLocalization.country}
+              disabled={isPending}
+              error={fieldError}
+              locale={locale}
+              phoneLabel={phoneLocalization.phoneNumber}
+              placeholder={phoneLocalization.phoneNumberPlaceholder}
+              value={phoneNumber}
+              onChange={(value) => {
+                setPhoneNumber(value)
+                setFieldError(undefined)
+              }}
+            />
             {Captcha && <div className="flex justify-center">{Captcha}</div>}
             <Button type="submit" disabled={isPending}>
               {isPending && <Spinner />}

--- a/apps/docs/src/components/auth/phone-number/international-phone-field.tsx
+++ b/apps/docs/src/components/auth/phone-number/international-phone-field.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import {
+  createPhoneNumberValue,
+  getPhoneNumberCountries,
+  type PhoneNumberAdapter,
+  type PhoneNumberCountryCode,
+  type PhoneNumberValue
+} from "@better-auth-ui/core/plugins/phone-number"
+import { useId, useMemo } from "react"
+
+import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+
+type InternationalPhoneFieldProps = {
+  adapter: PhoneNumberAdapter
+  countryLabel: string
+  countryCodes?: readonly PhoneNumberCountryCode[]
+  disabled?: boolean
+  error?: string
+  locale?: string
+  name?: string
+  phoneLabel: string
+  placeholder: string
+  value: PhoneNumberValue
+  onChange: (value: PhoneNumberValue) => void
+}
+
+export function InternationalPhoneField({
+  adapter,
+  countryLabel,
+  countryCodes,
+  disabled,
+  error,
+  locale,
+  name = "phoneNumber",
+  phoneLabel,
+  placeholder,
+  value,
+  onChange
+}: InternationalPhoneFieldProps) {
+  const id = useId()
+  const countries = useMemo(
+    () => getPhoneNumberCountries(locale, countryCodes),
+    [countryCodes, locale]
+  )
+
+  return (
+    <div className="grid grid-cols-[8.5rem_minmax(0,1fr)] gap-2">
+      <Field>
+        <FieldLabel htmlFor={`${id}-country`}>{countryLabel}</FieldLabel>
+        <Select
+          disabled={disabled}
+          value={value.country}
+          onValueChange={(country) => {
+            const nextCountry = country as PhoneNumberCountryCode
+            const input = value.display.startsWith("+") ? "" : value.display
+            onChange(createPhoneNumberValue(input, nextCountry, adapter))
+          }}
+        >
+          <SelectTrigger id={`${id}-country`} className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {countries.map((country) => (
+              <SelectItem key={country.code} value={country.code}>
+                <span className="flex w-full items-center justify-between gap-4">
+                  <span>{country.label}</span>
+                  <span className="text-muted-foreground">
+                    {country.callingCode}
+                  </span>
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </Field>
+      <Field data-invalid={Boolean(error)}>
+        <FieldLabel htmlFor={`${id}-number`}>{phoneLabel}</FieldLabel>
+        <Input
+          id={`${id}-number`}
+          aria-invalid={Boolean(error)}
+          autoComplete="tel-national"
+          disabled={disabled}
+          inputMode="tel"
+          name={name}
+          placeholder={placeholder}
+          required
+          type="tel"
+          value={value.display}
+          onChange={(event) =>
+            onChange(
+              createPhoneNumberValue(event.target.value, value.country, adapter)
+            )
+          }
+        />
+        <FieldError>{error}</FieldError>
+      </Field>
+    </div>
+  )
+}

--- a/apps/docs/src/components/auth/phone-number/phone-number.tsx
+++ b/apps/docs/src/components/auth/phone-number/phone-number.tsx
@@ -1,7 +1,10 @@
 "use client"
 
 import { authMutationKeys } from "@better-auth-ui/core"
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import {
   AuthPrompts,
   useAuth,
@@ -34,7 +37,6 @@ import {
   FieldLabel,
   FieldSeparator
 } from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
 import {
   InputGroup,
   InputGroupAddon,
@@ -48,6 +50,7 @@ import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
 import { OtpField } from "../otp-field"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
+import { InternationalPhoneField } from "./international-phone-field"
 
 type PhoneNumberMode = "code" | "password"
 
@@ -74,6 +77,10 @@ export function PhoneNumber({
     Link
   } = useAuth()
   const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
     localization: phoneLocalization,
     otpLength,
     passwordReset,
@@ -88,7 +95,9 @@ export function PhoneNumber({
   const [mode, setMode] = useState<PhoneNumberMode>(
     signIn ? "code" : "password"
   )
-  const [phoneNumber, setPhoneNumber] = useState("")
+  const [phoneNumber, setPhoneNumber] = useState(() =>
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
   const [password, setPassword] = useState("")
   const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
@@ -150,12 +159,26 @@ export function PhoneNumber({
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
 
-  const sendCode = () =>
-    sendOtp({ phoneNumber, fetchOptions } as Parameters<typeof sendOtp>[0])
+  const getPhoneNumber = () => {
+    if (phoneNumber.e164) return phoneNumber.e164
+    setFieldErrors((current) => ({
+      ...current,
+      phoneNumber: phoneLocalization.invalidPhoneNumber
+    }))
+  }
+  const sendCode = () => {
+    const normalizedPhoneNumber = getPhoneNumber()
+    if (!normalizedPhoneNumber) return
+    sendOtp({
+      phoneNumber: normalizedPhoneNumber,
+      fetchOptions
+    } as Parameters<typeof sendOtp>[0])
+  }
   const verifyCode = (completedCode: string) => {
     if (isPending || completedCode.length !== otpLength) return
 
-    verify({ phoneNumber, code: completedCode })
+    if (!phoneNumber.e164) return
+    verify({ phoneNumber: phoneNumber.e164, code: completedCode })
   }
   const switchMode = () => {
     setMode((current) => (current === "code" ? "password" : "code"))
@@ -168,9 +191,11 @@ export function PhoneNumber({
     event.preventDefault()
 
     if (mode === "password") {
+      const normalizedPhoneNumber = getPhoneNumber()
+      if (!normalizedPhoneNumber) return
       const formData = new FormData(event.currentTarget)
       signInWithPassword({
-        phoneNumber,
+        phoneNumber: normalizedPhoneNumber,
         password,
         ...(emailAndPassword?.rememberMe
           ? { rememberMe: formData.get("rememberMe") === "on" }
@@ -200,7 +225,7 @@ export function PhoneNumber({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              phoneNumber
+              phoneNumber.display
             )}
           </CardDescription>
         )}
@@ -234,38 +259,24 @@ export function PhoneNumber({
                 />
               ) : (
                 <>
-                  <Field data-invalid={Boolean(fieldErrors.phoneNumber)}>
-                    <FieldLabel htmlFor="phoneNumber">
-                      {phoneLocalization.phoneNumber}
-                    </FieldLabel>
-                    <Input
-                      id="phoneNumber"
-                      name="phoneNumber"
-                      type="tel"
-                      autoComplete="tel"
-                      inputMode="tel"
-                      value={phoneNumber}
-                      placeholder={phoneLocalization.phoneNumberPlaceholder}
-                      required
-                      disabled={isPending}
-                      onChange={(event) => {
-                        setPhoneNumber(event.target.value)
-                        setFieldErrors((current) => ({
-                          ...current,
-                          phoneNumber: undefined
-                        }))
-                      }}
-                      onInvalid={(event) => {
-                        event.preventDefault()
-                        setFieldErrors((current) => ({
-                          ...current,
-                          phoneNumber: event.currentTarget.validationMessage
-                        }))
-                      }}
-                      aria-invalid={Boolean(fieldErrors.phoneNumber)}
-                    />
-                    <FieldError>{fieldErrors.phoneNumber}</FieldError>
-                  </Field>
+                  <InternationalPhoneField
+                    adapter={adapter}
+                    countryCodes={countries}
+                    countryLabel={phoneLocalization.country}
+                    disabled={isPending}
+                    error={fieldErrors.phoneNumber}
+                    locale={locale}
+                    phoneLabel={phoneLocalization.phoneNumber}
+                    placeholder={phoneLocalization.phoneNumberPlaceholder}
+                    value={phoneNumber}
+                    onChange={(value) => {
+                      setPhoneNumber(value)
+                      setFieldErrors((current) => ({
+                        ...current,
+                        phoneNumber: undefined
+                      }))
+                    }}
+                  />
 
                   {mode === "password" && (
                     <Field data-invalid={Boolean(fieldErrors.password)}>

--- a/bun.lock
+++ b/bun.lock
@@ -392,6 +392,7 @@
       "name": "@better-auth-ui/core",
       "version": "1.7.2",
       "dependencies": {
+        "libphonenumber-js": "^1.13.11",
         "uqr": "^0.1.3",
       },
       "devDependencies": {
@@ -2510,6 +2511,8 @@
     "lefthook-windows-arm64": ["lefthook-windows-arm64@2.1.10", "", { "os": "win32", "cpu": "arm64" }, "sha512-5Q6etF0Fla2DDA4ilDySrdNgiR5+W7cJZwnZ69Je3kvWCaWm4wnkuc8FEdjp3kiL2x3ZXipdI00f5vpO8aWmog=="],
 
     "lefthook-windows-x64": ["lefthook-windows-x64@2.1.10", "", { "os": "win32", "cpu": "x64" }, "sha512-c/XH8YZtylG4XaxzqFfXluvq2LXq2W/p54Bnzn3+Z7E5X2Fk3JlFJAibulMbIt2+w8T7UI/r97ok5GqE4kGaeA=="],
+
+    "libphonenumber-js": ["libphonenumber-js@1.13.11", "", {}, "sha512-ETER2kMaIFTI/Nh1a8Gk03dUF/SL0VZqtI+CcVHZxp5WIHYwNS7S+uiYZDYCvLy3lOR4/DAD5jf0h5WkePPpqg=="],
 
     "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
 

--- a/examples/next-shadcn-example/src/components/auth/phone-number/change-phone-number.tsx
+++ b/examples/next-shadcn-example/src/components/auth/phone-number/change-phone-number.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import {
   useAuth,
   useAuthPlugin,
@@ -16,18 +19,13 @@ import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
+import { FieldDescription } from "@/components/ui/field"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
 import { OtpField } from "../otp-field"
+import { InternationalPhoneField } from "./international-phone-field"
 import { RemovePhoneNumberDialog } from "./remove-phone-number-dialog"
 
 type PhoneNumberUser = {
@@ -41,19 +39,32 @@ export type ChangePhoneNumberProps = {
 /** Add, replace, or remove the authenticated user's verified phone number. */
 export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
   const { authClient } = useAuth()
-  const { localization, otpLength } = useAuthPlugin(phoneNumberPlugin)
+  const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
+    localization,
+    otpLength
+  } = useAuthPlugin(phoneNumberPlugin)
   const phoneClient = authClient as PhoneNumberAuthClient
   const { data: session } = useSession(phoneClient)
   const currentPhoneNumber =
     (session?.user as PhoneNumberUser | undefined)?.phoneNumber ?? ""
-  const [phoneNumber, setPhoneNumber] = useState("")
+  const [phoneNumber, setPhoneNumber] = useState(() =>
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
   const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
   const [fieldError, setFieldError] = useState<string>()
 
   useEffect(() => {
-    if (session) setPhoneNumber(currentPhoneNumber)
-  }, [currentPhoneNumber, session])
+    if (session) {
+      setPhoneNumber(
+        createPhoneNumberValue(currentPhoneNumber, defaultCountry, adapter)
+      )
+    }
+  }, [adapter, currentPhoneNumber, defaultCountry, session])
 
   const { mutate: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
     phoneClient,
@@ -74,7 +85,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
     phoneClient,
     {
       onSuccess: () => {
-        setPhoneNumber("")
+        setPhoneNumber(createPhoneNumberValue("", defaultCountry, adapter))
         toast.success(localization.phoneNumberRemoved)
       }
     }
@@ -83,12 +94,16 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
 
   const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault()
+    if (!phoneNumber.e164) {
+      setFieldError(localization.invalidPhoneNumber)
+      return
+    }
     if (!codeSent) {
-      sendOtp({ phoneNumber })
+      sendOtp({ phoneNumber: phoneNumber.e164 })
       return
     }
 
-    verify({ phoneNumber, code, updatePhoneNumber: true })
+    verify({ phoneNumber: phoneNumber.e164, code, updatePhoneNumber: true })
   }
   const removePhoneNumber = () =>
     updateUser({
@@ -108,7 +123,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                 <FieldDescription>
                   {localization.codeSentTo.replace(
                     "{{phoneNumber}}",
-                    phoneNumber
+                    phoneNumber.display
                   )}
                 </FieldDescription>
                 <OtpField
@@ -121,39 +136,24 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                   onChange={setCode}
                 />
               </>
+            ) : session ? (
+              <InternationalPhoneField
+                adapter={adapter}
+                countryCodes={countries}
+                countryLabel={localization.country}
+                disabled={isPending}
+                error={fieldError}
+                locale={locale}
+                phoneLabel={localization.phoneNumber}
+                placeholder={localization.phoneNumberPlaceholder}
+                value={phoneNumber}
+                onChange={(value) => {
+                  setPhoneNumber(value)
+                  setFieldError(undefined)
+                }}
+              />
             ) : (
-              <Field data-invalid={Boolean(fieldError)}>
-                <FieldLabel htmlFor="settingsPhoneNumber">
-                  {localization.phoneNumber}
-                </FieldLabel>
-                {session ? (
-                  <Input
-                    id="settingsPhoneNumber"
-                    name="phoneNumber"
-                    type="tel"
-                    autoComplete="tel"
-                    inputMode="tel"
-                    value={phoneNumber}
-                    placeholder={localization.phoneNumberPlaceholder}
-                    required
-                    disabled={isPending}
-                    onChange={(event) => {
-                      setPhoneNumber(event.target.value)
-                      setFieldError(undefined)
-                    }}
-                    onInvalid={(event) => {
-                      event.preventDefault()
-                      setFieldError(event.currentTarget.validationMessage)
-                    }}
-                    aria-invalid={Boolean(fieldError)}
-                  />
-                ) : (
-                  <Skeleton>
-                    <Input className="invisible" />
-                  </Skeleton>
-                )}
-                <FieldError>{fieldError}</FieldError>
-              </Field>
+              <Skeleton className="h-14 w-full" />
             )}
           </CardContent>
           <CardFooter className="gap-3">
@@ -166,7 +166,13 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                 onClick={() => {
                   setCode("")
                   setCodeSent(false)
-                  setPhoneNumber(currentPhoneNumber)
+                  setPhoneNumber(
+                    createPhoneNumberValue(
+                      currentPhoneNumber,
+                      defaultCountry,
+                      adapter
+                    )
+                  )
                 }}
               >
                 {localization.cancel}

--- a/examples/next-shadcn-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/examples/next-shadcn-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -1,23 +1,20 @@
 "use client"
 
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import { useAuth, useAuthPlugin, useFetchOptions } from "@better-auth-ui/react"
 import { useRequestPhoneNumberPasswordReset } from "@better-auth-ui/react/plugins/phone-number"
 import { type SyntheticEvent, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldGroup,
-  FieldLabel
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
+import { FieldDescription, FieldGroup } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { InternationalPhoneField } from "./international-phone-field"
 
 export const PHONE_NUMBER_RESET_STORAGE_KEY =
   "better-auth-ui.phone-number-reset"
@@ -32,9 +29,18 @@ export function ForgotPhoneNumberPassword({
 }: ForgotPhoneNumberPasswordProps) {
   const { authClient, basePaths, localization, navigate, plugins, Link } =
     useAuth()
-  const { localization: phoneLocalization, viewPaths: phoneNumberViewPaths } =
-    useAuthPlugin(phoneNumberPlugin)
+  const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
+    localization: phoneLocalization,
+    viewPaths: phoneNumberViewPaths
+  } = useAuthPlugin(phoneNumberPlugin)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
+  const [phoneNumber, setPhoneNumber] = useState(() =>
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
   const [fieldError, setFieldError] = useState<string>()
   const { mutate: requestReset, isPending } =
     useRequestPhoneNumberPasswordReset(authClient as PhoneNumberAuthClient, {
@@ -52,9 +58,12 @@ export function ForgotPhoneNumberPassword({
 
   const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault()
-    const formData = new FormData(event.currentTarget)
+    if (!phoneNumber.e164) {
+      setFieldError(phoneLocalization.invalidPhoneNumber)
+      return
+    }
     requestReset({
-      phoneNumber: String(formData.get("phoneNumber") ?? ""),
+      phoneNumber: phoneNumber.e164,
       fetchOptions
     })
   }
@@ -69,28 +78,21 @@ export function ForgotPhoneNumberPassword({
       <CardContent>
         <form onSubmit={handleSubmit}>
           <FieldGroup>
-            <Field data-invalid={Boolean(fieldError)}>
-              <FieldLabel htmlFor="resetPhoneNumber">
-                {phoneLocalization.phoneNumber}
-              </FieldLabel>
-              <Input
-                id="resetPhoneNumber"
-                name="phoneNumber"
-                type="tel"
-                autoComplete="tel"
-                inputMode="tel"
-                placeholder={phoneLocalization.phoneNumberPlaceholder}
-                required
-                disabled={isPending}
-                onChange={() => setFieldError(undefined)}
-                onInvalid={(event) => {
-                  event.preventDefault()
-                  setFieldError(event.currentTarget.validationMessage)
-                }}
-                aria-invalid={Boolean(fieldError)}
-              />
-              <FieldError>{fieldError}</FieldError>
-            </Field>
+            <InternationalPhoneField
+              adapter={adapter}
+              countryCodes={countries}
+              countryLabel={phoneLocalization.country}
+              disabled={isPending}
+              error={fieldError}
+              locale={locale}
+              phoneLabel={phoneLocalization.phoneNumber}
+              placeholder={phoneLocalization.phoneNumberPlaceholder}
+              value={phoneNumber}
+              onChange={(value) => {
+                setPhoneNumber(value)
+                setFieldError(undefined)
+              }}
+            />
             {Captcha && <div className="flex justify-center">{Captcha}</div>}
             <Button type="submit" disabled={isPending}>
               {isPending && <Spinner />}

--- a/examples/next-shadcn-example/src/components/auth/phone-number/international-phone-field.tsx
+++ b/examples/next-shadcn-example/src/components/auth/phone-number/international-phone-field.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import {
+  createPhoneNumberValue,
+  getPhoneNumberCountries,
+  type PhoneNumberAdapter,
+  type PhoneNumberCountryCode,
+  type PhoneNumberValue
+} from "@better-auth-ui/core/plugins/phone-number"
+import { useId, useMemo } from "react"
+
+import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+
+type InternationalPhoneFieldProps = {
+  adapter: PhoneNumberAdapter
+  countryLabel: string
+  countryCodes?: readonly PhoneNumberCountryCode[]
+  disabled?: boolean
+  error?: string
+  locale?: string
+  name?: string
+  phoneLabel: string
+  placeholder: string
+  value: PhoneNumberValue
+  onChange: (value: PhoneNumberValue) => void
+}
+
+export function InternationalPhoneField({
+  adapter,
+  countryLabel,
+  countryCodes,
+  disabled,
+  error,
+  locale,
+  name = "phoneNumber",
+  phoneLabel,
+  placeholder,
+  value,
+  onChange
+}: InternationalPhoneFieldProps) {
+  const id = useId()
+  const countries = useMemo(
+    () => getPhoneNumberCountries(locale, countryCodes),
+    [countryCodes, locale]
+  )
+
+  return (
+    <div className="grid grid-cols-[8.5rem_minmax(0,1fr)] gap-2">
+      <Field>
+        <FieldLabel htmlFor={`${id}-country`}>{countryLabel}</FieldLabel>
+        <Select
+          disabled={disabled}
+          value={value.country}
+          onValueChange={(country) => {
+            const nextCountry = country as PhoneNumberCountryCode
+            const input = value.display.startsWith("+") ? "" : value.display
+            onChange(createPhoneNumberValue(input, nextCountry, adapter))
+          }}
+        >
+          <SelectTrigger id={`${id}-country`} className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {countries.map((country) => (
+              <SelectItem key={country.code} value={country.code}>
+                <span className="flex w-full items-center justify-between gap-4">
+                  <span>{country.label}</span>
+                  <span className="text-muted-foreground">
+                    {country.callingCode}
+                  </span>
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </Field>
+      <Field data-invalid={Boolean(error)}>
+        <FieldLabel htmlFor={`${id}-number`}>{phoneLabel}</FieldLabel>
+        <Input
+          id={`${id}-number`}
+          aria-invalid={Boolean(error)}
+          autoComplete="tel-national"
+          disabled={disabled}
+          inputMode="tel"
+          name={name}
+          placeholder={placeholder}
+          required
+          type="tel"
+          value={value.display}
+          onChange={(event) =>
+            onChange(
+              createPhoneNumberValue(event.target.value, value.country, adapter)
+            )
+          }
+        />
+        <FieldError>{error}</FieldError>
+      </Field>
+    </div>
+  )
+}

--- a/examples/next-shadcn-example/src/components/auth/phone-number/phone-number.tsx
+++ b/examples/next-shadcn-example/src/components/auth/phone-number/phone-number.tsx
@@ -1,7 +1,10 @@
 "use client"
 
 import { authMutationKeys } from "@better-auth-ui/core"
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import {
   AuthPrompts,
   useAuth,
@@ -34,7 +37,6 @@ import {
   FieldLabel,
   FieldSeparator
 } from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
 import {
   InputGroup,
   InputGroupAddon,
@@ -48,6 +50,7 @@ import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
 import { OtpField } from "../otp-field"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
+import { InternationalPhoneField } from "./international-phone-field"
 
 type PhoneNumberMode = "code" | "password"
 
@@ -74,6 +77,10 @@ export function PhoneNumber({
     Link
   } = useAuth()
   const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
     localization: phoneLocalization,
     otpLength,
     passwordReset,
@@ -88,7 +95,9 @@ export function PhoneNumber({
   const [mode, setMode] = useState<PhoneNumberMode>(
     signIn ? "code" : "password"
   )
-  const [phoneNumber, setPhoneNumber] = useState("")
+  const [phoneNumber, setPhoneNumber] = useState(() =>
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
   const [password, setPassword] = useState("")
   const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
@@ -150,12 +159,26 @@ export function PhoneNumber({
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
 
-  const sendCode = () =>
-    sendOtp({ phoneNumber, fetchOptions } as Parameters<typeof sendOtp>[0])
+  const getPhoneNumber = () => {
+    if (phoneNumber.e164) return phoneNumber.e164
+    setFieldErrors((current) => ({
+      ...current,
+      phoneNumber: phoneLocalization.invalidPhoneNumber
+    }))
+  }
+  const sendCode = () => {
+    const normalizedPhoneNumber = getPhoneNumber()
+    if (!normalizedPhoneNumber) return
+    sendOtp({
+      phoneNumber: normalizedPhoneNumber,
+      fetchOptions
+    } as Parameters<typeof sendOtp>[0])
+  }
   const verifyCode = (completedCode: string) => {
     if (isPending || completedCode.length !== otpLength) return
 
-    verify({ phoneNumber, code: completedCode })
+    if (!phoneNumber.e164) return
+    verify({ phoneNumber: phoneNumber.e164, code: completedCode })
   }
   const switchMode = () => {
     setMode((current) => (current === "code" ? "password" : "code"))
@@ -168,9 +191,11 @@ export function PhoneNumber({
     event.preventDefault()
 
     if (mode === "password") {
+      const normalizedPhoneNumber = getPhoneNumber()
+      if (!normalizedPhoneNumber) return
       const formData = new FormData(event.currentTarget)
       signInWithPassword({
-        phoneNumber,
+        phoneNumber: normalizedPhoneNumber,
         password,
         ...(emailAndPassword?.rememberMe
           ? { rememberMe: formData.get("rememberMe") === "on" }
@@ -200,7 +225,7 @@ export function PhoneNumber({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              phoneNumber
+              phoneNumber.display
             )}
           </CardDescription>
         )}
@@ -234,38 +259,24 @@ export function PhoneNumber({
                 />
               ) : (
                 <>
-                  <Field data-invalid={Boolean(fieldErrors.phoneNumber)}>
-                    <FieldLabel htmlFor="phoneNumber">
-                      {phoneLocalization.phoneNumber}
-                    </FieldLabel>
-                    <Input
-                      id="phoneNumber"
-                      name="phoneNumber"
-                      type="tel"
-                      autoComplete="tel"
-                      inputMode="tel"
-                      value={phoneNumber}
-                      placeholder={phoneLocalization.phoneNumberPlaceholder}
-                      required
-                      disabled={isPending}
-                      onChange={(event) => {
-                        setPhoneNumber(event.target.value)
-                        setFieldErrors((current) => ({
-                          ...current,
-                          phoneNumber: undefined
-                        }))
-                      }}
-                      onInvalid={(event) => {
-                        event.preventDefault()
-                        setFieldErrors((current) => ({
-                          ...current,
-                          phoneNumber: event.currentTarget.validationMessage
-                        }))
-                      }}
-                      aria-invalid={Boolean(fieldErrors.phoneNumber)}
-                    />
-                    <FieldError>{fieldErrors.phoneNumber}</FieldError>
-                  </Field>
+                  <InternationalPhoneField
+                    adapter={adapter}
+                    countryCodes={countries}
+                    countryLabel={phoneLocalization.country}
+                    disabled={isPending}
+                    error={fieldErrors.phoneNumber}
+                    locale={locale}
+                    phoneLabel={phoneLocalization.phoneNumber}
+                    placeholder={phoneLocalization.phoneNumberPlaceholder}
+                    value={phoneNumber}
+                    onChange={(value) => {
+                      setPhoneNumber(value)
+                      setFieldErrors((current) => ({
+                        ...current,
+                        phoneNumber: undefined
+                      }))
+                    }}
+                  />
 
                   {mode === "password" && (
                     <Field data-invalid={Boolean(fieldErrors.password)}>

--- a/examples/start-shadcn-baseui-example/src/components/auth/phone-number/change-phone-number.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/phone-number/change-phone-number.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import {
   useAuth,
   useAuthPlugin,
@@ -16,18 +19,13 @@ import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
+import { FieldDescription } from "@/components/ui/field"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
 import { OtpField } from "../otp-field"
+import { InternationalPhoneField } from "./international-phone-field"
 import { RemovePhoneNumberDialog } from "./remove-phone-number-dialog"
 
 type PhoneNumberUser = {
@@ -41,19 +39,32 @@ export type ChangePhoneNumberProps = {
 /** Add, replace, or remove the authenticated user's verified phone number. */
 export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
   const { authClient } = useAuth()
-  const { localization, otpLength } = useAuthPlugin(phoneNumberPlugin)
+  const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
+    localization,
+    otpLength
+  } = useAuthPlugin(phoneNumberPlugin)
   const phoneClient = authClient as PhoneNumberAuthClient
   const { data: session } = useSession(phoneClient)
   const currentPhoneNumber =
     (session?.user as PhoneNumberUser | undefined)?.phoneNumber ?? ""
-  const [phoneNumber, setPhoneNumber] = useState("")
+  const [phoneNumber, setPhoneNumber] = useState(() =>
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
   const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
   const [fieldError, setFieldError] = useState<string>()
 
   useEffect(() => {
-    if (session) setPhoneNumber(currentPhoneNumber)
-  }, [currentPhoneNumber, session])
+    if (session) {
+      setPhoneNumber(
+        createPhoneNumberValue(currentPhoneNumber, defaultCountry, adapter)
+      )
+    }
+  }, [adapter, currentPhoneNumber, defaultCountry, session])
 
   const { mutate: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
     phoneClient,
@@ -74,7 +85,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
     phoneClient,
     {
       onSuccess: () => {
-        setPhoneNumber("")
+        setPhoneNumber(createPhoneNumberValue("", defaultCountry, adapter))
         toast.success(localization.phoneNumberRemoved)
       }
     }
@@ -83,12 +94,16 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
 
   const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault()
+    if (!phoneNumber.e164) {
+      setFieldError(localization.invalidPhoneNumber)
+      return
+    }
     if (!codeSent) {
-      sendOtp({ phoneNumber })
+      sendOtp({ phoneNumber: phoneNumber.e164 })
       return
     }
 
-    verify({ phoneNumber, code, updatePhoneNumber: true })
+    verify({ phoneNumber: phoneNumber.e164, code, updatePhoneNumber: true })
   }
   const removePhoneNumber = () =>
     updateUser({
@@ -108,7 +123,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                 <FieldDescription>
                   {localization.codeSentTo.replace(
                     "{{phoneNumber}}",
-                    phoneNumber
+                    phoneNumber.display
                   )}
                 </FieldDescription>
                 <OtpField
@@ -121,39 +136,24 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                   onChange={setCode}
                 />
               </>
+            ) : session ? (
+              <InternationalPhoneField
+                adapter={adapter}
+                countryCodes={countries}
+                countryLabel={localization.country}
+                disabled={isPending}
+                error={fieldError}
+                locale={locale}
+                phoneLabel={localization.phoneNumber}
+                placeholder={localization.phoneNumberPlaceholder}
+                value={phoneNumber}
+                onChange={(value) => {
+                  setPhoneNumber(value)
+                  setFieldError(undefined)
+                }}
+              />
             ) : (
-              <Field data-invalid={Boolean(fieldError)}>
-                <FieldLabel htmlFor="settingsPhoneNumber">
-                  {localization.phoneNumber}
-                </FieldLabel>
-                {session ? (
-                  <Input
-                    id="settingsPhoneNumber"
-                    name="phoneNumber"
-                    type="tel"
-                    autoComplete="tel"
-                    inputMode="tel"
-                    value={phoneNumber}
-                    placeholder={localization.phoneNumberPlaceholder}
-                    required
-                    disabled={isPending}
-                    onChange={(event) => {
-                      setPhoneNumber(event.target.value)
-                      setFieldError(undefined)
-                    }}
-                    onInvalid={(event) => {
-                      event.preventDefault()
-                      setFieldError(event.currentTarget.validationMessage)
-                    }}
-                    aria-invalid={Boolean(fieldError)}
-                  />
-                ) : (
-                  <Skeleton>
-                    <Input className="invisible" />
-                  </Skeleton>
-                )}
-                <FieldError>{fieldError}</FieldError>
-              </Field>
+              <Skeleton className="h-14 w-full" />
             )}
           </CardContent>
           <CardFooter className="gap-3">
@@ -166,7 +166,13 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                 onClick={() => {
                   setCode("")
                   setCodeSent(false)
-                  setPhoneNumber(currentPhoneNumber)
+                  setPhoneNumber(
+                    createPhoneNumberValue(
+                      currentPhoneNumber,
+                      defaultCountry,
+                      adapter
+                    )
+                  )
                 }}
               >
                 {localization.cancel}

--- a/examples/start-shadcn-baseui-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -1,23 +1,20 @@
 "use client"
 
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import { useAuth, useAuthPlugin, useFetchOptions } from "@better-auth-ui/react"
 import { useRequestPhoneNumberPasswordReset } from "@better-auth-ui/react/plugins/phone-number"
 import { type SyntheticEvent, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldGroup,
-  FieldLabel
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
+import { FieldDescription, FieldGroup } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { InternationalPhoneField } from "./international-phone-field"
 
 export const PHONE_NUMBER_RESET_STORAGE_KEY =
   "better-auth-ui.phone-number-reset"
@@ -32,9 +29,18 @@ export function ForgotPhoneNumberPassword({
 }: ForgotPhoneNumberPasswordProps) {
   const { authClient, basePaths, localization, navigate, plugins, Link } =
     useAuth()
-  const { localization: phoneLocalization, viewPaths: phoneNumberViewPaths } =
-    useAuthPlugin(phoneNumberPlugin)
+  const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
+    localization: phoneLocalization,
+    viewPaths: phoneNumberViewPaths
+  } = useAuthPlugin(phoneNumberPlugin)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
+  const [phoneNumber, setPhoneNumber] = useState(() =>
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
   const [fieldError, setFieldError] = useState<string>()
   const { mutate: requestReset, isPending } =
     useRequestPhoneNumberPasswordReset(authClient as PhoneNumberAuthClient, {
@@ -52,9 +58,12 @@ export function ForgotPhoneNumberPassword({
 
   const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault()
-    const formData = new FormData(event.currentTarget)
+    if (!phoneNumber.e164) {
+      setFieldError(phoneLocalization.invalidPhoneNumber)
+      return
+    }
     requestReset({
-      phoneNumber: String(formData.get("phoneNumber") ?? ""),
+      phoneNumber: phoneNumber.e164,
       fetchOptions
     })
   }
@@ -69,28 +78,21 @@ export function ForgotPhoneNumberPassword({
       <CardContent>
         <form onSubmit={handleSubmit}>
           <FieldGroup>
-            <Field data-invalid={Boolean(fieldError)}>
-              <FieldLabel htmlFor="resetPhoneNumber">
-                {phoneLocalization.phoneNumber}
-              </FieldLabel>
-              <Input
-                id="resetPhoneNumber"
-                name="phoneNumber"
-                type="tel"
-                autoComplete="tel"
-                inputMode="tel"
-                placeholder={phoneLocalization.phoneNumberPlaceholder}
-                required
-                disabled={isPending}
-                onChange={() => setFieldError(undefined)}
-                onInvalid={(event) => {
-                  event.preventDefault()
-                  setFieldError(event.currentTarget.validationMessage)
-                }}
-                aria-invalid={Boolean(fieldError)}
-              />
-              <FieldError>{fieldError}</FieldError>
-            </Field>
+            <InternationalPhoneField
+              adapter={adapter}
+              countryCodes={countries}
+              countryLabel={phoneLocalization.country}
+              disabled={isPending}
+              error={fieldError}
+              locale={locale}
+              phoneLabel={phoneLocalization.phoneNumber}
+              placeholder={phoneLocalization.phoneNumberPlaceholder}
+              value={phoneNumber}
+              onChange={(value) => {
+                setPhoneNumber(value)
+                setFieldError(undefined)
+              }}
+            />
             {Captcha && <div className="flex justify-center">{Captcha}</div>}
             <Button type="submit" disabled={isPending}>
               {isPending && <Spinner />}

--- a/examples/start-shadcn-baseui-example/src/components/auth/phone-number/international-phone-field.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/phone-number/international-phone-field.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import {
+  createPhoneNumberValue,
+  getPhoneNumberCountries,
+  type PhoneNumberAdapter,
+  type PhoneNumberCountryCode,
+  type PhoneNumberValue
+} from "@better-auth-ui/core/plugins/phone-number"
+import { useId, useMemo } from "react"
+
+import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+
+type InternationalPhoneFieldProps = {
+  adapter: PhoneNumberAdapter
+  countryLabel: string
+  countryCodes?: readonly PhoneNumberCountryCode[]
+  disabled?: boolean
+  error?: string
+  locale?: string
+  name?: string
+  phoneLabel: string
+  placeholder: string
+  value: PhoneNumberValue
+  onChange: (value: PhoneNumberValue) => void
+}
+
+export function InternationalPhoneField({
+  adapter,
+  countryLabel,
+  countryCodes,
+  disabled,
+  error,
+  locale,
+  name = "phoneNumber",
+  phoneLabel,
+  placeholder,
+  value,
+  onChange
+}: InternationalPhoneFieldProps) {
+  const id = useId()
+  const countries = useMemo(
+    () => getPhoneNumberCountries(locale, countryCodes),
+    [countryCodes, locale]
+  )
+
+  return (
+    <div className="grid grid-cols-[8.5rem_minmax(0,1fr)] gap-2">
+      <Field>
+        <FieldLabel htmlFor={`${id}-country`}>{countryLabel}</FieldLabel>
+        <Select
+          disabled={disabled}
+          value={value.country}
+          onValueChange={(country) => {
+            const nextCountry = country as PhoneNumberCountryCode
+            const input = value.display.startsWith("+") ? "" : value.display
+            onChange(createPhoneNumberValue(input, nextCountry, adapter))
+          }}
+        >
+          <SelectTrigger id={`${id}-country`} className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {countries.map((country) => (
+              <SelectItem key={country.code} value={country.code}>
+                <span className="flex w-full items-center justify-between gap-4">
+                  <span>{country.label}</span>
+                  <span className="text-muted-foreground">
+                    {country.callingCode}
+                  </span>
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </Field>
+      <Field data-invalid={Boolean(error)}>
+        <FieldLabel htmlFor={`${id}-number`}>{phoneLabel}</FieldLabel>
+        <Input
+          id={`${id}-number`}
+          aria-invalid={Boolean(error)}
+          autoComplete="tel-national"
+          disabled={disabled}
+          inputMode="tel"
+          name={name}
+          placeholder={placeholder}
+          required
+          type="tel"
+          value={value.display}
+          onChange={(event) =>
+            onChange(
+              createPhoneNumberValue(event.target.value, value.country, adapter)
+            )
+          }
+        />
+        <FieldError>{error}</FieldError>
+      </Field>
+    </div>
+  )
+}

--- a/examples/start-shadcn-baseui-example/src/components/auth/phone-number/phone-number.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/phone-number/phone-number.tsx
@@ -1,7 +1,10 @@
 "use client"
 
 import { authMutationKeys } from "@better-auth-ui/core"
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import {
   AuthPrompts,
   useAuth,
@@ -34,7 +37,6 @@ import {
   FieldLabel,
   FieldSeparator
 } from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
 import {
   InputGroup,
   InputGroupAddon,
@@ -48,6 +50,7 @@ import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
 import { OtpField } from "../otp-field"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
+import { InternationalPhoneField } from "./international-phone-field"
 
 type PhoneNumberMode = "code" | "password"
 
@@ -74,6 +77,10 @@ export function PhoneNumber({
     Link
   } = useAuth()
   const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
     localization: phoneLocalization,
     otpLength,
     passwordReset,
@@ -88,7 +95,9 @@ export function PhoneNumber({
   const [mode, setMode] = useState<PhoneNumberMode>(
     signIn ? "code" : "password"
   )
-  const [phoneNumber, setPhoneNumber] = useState("")
+  const [phoneNumber, setPhoneNumber] = useState(() =>
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
   const [password, setPassword] = useState("")
   const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
@@ -150,12 +159,26 @@ export function PhoneNumber({
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
 
-  const sendCode = () =>
-    sendOtp({ phoneNumber, fetchOptions } as Parameters<typeof sendOtp>[0])
+  const getPhoneNumber = () => {
+    if (phoneNumber.e164) return phoneNumber.e164
+    setFieldErrors((current) => ({
+      ...current,
+      phoneNumber: phoneLocalization.invalidPhoneNumber
+    }))
+  }
+  const sendCode = () => {
+    const normalizedPhoneNumber = getPhoneNumber()
+    if (!normalizedPhoneNumber) return
+    sendOtp({
+      phoneNumber: normalizedPhoneNumber,
+      fetchOptions
+    } as Parameters<typeof sendOtp>[0])
+  }
   const verifyCode = (completedCode: string) => {
     if (isPending || completedCode.length !== otpLength) return
 
-    verify({ phoneNumber, code: completedCode })
+    if (!phoneNumber.e164) return
+    verify({ phoneNumber: phoneNumber.e164, code: completedCode })
   }
   const switchMode = () => {
     setMode((current) => (current === "code" ? "password" : "code"))
@@ -168,9 +191,11 @@ export function PhoneNumber({
     event.preventDefault()
 
     if (mode === "password") {
+      const normalizedPhoneNumber = getPhoneNumber()
+      if (!normalizedPhoneNumber) return
       const formData = new FormData(event.currentTarget)
       signInWithPassword({
-        phoneNumber,
+        phoneNumber: normalizedPhoneNumber,
         password,
         ...(emailAndPassword?.rememberMe
           ? { rememberMe: formData.get("rememberMe") === "on" }
@@ -200,7 +225,7 @@ export function PhoneNumber({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              phoneNumber
+              phoneNumber.display
             )}
           </CardDescription>
         )}
@@ -234,38 +259,24 @@ export function PhoneNumber({
                 />
               ) : (
                 <>
-                  <Field data-invalid={Boolean(fieldErrors.phoneNumber)}>
-                    <FieldLabel htmlFor="phoneNumber">
-                      {phoneLocalization.phoneNumber}
-                    </FieldLabel>
-                    <Input
-                      id="phoneNumber"
-                      name="phoneNumber"
-                      type="tel"
-                      autoComplete="tel"
-                      inputMode="tel"
-                      value={phoneNumber}
-                      placeholder={phoneLocalization.phoneNumberPlaceholder}
-                      required
-                      disabled={isPending}
-                      onChange={(event) => {
-                        setPhoneNumber(event.target.value)
-                        setFieldErrors((current) => ({
-                          ...current,
-                          phoneNumber: undefined
-                        }))
-                      }}
-                      onInvalid={(event) => {
-                        event.preventDefault()
-                        setFieldErrors((current) => ({
-                          ...current,
-                          phoneNumber: event.currentTarget.validationMessage
-                        }))
-                      }}
-                      aria-invalid={Boolean(fieldErrors.phoneNumber)}
-                    />
-                    <FieldError>{fieldErrors.phoneNumber}</FieldError>
-                  </Field>
+                  <InternationalPhoneField
+                    adapter={adapter}
+                    countryCodes={countries}
+                    countryLabel={phoneLocalization.country}
+                    disabled={isPending}
+                    error={fieldErrors.phoneNumber}
+                    locale={locale}
+                    phoneLabel={phoneLocalization.phoneNumber}
+                    placeholder={phoneLocalization.phoneNumberPlaceholder}
+                    value={phoneNumber}
+                    onChange={(value) => {
+                      setPhoneNumber(value)
+                      setFieldErrors((current) => ({
+                        ...current,
+                        phoneNumber: undefined
+                      }))
+                    }}
+                  />
 
                   {mode === "password" && (
                     <Field data-invalid={Boolean(fieldErrors.password)}>

--- a/examples/start-shadcn-example/registry.json
+++ b/examples/start-shadcn-example/registry.json
@@ -341,6 +341,7 @@
         "input",
         "input-group",
         "input-otp",
+        "select",
         "skeleton",
         "sonner",
         "spinner",
@@ -495,6 +496,11 @@
           "path": "src/components/auth/phone-number/phone-number.tsx",
           "type": "registry:component",
           "target": "@components/auth/phone-number/phone-number.tsx"
+        },
+        {
+          "path": "src/components/auth/phone-number/international-phone-field.tsx",
+          "type": "registry:component",
+          "target": "@components/auth/phone-number/international-phone-field.tsx"
         },
         {
           "path": "src/components/auth/phone-number/phone-number-button.tsx",

--- a/examples/start-shadcn-example/src/components/auth/phone-number/change-phone-number.tsx
+++ b/examples/start-shadcn-example/src/components/auth/phone-number/change-phone-number.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import {
   useAuth,
   useAuthPlugin,
@@ -16,18 +19,13 @@ import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
+import { FieldDescription } from "@/components/ui/field"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
 import { OtpField } from "../otp-field"
+import { InternationalPhoneField } from "./international-phone-field"
 import { RemovePhoneNumberDialog } from "./remove-phone-number-dialog"
 
 type PhoneNumberUser = {
@@ -41,19 +39,32 @@ export type ChangePhoneNumberProps = {
 /** Add, replace, or remove the authenticated user's verified phone number. */
 export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
   const { authClient } = useAuth()
-  const { localization, otpLength } = useAuthPlugin(phoneNumberPlugin)
+  const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
+    localization,
+    otpLength
+  } = useAuthPlugin(phoneNumberPlugin)
   const phoneClient = authClient as PhoneNumberAuthClient
   const { data: session } = useSession(phoneClient)
   const currentPhoneNumber =
     (session?.user as PhoneNumberUser | undefined)?.phoneNumber ?? ""
-  const [phoneNumber, setPhoneNumber] = useState("")
+  const [phoneNumber, setPhoneNumber] = useState(() =>
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
   const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
   const [fieldError, setFieldError] = useState<string>()
 
   useEffect(() => {
-    if (session) setPhoneNumber(currentPhoneNumber)
-  }, [currentPhoneNumber, session])
+    if (session) {
+      setPhoneNumber(
+        createPhoneNumberValue(currentPhoneNumber, defaultCountry, adapter)
+      )
+    }
+  }, [adapter, currentPhoneNumber, defaultCountry, session])
 
   const { mutate: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
     phoneClient,
@@ -74,7 +85,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
     phoneClient,
     {
       onSuccess: () => {
-        setPhoneNumber("")
+        setPhoneNumber(createPhoneNumberValue("", defaultCountry, adapter))
         toast.success(localization.phoneNumberRemoved)
       }
     }
@@ -83,12 +94,16 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
 
   const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault()
+    if (!phoneNumber.e164) {
+      setFieldError(localization.invalidPhoneNumber)
+      return
+    }
     if (!codeSent) {
-      sendOtp({ phoneNumber })
+      sendOtp({ phoneNumber: phoneNumber.e164 })
       return
     }
 
-    verify({ phoneNumber, code, updatePhoneNumber: true })
+    verify({ phoneNumber: phoneNumber.e164, code, updatePhoneNumber: true })
   }
   const removePhoneNumber = () =>
     updateUser({
@@ -108,7 +123,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                 <FieldDescription>
                   {localization.codeSentTo.replace(
                     "{{phoneNumber}}",
-                    phoneNumber
+                    phoneNumber.display
                   )}
                 </FieldDescription>
                 <OtpField
@@ -121,39 +136,24 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                   onChange={setCode}
                 />
               </>
+            ) : session ? (
+              <InternationalPhoneField
+                adapter={adapter}
+                countryCodes={countries}
+                countryLabel={localization.country}
+                disabled={isPending}
+                error={fieldError}
+                locale={locale}
+                phoneLabel={localization.phoneNumber}
+                placeholder={localization.phoneNumberPlaceholder}
+                value={phoneNumber}
+                onChange={(value) => {
+                  setPhoneNumber(value)
+                  setFieldError(undefined)
+                }}
+              />
             ) : (
-              <Field data-invalid={Boolean(fieldError)}>
-                <FieldLabel htmlFor="settingsPhoneNumber">
-                  {localization.phoneNumber}
-                </FieldLabel>
-                {session ? (
-                  <Input
-                    id="settingsPhoneNumber"
-                    name="phoneNumber"
-                    type="tel"
-                    autoComplete="tel"
-                    inputMode="tel"
-                    value={phoneNumber}
-                    placeholder={localization.phoneNumberPlaceholder}
-                    required
-                    disabled={isPending}
-                    onChange={(event) => {
-                      setPhoneNumber(event.target.value)
-                      setFieldError(undefined)
-                    }}
-                    onInvalid={(event) => {
-                      event.preventDefault()
-                      setFieldError(event.currentTarget.validationMessage)
-                    }}
-                    aria-invalid={Boolean(fieldError)}
-                  />
-                ) : (
-                  <Skeleton>
-                    <Input className="invisible" />
-                  </Skeleton>
-                )}
-                <FieldError>{fieldError}</FieldError>
-              </Field>
+              <Skeleton className="h-14 w-full" />
             )}
           </CardContent>
           <CardFooter className="gap-3">
@@ -166,7 +166,13 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                 onClick={() => {
                   setCode("")
                   setCodeSent(false)
-                  setPhoneNumber(currentPhoneNumber)
+                  setPhoneNumber(
+                    createPhoneNumberValue(
+                      currentPhoneNumber,
+                      defaultCountry,
+                      adapter
+                    )
+                  )
                 }}
               >
                 {localization.cancel}

--- a/examples/start-shadcn-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/examples/start-shadcn-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -1,23 +1,20 @@
 "use client"
 
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import { useAuth, useAuthPlugin, useFetchOptions } from "@better-auth-ui/react"
 import { useRequestPhoneNumberPasswordReset } from "@better-auth-ui/react/plugins/phone-number"
 import { type SyntheticEvent, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldGroup,
-  FieldLabel
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
+import { FieldDescription, FieldGroup } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { InternationalPhoneField } from "./international-phone-field"
 
 export const PHONE_NUMBER_RESET_STORAGE_KEY =
   "better-auth-ui.phone-number-reset"
@@ -32,9 +29,18 @@ export function ForgotPhoneNumberPassword({
 }: ForgotPhoneNumberPasswordProps) {
   const { authClient, basePaths, localization, navigate, plugins, Link } =
     useAuth()
-  const { localization: phoneLocalization, viewPaths: phoneNumberViewPaths } =
-    useAuthPlugin(phoneNumberPlugin)
+  const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
+    localization: phoneLocalization,
+    viewPaths: phoneNumberViewPaths
+  } = useAuthPlugin(phoneNumberPlugin)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
+  const [phoneNumber, setPhoneNumber] = useState(() =>
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
   const [fieldError, setFieldError] = useState<string>()
   const { mutate: requestReset, isPending } =
     useRequestPhoneNumberPasswordReset(authClient as PhoneNumberAuthClient, {
@@ -52,9 +58,12 @@ export function ForgotPhoneNumberPassword({
 
   const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault()
-    const formData = new FormData(event.currentTarget)
+    if (!phoneNumber.e164) {
+      setFieldError(phoneLocalization.invalidPhoneNumber)
+      return
+    }
     requestReset({
-      phoneNumber: String(formData.get("phoneNumber") ?? ""),
+      phoneNumber: phoneNumber.e164,
       fetchOptions
     })
   }
@@ -69,28 +78,21 @@ export function ForgotPhoneNumberPassword({
       <CardContent>
         <form onSubmit={handleSubmit}>
           <FieldGroup>
-            <Field data-invalid={Boolean(fieldError)}>
-              <FieldLabel htmlFor="resetPhoneNumber">
-                {phoneLocalization.phoneNumber}
-              </FieldLabel>
-              <Input
-                id="resetPhoneNumber"
-                name="phoneNumber"
-                type="tel"
-                autoComplete="tel"
-                inputMode="tel"
-                placeholder={phoneLocalization.phoneNumberPlaceholder}
-                required
-                disabled={isPending}
-                onChange={() => setFieldError(undefined)}
-                onInvalid={(event) => {
-                  event.preventDefault()
-                  setFieldError(event.currentTarget.validationMessage)
-                }}
-                aria-invalid={Boolean(fieldError)}
-              />
-              <FieldError>{fieldError}</FieldError>
-            </Field>
+            <InternationalPhoneField
+              adapter={adapter}
+              countryCodes={countries}
+              countryLabel={phoneLocalization.country}
+              disabled={isPending}
+              error={fieldError}
+              locale={locale}
+              phoneLabel={phoneLocalization.phoneNumber}
+              placeholder={phoneLocalization.phoneNumberPlaceholder}
+              value={phoneNumber}
+              onChange={(value) => {
+                setPhoneNumber(value)
+                setFieldError(undefined)
+              }}
+            />
             {Captcha && <div className="flex justify-center">{Captcha}</div>}
             <Button type="submit" disabled={isPending}>
               {isPending && <Spinner />}

--- a/examples/start-shadcn-example/src/components/auth/phone-number/international-phone-field.tsx
+++ b/examples/start-shadcn-example/src/components/auth/phone-number/international-phone-field.tsx
@@ -1,0 +1,108 @@
+"use client"
+
+import {
+  createPhoneNumberValue,
+  getPhoneNumberCountries,
+  type PhoneNumberAdapter,
+  type PhoneNumberCountryCode,
+  type PhoneNumberValue
+} from "@better-auth-ui/core/plugins/phone-number"
+import { useId, useMemo } from "react"
+
+import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+
+type InternationalPhoneFieldProps = {
+  adapter: PhoneNumberAdapter
+  countryLabel: string
+  countryCodes?: readonly PhoneNumberCountryCode[]
+  disabled?: boolean
+  error?: string
+  locale?: string
+  name?: string
+  phoneLabel: string
+  placeholder: string
+  value: PhoneNumberValue
+  onChange: (value: PhoneNumberValue) => void
+}
+
+export function InternationalPhoneField({
+  adapter,
+  countryLabel,
+  countryCodes,
+  disabled,
+  error,
+  locale,
+  name = "phoneNumber",
+  phoneLabel,
+  placeholder,
+  value,
+  onChange
+}: InternationalPhoneFieldProps) {
+  const id = useId()
+  const countries = useMemo(
+    () => getPhoneNumberCountries(locale, countryCodes),
+    [countryCodes, locale]
+  )
+
+  return (
+    <div className="grid grid-cols-[8.5rem_minmax(0,1fr)] gap-2">
+      <Field>
+        <FieldLabel htmlFor={`${id}-country`}>{countryLabel}</FieldLabel>
+        <Select
+          disabled={disabled}
+          value={value.country}
+          onValueChange={(country) => {
+            const nextCountry = country as PhoneNumberCountryCode
+            const input = value.display.startsWith("+") ? "" : value.display
+            onChange(createPhoneNumberValue(input, nextCountry, adapter))
+          }}
+        >
+          <SelectTrigger id={`${id}-country`} className="w-full">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {countries.map((country) => (
+              <SelectItem key={country.code} value={country.code}>
+                <span className="flex w-full items-center justify-between gap-4">
+                  <span>{country.label}</span>
+                  <span className="text-muted-foreground">
+                    {country.callingCode}
+                  </span>
+                </span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </Field>
+      <Field data-invalid={Boolean(error)}>
+        <FieldLabel htmlFor={`${id}-number`}>{phoneLabel}</FieldLabel>
+        <Input
+          id={`${id}-number`}
+          aria-invalid={Boolean(error)}
+          autoComplete="tel-national"
+          disabled={disabled}
+          inputMode="tel"
+          name={name}
+          placeholder={placeholder}
+          required
+          type="tel"
+          value={value.display}
+          onChange={(event) =>
+            onChange(
+              createPhoneNumberValue(event.target.value, value.country, adapter)
+            )
+          }
+        />
+        <FieldError>{error}</FieldError>
+      </Field>
+    </div>
+  )
+}

--- a/examples/start-shadcn-example/src/components/auth/phone-number/phone-number.tsx
+++ b/examples/start-shadcn-example/src/components/auth/phone-number/phone-number.tsx
@@ -1,7 +1,10 @@
 "use client"
 
 import { authMutationKeys } from "@better-auth-ui/core"
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import {
   AuthPrompts,
   useAuth,
@@ -34,7 +37,6 @@ import {
   FieldLabel,
   FieldSeparator
 } from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
 import {
   InputGroup,
   InputGroupAddon,
@@ -48,6 +50,7 @@ import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
 import { OtpField } from "../otp-field"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
+import { InternationalPhoneField } from "./international-phone-field"
 
 type PhoneNumberMode = "code" | "password"
 
@@ -74,6 +77,10 @@ export function PhoneNumber({
     Link
   } = useAuth()
   const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
     localization: phoneLocalization,
     otpLength,
     passwordReset,
@@ -88,7 +95,9 @@ export function PhoneNumber({
   const [mode, setMode] = useState<PhoneNumberMode>(
     signIn ? "code" : "password"
   )
-  const [phoneNumber, setPhoneNumber] = useState("")
+  const [phoneNumber, setPhoneNumber] = useState(() =>
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
   const [password, setPassword] = useState("")
   const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
@@ -150,12 +159,26 @@ export function PhoneNumber({
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
 
-  const sendCode = () =>
-    sendOtp({ phoneNumber, fetchOptions } as Parameters<typeof sendOtp>[0])
+  const getPhoneNumber = () => {
+    if (phoneNumber.e164) return phoneNumber.e164
+    setFieldErrors((current) => ({
+      ...current,
+      phoneNumber: phoneLocalization.invalidPhoneNumber
+    }))
+  }
+  const sendCode = () => {
+    const normalizedPhoneNumber = getPhoneNumber()
+    if (!normalizedPhoneNumber) return
+    sendOtp({
+      phoneNumber: normalizedPhoneNumber,
+      fetchOptions
+    } as Parameters<typeof sendOtp>[0])
+  }
   const verifyCode = (completedCode: string) => {
     if (isPending || completedCode.length !== otpLength) return
 
-    verify({ phoneNumber, code: completedCode })
+    if (!phoneNumber.e164) return
+    verify({ phoneNumber: phoneNumber.e164, code: completedCode })
   }
   const switchMode = () => {
     setMode((current) => (current === "code" ? "password" : "code"))
@@ -168,9 +191,11 @@ export function PhoneNumber({
     event.preventDefault()
 
     if (mode === "password") {
+      const normalizedPhoneNumber = getPhoneNumber()
+      if (!normalizedPhoneNumber) return
       const formData = new FormData(event.currentTarget)
       signInWithPassword({
-        phoneNumber,
+        phoneNumber: normalizedPhoneNumber,
         password,
         ...(emailAndPassword?.rememberMe
           ? { rememberMe: formData.get("rememberMe") === "on" }
@@ -200,7 +225,7 @@ export function PhoneNumber({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              phoneNumber
+              phoneNumber.display
             )}
           </CardDescription>
         )}
@@ -234,38 +259,24 @@ export function PhoneNumber({
                 />
               ) : (
                 <>
-                  <Field data-invalid={Boolean(fieldErrors.phoneNumber)}>
-                    <FieldLabel htmlFor="phoneNumber">
-                      {phoneLocalization.phoneNumber}
-                    </FieldLabel>
-                    <Input
-                      id="phoneNumber"
-                      name="phoneNumber"
-                      type="tel"
-                      autoComplete="tel"
-                      inputMode="tel"
-                      value={phoneNumber}
-                      placeholder={phoneLocalization.phoneNumberPlaceholder}
-                      required
-                      disabled={isPending}
-                      onChange={(event) => {
-                        setPhoneNumber(event.target.value)
-                        setFieldErrors((current) => ({
-                          ...current,
-                          phoneNumber: undefined
-                        }))
-                      }}
-                      onInvalid={(event) => {
-                        event.preventDefault()
-                        setFieldErrors((current) => ({
-                          ...current,
-                          phoneNumber: event.currentTarget.validationMessage
-                        }))
-                      }}
-                      aria-invalid={Boolean(fieldErrors.phoneNumber)}
-                    />
-                    <FieldError>{fieldErrors.phoneNumber}</FieldError>
-                  </Field>
+                  <InternationalPhoneField
+                    adapter={adapter}
+                    countryCodes={countries}
+                    countryLabel={phoneLocalization.country}
+                    disabled={isPending}
+                    error={fieldErrors.phoneNumber}
+                    locale={locale}
+                    phoneLabel={phoneLocalization.phoneNumber}
+                    placeholder={phoneLocalization.phoneNumberPlaceholder}
+                    value={phoneNumber}
+                    onChange={(value) => {
+                      setPhoneNumber(value)
+                      setFieldErrors((current) => ({
+                        ...current,
+                        phoneNumber: undefined
+                      }))
+                    }}
+                  />
 
                   {mode === "password" && (
                     <Field data-invalid={Boolean(fieldErrors.password)}>

--- a/examples/start-solid-zaidan-example/registry.manifest.ts
+++ b/examples/start-solid-zaidan-example/registry.manifest.ts
@@ -293,7 +293,8 @@ export const solidRegistryManifest = {
       registryDependencies: [
         betterAuthSolidRegistryDependency("auth-provider"),
         betterAuthSolidRegistryDependency("account-settings"),
-        "@zaidan/alert-dialog"
+        "@zaidan/alert-dialog",
+        "@zaidan/native-select"
       ],
       files: [
         libFile("src/lib/auth/phone-number-plugin.ts"),
@@ -301,6 +302,9 @@ export const solidRegistryManifest = {
         libFile("src/lib/auth/use-sign-in-continuation.ts"),
         componentFile("src/components/auth/otp-field.tsx"),
         componentFile("src/components/auth/phone-number/phone-number.tsx"),
+        componentFile(
+          "src/components/auth/phone-number/international-phone-field.tsx"
+        ),
         componentFile(
           "src/components/auth/phone-number/phone-number-button.tsx"
         ),

--- a/examples/start-solid-zaidan-example/src/components/auth/phone-number/change-phone-number.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/phone-number/change-phone-number.tsx
@@ -1,4 +1,7 @@
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import {
   useAuth,
   useAuthPlugin,
@@ -13,10 +16,9 @@ import { createEffect, createSignal, Show } from "solid-js"
 import { toast } from "solid-sonner"
 
 import { OtpField } from "@/components/auth/otp-field"
+import { InternationalPhoneField } from "@/components/auth/phone-number/international-phone-field"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
@@ -34,12 +36,21 @@ export type ChangePhoneNumberProps = {
 /** Add, replace, or remove the authenticated user's verified phone number. */
 export function ChangePhoneNumber(props: ChangePhoneNumberProps = {}) {
   const auth = useAuth()
-  const { localization, otpLength } = useAuthPlugin(phoneNumberPlugin)
+  const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
+    localization,
+    otpLength
+  } = useAuthPlugin(phoneNumberPlugin)
   const phoneClient = () => auth.authClient as PhoneNumberAuthClient
   const session = useSession(phoneClient())
   const currentPhoneNumber = () =>
     (session.data?.user as PhoneNumberUser | undefined)?.phoneNumber ?? ""
-  const [phoneNumber, setPhoneNumber] = createSignal("")
+  const [phoneNumber, setPhoneNumber] = createSignal(
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
   const [fieldError, setFieldError] = createSignal<string>()
   const [code, setCode] = createSignal("")
   const [codeSent, setCodeSent] = createSignal(false)
@@ -48,7 +59,9 @@ export function ChangePhoneNumber(props: ChangePhoneNumberProps = {}) {
   createEffect(() => {
     if (!session.data || initialized) return
     initialized = true
-    setPhoneNumber(currentPhoneNumber())
+    setPhoneNumber(
+      createPhoneNumberValue(currentPhoneNumber(), defaultCountry, adapter)
+    )
   })
 
   const sendOtp = useSendPhoneNumberOtp(phoneClient(), () => ({
@@ -64,7 +77,7 @@ export function ChangePhoneNumber(props: ChangePhoneNumberProps = {}) {
   }))
   const remove = useUpdateUser(phoneClient(), () => ({
     onSuccess: () => {
-      setPhoneNumber("")
+      setPhoneNumber(createPhoneNumberValue("", defaultCountry, adapter))
       toast.success(localization.phoneNumberRemoved)
     }
   }))
@@ -72,14 +85,18 @@ export function ChangePhoneNumber(props: ChangePhoneNumberProps = {}) {
     sendOtp.isPending || verify.isPending || remove.isPending
   const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
     event.preventDefault()
+    if (!phoneNumber().e164) {
+      setFieldError(localization.invalidPhoneNumber)
+      return
+    }
     if (!codeSent()) {
-      sendOtp.mutate({ phoneNumber: phoneNumber() } as Parameters<
+      sendOtp.mutate({ phoneNumber: phoneNumber().e164 } as Parameters<
         typeof sendOtp.mutate
       >[0])
       return
     }
     verify.mutate({
-      phoneNumber: phoneNumber(),
+      phoneNumber: phoneNumber().e164,
       code: code(),
       updatePhoneNumber: true
     } as Parameters<typeof verify.mutate>[0])
@@ -100,50 +117,33 @@ export function ChangePhoneNumber(props: ChangePhoneNumberProps = {}) {
             <Show
               when={codeSent()}
               fallback={
-                <Field data-invalid={Boolean(fieldError())}>
-                  <FieldLabel for="settings-phone-number">
-                    {localization.phoneNumber}
-                  </FieldLabel>
-                  <Show
-                    when={session.data}
-                    fallback={
-                      <Skeleton>
-                        <Input class="invisible" />
-                      </Skeleton>
-                    }
-                  >
-                    <Input
-                      aria-invalid={Boolean(fieldError())}
-                      autocomplete="tel"
-                      disabled={isPending()}
-                      id="settings-phone-number"
-                      inputmode="tel"
-                      name="phoneNumber"
-                      onInput={(event) => {
-                        setPhoneNumber(event.currentTarget.value)
-                        setFieldError(undefined)
-                      }}
-                      onInvalid={(event) => {
-                        event.preventDefault()
-                        setFieldError(event.currentTarget.validationMessage)
-                      }}
-                      placeholder={localization.phoneNumberPlaceholder}
-                      required
-                      type="tel"
-                      value={phoneNumber()}
-                    />
-                  </Show>
-                  <Show when={fieldError()}>
-                    {(message) => <FieldError>{message()}</FieldError>}
-                  </Show>
-                </Field>
+                <Show
+                  when={session.data}
+                  fallback={<Skeleton class="h-14 w-full" />}
+                >
+                  <InternationalPhoneField
+                    adapter={adapter}
+                    countryCodes={countries}
+                    countryLabel={localization.country}
+                    disabled={isPending()}
+                    error={fieldError()}
+                    locale={locale}
+                    phoneLabel={localization.phoneNumber}
+                    placeholder={localization.phoneNumberPlaceholder}
+                    value={phoneNumber()}
+                    onChange={(value) => {
+                      setPhoneNumber(value)
+                      setFieldError(undefined)
+                    }}
+                  />
+                </Show>
               }
             >
               <div class="flex flex-col gap-3">
                 <p class="text-sm text-muted-foreground">
                   {localization.codeSentTo.replace(
                     "{{phoneNumber}}",
-                    phoneNumber()
+                    phoneNumber().display
                   )}
                 </p>
                 <OtpField
@@ -166,7 +166,13 @@ export function ChangePhoneNumber(props: ChangePhoneNumberProps = {}) {
                 onClick={() => {
                   setCode("")
                   setCodeSent(false)
-                  setPhoneNumber(currentPhoneNumber())
+                  setPhoneNumber(
+                    createPhoneNumberValue(
+                      currentPhoneNumber(),
+                      defaultCountry,
+                      adapter
+                    )
+                  )
                 }}
                 size="sm"
                 type="button"

--- a/examples/start-solid-zaidan-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -1,4 +1,7 @@
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import {
   AuthLink,
   useAuth,
@@ -16,16 +19,11 @@ import {
   CardHeader,
   CardTitle
 } from "@/components/ui/card"
-import {
-  Field,
-  FieldError,
-  FieldGroup,
-  FieldLabel
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
+import { FieldGroup } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { InternationalPhoneField } from "./international-phone-field"
 
 export const PHONE_NUMBER_RESET_STORAGE_KEY =
   "better-auth-ui.phone-number-reset"
@@ -39,9 +37,18 @@ export function ForgotPhoneNumberPassword(
   props: ForgotPhoneNumberPasswordProps
 ) {
   const auth = useAuth()
-  const { localization, viewPaths: phoneNumberViewPaths } =
-    useAuthPlugin(phoneNumberPlugin)
+  const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
+    localization,
+    viewPaths: phoneNumberViewPaths
+  } = useAuthPlugin(phoneNumberPlugin)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
+  const [phoneNumber, setPhoneNumber] = createSignal(
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
   const [fieldError, setFieldError] = createSignal<string>()
   const requestReset = useRequestPhoneNumberPasswordReset(
     auth.authClient as PhoneNumberAuthClient,
@@ -58,9 +65,12 @@ export function ForgotPhoneNumberPassword(
   )
   const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
     event.preventDefault()
-    const formData = new FormData(event.currentTarget)
+    if (!phoneNumber().e164) {
+      setFieldError(localization.invalidPhoneNumber)
+      return
+    }
     requestReset.mutate({
-      phoneNumber: String(formData.get("phoneNumber") ?? ""),
+      phoneNumber: phoneNumber().e164,
       fetchOptions: fetchOptions()
     } as Parameters<typeof requestReset.mutate>[0])
   }
@@ -75,30 +85,21 @@ export function ForgotPhoneNumberPassword(
       <CardContent>
         <form aria-label={localization.forgotPassword} onSubmit={submit}>
           <FieldGroup>
-            <Field data-invalid={Boolean(fieldError())}>
-              <FieldLabel for="forgot-phone-number">
-                {localization.phoneNumber}
-              </FieldLabel>
-              <Input
-                aria-invalid={Boolean(fieldError())}
-                autocomplete="tel"
-                disabled={requestReset.isPending}
-                id="forgot-phone-number"
-                inputmode="tel"
-                name="phoneNumber"
-                onInput={() => setFieldError(undefined)}
-                onInvalid={(event) => {
-                  event.preventDefault()
-                  setFieldError(event.currentTarget.validationMessage)
-                }}
-                placeholder={localization.phoneNumberPlaceholder}
-                required
-                type="tel"
-              />
-              <Show when={fieldError()}>
-                {(message) => <FieldError>{message()}</FieldError>}
-              </Show>
-            </Field>
+            <InternationalPhoneField
+              adapter={adapter}
+              countryCodes={countries}
+              countryLabel={localization.country}
+              disabled={requestReset.isPending}
+              error={fieldError()}
+              locale={locale}
+              phoneLabel={localization.phoneNumber}
+              placeholder={localization.phoneNumberPlaceholder}
+              value={phoneNumber()}
+              onChange={(value) => {
+                setPhoneNumber(value)
+                setFieldError(undefined)
+              }}
+            />
             <Button
               class="w-full"
               disabled={requestReset.isPending}

--- a/examples/start-solid-zaidan-example/src/components/auth/phone-number/international-phone-field.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/phone-number/international-phone-field.tsx
@@ -1,0 +1,88 @@
+import {
+  createPhoneNumberValue,
+  getPhoneNumberCountries,
+  type PhoneNumberAdapter,
+  type PhoneNumberCountryCode,
+  type PhoneNumberValue
+} from "@better-auth-ui/core/plugins/phone-number"
+import { createMemo, createUniqueId, For } from "solid-js"
+
+import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+import { NativeSelect, NativeSelectOption } from "@/components/ui/native-select"
+
+type InternationalPhoneFieldProps = {
+  adapter: PhoneNumberAdapter
+  countryLabel: string
+  countryCodes?: readonly PhoneNumberCountryCode[]
+  disabled?: boolean
+  error?: string
+  locale?: string
+  name?: string
+  phoneLabel: string
+  placeholder: string
+  value: PhoneNumberValue
+  onChange: (value: PhoneNumberValue) => void
+}
+
+export function InternationalPhoneField(props: InternationalPhoneFieldProps) {
+  const id = createUniqueId()
+  const countries = createMemo(() =>
+    getPhoneNumberCountries(props.locale, props.countryCodes)
+  )
+
+  return (
+    <div class="grid grid-cols-[8.5rem_minmax(0,1fr)] gap-2">
+      <Field>
+        <FieldLabel for={`${id}-country`}>{props.countryLabel}</FieldLabel>
+        <NativeSelect
+          id={`${id}-country`}
+          disabled={props.disabled}
+          value={props.value.country}
+          onChange={(event) => {
+            const country = event.currentTarget.value as PhoneNumberCountryCode
+            const input = props.value.display.startsWith("+")
+              ? ""
+              : props.value.display
+            props.onChange(
+              createPhoneNumberValue(input, country, props.adapter)
+            )
+          }}
+        >
+          <For each={countries()}>
+            {(country) => (
+              <NativeSelectOption value={country.code}>
+                {country.label} ({country.callingCode})
+              </NativeSelectOption>
+            )}
+          </For>
+        </NativeSelect>
+      </Field>
+      <Field data-invalid={Boolean(props.error)}>
+        <FieldLabel for={`${id}-number`}>{props.phoneLabel}</FieldLabel>
+        <Input
+          id={`${id}-number`}
+          aria-invalid={Boolean(props.error)}
+          autocomplete="tel-national"
+          disabled={props.disabled}
+          inputmode="tel"
+          name={props.name ?? "phoneNumber"}
+          placeholder={props.placeholder}
+          required
+          type="tel"
+          value={props.value.display}
+          onInput={(event) =>
+            props.onChange(
+              createPhoneNumberValue(
+                event.currentTarget.value,
+                props.value.country,
+                props.adapter
+              )
+            )
+          }
+        />
+        <FieldError>{props.error}</FieldError>
+      </Field>
+    </div>
+  )
+}

--- a/examples/start-solid-zaidan-example/src/components/auth/phone-number/phone-number.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/phone-number/phone-number.tsx
@@ -1,4 +1,7 @@
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import {
   AuthLink,
   type AuthPlugin,
@@ -16,6 +19,7 @@ import type { BetterFetchError } from "better-auth/client"
 import { type Component, createSignal, For, Show } from "solid-js"
 
 import { OtpField } from "@/components/auth/otp-field"
+import { InternationalPhoneField } from "@/components/auth/phone-number/international-phone-field"
 import {
   ProviderButtons,
   type SocialLayout
@@ -58,6 +62,10 @@ export type PhoneNumberProps = {
 export function PhoneNumber(props: PhoneNumberProps) {
   const auth = useAuth()
   const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
     localization,
     otpLength,
     passwordReset,
@@ -72,7 +80,9 @@ export function PhoneNumber(props: PhoneNumberProps) {
   const [mode, setMode] = createSignal<PhoneNumberMode>(
     signIn ? "code" : "password"
   )
-  const [phoneNumber, setPhoneNumber] = createSignal("")
+  const [phoneNumber, setPhoneNumber] = createSignal(
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
   const [phoneError, setPhoneError] = createSignal<string>()
   const [password, setPassword] = createSignal("")
   const [passwordError, setPasswordError] = createSignal<string>()
@@ -106,24 +116,35 @@ export function PhoneNumber(props: PhoneNumberProps) {
   }))
   const isPending = () =>
     sendOtp.isPending || verify.isPending || signInWithPassword.isPending
-  const requestCode = () =>
+  const normalizedPhoneNumber = () => {
+    const value = phoneNumber().e164
+    if (value) return value
+    setPhoneError(localization.invalidPhoneNumber)
+  }
+  const requestCode = () => {
+    const value = normalizedPhoneNumber()
+    if (!value) return
     sendOtp.mutate({
-      phoneNumber: phoneNumber(),
+      phoneNumber: value,
       fetchOptions: fetchOptions()
     } as Parameters<typeof sendOtp.mutate>[0])
+  }
   const verifyCode = (completedCode: string) => {
     if (isPending() || completedCode.length !== otpLength) return
+    if (!phoneNumber().e164) return
     verify.mutate({
-      phoneNumber: phoneNumber(),
+      phoneNumber: phoneNumber().e164,
       code: completedCode
     } as Parameters<typeof verify.mutate>[0])
   }
   const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
     event.preventDefault()
     if (mode() === "password") {
+      const value = normalizedPhoneNumber()
+      if (!value) return
       const formData = new FormData(event.currentTarget)
       signInWithPassword.mutate({
-        phoneNumber: phoneNumber(),
+        phoneNumber: value,
         password: password(),
         ...(auth.emailAndPassword?.rememberMe
           ? { rememberMe: formData.get("rememberMe") === "on" }
@@ -162,7 +183,10 @@ export function PhoneNumber(props: PhoneNumberProps) {
         </CardTitle>
         <Show when={codeSent()}>
           <CardDescription>
-            {localization.codeSentTo.replace("{{phoneNumber}}", phoneNumber())}
+            {localization.codeSentTo.replace(
+              "{{phoneNumber}}",
+              phoneNumber().display
+            )}
           </CardDescription>
         </Show>
       </CardHeader>
@@ -186,34 +210,21 @@ export function PhoneNumber(props: PhoneNumberProps) {
                 when={codeSent()}
                 fallback={
                   <>
-                    <Field data-invalid={Boolean(phoneError())}>
-                      <FieldLabel for="phone-number">
-                        {localization.phoneNumber}
-                      </FieldLabel>
-                      <Input
-                        aria-invalid={Boolean(phoneError())}
-                        autocomplete="tel"
-                        disabled={isPending()}
-                        id="phone-number"
-                        inputmode="tel"
-                        name="phoneNumber"
-                        onInput={(event) => {
-                          setPhoneNumber(event.currentTarget.value)
-                          setPhoneError(undefined)
-                        }}
-                        onInvalid={(event) => {
-                          event.preventDefault()
-                          setPhoneError(event.currentTarget.validationMessage)
-                        }}
-                        placeholder={localization.phoneNumberPlaceholder}
-                        required
-                        type="tel"
-                        value={phoneNumber()}
-                      />
-                      <Show when={phoneError()}>
-                        {(message) => <FieldError>{message()}</FieldError>}
-                      </Show>
-                    </Field>
+                    <InternationalPhoneField
+                      adapter={adapter}
+                      countryCodes={countries}
+                      countryLabel={localization.country}
+                      disabled={isPending()}
+                      error={phoneError()}
+                      locale={locale}
+                      phoneLabel={localization.phoneNumber}
+                      placeholder={localization.phoneNumberPlaceholder}
+                      value={phoneNumber()}
+                      onChange={(value) => {
+                        setPhoneNumber(value)
+                        setPhoneError(undefined)
+                      }}
+                    />
                     <Show when={mode() === "password"}>
                       <Field data-invalid={Boolean(passwordError())}>
                         <FieldLabel for="phone-password">

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -247,6 +247,7 @@
     "access": "public"
   },
   "dependencies": {
+    "libphonenumber-js": "^1.13.11",
     "uqr": "^0.1.3"
   }
 }

--- a/packages/core/src/plugins/phone-number/index.ts
+++ b/packages/core/src/plugins/phone-number/index.ts
@@ -1,3 +1,4 @@
+export * from "./phone-number"
 export type * from "./phone-number-auth-client"
 export * from "./phone-number-localization"
 export * from "./phone-number-mutation-keys"

--- a/packages/core/src/plugins/phone-number/phone-number-localization.ts
+++ b/packages/core/src/plugins/phone-number/phone-number-localization.ts
@@ -1,4 +1,8 @@
 export const phoneNumberLocalization = {
+  /** @remarks `"Country or region"` */
+  country: "Country or region",
+  /** @remarks `"Enter a valid phone number"` */
+  invalidPhoneNumber: "Enter a valid phone number",
   /** @remarks `"Phone number"` */
   phoneNumber: "Phone number",
   /** @remarks `"+1 555 123 4567"` */

--- a/packages/core/src/plugins/phone-number/phone-number-plugin.ts
+++ b/packages/core/src/plugins/phone-number/phone-number-plugin.ts
@@ -3,6 +3,11 @@ import { createAuthPlugin } from "../../lib/create-auth-plugin"
 // same module instance that external consumers reach via `@better-auth-ui/core`.
 import type {} from "../../lib/view-paths"
 import {
+  defaultPhoneNumberAdapter,
+  type PhoneNumberAdapter,
+  type PhoneNumberCountryCode
+} from "./phone-number"
+import {
   type PhoneNumberLocalization,
   phoneNumberLocalization
 } from "./phone-number-localization"
@@ -20,6 +25,20 @@ declare module "../../lib/view-paths" {
 }
 
 export type PhoneNumberPluginOptions = {
+  /**
+   * Adapter used to format, validate, and normalize phone numbers.
+   * @default defaultPhoneNumberAdapter
+   */
+  adapter?: PhoneNumberAdapter
+  /**
+   * Country selected before the user enters a phone number.
+   * @default The first configured country, or "US" when `countries` is omitted.
+   */
+  defaultCountry?: PhoneNumberCountryCode
+  /** Countries shown in the country selector. Defaults to all supported countries. */
+  countries?: readonly PhoneNumberCountryCode[]
+  /** Locale used for country names and sorting. Defaults to the runtime locale. */
+  locale?: string
   /**
    * Override the plugin's default localization strings.
    * @remarks `PhoneNumberLocalization`
@@ -86,21 +105,38 @@ function resolveOtpLength(value?: number) {
 
 export const phoneNumberPlugin = createAuthPlugin(
   "phoneNumber",
-  (options: PhoneNumberPluginOptions = {}) => ({
-    localization: { ...phoneNumberLocalization, ...options.localization },
-    otpLength: resolveOtpLength(options.otpLength),
-    signIn: options.signIn ?? true,
-    passwordSignIn: options.passwordSignIn ?? false,
-    passwordReset: options.passwordReset ?? false,
-    changePhoneNumber: options.changePhoneNumber ?? true,
-    viewPaths: {
-      auth: {
-        phoneNumber: options.path ?? "phone-number",
-        phoneNumberForgotPassword:
-          options.forgotPasswordPath ?? "phone-number-forgot-password",
-        phoneNumberResetPassword:
-          options.resetPasswordPath ?? "phone-number-reset-password"
+  (options: PhoneNumberPluginOptions = {}) => {
+    const defaultCountry =
+      options.defaultCountry ?? options.countries?.[0] ?? "US"
+
+    if (options.countries?.length === 0) {
+      throw new Error("countries must include at least one country")
+    }
+
+    if (options.countries && !options.countries.includes(defaultCountry)) {
+      throw new Error("defaultCountry must be included in countries")
+    }
+
+    return {
+      adapter: options.adapter ?? defaultPhoneNumberAdapter,
+      countries: options.countries,
+      defaultCountry,
+      locale: options.locale,
+      localization: { ...phoneNumberLocalization, ...options.localization },
+      otpLength: resolveOtpLength(options.otpLength),
+      signIn: options.signIn ?? true,
+      passwordSignIn: options.passwordSignIn ?? false,
+      passwordReset: options.passwordReset ?? false,
+      changePhoneNumber: options.changePhoneNumber ?? true,
+      viewPaths: {
+        auth: {
+          phoneNumber: options.path ?? "phone-number",
+          phoneNumberForgotPassword:
+            options.forgotPasswordPath ?? "phone-number-forgot-password",
+          phoneNumberResetPassword:
+            options.resetPasswordPath ?? "phone-number-reset-password"
+        }
       }
     }
-  })
+  }
 )

--- a/packages/core/src/plugins/phone-number/phone-number.ts
+++ b/packages/core/src/plugins/phone-number/phone-number.ts
@@ -1,0 +1,91 @@
+import {
+  AsYouType,
+  type CountryCode,
+  getCountries,
+  getCountryCallingCode,
+  parsePhoneNumberFromString
+} from "libphonenumber-js/min"
+
+export type PhoneNumberCountryCode = CountryCode
+
+export type PhoneNumberCountry = {
+  callingCode: string
+  code: PhoneNumberCountryCode
+  label: string
+}
+
+export type PhoneNumberValue = {
+  country: PhoneNumberCountryCode
+  display: string
+  e164?: string
+  isValid: boolean
+}
+
+export type PhoneNumberAdapter = {
+  format: (value: string, country: PhoneNumberCountryCode) => string
+  getCountry: (value: string) => PhoneNumberCountryCode | undefined
+  normalize: (
+    value: string,
+    country: PhoneNumberCountryCode
+  ) => string | undefined
+}
+
+export const defaultPhoneNumberAdapter: PhoneNumberAdapter = {
+  format(value, country) {
+    if (!value.trim()) return ""
+    return new AsYouType(
+      value.trim().startsWith("+") ? undefined : country
+    ).input(value)
+  },
+  getCountry(value) {
+    return parsePhoneNumberFromString(value)?.country
+  },
+  normalize(value, country) {
+    const phoneNumber = parsePhoneNumberFromString(value, country)
+    return phoneNumber?.isValid() ? phoneNumber.number : undefined
+  }
+}
+
+export function createPhoneNumberValue(
+  value: string,
+  country: PhoneNumberCountryCode,
+  adapter: PhoneNumberAdapter = defaultPhoneNumberAdapter
+): PhoneNumberValue {
+  const display = adapter.format(value, country)
+  const e164 = adapter.normalize(display, country)
+  const resolvedCountry = adapter.getCountry(e164 ?? display) ?? country
+
+  return {
+    country: resolvedCountry,
+    display,
+    e164,
+    isValid: Boolean(e164)
+  }
+}
+
+export function getPhoneNumberCountries(
+  locale?: string,
+  countryCodes: readonly PhoneNumberCountryCode[] = getCountries()
+): PhoneNumberCountry[] {
+  let displayNames: Intl.DisplayNames | undefined
+  let resolvedLocale = locale
+
+  try {
+    displayNames = new Intl.DisplayNames(locale ? [locale] : undefined, {
+      type: "region"
+    })
+  } catch {
+    resolvedLocale = "en"
+    displayNames = new Intl.DisplayNames(["en"], { type: "region" })
+  }
+
+  return countryCodes
+    .map((code) => ({
+      callingCode: `+${getCountryCallingCode(code)}`,
+      code,
+      label: displayNames.of(code) ?? code
+    }))
+    .sort((left, right) =>
+      left.label.localeCompare(right.label, resolvedLocale)
+    )
+}

--- a/packages/core/tests/phone-number-plugin.test.ts
+++ b/packages/core/tests/phone-number-plugin.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest"
 import { authQueryKeys } from "../src"
 import {
+  createPhoneNumberValue,
+  defaultPhoneNumberAdapter,
+  getPhoneNumberCountries,
   phoneNumberLocalization,
   phoneNumberMutationKeys,
   phoneNumberPlugin,
@@ -22,6 +25,8 @@ describe("phoneNumberPlugin", () => {
     expect(phoneNumberPlugin.id).toBe("phoneNumber")
     expect(phoneNumberPlugin()).toMatchObject({
       id: "phoneNumber",
+      adapter: defaultPhoneNumberAdapter,
+      defaultCountry: "US",
       localization: phoneNumberLocalization,
       otpLength: 6,
       signIn: true,
@@ -40,6 +45,9 @@ describe("phoneNumberPlugin", () => {
 
   it("merges paths, code length, flow options, and localization", () => {
     const plugin = phoneNumberPlugin({
+      countries: ["CH", "DE"],
+      defaultCountry: "CH",
+      locale: "de-CH",
       path: "phone",
       forgotPasswordPath: "phone-forgot",
       resetPasswordPath: "phone-reset",
@@ -57,6 +65,9 @@ describe("phoneNumberPlugin", () => {
       phoneNumberResetPassword: "phone-reset"
     })
     expect(plugin.otpLength).toBe(8)
+    expect(plugin.countries).toEqual(["CH", "DE"])
+    expect(plugin.defaultCountry).toBe("CH")
+    expect(plugin.locale).toBe("de-CH")
     expect(plugin.signIn).toBe(false)
     expect(plugin.passwordSignIn).toBe(true)
     expect(plugin.passwordReset).toBe(true)
@@ -67,10 +78,67 @@ describe("phoneNumberPlugin", () => {
     })
   })
 
+  it("uses the first configured country when the default is omitted", () => {
+    expect(phoneNumberPlugin({ countries: ["CH", "DE"] })).toMatchObject({
+      countries: ["CH", "DE"],
+      defaultCountry: "CH"
+    })
+  })
+
+  it("rejects empty or inconsistent country configuration", () => {
+    expect(() => phoneNumberPlugin({ countries: [] })).toThrow(
+      "countries must include at least one country"
+    )
+    expect(() =>
+      phoneNumberPlugin({ countries: ["CH", "DE"], defaultCountry: "US" })
+    ).toThrow("defaultCountry must be included in countries")
+  })
+
   it("normalizes code length boundaries", () => {
     expect(phoneNumberPlugin({ otpLength: Number.NaN }).otpLength).toBe(6)
     expect(phoneNumberPlugin({ otpLength: 0 }).otpLength).toBe(1)
     expect(phoneNumberPlugin({ otpLength: -4 }).otpLength).toBe(1)
+  })
+
+  it("formats and normalizes national numbers to E.164", () => {
+    expect(createPhoneNumberValue("2025550123", "US")).toEqual({
+      country: "US",
+      display: "(202) 555-0123",
+      e164: "+12025550123",
+      isValid: true
+    })
+    expect(createPhoneNumberValue("020 7946 0018", "GB")).toMatchObject({
+      country: "GB",
+      e164: "+442079460018",
+      isValid: true
+    })
+  })
+
+  it("keeps invalid input visible without producing an E.164 value", () => {
+    expect(createPhoneNumberValue("123", "US")).toMatchObject({
+      country: "US",
+      display: "1 23",
+      isValid: false
+    })
+    expect(createPhoneNumberValue("123", "US").e164).toBeUndefined()
+  })
+
+  it("localizes and limits the country list", () => {
+    expect(getPhoneNumberCountries("de", ["US", "DE"])).toEqual([
+      { callingCode: "+49", code: "DE", label: "Deutschland" },
+      {
+        callingCode: "+1",
+        code: "US",
+        label: "Vereinigte Staaten"
+      }
+    ])
+  })
+
+  it("falls back to English names and sorting for an invalid locale", () => {
+    expect(getPhoneNumberCountries("invalid locale", ["US", "DE"])).toEqual([
+      { callingCode: "+49", code: "DE", label: "Germany" },
+      { callingCode: "+1", code: "US", label: "United States" }
+    ])
   })
 
   it("keeps password sign-in under the shared sign-in namespace", () => {

--- a/packages/heroui/src/components/auth/phone-number/change-phone-number.tsx
+++ b/packages/heroui/src/components/auth/phone-number/change-phone-number.tsx
@@ -1,4 +1,7 @@
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import {
   useAuth,
   useAuthPlugin,
@@ -14,20 +17,17 @@ import {
   Card,
   type CardProps,
   cn,
-  FieldError,
   Fieldset,
   Form,
-  Input,
-  Label,
   Skeleton,
   Spinner,
-  TextField,
   toast
 } from "@heroui/react"
 import { type SyntheticEvent, useEffect, useState } from "react"
 
 import { phoneNumberPlugin } from "../../../lib/auth/phone-number-plugin"
 import { OtpField } from "../otp-field"
+import { InternationalPhoneField } from "./international-phone-field"
 import { RemovePhoneNumberDialog } from "./remove-phone-number-dialog"
 
 type PhoneNumberUser = {
@@ -46,18 +46,30 @@ export function ChangePhoneNumber({
   ...props
 }: ChangePhoneNumberProps & Omit<CardProps, "children">) {
   const { authClient } = useAuth()
-  const { localization, otpLength } = useAuthPlugin(phoneNumberPlugin)
+  const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
+    localization,
+    otpLength
+  } = useAuthPlugin(phoneNumberPlugin)
   const phoneClient = authClient as PhoneNumberAuthClient
   const { data: session } = useSession(phoneClient)
   const currentPhoneNumber =
     (session?.user as PhoneNumberUser | undefined)?.phoneNumber ?? ""
-  const [phoneNumber, setPhoneNumber] = useState("")
+  const [phoneNumber, setPhoneNumber] = useState(() =>
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
+  const [phoneError, setPhoneError] = useState<string>()
   const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
 
   useEffect(() => {
-    setPhoneNumber(currentPhoneNumber)
-  }, [currentPhoneNumber])
+    setPhoneNumber(
+      createPhoneNumberValue(currentPhoneNumber, defaultCountry, adapter)
+    )
+  }, [adapter, currentPhoneNumber, defaultCountry])
 
   const { mutate: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
     phoneClient,
@@ -78,7 +90,7 @@ export function ChangePhoneNumber({
     phoneClient,
     {
       onSuccess: () => {
-        setPhoneNumber("")
+        setPhoneNumber(createPhoneNumberValue("", defaultCountry, adapter))
         toast.success(localization.phoneNumberRemoved)
       }
     }
@@ -87,11 +99,15 @@ export function ChangePhoneNumber({
 
   const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault()
-    if (!codeSent) {
-      sendOtp({ phoneNumber })
+    if (!phoneNumber.e164) {
+      setPhoneError(localization.invalidPhoneNumber)
       return
     }
-    verify({ phoneNumber, code, updatePhoneNumber: true })
+    if (!codeSent) {
+      sendOtp({ phoneNumber: phoneNumber.e164 })
+      return
+    }
+    verify({ phoneNumber: phoneNumber.e164, code, updatePhoneNumber: true })
   }
   const removePhoneNumber = () =>
     updateUser({
@@ -113,7 +129,7 @@ export function ChangePhoneNumber({
                     <p className="text-sm text-muted">
                       {localization.codeSentTo.replace(
                         "{{phoneNumber}}",
-                        phoneNumber
+                        phoneNumber.display
                       )}
                     </p>
                     <OtpField
@@ -127,30 +143,27 @@ export function ChangePhoneNumber({
                       onChange={setCode}
                     />
                   </div>
-                ) : (
-                  <TextField
-                    name="phoneNumber"
-                    type="tel"
-                    autoComplete="tel"
+                ) : session ? (
+                  <InternationalPhoneField
+                    adapter={adapter}
+                    countryCodes={countries}
+                    countryLabel={localization.country}
+                    error={phoneError}
+                    isDisabled={isPending}
+                    locale={locale}
+                    phoneLabel={localization.phoneNumber}
+                    placeholder={localization.phoneNumberPlaceholder}
                     value={phoneNumber}
-                    isDisabled={isPending || !session}
-                    onChange={setPhoneNumber}
-                  >
-                    <Label>{localization.phoneNumber}</Label>
-                    {session ? (
-                      <Input
-                        inputMode="tel"
-                        placeholder={localization.phoneNumberPlaceholder}
-                        required
-                        variant={
-                          variant === "transparent" ? "primary" : "secondary"
-                        }
-                      />
-                    ) : (
-                      <Skeleton className="h-10 w-full rounded-xl md:h-9" />
-                    )}
-                    <FieldError />
-                  </TextField>
+                    variant={
+                      variant === "transparent" ? "primary" : "secondary"
+                    }
+                    onChange={(value) => {
+                      setPhoneNumber(value)
+                      setPhoneError(undefined)
+                    }}
+                  />
+                ) : (
+                  <Skeleton className="h-14 w-full rounded-xl" />
                 )}
               </Fieldset.Group>
               <Fieldset.Actions>
@@ -162,7 +175,13 @@ export function ChangePhoneNumber({
                     onPress={() => {
                       setCode("")
                       setCodeSent(false)
-                      setPhoneNumber(currentPhoneNumber)
+                      setPhoneNumber(
+                        createPhoneNumberValue(
+                          currentPhoneNumber,
+                          defaultCountry,
+                          adapter
+                        )
+                      )
                     }}
                   >
                     {localization.cancel}

--- a/packages/heroui/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/packages/heroui/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -1,4 +1,7 @@
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import { useAuth, useAuthPlugin, useFetchOptions } from "@better-auth-ui/react"
 import { useRequestPhoneNumberPasswordReset } from "@better-auth-ui/react/plugins/phone-number"
 import {
@@ -7,17 +10,14 @@ import {
   type CardProps,
   cn,
   Description,
-  FieldError,
   Form,
-  Input,
-  Label,
   Link,
-  Spinner,
-  TextField
+  Spinner
 } from "@heroui/react"
-import type { SyntheticEvent } from "react"
+import { type SyntheticEvent, useState } from "react"
 
 import { phoneNumberPlugin } from "../../../lib/auth/phone-number-plugin"
+import { InternationalPhoneField } from "./international-phone-field"
 
 export const PHONE_NUMBER_RESET_STORAGE_KEY =
   "better-auth-ui.phone-number-reset"
@@ -33,8 +33,18 @@ export function ForgotPhoneNumberPassword({
   variant
 }: ForgotPhoneNumberPasswordProps) {
   const { authClient, basePaths, localization, navigate, plugins } = useAuth()
-  const { localization: phoneLocalization, viewPaths: phoneNumberViewPaths } =
-    useAuthPlugin(phoneNumberPlugin)
+  const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
+    localization: phoneLocalization,
+    viewPaths: phoneNumberViewPaths
+  } = useAuthPlugin(phoneNumberPlugin)
+  const [phoneNumber, setPhoneNumber] = useState(() =>
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
+  const [phoneError, setPhoneError] = useState<string>()
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
   const { mutate: requestReset, isPending } =
     useRequestPhoneNumberPasswordReset(authClient as PhoneNumberAuthClient, {
@@ -52,9 +62,12 @@ export function ForgotPhoneNumberPassword({
 
   const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault()
-    const formData = new FormData(event.currentTarget)
+    if (!phoneNumber.e164) {
+      setPhoneError(phoneLocalization.invalidPhoneNumber)
+      return
+    }
     requestReset({
-      phoneNumber: String(formData.get("phoneNumber") ?? ""),
+      phoneNumber: phoneNumber.e164,
       fetchOptions
     })
   }
@@ -71,24 +84,22 @@ export function ForgotPhoneNumberPassword({
       </Card.Header>
       <Card.Content className="gap-4">
         <Form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-          <TextField
-            name="phoneNumber"
-            type="tel"
-            autoComplete="tel"
+          <InternationalPhoneField
+            adapter={adapter}
+            countryCodes={countries}
+            countryLabel={phoneLocalization.country}
+            error={phoneError}
             isDisabled={isPending}
-            validate={(value) =>
-              value ? undefined : localization.auth.fieldRequired
-            }
-          >
-            <Label>{phoneLocalization.phoneNumber}</Label>
-            <Input
-              inputMode="tel"
-              placeholder={phoneLocalization.phoneNumberPlaceholder}
-              required
-              variant={variant === "transparent" ? "primary" : "secondary"}
-            />
-            <FieldError />
-          </TextField>
+            locale={locale}
+            phoneLabel={phoneLocalization.phoneNumber}
+            placeholder={phoneLocalization.phoneNumberPlaceholder}
+            value={phoneNumber}
+            variant={variant === "transparent" ? "primary" : "secondary"}
+            onChange={(value) => {
+              setPhoneNumber(value)
+              setPhoneError(undefined)
+            }}
+          />
           {Captcha && <div className="flex justify-center">{Captcha}</div>}
           <Button className="w-full" type="submit" isPending={isPending}>
             {isPending && <Spinner color="current" size="sm" />}

--- a/packages/heroui/src/components/auth/phone-number/international-phone-field.tsx
+++ b/packages/heroui/src/components/auth/phone-number/international-phone-field.tsx
@@ -1,0 +1,110 @@
+import {
+  createPhoneNumberValue,
+  getPhoneNumberCountries,
+  type PhoneNumberAdapter,
+  type PhoneNumberCountryCode,
+  type PhoneNumberValue
+} from "@better-auth-ui/core/plugins/phone-number"
+import {
+  FieldError,
+  Input,
+  Label,
+  ListBox,
+  Select,
+  TextField
+} from "@heroui/react"
+import { useMemo } from "react"
+
+type InternationalPhoneFieldProps = {
+  adapter: PhoneNumberAdapter
+  countryLabel: string
+  countryCodes?: readonly PhoneNumberCountryCode[]
+  error?: string
+  isDisabled?: boolean
+  locale?: string
+  name?: string
+  phoneLabel: string
+  placeholder: string
+  value: PhoneNumberValue
+  variant?: "primary" | "secondary"
+  onChange: (value: PhoneNumberValue) => void
+}
+
+export function InternationalPhoneField({
+  adapter,
+  countryLabel,
+  countryCodes,
+  error,
+  isDisabled,
+  locale,
+  name = "phoneNumber",
+  phoneLabel,
+  placeholder,
+  value,
+  variant,
+  onChange
+}: InternationalPhoneFieldProps) {
+  const countries = useMemo(
+    () => getPhoneNumberCountries(locale, countryCodes),
+    [countryCodes, locale]
+  )
+
+  return (
+    <div className="grid grid-cols-[8.5rem_minmax(0,1fr)] gap-2">
+      <Select
+        aria-label={countryLabel}
+        isDisabled={isDisabled}
+        value={value.country}
+        onChange={(country) => {
+          if (!country) return
+          const nextCountry = country as PhoneNumberCountryCode
+          const input = value.display.startsWith("+") ? "" : value.display
+          onChange(createPhoneNumberValue(input, nextCountry, adapter))
+        }}
+      >
+        <Label>{countryLabel}</Label>
+        <Select.Trigger>
+          <Select.Value />
+          <Select.Indicator />
+        </Select.Trigger>
+        <Select.Popover>
+          <ListBox>
+            {countries.map((country) => (
+              <ListBox.Item
+                key={country.code}
+                id={country.code}
+                textValue={`${country.label} ${country.callingCode}`}
+              >
+                <span className="flex w-full items-center justify-between gap-4">
+                  <span>{country.label}</span>
+                  <span className="text-muted">{country.callingCode}</span>
+                </span>
+                <ListBox.ItemIndicator />
+              </ListBox.Item>
+            ))}
+          </ListBox>
+        </Select.Popover>
+      </Select>
+      <TextField
+        name={name}
+        type="tel"
+        autoComplete="tel-national"
+        isDisabled={isDisabled}
+        isInvalid={Boolean(error)}
+        value={value.display}
+        onChange={(input) =>
+          onChange(createPhoneNumberValue(input, value.country, adapter))
+        }
+      >
+        <Label>{phoneLabel}</Label>
+        <Input
+          inputMode="tel"
+          placeholder={placeholder}
+          required
+          variant={variant}
+        />
+        <FieldError>{error}</FieldError>
+      </TextField>
+    </div>
+  )
+}

--- a/packages/heroui/src/components/auth/phone-number/phone-number.tsx
+++ b/packages/heroui/src/components/auth/phone-number/phone-number.tsx
@@ -1,5 +1,8 @@
 import { authMutationKeys } from "@better-auth-ui/core"
-import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
+import {
+  createPhoneNumberValue,
+  type PhoneNumberAuthClient
+} from "@better-auth-ui/core/plugins/phone-number"
 import {
   AuthPrompts,
   useAuth,
@@ -21,7 +24,6 @@ import {
   Description,
   FieldError,
   Form,
-  Input,
   InputGroup,
   Label,
   Link,
@@ -37,6 +39,7 @@ import { useSignInContinuation } from "../../../lib/auth/use-sign-in-continuatio
 import { FieldSeparator } from "../field-separator"
 import { OtpField } from "../otp-field"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
+import { InternationalPhoneField } from "./international-phone-field"
 
 type PhoneNumberMode = "code" | "password"
 
@@ -64,6 +67,10 @@ export function PhoneNumber({
     viewPaths
   } = useAuth()
   const {
+    adapter,
+    countries,
+    defaultCountry,
+    locale,
     localization: phoneLocalization,
     otpLength,
     passwordReset,
@@ -78,7 +85,10 @@ export function PhoneNumber({
   const [mode, setMode] = useState<PhoneNumberMode>(
     signIn ? "code" : "password"
   )
-  const [phoneNumber, setPhoneNumber] = useState("")
+  const [phoneNumber, setPhoneNumber] = useState(() =>
+    createPhoneNumberValue("", defaultCountry, adapter)
+  )
+  const [phoneError, setPhoneError] = useState<string>()
   const [password, setPassword] = useState("")
   const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
@@ -135,10 +145,19 @@ export function PhoneNumber({
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
 
-  const sendCode = () => sendOtp({ phoneNumber, fetchOptions })
+  const getPhoneNumber = () => {
+    if (phoneNumber.e164) return phoneNumber.e164
+    setPhoneError(phoneLocalization.invalidPhoneNumber)
+  }
+  const sendCode = () => {
+    const normalizedPhoneNumber = getPhoneNumber()
+    if (!normalizedPhoneNumber) return
+    sendOtp({ phoneNumber: normalizedPhoneNumber, fetchOptions })
+  }
   const verifyCode = (completedCode: string) => {
     if (isPending || completedCode.length !== otpLength) return
-    verify({ phoneNumber, code: completedCode })
+    if (!phoneNumber.e164) return
+    verify({ phoneNumber: phoneNumber.e164, code: completedCode })
   }
   const switchMode = () => {
     setMode((current) => (current === "code" ? "password" : "code"))
@@ -150,9 +169,11 @@ export function PhoneNumber({
     event.preventDefault()
 
     if (mode === "password") {
+      const normalizedPhoneNumber = getPhoneNumber()
+      if (!normalizedPhoneNumber) return
       const formData = new FormData(event.currentTarget)
       signInWithPassword({
-        phoneNumber,
+        phoneNumber: normalizedPhoneNumber,
         password,
         ...(emailAndPassword?.rememberMe
           ? { rememberMe: formData.get("rememberMe") === "on" }
@@ -182,7 +203,7 @@ export function PhoneNumber({
           <Card.Description>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              phoneNumber
+              phoneNumber.display
             )}
           </Card.Description>
         )}
@@ -211,26 +232,22 @@ export function PhoneNumber({
             />
           ) : (
             <>
-              <TextField
-                name="phoneNumber"
-                type="tel"
-                autoComplete="tel"
-                value={phoneNumber}
+              <InternationalPhoneField
+                adapter={adapter}
+                countryCodes={countries}
+                countryLabel={phoneLocalization.country}
+                error={phoneError}
                 isDisabled={isPending}
-                onChange={setPhoneNumber}
-                validate={(value) =>
-                  value ? undefined : localization.auth.fieldRequired
-                }
-              >
-                <Label>{phoneLocalization.phoneNumber}</Label>
-                <Input
-                  inputMode="tel"
-                  placeholder={phoneLocalization.phoneNumberPlaceholder}
-                  required
-                  variant={variant === "transparent" ? "primary" : "secondary"}
-                />
-                <FieldError />
-              </TextField>
+                locale={locale}
+                phoneLabel={phoneLocalization.phoneNumber}
+                placeholder={phoneLocalization.phoneNumberPlaceholder}
+                value={phoneNumber}
+                variant={variant === "transparent" ? "primary" : "secondary"}
+                onChange={(value) => {
+                  setPhoneNumber(value)
+                  setPhoneError(undefined)
+                }}
+              />
               {mode === "password" && (
                 <TextField
                   name="password"


### PR DESCRIPTION
Add a configurable phone adapter with localized country selection, progressive formatting, E.164 normalization, and validation. Use the shared field throughout sign-in, password reset, and account settings across HeroUI, shadcn, Base UI, and Solid/Zaidan.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added international phone-number fields with country selection, localized formatting, and validation.
  * Phone numbers are normalized to E.164 before authentication, verification, and password-reset requests.
  * Added configuration for default country, available countries, locale, and custom formatting adapters.
  * Added localized labels and invalid-number error messaging.
* **Bug Fixes**
  * Improved validation and display of phone numbers across authentication flows.
* **Documentation**
  * Updated plugin guidance for client-side formatting, server-side validation, and configuration options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->