### PR TITLE
fix(organization): scope API keys explicitly

### DIFF
--- a/examples/next-shadcn-example/src/components/auth/api-key/organization-api-keys.tsx
+++ b/examples/next-shadcn-example/src/components/auth/api-key/organization-api-keys.tsx
@@ -1,46 +1,46 @@
 "use client"
 
-import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
-import { useAuth, useSession } from "@better-auth-ui/react"
 import {
-  useActiveOrganization,
-  useListOrganizationMembers
-} from "@better-auth-ui/react/plugins/organization"
+  hasMemberRole,
+  type OrganizationAuthClient
+} from "@better-auth-ui/core/plugins/organization"
+import { useAuth, useSession } from "@better-auth-ui/react"
+import { useListOrganizationMembers } from "@better-auth-ui/react/plugins/organization"
 import { ApiKeys } from "./api-keys"
 
 export type OrganizationApiKeysProps = {
   className?: string
+  organizationId: string
+  organizationSlug: string
 }
 
 /**
- * {@link ApiKeys} scoped to the active organization.
+ * {@link ApiKeys} scoped to an explicit organization.
  *
  * Hidden for members whose role isn't `owner`. Better Auth's
  * `/organization/has-permission` endpoint isn't usable for `apiKey:*` checks
  * (it doesn't pass `allowCreatorAllPermissions` and the default org AC has no
  * `apiKey` statements), so we gate on role directly.
  */
-export function OrganizationApiKeys({ className }: OrganizationApiKeysProps) {
+export function OrganizationApiKeys({
+  className,
+  organizationId
+}: OrganizationApiKeysProps) {
   const { authClient } = useAuth<OrganizationAuthClient>()
   const { data: session } = useSession(authClient)
 
-  const { data: activeOrganization, isPending: activeOrganizationPending } =
-    useActiveOrganization(authClient)
-  const { data: membersData } = useListOrganizationMembers(authClient)
+  const { data: membersData } = useListOrganizationMembers(authClient, {
+    query: { organizationId }
+  })
 
   const canManageApiKeys = membersData?.members.some(
-    (member) => member.role === "owner" && member.userId === session?.user.id
+    (member) =>
+      hasMemberRole(member.role, "owner") && member.userId === session?.user.id
   )
 
   if (!canManageApiKeys) {
     return null
   }
 
-  return (
-    <ApiKeys
-      className={className}
-      organizationId={activeOrganization?.id}
-      isPending={activeOrganizationPending}
-    />
-  )
+  return <ApiKeys className={className} organizationId={organizationId} />
 }

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-settings.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-settings.tsx
@@ -9,6 +9,8 @@ import { OrganizationProfile } from "./organization-profile"
 
 export type OrganizationSettingsProps = {
   className?: string
+  organizationId: string
+  organizationSlug: string
 }
 
 /**
@@ -17,6 +19,8 @@ export type OrganizationSettingsProps = {
  */
 export function OrganizationSettings({
   className,
+  organizationId,
+  organizationSlug,
   ...props
 }: OrganizationSettingsProps & ComponentProps<"div">) {
   const { plugins } = useAuth()
@@ -26,8 +30,12 @@ export function OrganizationSettings({
       <OrganizationProfile />
 
       {plugins.flatMap((plugin) =>
-        plugin.organizationCards?.map((Card, index) => (
-          <Card key={`${plugin.id}-${index.toString()}`} />
+        plugin.organizationCards?.map((Card) => (
+          <Card
+            key={`${plugin.id}-${Card.displayName ?? Card.name}`}
+            organizationId={organizationId}
+            organizationSlug={organizationSlug}
+          />
         ))
       )}
 

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-settings.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-settings.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useAuth } from "@better-auth-ui/react"
+import { getOrganizationCardKey, useAuth } from "@better-auth-ui/react"
 import type { ComponentProps } from "react"
 
 import { cn } from "@/lib/utils"
@@ -32,7 +32,7 @@ export function OrganizationSettings({
       {plugins.flatMap((plugin) =>
         plugin.organizationCards?.map((Card) => (
           <Card
-            key={`${plugin.id}-${Card.displayName ?? Card.name}`}
+            key={getOrganizationCardKey(plugin.id, Card)}
             organizationId={organizationId}
             organizationSlug={organizationSlug}
           />

--- a/examples/next-shadcn-example/src/components/auth/organization/organization.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization.tsx
@@ -206,7 +206,12 @@ export function Organization({
       </div>
 
       <TabsContent value="settings" tabIndex={-1}>
-        <OrganizationSettings />
+        {activeOrganization && (
+          <OrganizationSettings
+            organizationId={activeOrganization.id}
+            organizationSlug={activeOrganization.slug}
+          />
+        )}
       </TabsContent>
 
       <TabsContent value="people" tabIndex={-1}>

--- a/examples/start-shadcn-baseui-example/src/components/auth/api-key/organization-api-keys.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/api-key/organization-api-keys.tsx
@@ -1,46 +1,46 @@
 "use client"
 
-import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
-import { useAuth, useSession } from "@better-auth-ui/react"
 import {
-  useActiveOrganization,
-  useListOrganizationMembers
-} from "@better-auth-ui/react/plugins/organization"
+  hasMemberRole,
+  type OrganizationAuthClient
+} from "@better-auth-ui/core/plugins/organization"
+import { useAuth, useSession } from "@better-auth-ui/react"
+import { useListOrganizationMembers } from "@better-auth-ui/react/plugins/organization"
 import { ApiKeys } from "./api-keys"
 
 export type OrganizationApiKeysProps = {
   className?: string
+  organizationId: string
+  organizationSlug: string
 }
 
 /**
- * {@link ApiKeys} scoped to the active organization.
+ * {@link ApiKeys} scoped to an explicit organization.
  *
  * Hidden for members whose role isn't `owner`. Better Auth's
  * `/organization/has-permission` endpoint isn't usable for `apiKey:*` checks
  * (it doesn't pass `allowCreatorAllPermissions` and the default org AC has no
  * `apiKey` statements), so we gate on role directly.
  */
-export function OrganizationApiKeys({ className }: OrganizationApiKeysProps) {
+export function OrganizationApiKeys({
+  className,
+  organizationId
+}: OrganizationApiKeysProps) {
   const { authClient } = useAuth<OrganizationAuthClient>()
   const { data: session } = useSession(authClient)
 
-  const { data: activeOrganization, isPending: activeOrganizationPending } =
-    useActiveOrganization(authClient)
-  const { data: membersData } = useListOrganizationMembers(authClient)
+  const { data: membersData } = useListOrganizationMembers(authClient, {
+    query: { organizationId }
+  })
 
   const canManageApiKeys = membersData?.members.some(
-    (member) => member.role === "owner" && member.userId === session?.user.id
+    (member) =>
+      hasMemberRole(member.role, "owner") && member.userId === session?.user.id
   )
 
   if (!canManageApiKeys) {
     return null
   }
 
-  return (
-    <ApiKeys
-      className={className}
-      organizationId={activeOrganization?.id}
-      isPending={activeOrganizationPending}
-    />
-  )
+  return <ApiKeys className={className} organizationId={organizationId} />
 }

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-settings.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-settings.tsx
@@ -9,6 +9,8 @@ import { OrganizationProfile } from "./organization-profile"
 
 export type OrganizationSettingsProps = {
   className?: string
+  organizationId: string
+  organizationSlug: string
 }
 
 /**
@@ -17,6 +19,8 @@ export type OrganizationSettingsProps = {
  */
 export function OrganizationSettings({
   className,
+  organizationId,
+  organizationSlug,
   ...props
 }: OrganizationSettingsProps & ComponentProps<"div">) {
   const { plugins } = useAuth()
@@ -26,8 +30,12 @@ export function OrganizationSettings({
       <OrganizationProfile />
 
       {plugins.flatMap((plugin) =>
-        plugin.organizationCards?.map((Card, index) => (
-          <Card key={`${plugin.id}-${index.toString()}`} />
+        plugin.organizationCards?.map((Card) => (
+          <Card
+            key={`${plugin.id}-${Card.displayName ?? Card.name}`}
+            organizationId={organizationId}
+            organizationSlug={organizationSlug}
+          />
         ))
       )}
 

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-settings.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-settings.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useAuth } from "@better-auth-ui/react"
+import { getOrganizationCardKey, useAuth } from "@better-auth-ui/react"
 import type { ComponentProps } from "react"
 
 import { cn } from "@/lib/utils"
@@ -32,7 +32,7 @@ export function OrganizationSettings({
       {plugins.flatMap((plugin) =>
         plugin.organizationCards?.map((Card) => (
           <Card
-            key={`${plugin.id}-${Card.displayName ?? Card.name}`}
+            key={getOrganizationCardKey(plugin.id, Card)}
             organizationId={organizationId}
             organizationSlug={organizationSlug}
           />

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization.tsx
@@ -206,7 +206,12 @@ export function Organization({
       </div>
 
       <TabsContent value="settings" tabIndex={-1}>
-        <OrganizationSettings />
+        {activeOrganization && (
+          <OrganizationSettings
+            organizationId={activeOrganization.id}
+            organizationSlug={activeOrganization.slug}
+          />
+        )}
       </TabsContent>
 
       <TabsContent value="people" tabIndex={-1}>

--- a/examples/start-shadcn-example/src/components/auth/api-key/organization-api-keys.tsx
+++ b/examples/start-shadcn-example/src/components/auth/api-key/organization-api-keys.tsx
@@ -1,46 +1,46 @@
 "use client"
 
-import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
-import { useAuth, useSession } from "@better-auth-ui/react"
 import {
-  useActiveOrganization,
-  useListOrganizationMembers
-} from "@better-auth-ui/react/plugins/organization"
+  hasMemberRole,
+  type OrganizationAuthClient
+} from "@better-auth-ui/core/plugins/organization"
+import { useAuth, useSession } from "@better-auth-ui/react"
+import { useListOrganizationMembers } from "@better-auth-ui/react/plugins/organization"
 import { ApiKeys } from "./api-keys"
 
 export type OrganizationApiKeysProps = {
   className?: string
+  organizationId: string
+  organizationSlug: string
 }
 
 /**
- * {@link ApiKeys} scoped to the active organization.
+ * {@link ApiKeys} scoped to an explicit organization.
  *
  * Hidden for members whose role isn't `owner`. Better Auth's
  * `/organization/has-permission` endpoint isn't usable for `apiKey:*` checks
  * (it doesn't pass `allowCreatorAllPermissions` and the default org AC has no
  * `apiKey` statements), so we gate on role directly.
  */
-export function OrganizationApiKeys({ className }: OrganizationApiKeysProps) {
+export function OrganizationApiKeys({
+  className,
+  organizationId
+}: OrganizationApiKeysProps) {
   const { authClient } = useAuth<OrganizationAuthClient>()
   const { data: session } = useSession(authClient)
 
-  const { data: activeOrganization, isPending: activeOrganizationPending } =
-    useActiveOrganization(authClient)
-  const { data: membersData } = useListOrganizationMembers(authClient)
+  const { data: membersData } = useListOrganizationMembers(authClient, {
+    query: { organizationId }
+  })
 
   const canManageApiKeys = membersData?.members.some(
-    (member) => member.role === "owner" && member.userId === session?.user.id
+    (member) =>
+      hasMemberRole(member.role, "owner") && member.userId === session?.user.id
   )
 
   if (!canManageApiKeys) {
     return null
   }
 
-  return (
-    <ApiKeys
-      className={className}
-      organizationId={activeOrganization?.id}
-      isPending={activeOrganizationPending}
-    />
-  )
+  return <ApiKeys className={className} organizationId={organizationId} />
 }

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-settings.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-settings.tsx
@@ -9,6 +9,8 @@ import { OrganizationProfile } from "./organization-profile"
 
 export type OrganizationSettingsProps = {
   className?: string
+  organizationId: string
+  organizationSlug: string
 }
 
 /**
@@ -17,6 +19,8 @@ export type OrganizationSettingsProps = {
  */
 export function OrganizationSettings({
   className,
+  organizationId,
+  organizationSlug,
   ...props
 }: OrganizationSettingsProps & ComponentProps<"div">) {
   const { plugins } = useAuth()
@@ -26,8 +30,12 @@ export function OrganizationSettings({
       <OrganizationProfile />
 
       {plugins.flatMap((plugin) =>
-        plugin.organizationCards?.map((Card, index) => (
-          <Card key={`${plugin.id}-${index.toString()}`} />
+        plugin.organizationCards?.map((Card) => (
+          <Card
+            key={`${plugin.id}-${Card.displayName ?? Card.name}`}
+            organizationId={organizationId}
+            organizationSlug={organizationSlug}
+          />
         ))
       )}
 

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-settings.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-settings.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useAuth } from "@better-auth-ui/react"
+import { getOrganizationCardKey, useAuth } from "@better-auth-ui/react"
 import type { ComponentProps } from "react"
 
 import { cn } from "@/lib/utils"
@@ -32,7 +32,7 @@ export function OrganizationSettings({
       {plugins.flatMap((plugin) =>
         plugin.organizationCards?.map((Card) => (
           <Card
-            key={`${plugin.id}-${Card.displayName ?? Card.name}`}
+            key={getOrganizationCardKey(plugin.id, Card)}
             organizationId={organizationId}
             organizationSlug={organizationSlug}
           />

--- a/examples/start-shadcn-example/src/components/auth/organization/organization.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization.tsx
@@ -206,7 +206,12 @@ export function Organization({
       </div>
 
       <TabsContent value="settings" tabIndex={-1}>
-        <OrganizationSettings />
+        {activeOrganization && (
+          <OrganizationSettings
+            organizationId={activeOrganization.id}
+            organizationSlug={activeOrganization.slug}
+          />
+        )}
       </TabsContent>
 
       <TabsContent value="people" tabIndex={-1}>

--- a/examples/start-solid-zaidan-example/src/components/auth/api-key/organization-api-keys.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/api-key/organization-api-keys.tsx
@@ -1,18 +1,20 @@
-import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
-import { useAuth, useSession } from "@better-auth-ui/solid"
 import {
-  useActiveOrganization,
-  useListOrganizationMembers
-} from "@better-auth-ui/solid/plugins/organization"
+  hasMemberRole,
+  type OrganizationAuthClient
+} from "@better-auth-ui/core/plugins/organization"
+import { useAuth, useSession } from "@better-auth-ui/solid"
+import { useListOrganizationMembers } from "@better-auth-ui/solid/plugins/organization"
 import { createMemo, Show } from "solid-js"
 import { ApiKeys } from "@/components/auth/api-key/api-keys"
 
 export type OrganizationApiKeysProps = {
   class?: string
+  organizationId: string
+  organizationSlug: string
 }
 
 /**
- * {@link ApiKeys} scoped to the active organization.
+ * {@link ApiKeys} scoped to an explicit organization.
  *
  * Hidden for members whose role isn't `owner`. Better Auth's
  * `/organization/has-permission` endpoint isn't usable for `apiKey:*` checks
@@ -22,24 +24,22 @@ export type OrganizationApiKeysProps = {
 export function OrganizationApiKeys(props: OrganizationApiKeysProps) {
   const auth = useAuth<OrganizationAuthClient>()
   const session = useSession(auth.authClient)
-  const activeOrganization = useActiveOrganization(auth.authClient)
-  const members = useListOrganizationMembers(auth.authClient)
+  const members = useListOrganizationMembers(auth.authClient, () => ({
+    query: { organizationId: props.organizationId }
+  }))
   const canManageApiKeys = createMemo(() =>
     Boolean(
       members.data?.members.some(
         (member: { role?: string | null; userId?: string | null }) =>
-          member.role === "owner" && member.userId === session.data?.user.id
+          hasMemberRole(member.role, "owner") &&
+          member.userId === session.data?.user.id
       )
     )
   )
 
   return (
     <Show when={canManageApiKeys()}>
-      <ApiKeys
-        class={props.class}
-        organizationId={activeOrganization.data?.id}
-        isPending={activeOrganization.isPending}
-      />
+      <ApiKeys class={props.class} organizationId={props.organizationId} />
     </Show>
   )
 }

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-settings.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-settings.tsx
@@ -6,6 +6,8 @@ import { OrganizationProfile } from "./organization-profile"
 
 export type OrganizationSettingsProps = {
   class?: string
+  organizationId: string
+  organizationSlug: string
 }
 
 export function OrganizationSettings(props: OrganizationSettingsProps) {
@@ -19,7 +21,12 @@ export function OrganizationSettings(props: OrganizationSettingsProps) {
     <div class={props.class ?? "grid gap-4 md:gap-6"}>
       <OrganizationProfile />
       <For each={organizationCards()}>
-        {(OrganizationCard) => <OrganizationCard />}
+        {(OrganizationCard) => (
+          <OrganizationCard
+            organizationId={props.organizationId}
+            organizationSlug={props.organizationSlug}
+          />
+        )}
       </For>
       <OrganizationDangerZone />
     </div>

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization.tsx
@@ -104,7 +104,10 @@ export function Organization(props: OrganizationProps) {
               value={config.viewPaths.organization.settings}
               tabIndex={-1}
             >
-              <OrganizationSettings />
+              <OrganizationSettings
+                organizationId={currentOrganization().id}
+                organizationSlug={currentOrganization().slug}
+              />
             </TabsContent>
 
             <TabsContent

--- a/examples/start-solid-zaidan-example/src/components/auth/settings/shared/types.ts
+++ b/examples/start-solid-zaidan-example/src/components/auth/settings/shared/types.ts
@@ -22,9 +22,14 @@ export type SecurityCardsPlugin = {
   securityCards?: Component[]
 }
 
+export type OrganizationCardProps = {
+  organizationId: string
+  organizationSlug: string
+}
+
 export type OrganizationCardsPlugin = {
   id: string
-  organizationCards?: Component[]
+  organizationCards?: Component<OrganizationCardProps>[]
 }
 
 export type ChangePasswordFieldErrors = {

--- a/examples/start-solid-zaidan-example/src/demos/organization/organization-settings.tsx
+++ b/examples/start-solid-zaidan-example/src/demos/organization/organization-settings.tsx
@@ -5,7 +5,10 @@ import { OrganizationDemoWrapper } from "./organization-demo-wrapper"
 export function OrganizationSettingsDemo() {
   return (
     <OrganizationDemoWrapper>
-      <OrganizationSettings />
+      <OrganizationSettings
+        organizationId="organization-id"
+        organizationSlug="acme"
+      />
     </OrganizationDemoWrapper>
   )
 }

--- a/examples/start-solid-zaidan-example/src/stories/organization.stories.tsx
+++ b/examples/start-solid-zaidan-example/src/stories/organization.stories.tsx
@@ -334,7 +334,10 @@ function OrganizationSettingsPreviewContent() {
     <OrganizationStoryProvider queryClient={queryClient} slug="acme">
       {() => (
         <main class="mx-auto min-h-[600px] w-full max-w-3xl bg-background p-6 text-foreground">
-          <OrganizationSettings />
+          <OrganizationSettings
+            organizationId="org_acme_docs"
+            organizationSlug="acme"
+          />
         </main>
       )}
     </OrganizationStoryProvider>

--- a/examples/start-solid-zaidan-example/tests/auth-route.test.ts
+++ b/examples/start-solid-zaidan-example/tests/auth-route.test.ts
@@ -2566,9 +2566,12 @@ describe("Solid auth route component selection", () => {
     expect(newApiKeyDialog).toContain("apiKeyLocalization.newApiKey")
     expect(deleteApiKeyDialog).toContain("useDeleteApiKey")
     expect(deleteApiKeyDialog).toContain('configId: "organization"')
-    expect(organizationApiKeys).toContain("useActiveOrganization")
+    expect(organizationApiKeys).not.toContain("useActiveOrganization")
     expect(organizationApiKeys).toContain("useListOrganizationMembers")
-    expect(organizationApiKeys).toContain('member.role === "owner"')
+    expect(organizationApiKeys).toContain('hasMemberRole(member.role, "owner")')
+    expect(organizationApiKeys).toContain(
+      "organizationId: props.organizationId"
+    )
     expect(organizationApiKeys).toContain("<ApiKeys")
     expect(apiKeyPlugin).toContain("coreApiKeyPlugin")
     expect(apiKeyPlugin).toContain("organizationCards: [OrganizationApiKeys]")
@@ -3073,7 +3076,10 @@ describe("Solid auth route component selection", () => {
     )
 
     expect(organization).toContain("OrganizationSettings")
-    expect(organization).not.toContain("organizationSlug: props.slug")
+    expect(organization).toContain("organizationId={currentOrganization().id}")
+    expect(organization).toContain(
+      "organizationSlug={currentOrganization().slug}"
+    )
     expect(organization).toContain("createOrganizationPath")
     expect(organization).toContain("slugPrefix")
 
@@ -3085,16 +3091,22 @@ describe("Solid auth route component selection", () => {
       expect(source).toContain("setActiveOrganization.mutate")
     }
 
-    expect(organizationApiKeys).toContain("useActiveOrganization")
+    expect(organizationApiKeys).not.toContain("useActiveOrganization")
     expect(organizationApiKeys).toContain("useListOrganizationMembers")
-    expect(organizationApiKeys).not.toContain("organizationSlug")
+    expect(organizationApiKeys).toContain("hasMemberRole")
+    expect(organizationApiKeys).toContain("organizationId: string")
+    expect(organizationApiKeys).toContain("organizationSlug: string")
     expect(organizationApiKeys).toContain(
-      "organizationId={activeOrganization.data?.id}"
+      "query: { organizationId: props.organizationId }"
     )
+    expect(organizationApiKeys).toContain('hasMemberRole(member.role, "owner")')
     expect(activeOrganizationQuery).toContain("resolveActiveOrganizationQuery")
     expect(coreActiveOrganizationQuery).toContain("organizationSlug === null")
     expect(coreActiveOrganizationQuery).toContain("async () => null")
     expect(listMembersQuery).toContain("activeOrganization.data?.id")
+    expect(listMembersQuery).toContain(
+      "enabled: !options?.().query?.organizationId"
+    )
   })
 
   it("adds Solid/Zaidan Organization profile settings parity", () => {
@@ -3170,6 +3182,12 @@ describe("Solid auth route component selection", () => {
     )
     expect(organizationSettings).toContain("OrganizationProfile")
     expect(organizationSettings).toContain("organizationCards")
+    expect(organizationSettings).toContain(
+      "organizationId={props.organizationId}"
+    )
+    expect(organizationSettings).toContain(
+      "organizationSlug={props.organizationSlug}"
+    )
     expect(organizationSettings).toContain("OrganizationDangerZone")
     expect(organizationProfile).toContain("useActiveOrganization")
     expect(organizationProfile).toContain("useUpdateOrganization")

--- a/packages/heroui/src/components/auth/api-key/organization-api-keys.tsx
+++ b/packages/heroui/src/components/auth/api-key/organization-api-keys.tsx
@@ -1,19 +1,21 @@
-import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
-import { useAuth, useSession } from "@better-auth-ui/react"
 import {
-  useActiveOrganization,
-  useListOrganizationMembers
-} from "@better-auth-ui/react/plugins/organization"
+  hasMemberRole,
+  type OrganizationAuthClient
+} from "@better-auth-ui/core/plugins/organization"
+import { useAuth, useSession } from "@better-auth-ui/react"
+import { useListOrganizationMembers } from "@better-auth-ui/react/plugins/organization"
 import type { CardProps } from "@heroui/react"
 import { ApiKeys } from "./api-keys"
 
 export type OrganizationApiKeysProps = {
   className?: string
+  organizationId: string
+  organizationSlug: string
   variant?: CardProps["variant"]
 }
 
 /**
- * {@link ApiKeys} scoped to the active organization.
+ * {@link ApiKeys} scoped to an explicit organization.
  *
  * Hidden for members whose role isn't `owner`. Better Auth's
  * `/organization/has-permission` endpoint isn't usable for `apiKey:*` checks
@@ -22,20 +24,20 @@ export type OrganizationApiKeysProps = {
  */
 export function OrganizationApiKeys({
   className,
+  organizationId,
   variant
 }: OrganizationApiKeysProps) {
   const { authClient } = useAuth()
   const { data: session } = useSession(authClient)
 
-  const { data: activeOrganization, isPending: activeOrganizationPending } =
-    useActiveOrganization(authClient as OrganizationAuthClient)
-
   const { data: membersData } = useListOrganizationMembers(
-    authClient as OrganizationAuthClient
+    authClient as OrganizationAuthClient,
+    { query: { organizationId } }
   )
 
   const canManageApiKeys = membersData?.members.some(
-    (member) => member.role === "owner" && member.userId === session?.user.id
+    (member) =>
+      hasMemberRole(member.role, "owner") && member.userId === session?.user.id
   )
 
   if (!canManageApiKeys) {
@@ -46,8 +48,7 @@ export function OrganizationApiKeys({
     <ApiKeys
       className={className}
       variant={variant}
-      organizationId={activeOrganization?.id}
-      isPending={activeOrganizationPending}
+      organizationId={organizationId}
     />
   )
 }

--- a/packages/heroui/src/components/auth/organization/organization-settings.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-settings.tsx
@@ -8,6 +8,8 @@ import { OrganizationProfile } from "./organization-profile"
 /** Props for the {@link OrganizationSettings} component. */
 export type OrganizationSettingsProps = {
   className?: string
+  organizationId: string
+  organizationSlug: string
   variant?: CardProps["variant"]
 }
 
@@ -17,6 +19,8 @@ export type OrganizationSettingsProps = {
  */
 export function OrganizationSettings({
   className,
+  organizationId,
+  organizationSlug,
   variant,
   ...props
 }: OrganizationSettingsProps & ComponentProps<"div">) {
@@ -27,8 +31,13 @@ export function OrganizationSettings({
       <OrganizationProfile variant={variant} />
 
       {plugins.flatMap((plugin) =>
-        plugin.organizationCards?.map((Card, index) => (
-          <Card key={`${plugin.id}-${index.toString()}`} variant={variant} />
+        plugin.organizationCards?.map((Card) => (
+          <Card
+            key={`${plugin.id}-${Card.displayName ?? Card.name}`}
+            organizationId={organizationId}
+            organizationSlug={organizationSlug}
+            variant={variant}
+          />
         ))
       )}
 

--- a/packages/heroui/src/components/auth/organization/organization-settings.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-settings.tsx
@@ -1,4 +1,4 @@
-import { useAuth } from "@better-auth-ui/react"
+import { getOrganizationCardKey, useAuth } from "@better-auth-ui/react"
 import { type CardProps, cn } from "@heroui/react"
 import type { ComponentProps } from "react"
 
@@ -33,7 +33,7 @@ export function OrganizationSettings({
       {plugins.flatMap((plugin) =>
         plugin.organizationCards?.map((Card) => (
           <Card
-            key={`${plugin.id}-${Card.displayName ?? Card.name}`}
+            key={getOrganizationCardKey(plugin.id, Card)}
             organizationId={organizationId}
             organizationSlug={organizationSlug}
             variant={variant}

--- a/packages/heroui/src/components/auth/organization/organization.tsx
+++ b/packages/heroui/src/components/auth/organization/organization.tsx
@@ -214,7 +214,13 @@ export function Organization({
       )}
 
       <Tabs.Panel id="settings" className="px-0">
-        <OrganizationSettings variant={variant} />
+        {activeOrganization && (
+          <OrganizationSettings
+            organizationId={activeOrganization.id}
+            organizationSlug={activeOrganization.slug}
+            variant={variant}
+          />
+        )}
       </Tabs.Panel>
 
       <Tabs.Panel id="people" className="px-0">

--- a/packages/react/src/lib/auth-plugin.ts
+++ b/packages/react/src/lib/auth-plugin.ts
@@ -62,6 +62,8 @@ export type AccountCardProps = {
 export type OrganizationCardProps = {
   className?: string
   children?: ReactNode
+  organizationId: string
+  organizationSlug: string
 }
 
 export type OrganizationTabProps = {

--- a/packages/react/src/lib/auth-plugin.ts
+++ b/packages/react/src/lib/auth-plugin.ts
@@ -4,6 +4,8 @@ import type { SettingsTab } from "./settings-tab"
 
 const authButtonIds = new WeakMap<ComponentType<AuthButtonProps>, number>()
 let nextAuthButtonId = 1
+const organizationCardIds = new WeakMap<object, number>()
+let nextOrganizationCardId = 1
 
 export type { AuthPluginViewPaths } from "@better-auth-ui/core"
 
@@ -31,6 +33,22 @@ export function getAuthButtonKey(
   }
 
   return `${pluginId}-${buttonId.toString()}`
+}
+
+/** Return a stable React key for a plugin-contributed organization card. */
+export function getOrganizationCardKey<TProps>(
+  pluginId: string,
+  OrganizationCard: ComponentType<TProps>
+) {
+  let cardId = organizationCardIds.get(OrganizationCard)
+
+  if (cardId === undefined) {
+    cardId = nextOrganizationCardId
+    nextOrganizationCardId += 1
+    organizationCardIds.set(OrganizationCard, cardId)
+  }
+
+  return `${pluginId}-${cardId.toString()}`
 }
 
 /** Props for plugin-contributed headless authentication prompts. */

--- a/packages/react/src/plugins/organization/hooks/queries/use-list-members.ts
+++ b/packages/react/src/plugins/organization/hooks/queries/use-list-members.ts
@@ -44,7 +44,7 @@ export function useListOrganizationMembers<
 
   const { data: activeOrganization } = useActiveOrganization(
     authClient,
-    undefined,
+    { enabled: !query?.organizationId },
     queryClient
   )
 

--- a/packages/react/tests/lib/auth-plugin.test.ts
+++ b/packages/react/tests/lib/auth-plugin.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+import { getOrganizationCardKey } from "../../src/lib/auth-plugin"
+
+describe("getOrganizationCardKey", () => {
+  it("keeps component identities stable when display names match", () => {
+    const FirstCard = () => null
+    const SecondCard = () => null
+    FirstCard.displayName = "OrganizationCard"
+    SecondCard.displayName = "OrganizationCard"
+
+    const firstKey = getOrganizationCardKey("api-key", FirstCard)
+    const secondKey = getOrganizationCardKey("api-key", SecondCard)
+
+    expect(firstKey).toBe(getOrganizationCardKey("api-key", FirstCard))
+    expect(secondKey).toBe(getOrganizationCardKey("api-key", SecondCard))
+    expect(firstKey).not.toBe(secondKey)
+    expect(getOrganizationCardKey("billing", FirstCard)).not.toBe(firstKey)
+  })
+})

--- a/packages/solid/src/plugins/organization/hooks/queries/use-list-members.ts
+++ b/packages/solid/src/plugins/organization/hooks/queries/use-list-members.ts
@@ -40,7 +40,7 @@ export function useListOrganizationMembers<
   const session = useSession(authClient, undefined, queryClient)
   const activeOrganization = useActiveOrganization(
     authClient,
-    undefined,
+    () => ({ enabled: !options?.().query?.organizationId }),
     queryClient
   )
 

--- a/packages/solid/tests/behavior-parity.test.ts
+++ b/packages/solid/tests/behavior-parity.test.ts
@@ -300,7 +300,13 @@ describe("Solid auth behavior parity", () => {
 
       expect(source).not.toContain("skipToken")
       expect(source).not.toContain("queryFn:")
-      expect(source).not.toContain("enabled:")
+      if (file.endsWith("use-list-members.ts")) {
+        expect(source).toContain(
+          "() => ({ enabled: !options?.().query?.organizationId })"
+        )
+      } else {
+        expect(source).not.toContain("enabled:")
+      }
       expect(source).toContain("initialData: initialData as undefined")
     }
   })


### PR DESCRIPTION
## Summary

- Pass explicit organization IDs and slugs to plugin-contributed organization settings cards.
- Remove active-organization dependence from organization API-key cards.
- Use hasMemberRole for owner checks so multi-role values such as owner,admin work correctly.
- Apply the fix across HeroUI, shadcn, Base UI, Next, and Zaidan copies.
- Disable the fallback active-organization query when an explicit organization ID is supplied.

## Stack

Depends on #507, which depends on #506.

## Validation

- Core, React, Solid, and HeroUI package suites passed.
- Organization-focused Solid parity and route tests passed.
- Biome, all available project lint targets, registry builds, and relevant type checks passed.

## Existing baseline failures

The full Solid/Zaidan example suite still reports three stale source-content assertions that also fail on origin/main: plugin navigation ordering, the Solid overview wording, and the invite-member email variable name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Organization settings and API-key views now support explicit organization details for reliable organization-scoped behavior.
  * Organization cards receive organization identifiers for organization-specific content.
  * Member queries prioritize explicitly selected organizations.

* **Bug Fixes**
  * Improved ownership validation and organization-specific API-key retrieval.
  * Settings render only when an active organization is available.

* **Tests**
  * Expanded coverage for organization propagation, member roles, API-key queries, and framework parity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->