### PR TITLE
feat(i18n): add locale bundles and runtime localization

### DIFF
--- a/apps/docs/content/docs/heroui/components/auth-provider.mdx
+++ b/apps/docs/content/docs/heroui/components/auth-provider.mdx
@@ -8,6 +8,59 @@ description: Provides AuthConfig to descendant components.
 ```tsx file=<rootDir>/../../examples/start-heroui-example/src/components/providers.tsx
 ```
 
+## Localization
+
+Install the locale package:
+
+```bash
+bun add @better-auth-ui/locales
+```
+
+Import one locale and pass it to `AuthProvider`:
+
+```tsx title="components/providers.tsx"
+import { deDE } from "@better-auth-ui/locales/de-DE"
+
+<AuthProvider authClient={authClient} locale={deDE} navigate={navigate}>
+  {children}
+</AuthProvider>
+```
+
+Locale bundles include the core messages and all built-in plugin messages. The locale also controls date, number, currency, and relative-time formatting in HeroUI components.
+
+Use `localization` for product-specific text. These values take priority over the selected locale:
+
+```tsx
+<AuthProvider
+  authClient={authClient}
+  locale={deDE}
+  localization={{ auth: { signIn: "Bei Acme anmelden" } }}
+  navigate={navigate}
+>
+  {children}
+</AuthProvider>
+```
+
+### Match the browser language
+
+In a client-only application, import the supported locales and match `navigator.languages` against that list:
+
+```tsx
+import { matchAuthLocale } from "@better-auth-ui/locales"
+import { deDE } from "@better-auth-ui/locales/de-DE"
+import { enUS } from "@better-auth-ui/locales/en-US"
+
+const locale = matchAuthLocale({
+  requested: navigator.languages,
+  supported: [enUS, deDE],
+  fallback: enUS
+})
+```
+
+For server rendering, resolve the same locale from a user preference or the `Accept-Language` header. Pass that locale during the first render to prevent a hydration mismatch.
+
+Changing the `locale` prop updates mounted auth components. Email components do not read `AuthProvider`; pass their localization on the server.
+
 ## Custom and Generic OAuth providers
 
 Built-in providers use their Better Auth ID as a string. For a custom or Generic OAuth provider, pass its ID, visible label, and optional icon.

--- a/apps/docs/content/docs/shadcn/components/auth-provider.mdx
+++ b/apps/docs/content/docs/shadcn/components/auth-provider.mdx
@@ -8,6 +8,59 @@ description: Provides AuthConfig to descendant components.
 ```tsx file=<rootDir>/../../examples/start-shadcn-example/src/components/providers.tsx
 ```
 
+## Localization
+
+Install the locale package:
+
+```bash
+bun add @better-auth-ui/locales
+```
+
+Import one locale and pass it to `AuthProvider`:
+
+```tsx title="components/providers.tsx"
+import { deDE } from "@better-auth-ui/locales/de-DE"
+
+<AuthProvider authClient={authClient} locale={deDE} navigate={navigate}>
+  {children}
+</AuthProvider>
+```
+
+Locale bundles include the core messages and all built-in plugin messages.
+
+Use `localization` for product-specific text. These values take priority over the selected locale:
+
+```tsx
+<AuthProvider
+  authClient={authClient}
+  locale={deDE}
+  localization={{ auth: { signIn: "Bei Acme anmelden" } }}
+  navigate={navigate}
+>
+  {children}
+</AuthProvider>
+```
+
+### Match the browser language
+
+In a client-only application, import the supported locales and match `navigator.languages` against that list:
+
+```tsx
+import { matchAuthLocale } from "@better-auth-ui/locales"
+import { deDE } from "@better-auth-ui/locales/de-DE"
+import { enUS } from "@better-auth-ui/locales/en-US"
+
+const locale = matchAuthLocale({
+  requested: navigator.languages,
+  supported: [enUS, deDE],
+  fallback: enUS
+})
+```
+
+For server rendering, resolve the same locale from a user preference or the `Accept-Language` header. Pass that locale during the first render to prevent a hydration mismatch.
+
+Changing the `locale` prop updates mounted auth components. Email components do not read `AuthProvider`; pass their localization on the server.
+
 ## Custom and Generic OAuth providers
 
 Built-in providers use their Better Auth ID as a string. For a custom or Generic OAuth provider, pass its ID, visible label, and optional icon.

--- a/apps/docs/content/docs/zaidan/components/auth-provider.mdx
+++ b/apps/docs/content/docs/zaidan/components/auth-provider.mdx
@@ -10,6 +10,58 @@ Install the provider registry payload with `npx shadcn@latest add https://better
 ```tsx file=<rootDir>/../../examples/start-solid-zaidan-example/src/components/providers.tsx
 ```
 
+## Localization
+
+Install the locale package:
+
+```bash
+bun add @better-auth-ui/locales
+```
+
+Import one locale and pass it to `AuthProvider`:
+
+```tsx title="components/providers.tsx"
+import { deDE } from "@better-auth-ui/locales/de-DE"
+
+<AuthProvider authClient={authClient} locale={deDE}>
+  {children}
+</AuthProvider>
+```
+
+Locale bundles include the core messages and all built-in plugin messages.
+
+Use `localization` for product-specific text. These values take priority over the selected locale:
+
+```tsx
+<AuthProvider
+  authClient={authClient}
+  locale={deDE}
+  localization={{ auth: { signIn: "Bei Acme anmelden" } }}
+>
+  {children}
+</AuthProvider>
+```
+
+### Match the browser language
+
+In a client-only application, import the supported locales and match `navigator.languages` against that list:
+
+```tsx
+import { matchAuthLocale } from "@better-auth-ui/locales"
+import { deDE } from "@better-auth-ui/locales/de-DE"
+import { enUS } from "@better-auth-ui/locales/en-US"
+
+const locale = matchAuthLocale({
+  requested: navigator.languages,
+  supported: [enUS, deDE],
+  fallback: enUS
+})
+```
+
+For server rendering, resolve the same locale from a user preference or the `Accept-Language` header. Pass that locale during the first render to prevent a hydration mismatch.
+
+Changing the `locale` prop updates mounted auth components. Email components do not read `AuthProvider`; pass their localization on the server.
+
 ## Popup social sign-in
 
 Set `socialSignInMode="popup"` to keep the current page open during social sign-in. Redirect mode remains the default.

--- a/bun.lock
+++ b/bun.lock
@@ -482,6 +482,19 @@
         "react-dom": ">=19.2.6",
       },
     },
+    "packages/locales": {
+      "name": "@better-auth-ui/locales",
+      "version": "1.7.6",
+      "devDependencies": {
+        "@better-auth-ui/core": "workspace:*",
+        "vite": "^8.2.1",
+        "vite-plugin-dts": "^5.0.3",
+        "vitest": "^4.1.9",
+      },
+      "peerDependencies": {
+        "@better-auth-ui/core": "*",
+      },
+    },
     "packages/react": {
       "name": "@better-auth-ui/react",
       "version": "1.7.6",
@@ -768,6 +781,8 @@
     "@better-auth-ui/core": ["@better-auth-ui/core@workspace:packages/core"],
 
     "@better-auth-ui/heroui": ["@better-auth-ui/heroui@workspace:packages/heroui"],
+
+    "@better-auth-ui/locales": ["@better-auth-ui/locales@workspace:packages/locales"],
 
     "@better-auth-ui/react": ["@better-auth-ui/react@workspace:packages/react"],
 

--- a/packages/core/src/config/additional-fields-config.ts
+++ b/packages/core/src/config/additional-fields-config.ts
@@ -207,9 +207,12 @@ export function fieldsWithModelValues(
 }
 
 /** Format a persisted additional-field value for compact read-only display. */
-export function formatAdditionalFieldValue(value: unknown): string | undefined {
+export function formatAdditionalFieldValue(
+  value: unknown,
+  languageTag?: string
+): string | undefined {
   if (value === null || value === undefined || value === "") return undefined
-  if (value instanceof Date) return value.toLocaleString()
+  if (value instanceof Date) return value.toLocaleString(languageTag)
   if (typeof value === "string") {
     const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
     if (dateOnly) {
@@ -218,12 +221,12 @@ export function formatAdditionalFieldValue(value: unknown): string | undefined {
         Number(year),
         Number(month) - 1,
         Number(day)
-      ).toLocaleString()
+      ).toLocaleString(languageTag)
     }
 
     const parsed = new Date(value)
     if (/^\d{4}-\d{2}-\d{2}T/.test(value) && !Number.isNaN(parsed.getTime())) {
-      return parsed.toLocaleString()
+      return parsed.toLocaleString(languageTag)
     }
     return value
   }

--- a/packages/core/src/config/auth-config.ts
+++ b/packages/core/src/config/auth-config.ts
@@ -1,10 +1,19 @@
 import type { AuthClient } from "../lib/auth-client"
+import {
+  type AuthLocale,
+  defaultAuthLocale,
+  localizeAuthPlugins
+} from "../lib/auth-locale"
 import type { AuthPlugin } from "../lib/auth-plugin"
 import { type BasePaths, basePaths } from "../lib/base-paths"
+import type { DeepPartial } from "../lib/deep-partial"
 import { type Localization, localization } from "../lib/localization"
-import { resizeAvatar } from "../lib/utils"
+import { deepmerge, resizeAvatar } from "../lib/utils"
 import { type ViewPaths, viewPaths } from "../lib/view-paths"
-import type { AdditionalFields } from "./additional-fields-config"
+import type {
+  AdditionalField,
+  AdditionalFields
+} from "./additional-fields-config"
 import type { AvatarConfig } from "./avatar-config"
 import type { EmailAndPasswordConfig } from "./email-and-password-config"
 import type { AuthSocialProvider } from "./social-provider-config"
@@ -53,6 +62,12 @@ export interface AuthConfig<TAuthClient extends AuthClient = AuthClient> {
    * @remarks `Localization`
    */
   localization: Localization
+  /**
+   * Language metadata and translated messages for all auth components.
+   * @remarks `AuthLocale`
+   * @default `defaultAuthLocale`
+   */
+  locale: AuthLocale
   /**
    * Registered auth plugins. UI packages widen the element type via the
    * `AuthPluginRegister` module-augmentation slot.
@@ -125,6 +140,7 @@ export const defaultAuthConfig: Omit<AuthConfig, "authClient"> = {
   socialSignInMode: "redirect",
   viewPaths,
   localization,
+  locale: defaultAuthLocale,
   navigate: ({ to, replace }) => {
     if (replace) {
       window.location.replace(to)
@@ -132,4 +148,45 @@ export const defaultAuthConfig: Omit<AuthConfig, "authClient"> = {
       window.location.href = to
     }
   }
+}
+
+export type AuthConfigOptions<TAuthClient extends AuthClient = AuthClient> =
+  DeepPartial<Omit<AuthConfig<TAuthClient>, "authClient" | "locale">> & {
+    authClient: TAuthClient
+    /** Imported locale bundle. Defaults to English (`en-US`). */
+    locale?: AuthLocale
+  }
+
+/** Resolves defaults, locale messages, plugin messages, and consumer overrides. */
+export function resolveAuthConfig<TAuthClient extends AuthClient = AuthClient>(
+  options: AuthConfigOptions<TAuthClient>
+): AuthConfig<TAuthClient> {
+  const locale = options.locale ?? defaultAuthLocale
+  const resolvedLocalization = deepmerge(
+    deepmerge(localization, locale.localization),
+    options.localization ?? {}
+  )
+  const plugins = localizeAuthPlugins(options.plugins ?? [], locale)
+  const mergedConfig = deepmerge<Omit<AuthConfig<TAuthClient>, "authClient">>(
+    defaultAuthConfig as Omit<AuthConfig<TAuthClient>, "authClient">,
+    {
+      ...options,
+      locale,
+      localization: resolvedLocalization,
+      plugins
+    }
+  )
+
+  const fieldsByName = new Map<string, AdditionalField>()
+  for (const plugin of plugins) {
+    for (const field of plugin.additionalFields ?? []) {
+      fieldsByName.set(field.name, field)
+    }
+  }
+  for (const field of mergedConfig.additionalFields ?? []) {
+    fieldsByName.set(field.name, field)
+  }
+  mergedConfig.additionalFields = Array.from(fieldsByName.values())
+
+  return { ...mergedConfig, authClient: options.authClient }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./config"
 export * from "./lib/auth-client"
+export * from "./lib/auth-locale"
 export * from "./lib/auth-mutation-keys"
 export * from "./lib/auth-plugin"
 export * from "./lib/auth-query-keys"

--- a/packages/core/src/lib/auth-locale.ts
+++ b/packages/core/src/lib/auth-locale.ts
@@ -1,0 +1,144 @@
+import type { AuthPlugin } from "./auth-plugin"
+import type { Localization } from "./localization"
+import { localization } from "./localization"
+import { deepmerge } from "./utils"
+
+export type AuthLocaleDirection = "ltr" | "rtl"
+
+/** A complete set of translated Better Auth UI messages. */
+export interface AuthLocale {
+  /** Canonical BCP 47 language tag, such as `de-DE` or `zh-CN`. */
+  languageTag: string
+  /** Text direction for this locale. @default "ltr" */
+  direction?: AuthLocaleDirection
+  /** Core authentication and settings messages. */
+  localization: Localization
+  /** Optional messages keyed by auth plugin ID. */
+  plugins?: Record<string, Record<string, unknown>>
+}
+
+export const defaultAuthLocale: AuthLocale = {
+  languageTag: "en-US",
+  direction: "ltr",
+  localization
+}
+
+/** Defines a locale while preserving its narrow language-tag type. */
+export function defineAuthLocale<const TLocale extends AuthLocale>(
+  locale: TLocale
+): TLocale {
+  return locale
+}
+
+function canonicalizeLanguageTag(languageTag: string) {
+  try {
+    return Intl.getCanonicalLocales(languageTag)[0]
+  } catch {
+    return undefined
+  }
+}
+
+function parseRequestedLanguages(
+  requested: string | readonly string[] | null | undefined
+) {
+  const values: readonly string[] = Array.isArray(requested)
+    ? requested
+    : typeof requested === "string"
+      ? requested.split(",")
+      : []
+
+  return values
+    .map((value, index) => {
+      const [languageTag, ...parameters] = value.trim().split(";")
+      const qualityParameter = parameters.find((parameter: string) =>
+        parameter.trim().toLowerCase().startsWith("q=")
+      )
+      const quality = qualityParameter
+        ? Number.parseFloat(qualityParameter.trim().slice(2))
+        : 1
+
+      return {
+        index,
+        languageTag: canonicalizeLanguageTag(languageTag),
+        quality: Number.isFinite(quality) ? quality : 0
+      }
+    })
+    .filter(
+      (
+        entry
+      ): entry is { index: number; languageTag: string; quality: number } =>
+        Boolean(entry.languageTag) && entry.quality > 0 && entry.quality <= 1
+    )
+    .sort(
+      (left, right) => right.quality - left.quality || left.index - right.index
+    )
+    .map((entry) => entry.languageTag)
+}
+
+export type MatchAuthLocaleOptions<TLocale extends AuthLocale> = {
+  /** Browser languages or an `Accept-Language` header value. */
+  requested: string | readonly string[] | null | undefined
+  /** Locales that the application has imported. */
+  supported: readonly TLocale[]
+  /** Locale returned when no requested language matches. */
+  fallback: TLocale
+}
+
+/** Matches exact language tags first, then matches their base languages. */
+export function matchAuthLocale<TLocale extends AuthLocale>({
+  requested,
+  supported,
+  fallback
+}: MatchAuthLocaleOptions<TLocale>): TLocale {
+  const candidates = supported
+    .map((locale) => ({
+      locale,
+      languageTag: canonicalizeLanguageTag(locale.languageTag)
+    }))
+    .filter((entry): entry is { locale: TLocale; languageTag: string } =>
+      Boolean(entry.languageTag)
+    )
+
+  for (const requestedLanguage of parseRequestedLanguages(requested)) {
+    const exact = candidates.find(
+      (candidate) => candidate.languageTag === requestedLanguage
+    )
+    if (exact) return exact.locale
+
+    const requestedBaseLanguage = requestedLanguage.split("-")[0]
+    const baseLanguage = candidates.find(
+      (candidate) =>
+        candidate.languageTag.split("-")[0] === requestedBaseLanguage
+    )
+    if (baseLanguage) return baseLanguage.locale
+  }
+
+  return fallback
+}
+
+/** Applies locale messages to registered plugins without mutating them. */
+export function localizeAuthPlugins(
+  plugins: AuthPlugin[],
+  locale: AuthLocale
+): AuthPlugin[] {
+  return plugins.map((plugin) => {
+    const localeMessages = locale.plugins?.[plugin.id] ?? {}
+    const resolver = plugin._localizationResolver
+
+    if (Object.keys(localeMessages).length === 0 && !resolver) {
+      return plugin
+    }
+
+    const localization = deepmerge(
+      deepmerge(plugin.localization ?? {}, localeMessages),
+      plugin._localizationOverrides ?? {}
+    )
+    const localizedPlugin = { ...plugin, localization } as AuthPlugin
+
+    return (resolver?.(localizedPlugin, {
+      direction: locale.direction ?? "ltr",
+      languageTag: locale.languageTag,
+      localization
+    }) ?? localizedPlugin) as AuthPlugin
+  })
+}

--- a/packages/core/src/lib/auth-plugin.ts
+++ b/packages/core/src/lib/auth-plugin.ts
@@ -1,5 +1,16 @@
 import type { AdditionalFields } from "../config/additional-fields-config"
 
+export type AuthPluginLocalizationContext = {
+  direction: "ltr" | "rtl"
+  languageTag: string
+  localization: Record<string, unknown>
+}
+
+export type AuthPluginLocalizationResolver = (
+  plugin: AuthPluginBase,
+  context: AuthPluginLocalizationContext
+) => AuthPluginBase
+
 /**
  * View-path contributions kept on the plugin object.
  *
@@ -27,6 +38,10 @@ export interface AuthPluginBase {
   id: string
   /** Localization defaults contributed by the plugin. */
   localization?: Record<string, unknown>
+  /** @internal Consumer overrides retained so they win over locale messages. */
+  _localizationOverrides?: Record<string, unknown>
+  /** @internal Recomputes values derived from localization. */
+  _localizationResolver?: AuthPluginLocalizationResolver
   /**
    * View-path segments the plugin contributes. Read by host components
    * (e.g. `<Auth>`, `MagicLinkButton`) via `useAuthPlugin(plugin).viewPaths`.

--- a/packages/core/src/lib/create-auth-plugin.ts
+++ b/packages/core/src/lib/create-auth-plugin.ts
@@ -21,10 +21,24 @@ export function createAuthPlugin<
   TArgs extends unknown[],
   TResult extends Omit<AuthPlugin, "id"> & object
 >(id: TId, factory: (...args: TArgs) => TResult) {
-  const wrapped = (...args: TArgs) => ({
-    ...factory(...args),
-    id
-  })
+  const wrapped = (...args: TArgs): TResult & { id: TId } => {
+    const plugin = { ...factory(...args), id }
+    const options = args[0]
+    const localizationOverrides =
+      options && typeof options === "object" && "localization" in options
+        ? (options.localization as Record<string, unknown> | undefined)
+        : undefined
+
+    if (localizationOverrides) {
+      Object.defineProperty(plugin, "_localizationOverrides", {
+        configurable: false,
+        enumerable: false,
+        value: localizationOverrides
+      })
+    }
+
+    return plugin
+  }
 
   return Object.assign(wrapped, { id })
 }

--- a/packages/core/src/plugins/organization/organization-plugin.ts
+++ b/packages/core/src/plugins/organization/organization-plugin.ts
@@ -1,6 +1,10 @@
 import { defaultAuthConfig } from "../../config"
 import type { AdditionalFields } from "../../config/additional-fields-config"
 import type { AvatarConfig } from "../../config/avatar-config"
+import type {
+  AuthPluginBase,
+  AuthPluginLocalizationContext
+} from "../../lib/auth-plugin"
 import { createAuthPlugin } from "../../lib/create-auth-plugin"
 import {
   type OrganizationLocalization,
@@ -186,6 +190,24 @@ export const organizationPlugin = createAuthPlugin(
           member: localization.member
         }),
         ...options.additionalRoles
+      },
+      _localizationResolver: (
+        plugin: AuthPluginBase,
+        context: AuthPluginLocalizationContext
+      ) => {
+        const messages = context.localization as OrganizationLocalization
+
+        return {
+          ...plugin,
+          roles: {
+            ...(options.roles ?? {
+              owner: messages.owner,
+              admin: messages.admin,
+              member: messages.member
+            }),
+            ...options.additionalRoles
+          }
+        }
       },
       additionalFields:
         options.modelFields?.organization ?? options.additionalFields ?? [],

--- a/packages/core/src/plugins/phone-number/phone-number-plugin.ts
+++ b/packages/core/src/plugins/phone-number/phone-number-plugin.ts
@@ -1,3 +1,7 @@
+import type {
+  AuthPluginBase,
+  AuthPluginLocalizationContext
+} from "../../lib/auth-plugin"
 import { createAuthPlugin } from "../../lib/create-auth-plugin"
 // Side-effect import so this file participates in declaration merging on the
 // same module instance that external consumers reach via `@better-auth-ui/core`.
@@ -123,6 +127,13 @@ export const phoneNumberPlugin = createAuthPlugin(
       defaultCountry,
       locale: options.locale,
       localization: { ...phoneNumberLocalization, ...options.localization },
+      _localizationResolver: (
+        plugin: AuthPluginBase,
+        context: AuthPluginLocalizationContext
+      ) => ({
+        ...plugin,
+        locale: options.locale ?? context.languageTag
+      }),
       otpLength: resolveOtpLength(options.otpLength),
       signIn: options.signIn ?? true,
       passwordSignIn: options.passwordSignIn ?? false,

--- a/packages/core/src/plugins/username/username-plugin.ts
+++ b/packages/core/src/plugins/username/username-plugin.ts
@@ -1,3 +1,7 @@
+import type {
+  AuthPluginBase,
+  AuthPluginLocalizationContext
+} from "../../lib/auth-plugin"
 import { createAuthPlugin } from "../../lib/create-auth-plugin"
 import {
   type UsernameLocalization,
@@ -42,35 +46,46 @@ export const usernamePlugin = createAuthPlugin(
     const maxUsernameLength = options.maxUsernameLength ?? 30
     const localization = { ...usernameLocalization, ...options.localization }
 
+    const createAdditionalFields = (messages: UsernameLocalization) => [
+      {
+        name: "username",
+        type: "string" as const,
+        label: messages.username,
+        placeholder: messages.usernamePlaceholder,
+        inputType: "input" as const,
+        signUp: "above" as const,
+        required: true
+      },
+      ...(options.displayUsername
+        ? [
+            {
+              name: "displayUsername",
+              type: "string" as const,
+              label: messages.displayUsername,
+              placeholder: messages.displayUsernamePlaceholder,
+              inputType: "input" as const,
+              signUp: "above" as const
+            }
+          ]
+        : [])
+    ]
+
     return {
       ...options,
       minUsernameLength,
       maxUsernameLength,
       usernamePrefix: options.usernamePrefix ?? "",
       localization,
-      additionalFields: [
-        {
-          name: "username",
-          type: "string" as const,
-          label: localization.username,
-          placeholder: localization.usernamePlaceholder,
-          inputType: "input" as const,
-          signUp: "above" as const,
-          required: true
-        },
-        ...(options.displayUsername
-          ? [
-              {
-                name: "displayUsername",
-                type: "string" as const,
-                label: localization.displayUsername,
-                placeholder: localization.displayUsernamePlaceholder,
-                inputType: "input" as const,
-                signUp: "above" as const
-              }
-            ]
-          : [])
-      ]
+      additionalFields: createAdditionalFields(localization),
+      _localizationResolver: (
+        plugin: AuthPluginBase,
+        context: AuthPluginLocalizationContext
+      ) => ({
+        ...plugin,
+        additionalFields: createAdditionalFields(
+          context.localization as UsernameLocalization
+        )
+      })
     }
   }
 )

--- a/packages/core/tests/auth-locale.test.ts
+++ b/packages/core/tests/auth-locale.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest"
+import {
+  createAuthPlugin,
+  deepmerge,
+  defaultAuthLocale,
+  defineAuthLocale,
+  localization,
+  matchAuthLocale,
+  resolveAuthConfig
+} from "../src"
+import { organizationPlugin } from "../src/plugins/organization"
+import { usernamePlugin } from "../src/plugins/username"
+
+const germanLocale = defineAuthLocale({
+  languageTag: "de-DE",
+  direction: "ltr",
+  localization: deepmerge(localization, {
+    auth: { signIn: "Anmelden", signOut: "Abmelden" }
+  }),
+  plugins: {
+    organization: {
+      admin: "Administrator",
+      member: "Mitglied",
+      organizations: "Organisationen",
+      owner: "Inhaber"
+    },
+    test: {
+      description: "Beschreibung",
+      label: "Bezeichnung"
+    },
+    username: {
+      displayUsername: "Anzeigename",
+      displayUsernamePlaceholder: "Anzeigename",
+      username: "Benutzername",
+      usernamePlaceholder: "Benutzername"
+    }
+  }
+})
+
+describe("matchAuthLocale", () => {
+  it("uses quality values and exact language tags", () => {
+    expect(
+      matchAuthLocale({
+        requested: "de-DE;q=0.9, en-US;q=0.4",
+        supported: [defaultAuthLocale, germanLocale],
+        fallback: defaultAuthLocale
+      })
+    ).toBe(germanLocale)
+  })
+
+  it("matches a regional request to an imported base language", () => {
+    expect(
+      matchAuthLocale({
+        requested: ["de-CH"],
+        supported: [defaultAuthLocale, germanLocale],
+        fallback: defaultAuthLocale
+      })
+    ).toBe(germanLocale)
+  })
+
+  it("returns the fallback for invalid and unsupported languages", () => {
+    expect(
+      matchAuthLocale({
+        requested: "not_a_locale, fr-FR;q=0.8",
+        supported: [defaultAuthLocale, germanLocale],
+        fallback: defaultAuthLocale
+      })
+    ).toBe(defaultAuthLocale)
+  })
+
+  it("ignores invalid quality values", () => {
+    expect(
+      matchAuthLocale({
+        requested: "de-DE;q=2, en-US;Q=0.8",
+        supported: [defaultAuthLocale, germanLocale],
+        fallback: germanLocale
+      })
+    ).toBe(defaultAuthLocale)
+  })
+})
+
+describe("resolveAuthConfig localization", () => {
+  const testPlugin = createAuthPlugin(
+    "test",
+    (options: { localization?: { label?: string } } = {}) => ({
+      localization: {
+        description: "Description",
+        label: "Label",
+        ...options.localization
+      }
+    })
+  )
+
+  it("applies locale messages before consumer overrides", () => {
+    const plugin = testPlugin({ localization: { label: "Custom label" } })
+    const config = resolveAuthConfig({
+      authClient: {},
+      locale: germanLocale,
+      localization: { auth: { signIn: "Bei Acme anmelden" } },
+      plugins: [plugin]
+    })
+
+    expect(config.localization.auth.signIn).toBe("Bei Acme anmelden")
+    expect(config.localization.auth.signOut).toBe("Abmelden")
+    expect(config.plugins[0]?.localization).toEqual({
+      description: "Beschreibung",
+      label: "Custom label"
+    })
+    expect(plugin.localization).toEqual({
+      description: "Description",
+      label: "Custom label"
+    })
+  })
+
+  it("recomputes plugin values derived from localization", () => {
+    const config = resolveAuthConfig({
+      authClient: {},
+      locale: germanLocale,
+      plugins: [usernamePlugin({ displayUsername: true }), organizationPlugin()]
+    })
+    const username = config.plugins.find((plugin) => plugin.id === "username")
+    const organization = config.plugins.find(
+      (plugin) => plugin.id === "organization"
+    )
+
+    expect(username?.additionalFields?.map((field) => field.label)).toEqual([
+      "Benutzername",
+      "Anzeigename"
+    ])
+    expect(organization).toMatchObject({
+      roles: {
+        admin: "Administrator",
+        member: "Mitglied",
+        owner: "Inhaber"
+      }
+    })
+  })
+})

--- a/packages/heroui/src/components/auth/api-key/api-key.tsx
+++ b/packages/heroui/src/components/auth/api-key/api-key.tsx
@@ -17,7 +17,7 @@ export type ApiKeyProps = {
 }
 
 export function ApiKey({ apiKey, hideDelete, organizationId }: ApiKeyProps) {
-  const { localization } = useAuth()
+  const { locale, localization } = useAuth()
   const { localization: apiKeyLocalization } = useAuthPlugin(apiKeyPlugin)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [editOpen, setEditOpen] = useState(false)
@@ -39,7 +39,7 @@ export function ApiKey({ apiKey, hideDelete, organizationId }: ApiKeyProps) {
 
         <span className="text-xs text-muted">
           {apiKeyLocalization.created}{" "}
-          {new Date(apiKey.createdAt).toLocaleString(undefined, {
+          {new Date(apiKey.createdAt).toLocaleString(locale.languageTag, {
             dateStyle: "medium",
             timeStyle: "short"
           })}
@@ -49,7 +49,7 @@ export function ApiKey({ apiKey, hideDelete, organizationId }: ApiKeyProps) {
           {apiKey.expiresAt
             ? `${apiKeyLocalization.expires} ${new Date(
                 apiKey.expiresAt
-              ).toLocaleString(undefined, {
+              ).toLocaleString(locale.languageTag, {
                 dateStyle: "medium",
                 timeStyle: "short"
               })}`
@@ -67,7 +67,7 @@ export function ApiKey({ apiKey, hideDelete, organizationId }: ApiKeyProps) {
         <span className="text-xs text-muted">
           {apiKeyLocalization.lastRequest}:{" "}
           {apiKey.lastRequest
-            ? new Date(apiKey.lastRequest).toLocaleString()
+            ? new Date(apiKey.lastRequest).toLocaleString(locale.languageTag)
             : apiKeyLocalization.neverRequested}
         </span>
       </div>

--- a/packages/heroui/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/packages/heroui/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -38,7 +38,7 @@ export function CreateApiKeyDialog({
   onOpenChange,
   organizationId
 }: CreateApiKeyDialogProps) {
-  const { authClient, localization } = useAuth()
+  const { authClient, locale, localization } = useAuth()
   const {
     configurations,
     keyExpiration,
@@ -238,13 +238,13 @@ export function CreateApiKeyDialog({
                             <ListBox.Item
                               id={String(days)}
                               key={days}
-                              textValue={`${days.toLocaleString()} ${
+                              textValue={`${days.toLocaleString(locale.languageTag)} ${
                                 days === 1
                                   ? apiKeyLocalization.day
                                   : apiKeyLocalization.days
                               }`}
                             >
-                              {days.toLocaleString()}{" "}
+                              {days.toLocaleString(locale.languageTag)}{" "}
                               {days === 1
                                 ? apiKeyLocalization.day
                                 : apiKeyLocalization.days}

--- a/packages/heroui/src/components/auth/billing/billing-settings.tsx
+++ b/packages/heroui/src/components/auth/billing/billing-settings.tsx
@@ -51,15 +51,15 @@ export type BillingSettingsProps = {
   variant?: CardProps["variant"]
 }
 
-const formatPrice = (amount: number, currency: string) => {
+const formatPrice = (amount: number, currency: string, languageTag: string) => {
   const fractionDigits =
-    new Intl.NumberFormat(undefined, {
+    new Intl.NumberFormat(languageTag, {
       style: "currency",
       currency
     }).resolvedOptions().maximumFractionDigits ?? 2
   const divisor = 10 ** fractionDigits
 
-  return new Intl.NumberFormat(undefined, {
+  return new Intl.NumberFormat(languageTag, {
     style: "currency",
     currency,
     maximumFractionDigits: amount % divisor === 0 ? 0 : fractionDigits
@@ -86,6 +86,7 @@ function PlanCard({
   onChoose: (plan: BillingPlan, priceId: string) => void
   variant?: CardProps["variant"]
 }) {
+  const { locale } = useAuth()
   const { localization } = useAuthPlugin(billingPlugin)
   const price = plan.prices.find((entry) => entry.interval === interval)
   if (!price) return null
@@ -117,7 +118,7 @@ function PlanCard({
       <Card.Content className="flex flex-1 flex-col gap-4">
         <div>
           <span className="text-2xl font-semibold tracking-tight">
-            {formatPrice(price.amount, price.currency)}
+            {formatPrice(price.amount, price.currency, locale.languageTag)}
           </span>
           <span className="text-muted ml-1 text-xs">{suffix}</span>
         </div>
@@ -193,6 +194,7 @@ export function BillingSettings({
   className,
   variant
 }: BillingSettingsProps) {
+  const { locale } = useAuth()
   const { localization } = useAuthPlugin(billingPlugin)
   const plans = useBillingPlans(adapter, scope)
   const state = useBillingState(adapter, scope)
@@ -269,7 +271,7 @@ export function BillingSettings({
                     : localization.renewsOn
                   ).replace(
                     "{{date}}",
-                    new Intl.DateTimeFormat(undefined, {
+                    new Intl.DateTimeFormat(locale.languageTag, {
                       dateStyle: "medium"
                     }).format(subscription.currentPeriodEnd)
                   )}

--- a/packages/heroui/src/components/auth/dash/activity.tsx
+++ b/packages/heroui/src/components/auth/dash/activity.tsx
@@ -71,14 +71,14 @@ const generateN = (count: number) =>
     (_, index) => index + 1
   )
 
-const numberFormatter = new Intl.NumberFormat()
-
-const formatRelativeTime = (value: string) => {
+const formatRelativeTime = (value: string, languageTag: string) => {
   const date = new Date(value)
   const seconds = Math.floor((Date.now() - date.getTime()) / 1000)
   if (!Number.isFinite(seconds)) return value
 
-  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" })
+  const formatter = new Intl.RelativeTimeFormat(languageTag, {
+    numeric: "auto"
+  })
   const units: [Intl.RelativeTimeFormatUnit, number][] = [
     ["year", 31_536_000],
     ["month", 2_592_000],
@@ -124,6 +124,7 @@ const getEventIcon = (eventType: string) => {
 }
 
 function ActivityRow({ event }: { event: DashAuditLog }) {
+  const { locale } = useAuth()
   const { localization, showIpAddress } = useAuthPlugin(dashPlugin)
   const Icon = getEventIcon(event.eventType)
   const title =
@@ -132,7 +133,9 @@ function ActivityRow({ event }: { event: DashAuditLog }) {
     localization.unknownEvent
   const detail = getDashEventDetail(event)
   const location = getDashEventLocation(event, showIpAddress)
-  const absoluteTime = new Date(event.createdAt).toLocaleString()
+  const absoluteTime = new Date(event.createdAt).toLocaleString(
+    locale.languageTag
+  )
 
   return (
     <li className="flex items-start gap-3 border-b border-dashed py-4 first:pt-0 last:border-b-0 last:pb-0">
@@ -148,7 +151,7 @@ function ActivityRow({ event }: { event: DashAuditLog }) {
             dateTime={event.createdAt}
             title={absoluteTime}
           >
-            {formatRelativeTime(event.createdAt)}
+            {formatRelativeTime(event.createdAt, locale.languageTag)}
           </time>
         </div>
 
@@ -181,9 +184,10 @@ function ActivityFeed({
   className,
   variant
 }: ActivityFeedProps) {
-  const { authClient } = useAuth()
+  const { authClient, locale } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
   const [page, setPage] = useState(0)
+  const numberFormatter = new Intl.NumberFormat(locale.languageTag)
   const offset = page * pageSize
   const params = { limit: pageSize, offset, organizationId }
   const userQuery = useDashAuditLogs(authClient as DashAuthClient, {

--- a/packages/heroui/src/components/auth/oauth-provider/authorized-application.tsx
+++ b/packages/heroui/src/components/auth/oauth-provider/authorized-application.tsx
@@ -29,7 +29,7 @@ export type AuthorizedApplicationProps = {
 export function AuthorizedApplication({
   application
 }: AuthorizedApplicationProps) {
-  const { authClient } = useAuth()
+  const { authClient, locale } = useAuth()
   const { localization, scopeMetadata } = useAuthPlugin(oauthProviderPlugin)
   const [removeOpen, setRemoveOpen] = useState(false)
 
@@ -84,7 +84,7 @@ export function AuthorizedApplication({
           {application.updatedAt ? (
             <span className="text-muted text-xs">
               {`${localization.lastAuthorized} ${application.updatedAt.toLocaleDateString(
-                undefined,
+                locale.languageTag,
                 { dateStyle: "medium" }
               )}`}
             </span>

--- a/packages/heroui/src/components/auth/organization/organization-invitation-row.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-invitation-row.tsx
@@ -24,7 +24,7 @@ export type OrganizationInvitationTableRowProps = {
 export function OrganizationInvitationTableRow({
   invitation
 }: OrganizationInvitationTableRowProps) {
-  const { authClient } = useAuth()
+  const { authClient, locale } = useAuth()
   const {
     modelFields: { invitation: invitationFields },
     localization: organizationLocalization,
@@ -81,7 +81,8 @@ export function OrganizationInvitationTableRow({
           <span className="font-medium text-sm">{invitation.email}</span>
           {invitationFields.map((field) => {
             const value = formatAdditionalFieldValue(
-              (invitation as unknown as Record<string, unknown>)[field.name]
+              (invitation as unknown as Record<string, unknown>)[field.name],
+              locale.languageTag
             )
             return value ? (
               <span className="text-muted text-xs" key={field.name}>
@@ -93,7 +94,7 @@ export function OrganizationInvitationTableRow({
       </Table.Cell>
 
       <Table.Cell className="text-muted text-xs tabular-nums whitespace-nowrap">
-        {new Date(invitation.createdAt).toLocaleString(undefined, {
+        {new Date(invitation.createdAt).toLocaleString(locale.languageTag, {
           dateStyle: "short",
           timeStyle: "short"
         })}

--- a/packages/heroui/src/components/auth/organization/organization-member-row.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-member-row.tsx
@@ -33,7 +33,7 @@ export function OrganizationMemberRow({
   isOwner,
   organization
 }: OrganizationMemberRowProps) {
-  const { authClient } = useAuth()
+  const { authClient, locale } = useAuth()
   const {
     modelFields: { member: memberFields },
     dynamicAccessControl,
@@ -91,7 +91,8 @@ export function OrganizationMemberRow({
           <UserView user={member.user} />
           {memberFields.map((field) => {
             const value = formatAdditionalFieldValue(
-              (member as unknown as Record<string, unknown>)[field.name]
+              (member as unknown as Record<string, unknown>)[field.name],
+              locale.languageTag
             )
             return value ? (
               <span className="text-muted text-xs" key={field.name}>

--- a/packages/heroui/src/components/auth/organization/user-invitation-row.tsx
+++ b/packages/heroui/src/components/auth/organization/user-invitation-row.tsx
@@ -18,7 +18,7 @@ export type UserInvitationRowProps = {
  * Single invitation row with accept/reject actions for the current user.
  */
 export function UserInvitationRow({ invitation }: UserInvitationRowProps) {
-  const { authClient } = useAuth()
+  const { authClient, locale } = useAuth()
   const { localization: organizationLocalization, roles } =
     useAuthPlugin(organizationPlugin)
 
@@ -44,7 +44,7 @@ export function UserInvitationRow({ invitation }: UserInvitationRowProps) {
         </div>
 
         <span className="truncate text-muted text-xs">
-          {new Date(invitation.createdAt).toLocaleString(undefined, {
+          {new Date(invitation.createdAt).toLocaleString(locale.languageTag, {
             dateStyle: "medium",
             timeStyle: "short"
           })}

--- a/packages/heroui/src/components/auth/passkey/passkey.tsx
+++ b/packages/heroui/src/components/auth/passkey/passkey.tsx
@@ -15,7 +15,7 @@ export type PasskeyProps = {
 }
 
 export function Passkey({ passkey }: PasskeyProps) {
-  const { localization } = useAuth()
+  const { locale, localization } = useAuth()
   const { localization: passkeyLocalization } = useAuthPlugin(passkeyPlugin)
   const [deleteOpen, setDeleteOpen] = useState(false)
   const [renameOpen, setRenameOpen] = useState(false)
@@ -34,7 +34,7 @@ export function Passkey({ passkey }: PasskeyProps) {
         </span>
 
         <span className="text-xs text-muted">
-          {new Date(passkey.createdAt).toLocaleString(undefined, {
+          {new Date(passkey.createdAt).toLocaleString(locale.languageTag, {
             dateStyle: "medium",
             timeStyle: "short"
           })}

--- a/packages/heroui/src/components/auth/settings/security/active-session.tsx
+++ b/packages/heroui/src/components/auth/settings/security/active-session.tsx
@@ -9,9 +9,9 @@ import { Button, Chip, Spinner, toast } from "@heroui/react"
 import type { Session } from "better-auth"
 import Bowser from "bowser"
 
-function timeAgo(date: Date) {
+function timeAgo(date: Date, languageTag: string) {
   const seconds = Math.floor((Date.now() - date.getTime()) / 1000)
-  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" })
+  const rtf = new Intl.RelativeTimeFormat(languageTag, { numeric: "auto" })
 
   const UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
     ["year", 31536000],
@@ -46,7 +46,8 @@ export type ActiveSessionProps = {
  * @returns A JSX element containing the active session row
  */
 export function ActiveSession({ activeSession }: ActiveSessionProps) {
-  const { authClient, basePaths, localization, viewPaths, navigate } = useAuth()
+  const { authClient, basePaths, locale, localization, viewPaths, navigate } =
+    useAuth()
   const { data: session } = useSession(authClient, { refetchOnMount: false })
 
   const { mutate: revokeSession, isPending: isRevoking } = useRevokeSession(
@@ -84,7 +85,7 @@ export function ActiveSession({ activeSession }: ActiveSessionProps) {
         ) : (
           activeSession.createdAt && (
             <span className="text-xs text-muted capitalize">
-              {timeAgo(activeSession.createdAt)}
+              {timeAgo(activeSession.createdAt, locale.languageTag)}
             </span>
           )
         )}

--- a/packages/heroui/src/lib/auth/billing-plugin.ts
+++ b/packages/heroui/src/lib/auth/billing-plugin.ts
@@ -1,5 +1,10 @@
-import { createAuthPlugin } from "@better-auth-ui/core"
 import {
+  type AuthPluginBase,
+  type AuthPluginLocalizationContext,
+  createAuthPlugin
+} from "@better-auth-ui/core"
+import {
+  type BillingLocalization,
   type BillingPluginOptions,
   billingPlugin as coreBillingPlugin
 } from "@better-auth-ui/core/plugins/billing"
@@ -23,14 +28,13 @@ export const billingPlugin = createAuthPlugin(
   coreBillingPlugin.id,
   (options: BillingPluginOptions) => {
     const core = coreBillingPlugin(options)
-    return {
-      ...core,
+    const localizedTabs = (localization: BillingLocalization) => ({
       ...(core.user
         ? {
             settingsTabs: [
               {
                 view: "billing" as const,
-                label: billingLabel(core.localization.billing),
+                label: billingLabel(localization.billing),
                 component: UserBillingSettings
               }
             ]
@@ -42,12 +46,24 @@ export const billingPlugin = createAuthPlugin(
               {
                 id: "billing",
                 path: core.viewPaths.settings.billing,
-                label: billingLabel(core.localization.billing),
+                label: billingLabel(localization.billing),
                 component: OrganizationBillingSettings
               }
             ]
           }
         : {})
+    })
+
+    return {
+      ...core,
+      ...localizedTabs(core.localization),
+      _localizationResolver: (
+        plugin: AuthPluginBase,
+        context: AuthPluginLocalizationContext
+      ) => ({
+        ...plugin,
+        ...localizedTabs(context.localization as BillingLocalization)
+      })
     }
   }
 )

--- a/packages/heroui/src/lib/auth/dash-plugin.ts
+++ b/packages/heroui/src/lib/auth/dash-plugin.ts
@@ -1,6 +1,11 @@
-import { createAuthPlugin } from "@better-auth-ui/core"
+import {
+  type AuthPluginBase,
+  type AuthPluginLocalizationContext,
+  createAuthPlugin
+} from "@better-auth-ui/core"
 import {
   dashPlugin as coreDashPlugin,
+  type DashLocalization,
   type DashPluginOptions
 } from "@better-auth-ui/core/plugins/dash"
 import { Pulse } from "@gravity-ui/icons"
@@ -22,14 +27,13 @@ export const dashPlugin = createAuthPlugin(
   coreDashPlugin.id,
   (options: DashPluginOptions = {}) => {
     const core = coreDashPlugin(options)
-    return {
-      ...core,
+    const localizedTabs = (localization: DashLocalization) => ({
       ...(core.user
         ? {
             settingsTabs: [
               {
                 view: "activity" as const,
-                label: activityLabel(core.localization.activity),
+                label: activityLabel(localization.activity),
                 component: UserActivity
               }
             ]
@@ -41,12 +45,24 @@ export const dashPlugin = createAuthPlugin(
               {
                 id: "activity",
                 path: core.viewPaths.settings.activity,
-                label: activityLabel(core.localization.activity),
+                label: activityLabel(localization.activity),
                 component: OrganizationActivity
               }
             ]
           }
         : {})
+    })
+
+    return {
+      ...core,
+      ...localizedTabs(core.localization),
+      _localizationResolver: (
+        plugin: AuthPluginBase,
+        context: AuthPluginLocalizationContext
+      ) => ({
+        ...plugin,
+        ...localizedTabs(context.localization as DashLocalization)
+      })
     }
   }
 )

--- a/packages/heroui/src/lib/auth/oauth-provider-plugin.ts
+++ b/packages/heroui/src/lib/auth/oauth-provider-plugin.ts
@@ -1,6 +1,11 @@
-import { createAuthPlugin } from "@better-auth-ui/core"
+import {
+  type AuthPluginBase,
+  type AuthPluginLocalizationContext,
+  createAuthPlugin
+} from "@better-auth-ui/core"
 import {
   oauthProviderPlugin as coreOAuthProviderPlugin,
+  type OAuthProviderLocalization,
   type OAuthProviderPluginOptions
 } from "@better-auth-ui/core/plugins/oauth-provider"
 import { Code } from "@gravity-ui/icons"
@@ -27,6 +32,31 @@ export const oauthProviderPlugin = createAuthPlugin(
   coreOAuthProviderPlugin.id,
   (options: OAuthProviderPluginOptions = {}) => {
     const core = coreOAuthProviderPlugin(options)
+    const localizedTabs = (localization: OAuthProviderLocalization) => ({
+      ...(core.clientManagement
+        ? {
+            settingsTabs: [
+              {
+                view: "oauthClients" as const,
+                label: clientManagementLabel(localization.oauthClients),
+                component: UserOAuthClients
+              }
+            ]
+          }
+        : {}),
+      ...(core.organizationClientManager
+        ? {
+            organizationTabs: [
+              {
+                id: "oauthClients",
+                path: options.clientManagementPath ?? "oauth-clients",
+                label: clientManagementLabel(localization.oauthClients),
+                component: OrganizationOAuthClients
+              }
+            ]
+          }
+        : {})
+    })
 
     return {
       ...core,
@@ -42,29 +72,14 @@ export const oauthProviderPlugin = createAuthPlugin(
       ...(core.showConnectedApplications
         ? { securityCards: [AuthorizedApplications] }
         : {}),
-      ...(core.clientManagement
-        ? {
-            settingsTabs: [
-              {
-                view: "oauthClients" as const,
-                label: clientManagementLabel(core.localization.oauthClients),
-                component: UserOAuthClients
-              }
-            ]
-          }
-        : {}),
-      ...(core.organizationClientManager
-        ? {
-            organizationTabs: [
-              {
-                id: "oauthClients",
-                path: options.clientManagementPath ?? "oauth-clients",
-                label: clientManagementLabel(core.localization.oauthClients),
-                component: OrganizationOAuthClients
-              }
-            ]
-          }
-        : {})
+      ...localizedTabs(core.localization),
+      _localizationResolver: (
+        plugin: AuthPluginBase,
+        context: AuthPluginLocalizationContext
+      ) => ({
+        ...plugin,
+        ...localizedTabs(context.localization as OAuthProviderLocalization)
+      })
     }
   }
 )

--- a/packages/heroui/src/lib/auth/organization-plugin.tsx
+++ b/packages/heroui/src/lib/auth/organization-plugin.tsx
@@ -1,4 +1,8 @@
-import { createAuthPlugin } from "@better-auth-ui/core"
+import {
+  type AuthPluginBase,
+  type AuthPluginLocalizationContext,
+  createAuthPlugin
+} from "@better-auth-ui/core"
 import {
   organizationPlugin as coreOrganizationPlugin,
   type OrganizationLocalization,
@@ -12,6 +16,18 @@ export const organizationPlugin = createAuthPlugin(
   coreOrganizationPlugin.id,
   (options: OrganizationPluginOptions = {}) => {
     const coreOptions = coreOrganizationPlugin(options)
+    const settingsTabs = (localization: OrganizationLocalization) => [
+      {
+        view: "organizations" as const,
+        label: (
+          <>
+            <Briefcase className="text-muted" />
+            {localization.organizations}
+          </>
+        ),
+        component: OrganizationsSettings
+      }
+    ]
 
     return {
       ...coreOptions,
@@ -19,18 +35,16 @@ export const organizationPlugin = createAuthPlugin(
       views: {
         auth: { acceptInvitation: AcceptInvitation }
       },
-      settingsTabs: [
-        {
-          view: "organizations",
-          label: (
-            <>
-              <Briefcase className="text-muted" />
-              {coreOptions.localization.organizations}
-            </>
-          ),
-          component: OrganizationsSettings
-        }
-      ]
+      settingsTabs: settingsTabs(coreOptions.localization),
+      _localizationResolver: (
+        plugin: AuthPluginBase,
+        context: AuthPluginLocalizationContext
+      ) => ({
+        ...(coreOptions._localizationResolver?.(plugin, context) ?? plugin),
+        settingsTabs: settingsTabs(
+          context.localization as OrganizationLocalization
+        )
+      })
     }
   }
 )

--- a/packages/locales/package.json
+++ b/packages/locales/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@better-auth-ui/locales",
+  "version": "1.7.6",
+  "type": "module",
+  "scripts": {
+    "build": "vite build",
+    "test": "vitest"
+  },
+  "files": [
+    "src",
+    "dist"
+  ],
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "src": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./en-US": {
+      "src": "./src/en-US.ts",
+      "types": "./dist/en-US.d.ts",
+      "import": "./dist/en-US.js"
+    },
+    "./de-DE": {
+      "src": "./src/de-DE.ts",
+      "types": "./dist/de-DE.d.ts",
+      "import": "./dist/de-DE.js"
+    }
+  },
+  "peerDependencies": {
+    "@better-auth-ui/core": "*"
+  },
+  "devDependencies": {
+    "@better-auth-ui/core": "workspace:*",
+    "vite": "^8.2.1",
+    "vite-plugin-dts": "^5.0.3",
+    "vitest": "^4.1.9"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/better-auth-ui/better-auth-ui",
+    "directory": "packages/locales"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/locales/src/de-DE-plugins.ts
+++ b/packages/locales/src/de-DE-plugins.ts
@@ -1,0 +1,606 @@
+import type { AdminLocalization } from "@better-auth-ui/core/plugins/admin"
+import type { AgentAuthLocalization } from "@better-auth-ui/core/plugins/agent-auth"
+import type { AnonymousLocalization } from "@better-auth-ui/core/plugins/anonymous"
+import type { ApiKeyLocalization } from "@better-auth-ui/core/plugins/api-key"
+import type { BillingLocalization } from "@better-auth-ui/core/plugins/billing"
+import type { DashLocalization } from "@better-auth-ui/core/plugins/dash"
+import type { DeleteUserLocalization } from "@better-auth-ui/core/plugins/delete-user"
+import type { DeviceAuthorizationLocalization } from "@better-auth-ui/core/plugins/device-authorization"
+import type { EmailOtpLocalization } from "@better-auth-ui/core/plugins/email-otp"
+import type { LastLoginMethodLocalization } from "@better-auth-ui/core/plugins/last-login-method"
+import type { MagicLinkLocalization } from "@better-auth-ui/core/plugins/magic-link"
+import type { MultiSessionLocalization } from "@better-auth-ui/core/plugins/multi-session"
+import type { OAuthProviderLocalization } from "@better-auth-ui/core/plugins/oauth-provider"
+import type { OrganizationLocalization } from "@better-auth-ui/core/plugins/organization"
+import type { PasskeyLocalization } from "@better-auth-ui/core/plugins/passkey"
+import type { PhoneNumberLocalization } from "@better-auth-ui/core/plugins/phone-number"
+import type { SiweLocalization } from "@better-auth-ui/core/plugins/siwe"
+import type { SsoLocalization } from "@better-auth-ui/core/plugins/sso"
+import type { ThemeLocalization } from "@better-auth-ui/core/plugins/theme"
+import type { TwoFactorLocalization } from "@better-auth-ui/core/plugins/two-factor"
+import type { UsernameLocalization } from "@better-auth-ui/core/plugins/username"
+
+type Translated<T> = {
+  [TKey in keyof T]: T[TKey] extends Record<string, unknown>
+    ? Translated<T[TKey]>
+    : string
+}
+
+export const deDEPlugins = {
+  admin: {
+    stopImpersonating: "Identitätswechsel beenden"
+  } satisfies Translated<AdminLocalization>,
+  agentAuth: {
+    approvalTitle: "Agentenzugriff genehmigen",
+    approvalDescription:
+      "Prüfe, was dieser Agent in deinem Namen ausführen möchte.",
+    requestedCapabilities: "Angeforderte Berechtigungen",
+    requestReason: "Grund",
+    constraints: "Einschränkungen",
+    delegatedAgent: "Delegierter Agent",
+    autonomousAgent: "Autonomer Agent",
+    approvalNone: "Keine zusätzliche Prüfung",
+    approvalSession: "Kürzliche Anmeldung",
+    approvalWebauthn: "Passkey erforderlich",
+    allow: "Auswahl erlauben",
+    deny: "Ablehnen",
+    approvedTitle: "Zugriff genehmigt",
+    approvedDescription:
+      "Der Agent kann jetzt die ausgewählten Berechtigungen verwenden.",
+    deniedTitle: "Zugriff abgelehnt",
+    deniedDescription: "Der Agent hat keinen Zugriff erhalten.",
+    noCapabilities: "Diese Anfrage enthält keine offenen Berechtigungen.",
+    invalidRequest: "In diesem Genehmigungslink fehlt die Agentenkennung.",
+    approvalError:
+      "Diese Anfrage konnte nicht aktualisiert werden. Versuche es erneut.",
+    agents: "Agentenzugriff",
+    agentsDescription:
+      "Prüfe Agenten und widerrufe nicht mehr vertrauenswürdige Berechtigungen.",
+    noAgents: "Keine Agenten haben Zugriff auf dein Konto.",
+    active: "Aktiv",
+    pending: "Ausstehend",
+    denied: "Abgelehnt",
+    revoked: "Widerrufen",
+    expires: "Läuft am {date} ab",
+    lastUsed: "Zuletzt verwendet am {date}",
+    neverUsed: "Nie verwendet",
+    revoke: "Widerrufen",
+    revokeTitle: "Berechtigung widerrufen?",
+    revokeDescription: "Der Agent verliert diese Berechtigung sofort.",
+    confirmRevoke: "Berechtigung widerrufen"
+  } satisfies Translated<AgentAuthLocalization>,
+  anonymous: {
+    continueAsGuest: "Als Gast fortfahren"
+  } satisfies Translated<AnonymousLocalization>,
+  apiKey: {
+    apiKey: "API-Schlüssel",
+    apiKeys: "API-Schlüssel",
+    apiKeysDescription:
+      "Erstelle einen API-Schlüssel für den programmatischen Zugriff auf dein Konto.",
+    createApiKey: "API-Schlüssel erstellen",
+    noApiKeys: "Keine API-Schlüssel",
+    name: "Name",
+    expiration: "Ablauf",
+    day: "Tag",
+    days: "Tage",
+    never: "Nie",
+    created: "Erstellt",
+    expires: "Läuft ab",
+    neverExpires: "Läuft nie ab",
+    newApiKey: "Neuer API-Schlüssel",
+    newApiKeyWarning:
+      "Dieser API-Schlüssel wird nur jetzt angezeigt. Kopiere ihn und bewahre ihn sicher auf.",
+    deleteApiKey: "API-Schlüssel löschen",
+    deleteApiKeyWarning:
+      "Diese Aktion kann nicht rückgängig gemacht werden. Alle Dienste mit diesem API-Schlüssel funktionieren sofort nicht mehr.",
+    dismissNewKey: "Ich habe meinen Schlüssel gespeichert",
+    editApiKey: "API-Schlüssel bearbeiten",
+    configuration: "Konfiguration",
+    enabled: "Aktiviert",
+    disabled: "Deaktiviert",
+    permissions: "Berechtigungen",
+    metadata: "Metadaten (JSON)",
+    quota: "Anfragelimit",
+    refillAmount: "Auffüllmenge",
+    refillInterval: "Auffüllintervall (Millisekunden)",
+    rateLimit: "Ratenbegrenzung",
+    rateLimitMax: "Maximale Anfragen",
+    rateLimitWindow: "Zeitfenster (Millisekunden)",
+    requests: "Anfragen",
+    remaining: "Verbleibend",
+    lastRequest: "Letzte Anfrage",
+    neverRequested: "Nie angefragt",
+    sortBy: "Sortieren nach",
+    newest: "Neueste",
+    oldest: "Älteste",
+    nameAscending: "Name A–Z",
+    nameDescending: "Name Z–A",
+    previousPage: "Vorherige Seite",
+    nextPage: "Nächste Seite"
+  } satisfies Translated<ApiKeyLocalization>,
+  billing: {
+    billing: "Abrechnung",
+    billingDescription:
+      "Verwalte Tarife, Abonnementdetails, Plätze und Nutzung.",
+    plans: "Tarife",
+    currentPlan: "Aktueller Tarif",
+    choosePlan: "Tarif auswählen",
+    changePlan: "Tarif ändern",
+    perMonth: "pro Monat",
+    perYear: "pro Jahr",
+    oneTime: "einmalig",
+    popular: "Beliebt",
+    subscription: "Abonnement",
+    noSubscription: "Kein aktives Abonnement",
+    noSubscriptionDescription:
+      "Wähle einen Tarif, um ein Abonnement zu starten.",
+    manageBilling: "Abrechnung verwalten",
+    renewsOn: "Verlängert sich am {{date}}",
+    endsOn: "Endet am {{date}}",
+    cancelSubscription: "Abonnement kündigen",
+    cancelSubscriptionTitle: "Abonnement kündigen?",
+    cancelSubscriptionDescription:
+      "Dein Zugriff bleibt bis zum Ende des aktuellen Abrechnungszeitraums bestehen.",
+    restoreSubscription: "Abonnement wiederherstellen",
+    restoreSubscriptionTitle: "Abonnement wiederherstellen?",
+    restoreSubscriptionDescription:
+      "Dein Abonnement verlängert sich weiterhin mit dem aktuellen Tarif.",
+    confirm: "Bestätigen",
+    cancel: "Abbrechen",
+    seats: "Plätze",
+    updateSeats: "Plätze aktualisieren",
+    usage: "Nutzung",
+    unlimited: "Unbegrenzt",
+    used: "{{used}} verwendet",
+    loadingBilling: "Abrechnungsdaten werden geladen"
+  } satisfies Translated<BillingLocalization>,
+  dash: {
+    activity: "Aktivität",
+    activityDescription:
+      "Prüfe die letzten Authentifizierungs- und Kontoaktivitäten.",
+    organizationActivityDescription:
+      "Prüfe die für dich sichtbaren Aktivitäten dieser Organisation.",
+    organizationWide: "Gesamte Organisation",
+    personalOnly: "Deine Aktivität",
+    noActivity: "Keine gespeicherte Aktivität",
+    noActivityDescription:
+      "Keine gespeicherte Aktivität entspricht dieser Ansicht.",
+    activityLoadError: "Aktivität konnte nicht geladen werden",
+    activityLoadErrorDescription:
+      "Prüfe die Dash-Client-Konfiguration und versuche es erneut.",
+    retry: "Erneut versuchen",
+    paginationRange: "{{from}}–{{to}} von {{total}}",
+    previousPage: "Vorherige Seite",
+    nextPage: "Nächste Seite",
+    unknownEvent: "Aktivitätsereignis",
+    eventLabels: {
+      account_linked: "Konto verknüpft",
+      account_unlinked: "Kontoverknüpfung aufgehoben",
+      all_sessions_revoked: "Alle Sitzungen widerrufen",
+      email_changed: "E-Mail-Adresse geändert",
+      email_verification_sent: "Bestätigungs-E-Mail gesendet",
+      email_verified: "E-Mail-Adresse bestätigt",
+      organization_created: "Organisation erstellt",
+      organization_member_added: "Mitglied hinzugefügt",
+      organization_member_invite_accepted: "Einladung angenommen",
+      organization_member_invite_canceled: "Einladung abgebrochen",
+      organization_member_invite_rejected: "Einladung abgelehnt",
+      organization_member_invited: "Mitglied eingeladen",
+      organization_member_removed: "Mitglied entfernt",
+      organization_member_role_updated: "Mitgliedsrolle aktualisiert",
+      organization_team_created: "Team erstellt",
+      organization_team_deleted: "Team gelöscht",
+      organization_team_member_added: "Teammitglied hinzugefügt",
+      organization_team_member_removed: "Teammitglied entfernt",
+      organization_team_updated: "Team aktualisiert",
+      organization_updated: "Organisation aktualisiert",
+      password_changed: "Passwort geändert",
+      password_reset_completed: "Passwort zurückgesetzt",
+      password_reset_requested: "Passwortzurücksetzung angefordert",
+      profile_image_updated: "Profilbild aktualisiert",
+      profile_updated: "Profil aktualisiert",
+      session_created: "Sitzung erstellt",
+      session_revoked: "Sitzung widerrufen",
+      two_factor_disabled: "Zwei-Faktor-Authentifizierung deaktiviert",
+      two_factor_enabled: "Zwei-Faktor-Authentifizierung aktiviert",
+      two_factor_verified: "Zwei-Faktor-Authentifizierung bestätigt",
+      user_banned: "Benutzer gesperrt",
+      user_created: "Konto erstellt",
+      user_deleted: "Benutzer gelöscht",
+      user_impersonated: "Benutzeridentität übernommen",
+      user_impersonated_stopped: "Identitätsübernahme beendet",
+      user_sign_in_failed: "Anmeldung fehlgeschlagen",
+      user_signed_in: "Angemeldet",
+      user_signed_out: "Abgemeldet",
+      user_unbanned: "Benutzersperre aufgehoben"
+    }
+  } satisfies Translated<DashLocalization>,
+  deleteUser: {
+    deleteAccount: "Konto löschen",
+    deleteAccountDescription:
+      "Lösche dein Konto und alle zugehörigen Daten dauerhaft. Diese Aktion kann nicht rückgängig gemacht werden.",
+    deleteUserVerificationSent:
+      "Prüfe deine E-Mails, um die Kontolöschung zu bestätigen.",
+    deleteUserSuccess: "Dein Konto wurde gelöscht."
+  } satisfies Translated<DeleteUserLocalization>,
+  deviceAuthorization: {
+    deviceAuthorization: "Geräteautorisierung",
+    deviceAuthorizationDescription:
+      "Gib den auf deinem Gerät angezeigten Code ein.",
+    deviceCode: "Gerätecode",
+    invalidDeviceCode: "Der Code ist ungültig oder abgelaufen.",
+    continue: "Weiter",
+    approveDevice: "Gerät genehmigen",
+    approveDeviceDescription: "Ein Gerät fordert Zugriff auf dein Konto an.",
+    signedInAs: "Angemeldet als",
+    approve: "Genehmigen",
+    deny: "Ablehnen",
+    deviceApproved: "Gerät genehmigt",
+    deviceApprovedDescription:
+      "Das Gerät kann jetzt auf dein Konto zugreifen. Kehre zum Gerät zurück und fahre fort.",
+    deviceDenied: "Gerät abgelehnt",
+    deviceDeniedDescription:
+      "Das Gerät hat keinen Zugriff auf dein Konto erhalten.",
+    returnToApplication: "Zur Anwendung zurückkehren"
+  } satisfies Translated<DeviceAuthorizationLocalization>,
+  emailOtp: {
+    emailOtp: "E-Mail-Code",
+    sendCode: "Code senden",
+    code: "Code",
+    verifyCode: "Code bestätigen",
+    codeSentTo: "Wir haben einen Code an {{email}} gesendet",
+    codeLengthMismatch: "Gib den {{length}}-stelligen Code ein",
+    useDifferentEmail: "Andere E-Mail-Adresse verwenden",
+    codeSent: "Code gesendet",
+    emailVerified: "E-Mail-Adresse bestätigt",
+    confirmCurrentEmail: "Aktuelle E-Mail-Adresse bestätigen",
+    confirmNewEmail: "Neue E-Mail-Adresse bestätigen",
+    confirmEmailDescription:
+      "Gib den an {{email}} gesendeten Code ein, um die Änderung abzuschließen"
+  } satisfies Translated<EmailOtpLocalization>,
+  lastLoginMethod: {
+    lastUsed: "Zuletzt verwendet",
+    lastUsedShort: "Zuletzt"
+  } satisfies Translated<LastLoginMethodLocalization>,
+  magicLink: {
+    magicLink: "Magischer Link",
+    sendMagicLink: "Magischen Link senden",
+    magicLinkSent: "Prüfe deine E-Mails auf den magischen Link",
+    magicLinkSentTo: "Wir haben einen magischen Link an {{email}} gesendet"
+  } satisfies Translated<MagicLinkLocalization>,
+  multiSession: {
+    switchAccount: "Konto wechseln",
+    addAccount: "Konto hinzufügen",
+    manageAccounts: "Konten verwalten",
+    manageAccountsDescription:
+      "Verwalte deine Konten für einen sicheren Zugriff."
+  } satisfies Translated<MultiSessionLocalization>,
+  oauthProvider: {
+    authorize: "{{client}} autorisieren",
+    authorizationDescription: "{{client}} möchte auf dein Konto zugreifen.",
+    requestedPermissions: "Dadurch kann {{client}} Folgendes ausführen:",
+    signedInAs: "Angemeldet als",
+    allow: "Erlauben",
+    cancel: "Abbrechen",
+    privacyPolicy: "Datenschutzrichtlinie",
+    termsOfService: "Nutzungsbedingungen",
+    invalidRequest: "Ungültige Autorisierungsanfrage",
+    invalidRequestDescription:
+      "In dieser Autorisierungsanfrage fehlen erforderliche Daten oder die Anfrage ist nicht mehr gültig.",
+    application: "Anwendung",
+    selectAccount: "Konto auswählen",
+    selectAccountDescription:
+      "Wähle das Konto aus, das du mit {{client}} verwenden möchtest.",
+    currentAccount: "Aktuell",
+    continue: "Weiter",
+    noAccounts: "Keine Konten verfügbar",
+    noAccountsDescription: "Melde dich an, um mit {{client}} fortzufahren.",
+    accountCreated: "Konto erstellt",
+    continuing: "Du wirst zu {{client}} zurückgeleitet.",
+    continueFailed:
+      "Dein Konto ist bereit, aber du konntest nicht zu {{client}} zurückgeleitet werden.",
+    tryAgain: "Erneut versuchen",
+    connectedApplications: "Verbundene Anwendungen",
+    noConnectedApplications: "Keine verbundenen Anwendungen",
+    connectedApplicationsDescription:
+      "Von dir autorisierte Anwendungen werden hier angezeigt.",
+    lastAuthorized: "Zuletzt autorisiert",
+    removeAuthorization: "Autorisierung entfernen",
+    removeAuthorizationTitle: "Autorisierung entfernen?",
+    removeAuthorizationDescription:
+      "Diese Anwendung benötigt deine Genehmigung, bevor sie neuen Zugriff erhält. Bestehende Token können bis zu ihrem Ablauf gültig bleiben.",
+    remove: "Entfernen",
+    oauthClients: "OAuth-Clients",
+    oauthClientsDescription:
+      "Erstelle und verwalte Anwendungen, die Kontozugriff anfordern können.",
+    noOAuthClients: "Keine OAuth-Clients",
+    noOAuthClientsDescription:
+      "Erstelle einen Client, wenn deine Anwendung OAuth verwenden kann.",
+    createClient: "Client erstellen",
+    editClient: "Client bearbeiten",
+    clientName: "Clientname",
+    applicationType: "Anwendungstyp",
+    webApplication: "Web",
+    nativeApplication: "Nativ",
+    redirectUrls: "Weiterleitungs-URLs",
+    redirectUrlsDescription: "Gib eine URL pro Zeile ein.",
+    applicationUrl: "Anwendungs-URL",
+    logoUrl: "Logo-URL",
+    scopes: "Geltungsbereiche",
+    saveChanges: "Änderungen speichern",
+    clientId: "Client-ID",
+    clientSecret: "Clientschlüssel",
+    clientSecretWarning:
+      "Kopiere diesen Schlüssel jetzt. Er wird nicht erneut angezeigt.",
+    rotateSecret: "Schlüssel rotieren",
+    rotateSecretTitle: "Clientschlüssel rotieren?",
+    rotateSecretDescription:
+      "Der aktuelle Schlüssel funktioniert sofort nicht mehr.",
+    deleteClient: "Client löschen",
+    deleteClientTitle: "OAuth-Client löschen?",
+    deleteClientDescription:
+      "Dadurch wird der Client dauerhaft entfernt und neue Autorisierungsanfragen werden beendet.",
+    enabled: "Aktiviert",
+    disabled: "Deaktiviert",
+    clientCreated: "Client erstellt",
+    secretRotated: "Schlüssel rotiert"
+  } satisfies Translated<OAuthProviderLocalization>,
+  organization: {
+    accept: "Annehmen",
+    acceptInvitationTitle: "Organisationseinladung",
+    acceptInvitationDescription:
+      "Du wurdest eingeladen, {{organization}} als {{role}} beizutreten.",
+    accepted: "Angenommen",
+    actions: "Aktionen",
+    admin: "Administrator",
+    all: "Alle",
+    canceled: "Abgebrochen",
+    cancelInvitation: "Einladung abbrechen",
+    changeLogo: "Logo ändern",
+    changeMemberRole: "Rolle ändern",
+    clear: "Leeren",
+    createOrganization: "Organisation erstellen",
+    deleteLogo: "Logo löschen",
+    deleteOrganization: "Organisation löschen",
+    deleteOrganizationDescription:
+      "Lösche diese Organisation und alle zugehörigen Daten dauerhaft. Alle Mitglieder verlieren den Zugriff. Diese Aktion kann nicht rückgängig gemacht werden.",
+    invitations: "Einladungen",
+    invitationResent: "Einladung erneut gesendet",
+    invitationUnavailable: "Einladung nicht verfügbar",
+    invitationUnavailableDescription:
+      "Diese Einladung ist ungültig, abgelaufen oder wurde bereits bearbeitet.",
+    invitedAt: "Eingeladen am",
+    inviteMember: "Mitglied einladen",
+    inviteMemberSuccess: "Mitglied erfolgreich eingeladen",
+    inviteMemberDescription:
+      "Wir senden einen Link zum Beitritt per E-Mail. Wähle die Rolle aus, die nach der Annahme gilt.",
+    leftOrganization: "Du hast die Organisation verlassen",
+    leaveOrganization: "Organisation verlassen",
+    leaveOrganizationDescription:
+      "Verlasse diese Organisation und verliere den Zugriff auf ihre Daten und Ressourcen. Für einen erneuten Beitritt benötigst du eine neue Einladung.",
+    logo: "Logo",
+    logoChangedSuccess: "Logo erfolgreich aktualisiert",
+    logoDeletedSuccess: "Logo erfolgreich entfernt",
+    manage: "Verwalten",
+    member: "Mitglied",
+    memberRemoved: "Mitglied entfernt",
+    memberRoleUpdated: "Mitgliedsrolle aktualisiert",
+    members: "Mitglieder",
+    people: "Personen",
+    name: "Name",
+    namePlaceholder: "Name der Organisation eingeben",
+    noInvitations: "Keine Einladungen",
+    noOrganizations: "Keine Organisationen",
+    organization: "Organisation",
+    organizationDeleted: "Organisation gelöscht",
+    organizationInvitationsEmptyDescription:
+      "Lade ein Teammitglied zur Zusammenarbeit in dieser Organisation ein.",
+    organizations: "Organisationen",
+    organizationsDescription:
+      "Erstelle eine Organisation, um mit anderen zusammenzuarbeiten und gemeinsamen Zugriff zu verwalten.",
+    organizationProfile: "Organisationsprofil",
+    organizationUpdatedSuccess: "Organisation erfolgreich aktualisiert",
+    owner: "Inhaber",
+    pending: "Ausstehend",
+    nextPage: "Nächste Seite",
+    personalAccount: "Persönliches Konto",
+    previousPage: "Vorherige Seite",
+    rejected: "Abgelehnt",
+    paginationRange: "{{from}}–{{to}} von {{total}}",
+    return: "Zurück",
+    rejectInvitation: "Einladung ablehnen",
+    removeMember: "Mitglied entfernen",
+    removeMemberWarning:
+      "Möchtest du dieses Mitglied aus der Organisation entfernen? Der Zugriff geht sofort verloren.",
+    resendInvitation: "Einladung erneut senden",
+    role: "Rolle",
+    search: "Suchen...",
+    selectRoles: "Rollen auswählen",
+    slug: "Slug",
+    slugPlaceholder: "organisations-slug",
+    status: "Status",
+    uploadLogo: "Logo hochladen",
+    userInvitationsEmptyDescription:
+      "Einladungen zum Beitritt zu einer Organisation werden hier angezeigt.",
+    teams: "Teams",
+    team: "Team",
+    teamsDescription: "Erstelle Teams und verwalte ihre Mitglieder.",
+    selectTeam: "Team auswählen",
+    allTeams: "Alle Teams",
+    selectMember: "Mitglied auswählen",
+    createTeam: "Team erstellen",
+    renameTeam: "Team umbenennen",
+    deleteTeam: "Team löschen",
+    noTeams: "Keine Teams",
+    noTeamsDescription:
+      "Erstelle ein Team, um den Zugriff innerhalb dieser Organisation zu ordnen.",
+    teamMembers: "Teammitglieder",
+    addTeamMember: "Teammitglied hinzufügen",
+    removeTeamMember: "Aus Team entfernen",
+    teamCreated: "Team erstellt",
+    teamUpdated: "Team aktualisiert",
+    teamDeleted: "Team gelöscht",
+    teamLimitReached: "Diese Organisation hat ihr Teamlimit erreicht.",
+    teamMemberLimitReached: "Dieses Team hat sein Mitgliederlimit erreicht.",
+    lastTeamRemovalDisabled:
+      "Diese Organisation muss mindestens ein Team behalten.",
+    limitReached: "Limit erreicht",
+    organizationLimitReached: "Du hast das Organisationslimit erreicht.",
+    membershipLimitReached:
+      "Diese Organisation hat ihr Mitgliederlimit erreicht.",
+    invitationLimitReached:
+      "Diese Organisation hat ihr Einladungslimit erreicht.",
+    roles: "Rollen",
+    rolesDescription:
+      "Erstelle Rollen und lege fest, was jede Rolle ausführen kann.",
+    createRole: "Rolle erstellen",
+    editRole: "Rolle bearbeiten",
+    deleteRole: "Rolle löschen",
+    deleteRoleDescription:
+      "Lösche diese Rolle dauerhaft. Mitglieder müssen zuerst einer anderen Rolle zugewiesen werden.",
+    roleName: "Rollenname",
+    permissions: "Berechtigungen",
+    noRoles: "Keine benutzerdefinierten Rollen",
+    noRolesDescription:
+      "Erstelle eine Rolle, um einen benutzerdefinierten Organisationszugriff festzulegen.",
+    roleCreated: "Rolle erstellt",
+    roleUpdated: "Rolle aktualisiert",
+    roleDeleted: "Rolle gelöscht",
+    roleInUse: "Diese Rolle ist {{count}} Mitgliedern zugewiesen.",
+    roleNamePlaceholder: "support-agent"
+  } satisfies Translated<OrganizationLocalization>,
+  passkey: {
+    passkey: "Passkey",
+    addPasskey: "Passkey hinzufügen",
+    deletePasskey: "Passkey {{name}} löschen",
+    deletePasskeyTitle: "Passkey löschen",
+    deletePasskeyWarning:
+      "Diese Aktion kann nicht rückgängig gemacht werden. Du musst diesen Passkey erneut hinzufügen, bevor du ihn wieder zur Anmeldung verwenden kannst.",
+    passkeys: "Passkeys",
+    passkeysDescription:
+      "Erstelle einen Passkey für den sicheren Zugriff auf dein Konto.",
+    noPasskeys: "Keine Passkeys",
+    name: "Name",
+    renamePasskey: "Passkey umbenennen",
+    renamePasskeySuccess: "Passkey umbenannt"
+  } satisfies Translated<PasskeyLocalization>,
+  phoneNumber: {
+    country: "Land oder Region",
+    invalidPhoneNumber: "Gib eine gültige Telefonnummer ein",
+    phoneNumber: "Telefonnummer",
+    phoneNumberPlaceholder: "+49 151 12345678",
+    phoneCode: "Telefoncode",
+    sendCode: "Code senden",
+    verifyCode: "Code bestätigen",
+    codeSentTo: "Wir haben einen Code an {{phoneNumber}} gesendet",
+    codeLengthMismatch: "Gib den {{length}}-stelligen Code ein",
+    useDifferentPhoneNumber: "Andere Telefonnummer verwenden",
+    usePassword: "Passwort verwenden",
+    useVerificationCode: "Bestätigungscode verwenden",
+    forgotPassword: "Passwort vergessen?",
+    resetPassword: "Passwort zurücksetzen",
+    changePhoneNumber: "Telefonnummer ändern",
+    updatePhoneNumber: "Telefonnummer aktualisieren",
+    phoneNumberUpdated: "Telefonnummer aktualisiert",
+    removePhoneNumber: "Telefonnummer entfernen",
+    phoneNumberRemoved: "Telefonnummer entfernt",
+    removePhoneNumberTitle: "Diese Telefonnummer aus deinem Konto entfernen?",
+    removePhoneNumberDescription:
+      "Du kannst sie danach nicht mehr für die Anmeldung oder zum Zurücksetzen deines Passworts verwenden.",
+    cancel: "Abbrechen"
+  } satisfies Translated<PhoneNumberLocalization>,
+  siwe: {
+    ethereum: "Ethereum",
+    continueWithEthereum: "Mit Ethereum fortfahren",
+    signMessage: "Nachricht signieren",
+    email: "E-Mail-Adresse",
+    emailDescription: "Füge diesem Wallet-Konto eine E-Mail-Adresse hinzu.",
+    emailOptional: "E-Mail-Adresse (optional)",
+    wallets: "Wallets",
+    walletsDescription:
+      "Verwalte die mit deinem Konto verbundenen Ethereum-Wallets.",
+    connectWallet: "Wallet verbinden",
+    noWallets: "Keine Ethereum-Wallets sind verbunden.",
+    primary: "Primär",
+    setPrimary: "Als primär festlegen",
+    removeWallet: "Wallet entfernen",
+    removeWalletTitle: "Ethereum-Wallet entfernen?",
+    removeWalletWarning:
+      "Du kannst dich mit diesem Wallet nicht anmelden, bis du es erneut verbindest.",
+    chain: "Chain {{chainId}}"
+  } satisfies Translated<SiweLocalization>,
+  sso: {
+    continueWithEmail: "Mit E-Mail-Adresse fortfahren",
+    continueWithSso: "Mit SSO fortfahren",
+    emailFirstDescription:
+      "Gib deine geschäftliche E-Mail-Adresse ein, um fortzufahren.",
+    useDifferentEmail: "Andere E-Mail-Adresse verwenden",
+    noProvider:
+      "Es wurde keine Organisationsanmeldung gefunden. Wähle eine andere Methode, um fortzufahren.",
+    ssoUnavailable:
+      "Die Organisationsanmeldung ist nicht verfügbar. Versuche eine andere Anmeldemethode."
+  } satisfies Translated<SsoLocalization>,
+  theme: {
+    appearance: "Darstellung",
+    theme: "Design",
+    system: "System",
+    light: "Hell",
+    dark: "Dunkel"
+  } satisfies Translated<ThemeLocalization>,
+  twoFactor: {
+    twoFactor: "Zwei-Faktor-Authentifizierung",
+    twoFactorDescription:
+      "Füge der Anmeldung einen zweiten Schritt hinzu, damit ein gestohlenes Passwort nicht ausreicht",
+    enableTwoFactor: "Zwei-Faktor-Authentifizierung aktivieren",
+    disableTwoFactor: "Zwei-Faktor-Authentifizierung deaktivieren",
+    twoFactorEnabled: "Zwei-Faktor-Authentifizierung ist aktiviert",
+    twoFactorDisabled: "Zwei-Faktor-Authentifizierung ist deaktiviert",
+    passwordConfirmation: "Gib dein Passwort ein, um fortzufahren",
+    scanQrCode: "Scanne dies mit deiner Authenticator-App",
+    setupKey: "Scannen nicht möglich? Gib stattdessen diesen Schlüssel ein",
+    setupKeyCopied: "Einrichtungsschlüssel kopiert",
+    setupKeyCopyFailed:
+      "Der Einrichtungsschlüssel konnte nicht kopiert werden. Wähle ihn aus und kopiere ihn manuell.",
+    authenticatorCode: "Authenticator-Code",
+    authenticatorCodeDescription:
+      "Gib den Code aus deiner Authenticator-App ein",
+    emailedCode: "Code per E-Mail",
+    emailedCodeDescription:
+      "Wir haben dir einen Code per E-Mail gesendet. Gib ihn ein, um die Anmeldung abzuschließen",
+    sendEmailCode: "Code per E-Mail senden",
+    backupCode: "Wiederherstellungscode",
+    backupCodeDescription:
+      "Gib einen deiner gespeicherten Wiederherstellungscodes ein",
+    backupCodes: "Wiederherstellungscodes",
+    backupCodesForWebsite: "Wiederherstellungscodes für {{website}}",
+    backupCodesDescription:
+      "Bewahre diese Codes sicher auf. Jeder Code funktioniert einmal, falls du deinen Authenticator verlierst.",
+    backupCodesCopied: "Wiederherstellungscodes kopiert",
+    backupCodesCopyFailed:
+      "Die Wiederherstellungscodes konnten nicht kopiert werden. Wähle sie aus und kopiere sie manuell.",
+    downloadBackupCodes: ".txt herunterladen",
+    printBackupCodes: "Drucken",
+    regenerateBackupCodes: "Wiederherstellungscodes neu erstellen",
+    backupCodesRegenerated:
+      "Neue Wiederherstellungscodes erstellt. Die alten Codes funktionieren nicht mehr.",
+    useAuthenticator: "Authenticator-App verwenden",
+    useEmailedCode: "Code per E-Mail verwenden",
+    useBackupCode: "Wiederherstellungscode verwenden",
+    trustDevice: "Diesem Gerät vertrauen",
+    trustDeviceDescription:
+      "Den zweiten Schritt auf diesem Gerät zukünftig überspringen",
+    verify: "Bestätigen",
+    codeLengthMismatch: "Gib den {{length}}-stelligen Code ein",
+    backToSignIn: "Zurück zur Anmeldung",
+    done: "Fertig"
+  } satisfies Translated<TwoFactorLocalization>,
+  username: {
+    username: "Benutzername",
+    usernamePlaceholder: "Benutzername",
+    usernameOrEmailPlaceholder: "Benutzername oder E-Mail-Adresse",
+    usernameAvailable: "Benutzername ist verfügbar",
+    usernameTaken: "Benutzername ist bereits vergeben. Versuche einen anderen.",
+    displayUsername: "Anzeigename",
+    displayUsernamePlaceholder: "Anzeigename"
+  } satisfies Translated<UsernameLocalization>
+}

--- a/packages/locales/src/de-DE.ts
+++ b/packages/locales/src/de-DE.ts
@@ -1,0 +1,170 @@
+import { deepmerge, defineAuthLocale, localization } from "@better-auth-ui/core"
+import { deDEPlugins } from "./de-DE-plugins"
+
+const deLocalization = deepmerge(localization, {
+  auth: {
+    callbackAccountLinkedTitle: "Konto verknüpft",
+    callbackAccountLinkedDescription: "Dein Konto ist jetzt verbunden.",
+    callbackAccountLinkConflictTitle: "Dieses Konto ist bereits verbunden",
+    callbackAccountLinkConflictDescription:
+      "Das Anbieterkonto gehört zu einem anderen Benutzer oder kann nicht sicher verknüpft werden.",
+    callbackCancelledTitle: "Authentifizierung abgebrochen",
+    callbackCancelledDescription:
+      "Es wurden keine Änderungen vorgenommen. Du kannst es erneut versuchen, wenn du bereit bist.",
+    callbackFailedTitle:
+      "Die Authentifizierung konnte nicht abgeschlossen werden",
+    callbackFailedDescription:
+      "Der Rückruf konnte nicht geprüft werden. Kehre zur Anmeldung zurück und versuche es erneut.",
+    callbackContinue: "Weiter",
+    callbackEmailVerifiedTitle: "E-Mail-Adresse bestätigt",
+    callbackEmailVerifiedDescription:
+      "Deine E-Mail-Adresse ist bestätigt. Du kannst mit deinem Konto fortfahren.",
+    callbackEmailNotVerifiedTitle: "Bestätige zuerst deine E-Mail-Adresse",
+    callbackEmailNotVerifiedDescription:
+      "Prüfe vor der Anmeldung deinen Posteingang auf einen Bestätigungslink.",
+    callbackExpiredLinkTitle: "Dieser Link ist abgelaufen",
+    callbackExpiredLinkDescription:
+      "Fordere einen neuen Link an und verwende die neueste Nachricht in deinem Posteingang.",
+    callbackGenericErrorTitle: "Etwas ist schiefgelaufen",
+    callbackGenericErrorDescription:
+      "Die Anfrage konnte nicht abgeschlossen werden. Kehre zur Anmeldung zurück und versuche es erneut.",
+    callbackGenericSuccessTitle: "Alles erledigt",
+    callbackGenericSuccessDescription:
+      "Die Authentifizierung wurde erfolgreich abgeschlossen.",
+    callbackMissingEmailTitle: "E-Mail-Adresse nicht verfügbar",
+    callbackMissingEmailDescription:
+      "Der Anbieter hat keine E-Mail-Adresse übermittelt. Versuche eine andere Anmeldemethode.",
+    callbackPasswordResetTitle: "Passwort zurückgesetzt",
+    callbackPasswordResetDescription:
+      "Dein Passwort wurde zurückgesetzt. Melde dich mit deinem neuen Passwort an.",
+    callbackSignupCompleteTitle: "Konto erstellt",
+    callbackSignupCompleteDescription:
+      "Dein Konto ist bereit. Du kannst fortfahren.",
+    callbackSignupDisabledTitle: "Registrierung nicht verfügbar",
+    callbackSignupDisabledDescription:
+      "Mit dieser Anmeldemethode können keine neuen Konten erstellt werden. Versuche stattdessen, dich anzumelden.",
+    callbackViewAccountSettings: "Kontoeinstellungen",
+    account: "Konto",
+    alreadyHaveAnAccount: "Du hast bereits ein Konto?",
+    alreadyVerifiedYourEmail: "E-Mail-Adresse bereits bestätigt?",
+    confirmPassword: "Passwort bestätigen",
+    confirmPasswordPlaceholder: "Bestätige dein Passwort",
+    checkYourEmail: "Prüfe deine E-Mails auf einen Bestätigungslink",
+    checkYourEmailTitle: "Prüfe deine E-Mails",
+    continueWith: "Mit {{provider}} fortfahren",
+    email: "E-Mail-Adresse",
+    emailPlaceholder: "name@beispiel.de",
+    fieldRequired: "Dieses Feld ist erforderlich",
+    forgotPassword: "Passwort vergessen",
+    forgotPasswordLink: "Passwort vergessen?",
+    hidePassword: "Passwort ausblenden",
+    invalidEmail: "Gib eine gültige E-Mail-Adresse ein",
+    invalidResetPasswordToken:
+      "Ungültiger Token zum Zurücksetzen des Passworts",
+    name: "Name",
+    namePlaceholder: "Name",
+    needToCreateAnAccount: "Du benötigst ein Konto?",
+    newPassword: "Neues Passwort",
+    newPasswordPlaceholder: "Neues Passwort",
+    openEmailProvider: "{{provider}} öffnen",
+    or: "ODER",
+    optional: " (optional)",
+    password: "Passwort",
+    passwordCompromised:
+      "Dieses Passwort ist in einem Datenleck aufgetaucht. Wähle ein anderes Passwort.",
+    passwordFair: "Mittel",
+    passwordGood: "Gut",
+    passwordPlaceholder: "Passwort",
+    passwordResetEmailSent: "E-Mail zum Zurücksetzen des Passworts gesendet",
+    passwordResetErrorDescription:
+      "Dein Passwort konnte nicht zurückgesetzt werden. Versuche es erneut.",
+    passwordResetSuccess: "Passwort erfolgreich zurückgesetzt",
+    passwordResetSuccessDescription:
+      "Das Passwort wurde erfolgreich zurückgesetzt. Du kannst dich mit deinem neuen Passwort anmelden.",
+    passwordStrength: "Passwortstärke",
+    passwordStrong: "Stark",
+    passwordWeak: "Schwach",
+    passwordsDoNotMatch: "Die Passwörter stimmen nicht überein",
+    rememberMe: "Angemeldet bleiben",
+    tooLong: "Darf höchstens {{max}} Zeichen lang sein",
+    tooShort: "Muss mindestens {{min}} Zeichen lang sein",
+    rememberYourPassword: "Du kennst dein Passwort wieder?",
+    resend: "Erneut senden",
+    resendIn: "In {{seconds}} s erneut senden",
+    resetLinkSentTo:
+      "Wir haben einen Link zum Zurücksetzen des Passworts an {{email}} gesendet",
+    resetPassword: "Passwort zurücksetzen",
+    sendResetLink: "Link zum Zurücksetzen senden",
+    scanToOpenEmailProvider:
+      "Scanne den Code, um {{provider}} auf deinem Mobiltelefon zu öffnen",
+    showPassword: "Passwort anzeigen",
+    signIn: "Anmelden",
+    signOut: "Abmelden",
+    signUp: "Registrieren",
+    verificationEmailSent: "Bestätigungs-E-Mail gesendet!",
+    verifyEmail: "E-Mail-Adresse bestätigen"
+  },
+  settings: {
+    account: "Konto",
+    accountUnlinked: "Kontoverknüpfung aufgehoben",
+    active: "Aktiv",
+    activeSessions: "Aktive Sitzungen",
+    freshSessionTitle: "Bestätige deine Identität",
+    freshSessionDescription:
+      "Gib dein Passwort erneut ein, um diese sensible Einstellung zu verwalten.",
+    freshSessionSubmit: "Bestätigen und fortfahren",
+    freshSessionSignIn: "Erneut anmelden",
+    freshSessionSuccess: "Deine Identität wurde bestätigt.",
+    avatar: "Profilbild",
+    currentSession: "Aktuelle Sitzung",
+    avatarChangedSuccess: "Profilbild erfolgreich geändert",
+    avatarDeletedSuccess: "Profilbild erfolgreich gelöscht",
+    changeAvatar: "Profilbild ändern",
+    deleteAvatar: "Profilbild löschen",
+    link: "Verknüpfen",
+    linkedAccounts: "Verknüpfte Konten",
+    linkProvider: "{{provider}}-Konto verknüpfen",
+    cancel: "Abbrechen",
+    copyToClipboard: "In die Zwischenablage kopieren",
+    copiedToClipboard: "In die Zwischenablage kopiert",
+    changeEmail: "E-Mail-Adresse ändern",
+    changeEmailSuccess: "Prüfe deine E-Mails, um die Änderung zu bestätigen",
+    changePassword: "Passwort ändern",
+    changePasswordSuccess: "Passwort erfolgreich geändert",
+    currentPassword: "Aktuelles Passwort",
+    currentPasswordPlaceholder: "Gib dein aktuelles Passwort ein",
+    dangerZone: "Gefahrenbereich",
+    delete: "Löschen",
+    optional: "Optional",
+    profileUpdatedSuccess: "Profil erfolgreich aktualisiert",
+    revoke: "Widerrufen",
+    revokeSession: "Sitzung widerrufen",
+    revokeSessionSuccess: "Sitzung erfolgreich widerrufen",
+    signOutOtherDevices: "Von anderen Geräten abmelden",
+    signOutOtherDevicesDescription:
+      "Du wirst auf allen Geräten außer diesem abgemeldet.",
+    signOutOtherDevicesSuccess: "Andere Geräte wurden erfolgreich abgemeldet",
+    signOutEverywhere: "Überall abmelden",
+    signOutEverywhereDescription:
+      "Du wirst auf diesem und allen anderen Geräten abgemeldet.",
+    saveChanges: "Änderungen speichern",
+    setPassword: "Passwort festlegen",
+    setPasswordDescription:
+      "Du hast noch kein Passwort. Fordere einen Link zum Zurücksetzen an, um ein Passwort festzulegen.",
+    security: "Sicherheit",
+    settings: "Einstellungen",
+    time: "Zeit",
+    unlinkProvider: "Verknüpfung mit {{provider}} aufheben",
+    updateEmail: "E-Mail-Adresse aktualisieren",
+    updatePassword: "Passwort aktualisieren",
+    uploadAvatar: "Profilbild hochladen",
+    userProfile: "Benutzerprofil"
+  }
+})
+
+export const deDE = defineAuthLocale({
+  languageTag: "de-DE",
+  direction: "ltr",
+  localization: deLocalization,
+  plugins: deDEPlugins
+})

--- a/packages/locales/src/en-US-plugins.ts
+++ b/packages/locales/src/en-US-plugins.ts
@@ -1,0 +1,45 @@
+import { adminLocalization } from "@better-auth-ui/core/plugins/admin"
+import { agentAuthLocalization } from "@better-auth-ui/core/plugins/agent-auth"
+import { anonymousLocalization } from "@better-auth-ui/core/plugins/anonymous"
+import { apiKeyLocalization } from "@better-auth-ui/core/plugins/api-key"
+import { billingLocalization } from "@better-auth-ui/core/plugins/billing"
+import { dashLocalization } from "@better-auth-ui/core/plugins/dash"
+import { deleteUserLocalization } from "@better-auth-ui/core/plugins/delete-user"
+import { deviceAuthorizationLocalization } from "@better-auth-ui/core/plugins/device-authorization"
+import { emailOtpLocalization } from "@better-auth-ui/core/plugins/email-otp"
+import { lastLoginMethodLocalization } from "@better-auth-ui/core/plugins/last-login-method"
+import { magicLinkLocalization } from "@better-auth-ui/core/plugins/magic-link"
+import { multiSessionLocalization } from "@better-auth-ui/core/plugins/multi-session"
+import { oauthProviderLocalization } from "@better-auth-ui/core/plugins/oauth-provider"
+import { organizationLocalization } from "@better-auth-ui/core/plugins/organization"
+import { passkeyLocalization } from "@better-auth-ui/core/plugins/passkey"
+import { phoneNumberLocalization } from "@better-auth-ui/core/plugins/phone-number"
+import { siweLocalization } from "@better-auth-ui/core/plugins/siwe"
+import { ssoLocalization } from "@better-auth-ui/core/plugins/sso"
+import { themeLocalization } from "@better-auth-ui/core/plugins/theme"
+import { twoFactorLocalization } from "@better-auth-ui/core/plugins/two-factor"
+import { usernameLocalization } from "@better-auth-ui/core/plugins/username"
+
+export const enUSPlugins = {
+  admin: adminLocalization,
+  agentAuth: agentAuthLocalization,
+  anonymous: anonymousLocalization,
+  apiKey: apiKeyLocalization,
+  billing: billingLocalization,
+  dash: dashLocalization,
+  deleteUser: deleteUserLocalization,
+  deviceAuthorization: deviceAuthorizationLocalization,
+  emailOtp: emailOtpLocalization,
+  lastLoginMethod: lastLoginMethodLocalization,
+  magicLink: magicLinkLocalization,
+  multiSession: multiSessionLocalization,
+  oauthProvider: oauthProviderLocalization,
+  organization: organizationLocalization,
+  passkey: passkeyLocalization,
+  phoneNumber: phoneNumberLocalization,
+  siwe: siweLocalization,
+  sso: ssoLocalization,
+  theme: themeLocalization,
+  twoFactor: twoFactorLocalization,
+  username: usernameLocalization
+}

--- a/packages/locales/src/en-US.ts
+++ b/packages/locales/src/en-US.ts
@@ -1,0 +1,9 @@
+import { defineAuthLocale, localization } from "@better-auth-ui/core"
+import { enUSPlugins } from "./en-US-plugins"
+
+export const enUS = defineAuthLocale({
+  languageTag: "en-US",
+  direction: "ltr",
+  localization,
+  plugins: enUSPlugins
+})

--- a/packages/locales/src/index.ts
+++ b/packages/locales/src/index.ts
@@ -1,0 +1,6 @@
+export type {
+  AuthLocale,
+  AuthLocaleDirection,
+  MatchAuthLocaleOptions
+} from "@better-auth-ui/core"
+export { defineAuthLocale, matchAuthLocale } from "@better-auth-ui/core"

--- a/packages/locales/tests/locales.test.ts
+++ b/packages/locales/tests/locales.test.ts
@@ -45,8 +45,10 @@ describe("locale bundles", () => {
       plugins: deDE.plugins
     })
 
+    expect(Object.keys(german).sort()).toEqual(Object.keys(english).sort())
+
     for (const [path, message] of Object.entries(english)) {
-      expect(placeholders(german[path] ?? ""), path).toEqual(
+      expect(placeholders(german[path] as string), path).toEqual(
         placeholders(message)
       )
     }

--- a/packages/locales/tests/locales.test.ts
+++ b/packages/locales/tests/locales.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import { deDE } from "../src/de-DE"
+import { enUS } from "../src/en-US"
+
+function flattenMessages(
+  value: Record<string, unknown>,
+  prefix = ""
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(value).flatMap(([key, entry]) => {
+      const path = prefix ? `${prefix}.${key}` : key
+      return typeof entry === "string"
+        ? [[path, entry]]
+        : Object.entries(
+            flattenMessages(entry as Record<string, unknown>, path)
+          )
+    })
+  )
+}
+
+function placeholders(message: string) {
+  return message.match(/\{\{[^{}]+\}\}|\{[^{}]+\}/g) ?? []
+}
+
+describe("locale bundles", () => {
+  it("exports canonical language tags and complete localization trees", () => {
+    expect(enUS.languageTag).toBe("en-US")
+    expect(deDE.languageTag).toBe("de-DE")
+    expect(Object.keys(deDE.localization.auth)).toEqual(
+      Object.keys(enUS.localization.auth)
+    )
+    expect(Object.keys(deDE.localization.settings)).toEqual(
+      Object.keys(enUS.localization.settings)
+    )
+    expect(Object.keys(deDE.plugins)).toEqual(Object.keys(enUS.plugins))
+  })
+
+  it("preserves interpolation placeholders", () => {
+    const english = flattenMessages({
+      ...enUS.localization,
+      plugins: enUS.plugins
+    })
+    const german = flattenMessages({
+      ...deDE.localization,
+      plugins: deDE.plugins
+    })
+
+    for (const [path, message] of Object.entries(english)) {
+      expect(placeholders(german[path] ?? ""), path).toEqual(
+        placeholders(message)
+      )
+    }
+  })
+})

--- a/packages/locales/tsconfig.json
+++ b/packages/locales/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "ignoreDeprecations": "6.0"
+  },
+  "include": ["src"]
+}

--- a/packages/locales/vite.config.ts
+++ b/packages/locales/vite.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "vite"
+import dts from "vite-plugin-dts"
+
+export default defineConfig({
+  plugins: [dts({ tsconfigPath: "./tsconfig.json" })],
+  build: {
+    lib: {
+      entry: {
+        index: "src/index.ts",
+        "en-US": "src/en-US.ts",
+        "de-DE": "src/de-DE.ts"
+      },
+      formats: ["es"],
+      fileName: "[name]"
+    },
+    rolldownOptions: {
+      external: /^[^./](?!:[/\\])/
+    }
+  }
+})

--- a/packages/locales/vitest.config.ts
+++ b/packages/locales/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node"
+  }
+})

--- a/packages/react/src/components/auth/auth-provider.tsx
+++ b/packages/react/src/components/auth/auth-provider.tsx
@@ -18,7 +18,8 @@ import {
   type PropsWithChildren,
   type ReactNode,
   useContext,
-  useMemo
+  useMemo,
+  useRef
 } from "react"
 import { MutationInvalidator } from "../mutation-invalidator"
 import { AuthContext } from "./auth-context"
@@ -35,6 +36,21 @@ const fallbackQueryClient = new QueryClient({
     }
   }
 })
+
+function useShallowStableObject<T extends object>(value: T): T {
+  const reference = useRef(value)
+  const previousKeys = Object.keys(reference.current)
+  const nextKeys = Object.keys(value)
+  const isStable =
+    previousKeys.length === nextKeys.length &&
+    nextKeys.every((key) =>
+      Object.is(reference.current[key as keyof T], value[key as keyof T])
+    )
+
+  if (!isStable) reference.current = value
+
+  return reference.current
+}
 
 declare module "@better-auth-ui/core" {
   /** Widen `AdditionalField.label` to `ReactNode` in the React package. */
@@ -74,23 +90,28 @@ export function AuthProvider<TAuthClient extends AuthClient = AuthClient>({
   queryClient,
   ...config
 }: AuthProviderProps<TAuthClient>) {
-  const { authClient, ...partialConfig } = config
-  const mergedConfig = resolveAuthConfig({
-    ...partialConfig,
-    authClient
-  }) as AuthConfig<TAuthClient>
-  const configuredRedirectTo = mergedConfig.redirectTo
+  const stableConfig = useShallowStableObject(config)
+  const mergedConfig = useMemo(() => {
+    const { authClient, ...partialConfig } = stableConfig
+    const resolvedConfig = resolveAuthConfig({
+      ...partialConfig,
+      authClient
+    }) as AuthConfig<TAuthClient>
+    const configuredRedirectTo = resolvedConfig.redirectTo
 
-  Object.defineProperty(mergedConfig, "redirectTo", {
-    configurable: true,
-    enumerable: true,
-    get: () =>
-      (typeof window !== "undefined" &&
-        new URLSearchParams(window.location.search)
-          .get("redirectTo")
-          ?.trim()) ||
-      configuredRedirectTo
-  })
+    Object.defineProperty(resolvedConfig, "redirectTo", {
+      configurable: true,
+      enumerable: true,
+      get: () =>
+        (typeof window !== "undefined" &&
+          new URLSearchParams(window.location.search)
+            .get("redirectTo")
+            ?.trim()) ||
+        configuredRedirectTo
+    })
+
+    return resolvedConfig
+  }, [stableConfig])
 
   const contextQueryClient = useContext(QueryClientContext)
   const resolvedQueryClient =

--- a/packages/react/src/components/auth/auth-provider.tsx
+++ b/packages/react/src/components/auth/auth-provider.tsx
@@ -1,14 +1,12 @@
 "use client"
 
 import {
-  type AdditionalField,
   type AuthClient,
   type AuthConfig,
+  type AuthConfigOptions,
   authQueryKeys,
   createAuthQueryRetryOptions,
-  type DeepPartial,
-  deepmerge,
-  defaultAuthConfig
+  resolveAuthConfig
 } from "@better-auth-ui/core"
 import {
   environmentManager,
@@ -52,8 +50,7 @@ declare module "@better-auth-ui/core" {
 
 export type AuthProviderProps<TAuthClient extends AuthClient = AuthClient> =
   PropsWithChildren<
-    DeepPartial<Omit<AuthConfig, "authClient">> & {
-      authClient: TAuthClient
+    Omit<AuthConfigOptions<TAuthClient>, "navigate"> & {
       navigate: (options: { to: string; replace?: boolean }) => void
       /** TanStack QueryClient to use for your application's queries */
       queryClient?: QueryClient
@@ -78,10 +75,10 @@ export function AuthProvider<TAuthClient extends AuthClient = AuthClient>({
   ...config
 }: AuthProviderProps<TAuthClient>) {
   const { authClient, ...partialConfig } = config
-  const mergedConfig = {
-    ...deepmerge(defaultAuthConfig, partialConfig),
+  const mergedConfig = resolveAuthConfig({
+    ...partialConfig,
     authClient
-  } as AuthConfig<TAuthClient>
+  }) as AuthConfig<TAuthClient>
   const configuredRedirectTo = mergedConfig.redirectTo
 
   Object.defineProperty(mergedConfig, "redirectTo", {
@@ -94,20 +91,6 @@ export function AuthProvider<TAuthClient extends AuthClient = AuthClient>({
           ?.trim()) ||
       configuredRedirectTo
   })
-
-  // Merge plugin-contributed `additionalFields` with user-supplied ones.
-  // Plugin order is preserved; user-supplied entries with the same `name`
-  // override the plugin contribution.
-  const fieldsByName = new Map<string, AdditionalField>()
-  for (const plugin of mergedConfig.plugins ?? []) {
-    for (const field of plugin.additionalFields ?? []) {
-      fieldsByName.set(field.name, field)
-    }
-  }
-  for (const field of mergedConfig.additionalFields ?? []) {
-    fieldsByName.set(field.name, field)
-  }
-  mergedConfig.additionalFields = Array.from(fieldsByName.values())
 
   const contextQueryClient = useContext(QueryClientContext)
   const resolvedQueryClient =

--- a/packages/react/tests/auth-provider.test.tsx
+++ b/packages/react/tests/auth-provider.test.tsx
@@ -136,4 +136,31 @@ describe("AuthProvider locale changes", () => {
     expect(signInLabel).toBe("Anmelden")
     expect(languageTag).toBe("de-DE")
   })
+
+  it("keeps resolved config identities stable across equivalent renders", () => {
+    let currentConfig: ReturnType<typeof useAuth> | undefined
+    const navigate = () => {}
+
+    function ConfigConsumer() {
+      currentConfig = useAuth()
+      return null
+    }
+
+    const view = render(
+      <AuthProvider authClient={authClient} navigate={navigate}>
+        <ConfigConsumer />
+      </AuthProvider>
+    )
+    const firstConfig = currentConfig
+
+    view.rerender(
+      <AuthProvider authClient={authClient} navigate={navigate}>
+        <ConfigConsumer />
+      </AuthProvider>
+    )
+
+    expect(currentConfig).toBe(firstConfig)
+    expect(currentConfig?.localization).toBe(firstConfig?.localization)
+    expect(currentConfig?.plugins).toBe(firstConfig?.plugins)
+  })
 })

--- a/packages/react/tests/auth-provider.test.tsx
+++ b/packages/react/tests/auth-provider.test.tsx
@@ -1,4 +1,9 @@
-import { authQueryKeys } from "@better-auth-ui/core"
+import {
+  authQueryKeys,
+  deepmerge,
+  defineAuthLocale,
+  localization
+} from "@better-auth-ui/core"
 import {
   QueryClient,
   QueryClientProvider,
@@ -10,7 +15,8 @@ import { describe, expect, it, vi } from "vitest"
 
 import {
   AuthProvider,
-  type AuthProviderProps
+  type AuthProviderProps,
+  useAuth
 } from "../src/components/auth/auth-provider"
 
 const retryQueryKey = [...authQueryKeys.all, "retry-test"] as const
@@ -87,4 +93,47 @@ describe("AuthProvider query defaults", () => {
       expect(queryFn).toHaveBeenCalledTimes(4)
     }
   )
+})
+
+describe("AuthProvider locale changes", () => {
+  const germanLocale = defineAuthLocale({
+    languageTag: "de-DE",
+    localization: deepmerge(localization, {
+      auth: { signIn: "Anmelden" }
+    })
+  })
+
+  it("updates context when the locale prop changes", () => {
+    let signInLabel: string | undefined
+    let languageTag: string | undefined
+
+    function LocaleConsumer() {
+      const auth = useAuth()
+      signInLabel = auth.localization.auth.signIn
+      languageTag = auth.locale.languageTag
+      return null
+    }
+
+    const view = render(
+      <AuthProvider authClient={authClient} navigate={() => {}}>
+        <LocaleConsumer />
+      </AuthProvider>
+    )
+
+    expect(signInLabel).toBe("Sign In")
+    expect(languageTag).toBe("en-US")
+
+    view.rerender(
+      <AuthProvider
+        authClient={authClient}
+        locale={germanLocale}
+        navigate={() => {}}
+      >
+        <LocaleConsumer />
+      </AuthProvider>
+    )
+
+    expect(signInLabel).toBe("Anmelden")
+    expect(languageTag).toBe("de-DE")
+  })
 })

--- a/packages/solid/src/lib/auth-config.ts
+++ b/packages/solid/src/lib/auth-config.ts
@@ -1,30 +1,15 @@
-import type { AuthClient } from "@better-auth-ui/core"
 import {
+  type AuthClient,
   type AuthConfig,
-  type DeepPartial,
-  deepmerge,
-  defaultAuthConfig
+  type AuthConfigOptions,
+  resolveAuthConfig as resolveCoreAuthConfig
 } from "@better-auth-ui/core"
-import { mergeAdditionalFields, resolveRedirectTo } from "./auth-utils"
+import { resolveRedirectTo } from "./auth-utils"
 
 export function resolveAuthConfig<TAuthClient extends AuthClient>(
-  config: DeepPartial<Omit<AuthConfig, "authClient">> & {
-    authClient: TAuthClient
-  }
+  config: AuthConfigOptions<TAuthClient>
 ): AuthConfig<TAuthClient> {
-  const mergedConfig = deepmerge(defaultAuthConfig, {
-    ...config,
-    viewPaths: {
-      auth: {
-        ...defaultAuthConfig.viewPaths.auth,
-        ...config.viewPaths?.auth
-      },
-      settings: {
-        ...defaultAuthConfig.viewPaths.settings,
-        ...config.viewPaths?.settings
-      }
-    }
-  } as AuthConfig<TAuthClient>)
+  const mergedConfig = resolveCoreAuthConfig(config)
   const configuredRedirectTo = mergedConfig.redirectTo
 
   Object.defineProperty(mergedConfig, "redirectTo", {
@@ -32,10 +17,5 @@ export function resolveAuthConfig<TAuthClient extends AuthClient>(
     enumerable: true,
     get: () => resolveRedirectTo(configuredRedirectTo)
   })
-  mergedConfig.additionalFields = mergeAdditionalFields(
-    mergedConfig.plugins?.flatMap((plugin) => plugin.additionalFields ?? []),
-    mergedConfig.additionalFields
-  )
-
-  return mergedConfig as AuthConfig<TAuthClient>
+  return mergedConfig
 }

--- a/packages/solid/src/lib/auth-provider.tsx
+++ b/packages/solid/src/lib/auth-provider.tsx
@@ -1,19 +1,26 @@
 import {
   type AuthClient,
   type AuthConfig,
+  type AuthConfigOptions,
   authQueryKeys,
-  createAuthQueryRetryOptions,
-  type DeepPartial
+  createAuthQueryRetryOptions
 } from "@better-auth-ui/core"
 import {
   environmentManager,
   QueryClient,
   QueryClientProvider
 } from "@tanstack/solid-query"
-import { type Component, createContext, type JSX, useContext } from "solid-js"
+import {
+  type Component,
+  createContext,
+  createMemo,
+  type JSX,
+  useContext
+} from "solid-js"
 import { resolveAuthConfig } from "./auth-config"
 import { FetchOptionsProvider } from "./fetch-options-provider"
 import { MutationInvalidator } from "./mutation-invalidator"
+import { createReactiveAuthConfig } from "./reactive-auth-config"
 
 declare module "@better-auth-ui/core" {
   /** Custom social provider icons are Solid components that accept a class. */
@@ -39,8 +46,7 @@ const fallbackQueryClient = new QueryClient({
 })
 
 export type AuthProviderProps<TAuthClient extends AuthClient = AuthClient> =
-  DeepPartial<Omit<AuthConfig, "authClient">> & {
-    authClient: TAuthClient
+  AuthConfigOptions<TAuthClient> & {
     children?: JSX.Element | (() => JSX.Element)
     /** TanStack QueryClient to use for your application's queries. */
     queryClient?: QueryClient
@@ -52,19 +58,26 @@ const resolveProviderChildren = (children: AuthProviderProps["children"]) =>
 export function AuthProvider<TAuthClient extends AuthClient = AuthClient>(
   props: AuthProviderProps<TAuthClient>
 ) {
-  const { children, queryClient: qc, ...configInput } = props
-  const config = resolveAuthConfig(configInput)
-  const queryClient = qc || fallbackQueryClient
+  const config = createMemo(() => {
+    const {
+      children: _children,
+      queryClient: _queryClient,
+      ...configInput
+    } = props
+    return resolveAuthConfig(configInput)
+  })
+  const reactiveConfig = createReactiveAuthConfig(config)
+  const queryClient = props.queryClient || fallbackQueryClient
 
   queryClient.setQueryDefaults(authQueryKeys.all, authQueryRetryOptions)
 
   return (
-    <AuthContext.Provider value={config}>
-      <RenderingAuthConfigContext.Provider value={config}>
+    <AuthContext.Provider value={reactiveConfig}>
+      <RenderingAuthConfigContext.Provider value={reactiveConfig}>
         <QueryClientProvider client={queryClient}>
           <FetchOptionsProvider>
             <MutationInvalidator queryClient={queryClient} />
-            {resolveProviderChildren(children)}
+            {resolveProviderChildren(props.children)}
           </FetchOptionsProvider>
         </QueryClientProvider>
       </RenderingAuthConfigContext.Provider>

--- a/packages/solid/src/lib/reactive-auth-config.ts
+++ b/packages/solid/src/lib/reactive-auth-config.ts
@@ -1,0 +1,77 @@
+import type { AuthClient, AuthConfig } from "@better-auth-ui/core"
+
+type ShouldProjectChild = (property: PropertyKey, depth: number) => boolean
+
+const reactivePluginFields = new Set<PropertyKey>([
+  "additionalFields",
+  "localization",
+  "roles"
+])
+
+function createReactiveProjection<T extends object>(
+  read: () => T,
+  shouldProjectChild: ShouldProjectChild = () => true,
+  depth = 0
+): T {
+  const initialValue = read()
+  const childProjections = new Map<PropertyKey, object>()
+  const target = Array.isArray(initialValue) ? [] : {}
+
+  return new Proxy(target as T, {
+    get: (_target, property) => {
+      const value = Reflect.get(read(), property)
+
+      if (
+        value === null ||
+        typeof value !== "object" ||
+        !shouldProjectChild(property, depth)
+      ) {
+        return value
+      }
+
+      const existing = childProjections.get(property)
+      if (existing) return existing
+
+      const projection = createReactiveProjection(
+        () => Reflect.get(read(), property) as object,
+        shouldProjectChild,
+        depth + 1
+      )
+      childProjections.set(property, projection)
+      return projection
+    },
+    getOwnPropertyDescriptor: (_target, property) => {
+      const descriptor = Reflect.getOwnPropertyDescriptor(read(), property)
+      if (!descriptor) return undefined
+
+      return {
+        ...descriptor,
+        configurable: !(Array.isArray(initialValue) && property === "length")
+      }
+    },
+    has: (_target, property) => Reflect.has(read(), property),
+    ownKeys: () => Reflect.ownKeys(read())
+  })
+}
+
+/** Keeps locale-sensitive config objects stable while reading their latest values. */
+export function createReactiveAuthConfig<TAuthClient extends AuthClient>(
+  read: () => AuthConfig<TAuthClient>
+): AuthConfig<TAuthClient> {
+  const locale = createReactiveProjection(() => read().locale)
+  const localization = createReactiveProjection(() => read().localization)
+  const plugins = createReactiveProjection(
+    () => read().plugins,
+    (property, depth) => depth === 0 || reactivePluginFields.has(property)
+  )
+
+  return new Proxy({} as AuthConfig<TAuthClient>, {
+    get: (_target, property) => {
+      if (property === "locale") return locale
+      if (property === "localization") return localization
+      if (property === "plugins") return plugins
+
+      return read()[property as keyof AuthConfig]
+    }
+  })
+}

--- a/packages/solid/tests/auth-provider-render.test.tsx
+++ b/packages/solid/tests/auth-provider-render.test.tsx
@@ -1,7 +1,11 @@
 import {
   authQueryKeys,
   basePaths,
-  createAuthPlugin
+  createAuthPlugin,
+  deepmerge,
+  defineAuthLocale,
+  localization,
+  resolveAuthConfig
 } from "@better-auth-ui/core"
 import { QueryClient } from "@tanstack/solid-query"
 import { renderToString } from "solid-js/web"
@@ -14,6 +18,7 @@ import {
   useAuth,
   useAuthPlugin
 } from "../src"
+import { createReactiveAuthConfig } from "../src/lib/reactive-auth-config"
 
 function AuthConsumer() {
   const auth = useAuth()
@@ -21,7 +26,9 @@ function AuthConsumer() {
   return auth.basePaths.auth
 }
 
-const testPlugin = createAuthPlugin("test", (label: string) => ({ label }))
+const testPlugin = createAuthPlugin("test", (label: string) => ({
+  localization: { label }
+}))
 
 describe("Solid AuthProvider render context", () => {
   it("disables auth query retries during server rendering", () => {
@@ -69,7 +76,7 @@ describe("Solid AuthProvider render context", () => {
     ).toContain(basePaths.auth)
   })
 
-  it("returns the registered plugin from the provider context", () => {
+  it("returns the registered plugin configuration from provider context", () => {
     const authClient = { getSession: vi.fn() }
     const registeredPlugin = testPlugin("Registered plugin")
     let resolvedPlugin: typeof registeredPlugin | undefined
@@ -88,7 +95,7 @@ describe("Solid AuthProvider render context", () => {
       </AuthProvider>
     ))
 
-    expect(resolvedPlugin).toBe(registeredPlugin)
+    expect(resolvedPlugin).toMatchObject(registeredPlugin)
   })
 
   it("renders internal links through the configured router adapter", () => {
@@ -107,5 +114,36 @@ describe("Solid AuthProvider render context", () => {
     ))
 
     expect(receivedHref).toBe("/login/sign-in")
+  })
+
+  it("keeps destructured locale values current when the config changes", () => {
+    const germanLocale = defineAuthLocale({
+      languageTag: "de-DE",
+      localization: deepmerge(localization, {
+        auth: { signIn: "Anmelden" }
+      }),
+      plugins: { test: { label: "Erweiterung" } }
+    })
+    const plugin = testPlugin("Plugin")
+    let config = resolveAuthConfig({ authClient: {}, plugins: [plugin] })
+    const reactiveConfig = createReactiveAuthConfig(() => config)
+    const destructuredLocalization = reactiveConfig.localization
+    const destructuredLocale = reactiveConfig.locale
+    const destructuredPlugin = reactiveConfig.plugins[0]
+    const destructuredPluginLocalization = destructuredPlugin?.localization
+
+    expect(destructuredLocalization.auth.signIn).toBe("Sign In")
+    expect(destructuredLocale).toBeDefined()
+    expect(destructuredPluginLocalization?.label).toBe("Plugin")
+
+    config = resolveAuthConfig({
+      authClient: {},
+      locale: germanLocale,
+      plugins: [plugin]
+    })
+
+    expect(destructuredLocalization.auth.signIn).toBe("Anmelden")
+    expect(destructuredLocale.languageTag).toBe("de-DE")
+    expect(destructuredPluginLocalization?.label).toBe("Erweiterung")
   })
 })


### PR DESCRIPTION
Closes #96

## Summary

- add shared locale types, Accept-Language matching, and deterministic localization precedence
- add the tree-shakeable `@better-auth-ui/locales` package with complete English and German core/plugin bundles
- localize plugin-derived fields, roles, country names, and HeroUI date, number, currency, and relative-time formatting
- support runtime locale changes in React and Solid while keeping SSR locale selection explicit
- document fixed, browser-matched, and server-resolved locale setup for HeroUI, shadcn, and Zaidan

## Validation

- `bunx biome check .`
- `bun nx run-many -t typecheck test build -p @better-auth-ui/core @better-auth-ui/react @better-auth-ui/solid @better-auth-ui/heroui @better-auth-ui/locales`
- package tests: core 300, React 57, Solid 90, HeroUI 137, locales 2

A workspace-wide `typecheck test build` run completed all builds and typechecks. Its test phase also reproduced four unrelated baseline assertion failures in unchanged Zaidan/docs files:

- two Zaidan registry/source-string assertions
- two docs wording assertions


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authentication localization with locale selection, browser-language matching, runtime updates, and server-rendering guidance.
  * Added English and German locale bundles covering authentication and account-management features.
  * Localized dates, times, numbers, relative timestamps, plugin labels, tabs, roles, and additional fields.
  * Added product-specific localization overrides.

* **Documentation**
  * Expanded AuthProvider documentation with installation, configuration, overrides, hydration, and runtime localization guidance.

* **Bug Fixes**
  * Ensured displayed values consistently follow the configured authentication locale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->