### PR TITLE
feat(admin): add user management views

### DIFF
--- a/apps/docs/content/docs/heroui/plugins/admin.mdx
+++ b/apps/docs/content/docs/heroui/plugins/admin.mdx
@@ -1,14 +1,13 @@
 ---
 icon: ShieldCheck
 title: Admin
-description: Let administrators stop impersonating a user from the user button.
+description: Add static user management, session details, and impersonation to an administration area.
 ---
 
 import { Step, Steps } from "fumadocs-ui/components/steps"
 
-The Admin plugin adds a "Stop impersonating" action to `<UserButton />`. The
-action appears only while Better Auth marks the current session as an
-impersonation session.
+The Admin plugin adds a static `/admin/users` page and a user-detail drawer.
+It also adds a "Stop impersonating" action to `<UserButton />`.
 
 ## Setup
 
@@ -65,6 +64,57 @@ import { adminPlugin } from "@better-auth-ui/heroui/plugins" // [!code highlight
 
 </Step>
 </Steps>
+
+## Add the users route
+
+Create one static route for the users page:
+
+```tsx title="app/admin/users/page.tsx"
+import { Admin } from "@better-auth-ui/heroui"
+
+export default function AdminUsersPage() {
+  return <Admin view="users" />
+}
+```
+
+Use `<Admin path="users" />` when a parent route passes the final static path
+segment. The user-detail drawer keeps user IDs out of the route contract.
+
+Applications can control the drawer through `<AdminUsers />`:
+
+```tsx
+<AdminUsers
+  selectedUserId={selectedUserId}
+  onSelectedUserIdChange={setSelectedUserId}
+/>
+```
+
+## Permissions and privacy
+
+The users page calls the Better Auth permission API before it requests the
+user list. Do not authorize the page from a role string alone.
+
+The table searches one field per request. The supported fields are `email`
+and `name`.
+
+Passwords stay in local form state and never enter query keys. Session IP
+addresses are hidden unless `showIpAddress` is `true`.
+
+Configure custom roles with the same names in Better Auth and the UI plugin:
+
+```ts
+adminPlugin({
+  defaultRole: "member",
+  impersonationRedirectTo: "/",
+  pageSize: 25,
+  roles: ["member", "support", "admin"],
+  showIpAddress: false
+})
+```
+
+The public Admin client does not provide account disconnection, global
+organization administration, or a Sentinel dashboard. These views are not
+part of this integration.
 
 ## User button behavior
 

--- a/apps/docs/content/docs/shadcn/plugins/admin.mdx
+++ b/apps/docs/content/docs/shadcn/plugins/admin.mdx
@@ -100,6 +100,9 @@ export default function AdminUsersPage() {
 TanStack Start can use the same component in `routes/admin/users.tsx`:
 
 ```tsx
+import { createFileRoute } from "@tanstack/react-router"
+import { Admin } from "@/components/auth/admin/admin"
+
 export const Route = createFileRoute("/admin/users")({
   component: () => <Admin view="users" />
 })

--- a/apps/docs/content/docs/shadcn/plugins/admin.mdx
+++ b/apps/docs/content/docs/shadcn/plugins/admin.mdx
@@ -112,6 +112,8 @@ Use `<Admin path="users" />` when a parent route passes the final static path
 segment. Applications can control the drawer without changing this route:
 
 ```tsx
+import { AdminUsers } from "@/components/auth/admin/admin-users"
+
 <AdminUsers
   selectedUserId={selectedUserId}
   onSelectedUserIdChange={setSelectedUserId}

--- a/apps/docs/content/docs/shadcn/plugins/admin.mdx
+++ b/apps/docs/content/docs/shadcn/plugins/admin.mdx
@@ -1,14 +1,13 @@
 ---
 icon: ShieldCheck
 title: Admin
-description: Let administrators stop impersonating a user from the user button.
+description: Add static user management, session controls, and impersonation to an administration area.
 ---
 
 import { Step, Steps } from "fumadocs-ui/components/steps"
 
-The Admin plugin adds a "Stop impersonating" action to `<UserButton />`. The
-action appears only while Better Auth marks the current session as an
-impersonation session.
+The Admin plugin adds a static `/admin/users` page and a user-detail drawer.
+It also adds a "Stop impersonating" action to `<UserButton />`.
 
 ## Setup
 
@@ -61,6 +60,8 @@ This installs:
 
 - `src/lib/auth/auth-plugin.ts`
 - `src/lib/auth/admin-plugin.ts`
+- `src/components/auth/admin/admin.tsx`
+- `src/components/auth/admin/admin-users.tsx`
 - `src/components/auth/admin/stop-impersonating.tsx`
 
 </Step>
@@ -82,6 +83,88 @@ import { adminPlugin } from "@/lib/auth/admin-plugin" // [!code highlight]
 
 </Step>
 </Steps>
+
+## Add the users route
+
+Create one static route for the users page. The drawer keeps user IDs out of
+the route contract.
+
+```tsx title="app/admin/users/page.tsx"
+import { Admin } from "@/components/auth/admin/admin"
+
+export default function AdminUsersPage() {
+  return <Admin view="users" />
+}
+```
+
+TanStack Start can use the same component in `routes/admin/users.tsx`:
+
+```tsx
+export const Route = createFileRoute("/admin/users")({
+  component: () => <Admin view="users" />
+})
+```
+
+Use `<Admin path="users" />` when a parent route passes the final static path
+segment. Applications can control the drawer without changing this route:
+
+```tsx
+<AdminUsers
+  selectedUserId={selectedUserId}
+  onSelectedUserIdChange={setSelectedUserId}
+/>
+```
+
+This API lets an application connect search parameters later. Search
+parameters are not required by the library.
+
+## Permissions
+
+The users page calls the Better Auth permission API before it requests the
+user list. Each server endpoint remains the final security boundary.
+
+Do not authorize this page from a role string alone. Better Auth also supports
+custom roles, custom permissions, and `adminUserIds`.
+
+The table searches one field per request. Select `Email` or `Name` before you
+enter a search value. The public Admin API does not provide one combined
+search across names, email addresses, and user IDs.
+
+## User inspector
+
+Select a row to open the user inspector. The inspector uses local Overview and
+Sessions tabs. These tabs are not routes.
+
+The inspector can change roles, set passwords, ban users, impersonate users,
+remove users, and revoke sessions. Dangerous actions require confirmation.
+The UI disables self-destructive actions and still relies on the server.
+
+Passwords stay in local form state. The forms clear each password after the
+request or after the user closes the form.
+
+Session IP addresses are hidden by default. Set `showIpAddress: true` only when
+your privacy policy permits this data.
+
+## Custom roles and options
+
+```ts
+adminPlugin({
+  defaultRole: "member",
+  impersonationRedirectTo: "/",
+  pageSize: 25,
+  roles: ["member", "support", "admin"],
+  showIpAddress: false
+})
+```
+
+Configure the same roles and permissions in Better Auth `admin()` and
+`adminClient()`. The UI list only controls which role choices it shows.
+
+## Scope
+
+This integration uses the public Better Auth Admin client. It does not add
+account disconnection, organization membership management, global
+organization administration, analytics, or a Sentinel dashboard.
 
 ## User button behavior
 

--- a/apps/docs/content/docs/zaidan/plugins/admin.mdx
+++ b/apps/docs/content/docs/zaidan/plugins/admin.mdx
@@ -1,14 +1,13 @@
 ---
 icon: ShieldCheck
 title: Admin
-description: Add a stop-impersonating user menu action to Solid and Zaidan.
+description: Add static user management, session details, and impersonation to Solid and Zaidan.
 ---
 
 import { Step, Steps } from "fumadocs-ui/components/steps"
 
-The Admin plugin adds a "Stop impersonating" action to the copied
-`<UserButton />`. The action appears only while Better Auth marks the current
-session as an impersonation session.
+The Admin plugin adds a static `/admin/users` page and a user-detail dialog.
+It also adds a "Stop impersonating" action to the copied `<UserButton />`.
 
 ## Setup
 
@@ -55,6 +54,8 @@ npx shadcn@latest add https://better-auth-ui.com/r/solid/admin.json
 This copies:
 
 - `src/lib/auth/admin-plugin.ts`
+- `src/components/auth/admin/admin.tsx`
+- `src/components/auth/admin/admin-users.tsx`
 - `src/components/auth/admin/stop-impersonating.tsx`
 
 </Step>
@@ -75,6 +76,53 @@ import { adminPlugin } from "@/lib/auth/admin-plugin" // [!code highlight]
 
 </Step>
 </Steps>
+
+## Add the users route
+
+Create one static TanStack Start route:
+
+```tsx title="src/routes/admin/users.tsx"
+import { Admin } from "@/components/auth/admin/admin"
+
+export const Route = createFileRoute("/admin/users")({
+  component: () => <Admin view="users" />
+})
+```
+
+Use `<Admin path="users" />` when a parent route supplies the final static path
+segment. The user-detail dialog keeps user IDs out of the route contract.
+
+Applications can control the selected user through `<AdminUsers />`:
+
+```tsx
+<AdminUsers
+  selectedUserId={selectedUserId()}
+  onSelectedUserIdChange={setSelectedUserId}
+/>
+```
+
+## Permissions and privacy
+
+The users page calls the Better Auth permission API before it requests the
+user list. Do not authorize the page from a role string alone.
+
+The table searches either `email` or `name` in each request. Passwords stay in
+local form state. Session IP addresses are hidden unless `showIpAddress` is
+`true`.
+
+```ts
+adminPlugin({
+  defaultRole: "member",
+  impersonationRedirectTo: "/",
+  pageSize: 25,
+  roles: ["member", "support", "admin"],
+  showIpAddress: false
+})
+```
+
+The public Admin client does not provide account disconnection, global
+organization administration, or a Sentinel dashboard. These views are not
+part of this integration.
 
 ## User button behavior
 

--- a/apps/docs/content/docs/zaidan/plugins/admin.mdx
+++ b/apps/docs/content/docs/zaidan/plugins/admin.mdx
@@ -96,6 +96,8 @@ segment. The user-detail dialog keeps user IDs out of the route contract.
 Applications can control the selected user through `<AdminUsers />`:
 
 ```tsx
+import { AdminUsers } from "@/components/auth/admin/admin-users"
+
 <AdminUsers
   selectedUserId={selectedUserId()}
   onSelectedUserIdChange={setSelectedUserId}

--- a/apps/docs/content/docs/zaidan/plugins/admin.mdx
+++ b/apps/docs/content/docs/zaidan/plugins/admin.mdx
@@ -82,6 +82,7 @@ import { adminPlugin } from "@/lib/auth/admin-plugin" // [!code highlight]
 Create one static TanStack Start route:
 
 ```tsx title="src/routes/admin/users.tsx"
+import { createFileRoute } from "@tanstack/solid-router"
 import { Admin } from "@/components/auth/admin/admin"
 
 export const Route = createFileRoute("/admin/users")({

--- a/apps/docs/src/components/auth/admin/admin-users.tsx
+++ b/apps/docs/src/components/auth/admin/admin-users.tsx
@@ -1,0 +1,1103 @@
+"use client"
+
+import {
+  type AdminAuthClient,
+  type AdminListUsersParams,
+  banAdminUserOptions,
+  createAdminUserOptions,
+  impersonateAdminUserOptions,
+  removeAdminUserOptions,
+  revokeAdminUserSessionOptions,
+  revokeAdminUserSessionsOptions,
+  setAdminUserPasswordOptions,
+  setAdminUserRoleOptions,
+  unbanAdminUserOptions
+} from "@better-auth-ui/core/plugins/admin"
+import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
+import {
+  useAdminPermission,
+  useAdminUser,
+  useAdminUserSessions,
+  useAdminUsers
+} from "@better-auth-ui/react/plugins/admin"
+import { keepPreviousData, useMutation } from "@tanstack/react-query"
+import {
+  BanIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CopyIcon,
+  KeyRoundIcon,
+  LogInIcon,
+  SearchIcon,
+  ShieldAlertIcon,
+  Trash2Icon,
+  UserPlusIcon
+} from "lucide-react"
+import {
+  type FormEvent,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState
+} from "react"
+import { UserAvatar } from "@/components/auth/user/user-avatar"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput
+} from "@/components/ui/input-group"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle
+} from "@/components/ui/sheet"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@/components/ui/table"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { adminPlugin } from "@/lib/auth/admin-plugin"
+
+type SearchField = "email" | "name"
+type StatusFilter = "all" | "active" | "banned"
+type SortDirection = "asc" | "desc"
+type DangerousAction = "ban" | "delete" | "impersonate" | "revokeAll"
+
+export type AdminUsersProps = {
+  className?: string
+  onSelectedUserIdChange?: (userId: string | undefined) => void
+  selectedUserId?: string
+}
+
+const formatDate = (value: Date | string | undefined | null) =>
+  value
+    ? new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(
+        new Date(value)
+      )
+    : "–"
+
+const asAdminRole = (role: string) => role as "user" | "admin"
+
+/** Server-paginated user management with optional controlled inspector state. */
+export function AdminUsers({
+  className,
+  onSelectedUserIdChange,
+  selectedUserId: controlledSelectedUserId
+}: AdminUsersProps) {
+  const auth = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const { localization } = config
+  const [localSelectedUserId, setLocalSelectedUserId] = useState<string>()
+  const [page, setPage] = useState(0)
+  const [search, setSearch] = useState("")
+  const [searchField, setSearchField] = useState<SearchField>("email")
+  const [status, setStatus] = useState<StatusFilter>("all")
+  const [sortBy, setSortBy] = useState("createdAt")
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc")
+  const [createOpen, setCreateOpen] = useState(false)
+  const deferredSearch = useDeferredValue(search.trim())
+  const isSelectionControlled = onSelectedUserIdChange !== undefined
+  const selectedUserId = isSelectionControlled
+    ? controlledSelectedUserId
+    : localSelectedUserId
+
+  const setSelectedUserId = (userId: string | undefined) => {
+    if (!isSelectionControlled) setLocalSelectedUserId(userId)
+    onSelectedUserIdChange?.(userId)
+  }
+
+  const params = useMemo<AdminListUsersParams>(
+    () => ({
+      limit: config.pageSize,
+      offset: page * config.pageSize,
+      searchField,
+      searchOperator: "contains",
+      searchValue: deferredSearch || undefined,
+      sortBy,
+      sortDirection,
+      ...(status === "all"
+        ? {}
+        : {
+            filterField: "banned",
+            filterOperator: "eq" as const,
+            filterValue: status === "banned"
+          })
+    }),
+    [
+      config.pageSize,
+      deferredSearch,
+      page,
+      searchField,
+      sortBy,
+      sortDirection,
+      status
+    ]
+  )
+  const permission = useAdminPermission(auth.authClient, { user: ["list"] })
+  const users = useAdminUsers(auth.authClient, {
+    enabled: permission.data?.success === true,
+    params,
+    placeholderData: keepPreviousData
+  })
+  const canCreate = useAdminPermission(auth.authClient, { user: ["create"] })
+
+  const changeSort = (field: string) => {
+    if (sortBy === field) {
+      setSortDirection((value) => (value === "asc" ? "desc" : "asc"))
+    } else {
+      setSortBy(field)
+      setSortDirection("asc")
+    }
+  }
+
+  const total = users.data?.total ?? 0
+  const from = total ? page * config.pageSize + 1 : 0
+  const to = Math.min(total, (page + 1) * config.pageSize)
+
+  return (
+    <section className={className}>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div className="flex flex-col gap-1">
+            <h1 className="text-xl font-semibold tracking-tight">
+              {localization.users}
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              {localization.usersDescription}
+            </p>
+          </div>
+          {canCreate.isPending ? (
+            <Skeleton className="h-8 w-28" />
+          ) : canCreate.data?.success ? (
+            <Button onClick={() => setCreateOpen(true)}>
+              <UserPlusIcon />
+              {localization.createUser}
+            </Button>
+          ) : null}
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Select
+            value={searchField}
+            onValueChange={(value) => {
+              setSearchField(value as SearchField)
+              setPage(0)
+            }}
+          >
+            <SelectTrigger
+              aria-label={localization.search}
+              className="w-full sm:w-36"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="email">{localization.email}</SelectItem>
+              <SelectItem value="name">{localization.name}</SelectItem>
+            </SelectContent>
+          </Select>
+          <InputGroup className="sm:max-w-md">
+            <InputGroupAddon>
+              <SearchIcon />
+            </InputGroupAddon>
+            <InputGroupInput
+              aria-label={
+                searchField === "email"
+                  ? localization.searchByEmail
+                  : localization.searchByName
+              }
+              onChange={(event) => {
+                setSearch(event.target.value)
+                setPage(0)
+              }}
+              placeholder={
+                searchField === "email"
+                  ? localization.searchByEmail
+                  : localization.searchByName
+              }
+              value={search}
+            />
+          </InputGroup>
+          <Select
+            value={status}
+            onValueChange={(value) => {
+              setStatus(value as StatusFilter)
+              setPage(0)
+            }}
+          >
+            <SelectTrigger
+              aria-label={localization.status}
+              className="w-full sm:w-36"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">{localization.status}</SelectItem>
+              <SelectItem value="active">{localization.active}</SelectItem>
+              <SelectItem value="banned">{localization.banned}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {permission.isPending ? (
+          <UserTableSkeleton />
+        ) : !permission.data?.success ? (
+          <AdminState
+            icon={<ShieldAlertIcon />}
+            title={localization.accessDenied}
+            description={localization.accessDeniedDescription}
+          />
+        ) : users.isError ? (
+          <AdminState
+            icon={<ShieldAlertIcon />}
+            title={localization.loadUsersError}
+            description={localization.loadUsersErrorDescription}
+            action={
+              <Button variant="outline" onClick={() => users.refetch()}>
+                {localization.retry}
+              </Button>
+            }
+          />
+        ) : (
+          <div className="overflow-hidden rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>
+                    <SortButton
+                      active={sortBy === "name"}
+                      direction={sortDirection}
+                      onClick={() => changeSort("name")}
+                    >
+                      {localization.name}
+                    </SortButton>
+                  </TableHead>
+                  <TableHead className="hidden md:table-cell">
+                    <SortButton
+                      active={sortBy === "role"}
+                      direction={sortDirection}
+                      onClick={() => changeSort("role")}
+                    >
+                      {localization.role}
+                    </SortButton>
+                  </TableHead>
+                  <TableHead>{localization.status}</TableHead>
+                  <TableHead className="hidden lg:table-cell">
+                    <SortButton
+                      active={sortBy === "createdAt"}
+                      direction={sortDirection}
+                      onClick={() => changeSort("createdAt")}
+                    >
+                      {localization.created}
+                    </SortButton>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {users.isPending ? (
+                  <UserRowsSkeleton />
+                ) : users.data?.users.length ? (
+                  users.data.users.map((user) => (
+                    <TableRow
+                      key={user.id}
+                      aria-selected={selectedUserId === user.id}
+                      className="cursor-pointer"
+                      onClick={() => setSelectedUserId(user.id)}
+                    >
+                      <TableCell>
+                        <div className="flex items-center gap-3">
+                          <UserAvatar className="size-8" user={user} />
+                          <div className="min-w-0">
+                            <div className="truncate font-medium">
+                              {user.name}
+                            </div>
+                            <div className="truncate text-xs text-muted-foreground">
+                              {user.email}
+                            </div>
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell className="hidden md:table-cell">
+                        <Badge variant="outline">
+                          {user.role ?? config.defaultRole}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={user.banned ? "destructive" : "secondary"}
+                        >
+                          {user.banned
+                            ? localization.banned
+                            : localization.active}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="hidden text-muted-foreground lg:table-cell">
+                        {formatDate(user.createdAt)}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={4} className="h-40 text-center">
+                      <strong className="block font-medium">
+                        {localization.noUsers}
+                      </strong>
+                      <span className="text-muted-foreground">
+                        {localization.noUsersDescription}
+                      </span>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+
+        <div className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
+          <span>
+            {localization.usersPaginationRange
+              .replace("{{from}}", String(from))
+              .replace("{{to}}", String(to))
+              .replace("{{total}}", String(total))}
+          </span>
+          <div className="flex gap-1">
+            <Button
+              aria-label={localization.previousPage}
+              disabled={page === 0 || users.isFetching}
+              onClick={() => setPage((value) => Math.max(0, value - 1))}
+              size="icon-sm"
+              variant="outline"
+            >
+              <ChevronLeftIcon />
+            </Button>
+            <Button
+              aria-label={localization.nextPage}
+              disabled={to >= total || users.isFetching}
+              onClick={() => setPage((value) => value + 1)}
+              size="icon-sm"
+              variant="outline"
+            >
+              <ChevronRightIcon />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <CreateUserDialog open={createOpen} onOpenChange={setCreateOpen} />
+      <UserInspector
+        open={Boolean(selectedUserId)}
+        onOpenChange={(open) => !open && setSelectedUserId(undefined)}
+        userId={selectedUserId}
+      />
+    </section>
+  )
+}
+
+function SortButton({
+  active,
+  children,
+  direction,
+  onClick
+}: {
+  active: boolean
+  children: React.ReactNode
+  direction: SortDirection
+  onClick: () => void
+}) {
+  return (
+    <button
+      className="inline-flex items-center gap-1 hover:text-foreground"
+      onClick={onClick}
+      type="button"
+    >
+      {children}
+      {active ? (direction === "asc" ? "↑" : "↓") : null}
+    </button>
+  )
+}
+
+function AdminState({
+  action,
+  description,
+  icon,
+  title
+}: {
+  action?: React.ReactNode
+  description: string
+  icon: React.ReactNode
+  title: string
+}) {
+  return (
+    <div className="flex min-h-64 flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-8 text-center">
+      <span className="text-muted-foreground [&>svg]:size-8">{icon}</span>
+      <div className="flex flex-col gap-1">
+        <h2 className="font-medium">{title}</h2>
+        <p className="max-w-md text-sm text-muted-foreground">{description}</p>
+      </div>
+      {action}
+    </div>
+  )
+}
+
+const skeletonRowIds = [
+  "admin-row-1",
+  "admin-row-2",
+  "admin-row-3",
+  "admin-row-4",
+  "admin-row-5"
+]
+
+function UserRowsSkeleton() {
+  return skeletonRowIds.map((id) => (
+    <TableRow key={id}>
+      <TableCell>
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-8 rounded-full" />
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-48" />
+          </div>
+        </div>
+      </TableCell>
+      <TableCell className="hidden md:table-cell">
+        <Skeleton className="h-5 w-16" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-5 w-16" />
+      </TableCell>
+      <TableCell className="hidden lg:table-cell">
+        <Skeleton className="h-4 w-24" />
+      </TableCell>
+    </TableRow>
+  ))
+}
+
+function UserTableSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-lg border">
+      <Table>
+        <TableBody>
+          <UserRowsSkeleton />
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+function CreateUserDialog({
+  open,
+  onOpenChange
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const auth = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const { data: session } = useSession(auth.authClient)
+  const [password, setPassword] = useState("")
+  const createUser = useMutation(
+    createAdminUserOptions(auth.authClient, session?.user.id)
+  )
+
+  const close = () => {
+    setPassword("")
+    createUser.reset()
+    onOpenChange(false)
+  }
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const data = new FormData(event.currentTarget)
+    createUser.mutate(
+      {
+        email: String(data.get("email")),
+        name: String(data.get("name")),
+        password,
+        role: asAdminRole(String(data.get("role") || config.defaultRole))
+      },
+      { onSuccess: close }
+    )
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(value) => (value ? onOpenChange(true) : close())}
+    >
+      <DialogContent>
+        <form className="flex flex-col gap-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{config.localization.createUser}</DialogTitle>
+            <DialogDescription>
+              {config.localization.usersDescription}
+            </DialogDescription>
+          </DialogHeader>
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor="admin-create-name">
+                {config.localization.name}
+              </FieldLabel>
+              <InputGroup>
+                <InputGroupInput id="admin-create-name" name="name" required />
+              </InputGroup>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="admin-create-email">
+                {config.localization.email}
+              </FieldLabel>
+              <InputGroup>
+                <InputGroupInput
+                  autoComplete="off"
+                  id="admin-create-email"
+                  name="email"
+                  required
+                  type="email"
+                />
+              </InputGroup>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="admin-create-password">
+                {config.localization.password}
+              </FieldLabel>
+              <InputGroup>
+                <InputGroupInput
+                  autoComplete="new-password"
+                  id="admin-create-password"
+                  onChange={(event) => setPassword(event.target.value)}
+                  required
+                  type="password"
+                  value={password}
+                />
+              </InputGroup>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="admin-create-role">
+                {config.localization.role}
+              </FieldLabel>
+              <select
+                className="h-8 rounded-lg border bg-transparent px-2 text-sm"
+                defaultValue={config.defaultRole}
+                id="admin-create-role"
+                name="role"
+              >
+                {config.roles.map((role) => (
+                  <option key={role} value={role}>
+                    {role}
+                  </option>
+                ))}
+              </select>
+            </Field>
+          </FieldGroup>
+          <DialogFooter>
+            <Button onClick={close} type="button" variant="outline">
+              {config.localization.cancel}
+            </Button>
+            <Button disabled={createUser.isPending} type="submit">
+              {config.localization.createUser}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function UserInspector({
+  open,
+  onOpenChange,
+  userId
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  userId?: string
+}) {
+  const auth = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const detail = useAdminUser(auth.authClient, userId)
+  const sessionsPermission = useAdminPermission(
+    auth.authClient,
+    {
+      session: ["list"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const sessions = useAdminUserSessions(auth.authClient, userId, {
+    enabled: sessionsPermission.data?.success === true
+  })
+  const { data: actor } = useSession(auth.authClient)
+  const canSetRole = useAdminPermission(
+    auth.authClient,
+    {
+      user: ["set-role"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const canSetPassword = useAdminPermission(
+    auth.authClient,
+    {
+      user: ["set-password"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const canBan = useAdminPermission(
+    auth.authClient,
+    { user: ["ban"] },
+    { enabled: Boolean(userId) }
+  )
+  const canImpersonate = useAdminPermission(
+    auth.authClient,
+    {
+      user: ["impersonate"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const canDelete = useAdminPermission(
+    auth.authClient,
+    { user: ["delete"] },
+    { enabled: Boolean(userId) }
+  )
+  const canRevoke = useAdminPermission(
+    auth.authClient,
+    {
+      session: ["revoke"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const [role, setRole] = useState(config.defaultRole)
+  const [passwordOpen, setPasswordOpen] = useState(false)
+  const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
+  const user = detail.data
+  const isSelf = user?.id === actor?.user.id
+  useEffect(() => {
+    if (user?.role) setRole(user.role)
+  }, [user?.role])
+
+  const setRoleMutation = useMutation(
+    setAdminUserRoleOptions(auth.authClient, actor?.user.id)
+  )
+  const ban = useMutation(banAdminUserOptions(auth.authClient, actor?.user.id))
+  const unban = useMutation(
+    unbanAdminUserOptions(auth.authClient, actor?.user.id)
+  )
+  const remove = useMutation(
+    removeAdminUserOptions(auth.authClient, actor?.user.id)
+  )
+  const impersonate = useMutation(
+    impersonateAdminUserOptions(auth.authClient, actor?.user.id)
+  )
+  const revokeSession = useMutation(
+    revokeAdminUserSessionOptions(auth.authClient, actor?.user.id, userId)
+  )
+  const revokeSessions = useMutation(
+    revokeAdminUserSessionsOptions(auth.authClient, actor?.user.id, userId)
+  )
+
+  const confirm = () => {
+    if (!user) return
+    if (dangerousAction === "ban")
+      ban.mutate(
+        { userId: user.id },
+        { onSuccess: () => setDangerousAction(undefined) }
+      )
+    if (dangerousAction === "delete")
+      remove.mutate(
+        { userId: user.id },
+        {
+          onSuccess: () => {
+            setDangerousAction(undefined)
+            onOpenChange(false)
+          }
+        }
+      )
+    if (dangerousAction === "revokeAll")
+      revokeSessions.mutate(
+        { userId: user.id },
+        { onSuccess: () => setDangerousAction(undefined) }
+      )
+    if (dangerousAction === "impersonate")
+      impersonate.mutate(
+        { userId: user.id },
+        {
+          onSuccess: () => {
+            setDangerousAction(undefined)
+            if (config.impersonationRedirectTo)
+              auth.navigate({ to: config.impersonationRedirectTo })
+          }
+        }
+      )
+  }
+  const dangerLabel =
+    dangerousAction === "ban"
+      ? config.localization.banUser
+      : dangerousAction === "delete"
+        ? config.localization.deleteUser
+        : dangerousAction === "revokeAll"
+          ? config.localization.revokeAllSessions
+          : config.localization.impersonateUser
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent className="w-full overflow-y-auto sm:max-w-lg">
+          <SheetHeader>
+            <SheetTitle>{config.localization.userDetails}</SheetTitle>
+            <SheetDescription>
+              {user?.email ?? config.localization.usersDescription}
+            </SheetDescription>
+          </SheetHeader>
+          {detail.isPending ? (
+            <div className="flex flex-col gap-3 p-4">
+              <Skeleton className="size-14 rounded-full" />
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-4 w-64" />
+            </div>
+          ) : user ? (
+            <Tabs className="px-4 pb-6" defaultValue="overview">
+              <TabsList>
+                <TabsTrigger value="overview">
+                  {config.localization.overview}
+                </TabsTrigger>
+                <TabsTrigger value="sessions">
+                  {config.localization.sessions}
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent
+                className="flex flex-col gap-6 pt-4"
+                value="overview"
+              >
+                <div className="flex items-center gap-3">
+                  <UserAvatar className="size-12" user={user} />
+                  <div>
+                    <div className="font-medium">{user.name}</div>
+                    <div className="text-sm text-muted-foreground">
+                      {user.email}
+                    </div>
+                  </div>
+                </div>
+                <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-3 text-sm">
+                  <dt className="text-muted-foreground">
+                    {config.localization.userId}
+                  </dt>
+                  <dd className="flex min-w-0 items-center gap-1">
+                    <code className="truncate text-xs">{user.id}</code>
+                    <Button
+                      aria-label={config.localization.copyUserId}
+                      onClick={() => navigator.clipboard.writeText(user.id)}
+                      size="icon-xs"
+                      variant="ghost"
+                    >
+                      <CopyIcon />
+                    </Button>
+                  </dd>
+                  <dt className="text-muted-foreground">
+                    {config.localization.created}
+                  </dt>
+                  <dd>{formatDate(user.createdAt)}</dd>
+                  <dt className="text-muted-foreground">
+                    {config.localization.status}
+                  </dt>
+                  <dd>
+                    <Badge variant={user.banned ? "destructive" : "secondary"}>
+                      {user.banned
+                        ? config.localization.banned
+                        : config.localization.active}
+                    </Badge>
+                  </dd>
+                </dl>
+                <div className="flex items-end gap-2">
+                  <Field className="flex-1">
+                    <FieldLabel>{config.localization.role}</FieldLabel>
+                    <Select value={role} onValueChange={setRole}>
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {config.roles.map((item) => (
+                          <SelectItem key={item} value={item}>
+                            {item}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </Field>
+                  <Button
+                    disabled={
+                      setRoleMutation.isPending ||
+                      canSetRole.isPending ||
+                      !canSetRole.data?.success ||
+                      isSelf
+                    }
+                    onClick={() =>
+                      setRoleMutation.mutate({
+                        userId: user.id,
+                        role: asAdminRole(role)
+                      })
+                    }
+                    variant="outline"
+                  >
+                    {config.localization.saveRole}
+                  </Button>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    disabled={
+                      canSetPassword.isPending || !canSetPassword.data?.success
+                    }
+                    onClick={() => setPasswordOpen(true)}
+                    variant="outline"
+                  >
+                    <KeyRoundIcon />
+                    {config.localization.setPassword}
+                  </Button>
+                  <Button
+                    disabled={
+                      canBan.isPending || !canBan.data?.success || isSelf
+                    }
+                    onClick={() =>
+                      user.banned
+                        ? unban.mutate({ userId: user.id })
+                        : setDangerousAction("ban")
+                    }
+                    variant="outline"
+                  >
+                    <BanIcon />
+                    {user.banned
+                      ? config.localization.unbanUser
+                      : config.localization.banUser}
+                  </Button>
+                  <Button
+                    disabled={
+                      canImpersonate.isPending ||
+                      !canImpersonate.data?.success ||
+                      isSelf
+                    }
+                    onClick={() => setDangerousAction("impersonate")}
+                    variant="outline"
+                  >
+                    <LogInIcon />
+                    {config.localization.impersonateUser}
+                  </Button>
+                  <Button
+                    disabled={
+                      canDelete.isPending || !canDelete.data?.success || isSelf
+                    }
+                    onClick={() => setDangerousAction("delete")}
+                    variant="destructive"
+                  >
+                    <Trash2Icon />
+                    {config.localization.deleteUser}
+                  </Button>
+                </div>
+              </TabsContent>
+              <TabsContent
+                className="flex flex-col gap-3 pt-4"
+                value="sessions"
+              >
+                {sessionsPermission.isPending || sessions.isPending ? (
+                  skeletonRowIds
+                    .slice(0, 3)
+                    .map((id) => (
+                      <Skeleton className="h-20 w-full" key={`session-${id}`} />
+                    ))
+                ) : !sessionsPermission.data?.success ? (
+                  <p className="text-sm text-muted-foreground">
+                    {config.localization.accessDeniedDescription}
+                  </p>
+                ) : sessions.data?.sessions.length ? (
+                  <>
+                    <Button
+                      className="self-end"
+                      disabled={
+                        canRevoke.isPending ||
+                        !canRevoke.data?.success ||
+                        isSelf
+                      }
+                      onClick={() => setDangerousAction("revokeAll")}
+                      variant="outline"
+                    >
+                      {config.localization.revokeAllSessions}
+                    </Button>
+                    {sessions.data.sessions.map((item) => (
+                      <div
+                        className="flex items-start justify-between gap-3 rounded-lg border p-3"
+                        key={item.id}
+                      >
+                        <div className="min-w-0 text-sm">
+                          <div className="truncate font-medium">
+                            {item.userAgent || config.localization.sessions}
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            {formatDate(item.createdAt)} ·{" "}
+                            {formatDate(item.expiresAt)}
+                          </div>
+                          {config.showIpAddress && item.ipAddress ? (
+                            <div className="mt-1 font-mono text-xs text-muted-foreground">
+                              {item.ipAddress}
+                            </div>
+                          ) : null}
+                        </div>
+                        <Button
+                          aria-label={config.localization.revoke}
+                          disabled={
+                            revokeSession.isPending ||
+                            canRevoke.isPending ||
+                            !canRevoke.data?.success ||
+                            isSelf
+                          }
+                          onClick={() =>
+                            revokeSession.mutate({ sessionToken: item.token })
+                          }
+                          size="icon-sm"
+                          variant="ghost"
+                        >
+                          <Trash2Icon />
+                        </Button>
+                      </div>
+                    ))}
+                  </>
+                ) : (
+                  <p className="py-8 text-center text-sm text-muted-foreground">
+                    {config.localization.noSessions}
+                  </p>
+                )}
+              </TabsContent>
+            </Tabs>
+          ) : (
+            <AdminState
+              icon={<ShieldAlertIcon />}
+              title={config.localization.loadUsersError}
+              description={config.localization.loadUsersErrorDescription}
+            />
+          )}
+        </SheetContent>
+      </Sheet>
+      <PasswordDialog
+        open={passwordOpen}
+        onOpenChange={setPasswordOpen}
+        userId={user?.id}
+      />
+      <AlertDialog
+        open={Boolean(dangerousAction)}
+        onOpenChange={(value) => !value && setDangerousAction(undefined)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{dangerLabel}</AlertDialogTitle>
+            <AlertDialogDescription>{user?.email}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{config.localization.cancel}</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isSelf}
+              onClick={confirm}
+              variant={dangerousAction === "delete" ? "destructive" : "default"}
+            >
+              {dangerLabel}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}
+
+function PasswordDialog({
+  open,
+  onOpenChange,
+  userId
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  userId?: string
+}) {
+  const auth = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const [password, setPassword] = useState("")
+  const mutation = useMutation(setAdminUserPasswordOptions(auth.authClient))
+  const close = () => {
+    setPassword("")
+    mutation.reset()
+    onOpenChange(false)
+  }
+  const submit = (event: FormEvent) => {
+    event.preventDefault()
+    if (userId)
+      mutation.mutate(
+        { userId, newPassword: password },
+        { onSuccess: close, onSettled: () => setPassword("") }
+      )
+  }
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(value) => (value ? onOpenChange(true) : close())}
+    >
+      <DialogContent>
+        <form className="flex flex-col gap-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{config.localization.setPassword}</DialogTitle>
+            <DialogDescription>
+              {config.localization.userDetails}
+            </DialogDescription>
+          </DialogHeader>
+          <Field>
+            <FieldLabel htmlFor="admin-new-password">
+              {config.localization.password}
+            </FieldLabel>
+            <InputGroup>
+              <InputGroupInput
+                autoComplete="new-password"
+                id="admin-new-password"
+                onChange={(event) => setPassword(event.target.value)}
+                required
+                type="password"
+                value={password}
+              />
+            </InputGroup>
+          </Field>
+          <DialogFooter>
+            <Button onClick={close} type="button" variant="outline">
+              {config.localization.cancel}
+            </Button>
+            <Button disabled={!password || mutation.isPending} type="submit">
+              {config.localization.setPassword}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/docs/src/components/auth/admin/admin-users.tsx
+++ b/apps/docs/src/components/auth/admin/admin-users.tsx
@@ -354,9 +354,16 @@ export function AdminUsers({
                         <div className="flex items-center gap-3">
                           <UserAvatar className="size-8" user={user} />
                           <div className="min-w-0">
-                            <div className="truncate font-medium">
-                              {user.name}
-                            </div>
+                            <Button
+                              className="h-auto min-w-0 justify-start p-0 font-medium"
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                setSelectedUserId(user.id)
+                              }}
+                              variant="link"
+                            >
+                              <span className="truncate">{user.name}</span>
+                            </Button>
                             <div className="truncate text-xs text-muted-foreground">
                               {user.email}
                             </div>
@@ -881,6 +888,11 @@ function UserInspector({
                         ))}
                       </SelectContent>
                     </Select>
+                    {setRoleMutation.error ? (
+                      <FieldError>
+                        {getAdminErrorMessage(setRoleMutation.error)}
+                      </FieldError>
+                    ) : null}
                   </Field>
                   <Button
                     disabled={
@@ -950,6 +962,9 @@ function UserInspector({
                     {config.localization.deleteUser}
                   </Button>
                 </div>
+                {unban.error ? (
+                  <FieldError>{getAdminErrorMessage(unban.error)}</FieldError>
+                ) : null}
               </TabsContent>
               <TabsContent
                 className="flex flex-col gap-3 pt-4"
@@ -1058,7 +1073,10 @@ function UserInspector({
             <AlertDialogCancel>{config.localization.cancel}</AlertDialogCancel>
             <AlertDialogAction
               disabled={isSelf || dangerousMutation.isPending}
-              onClick={confirm}
+              onClick={(event) => {
+                event.preventDefault()
+                confirm()
+              }}
               variant={dangerousAction === "delete" ? "destructive" : "default"}
             >
               {dangerLabel}

--- a/apps/docs/src/components/auth/admin/admin-users.tsx
+++ b/apps/docs/src/components/auth/admin/admin-users.tsx
@@ -21,6 +21,7 @@ import {
   useAdminUsers
 } from "@better-auth-ui/react/plugins/admin"
 import { keepPreviousData, useMutation } from "@tanstack/react-query"
+import type { BetterFetchError } from "better-auth/react"
 import {
   BanIcon,
   ChevronLeftIcon,
@@ -61,7 +62,12 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel
+} from "@/components/ui/field"
 import {
   InputGroup,
   InputGroupAddon,
@@ -112,6 +118,11 @@ const formatDate = (value: Date | string | undefined | null) =>
     : "–"
 
 const asAdminRole = (role: string) => role as "user" | "admin"
+
+const getAdminErrorMessage = (error: Error | null) => {
+  const authError = error as BetterFetchError | null
+  return authError?.error?.message ?? authError?.message
+}
 
 /** Server-paginated user management with optional controlled inspector state. */
 export function AdminUsers({
@@ -177,6 +188,7 @@ export function AdminUsers({
   const canCreate = useAdminPermission(auth.authClient, { user: ["create"] })
 
   const changeSort = (field: string) => {
+    setPage(0)
     if (sortBy === field) {
       setSortDirection((value) => (value === "asc" ? "desc" : "asc"))
     } else {
@@ -621,6 +633,7 @@ function CreateUserDialog({
               </select>
             </Field>
           </FieldGroup>
+          <FieldError>{getAdminErrorMessage(createUser.error)}</FieldError>
           <DialogFooter>
             <Button onClick={close} type="button" variant="outline">
               {config.localization.cancel}
@@ -759,6 +772,22 @@ function UserInspector({
         }
       )
   }
+  const closeDangerousAction = () => {
+    ban.reset()
+    remove.reset()
+    revokeSessions.reset()
+    impersonate.reset()
+    setDangerousAction(undefined)
+  }
+  const dangerousMutation =
+    dangerousAction === "ban"
+      ? ban
+      : dangerousAction === "delete"
+        ? remove
+        : dangerousAction === "revokeAll"
+          ? revokeSessions
+          : impersonate
+  const dangerousError = getAdminErrorMessage(dangerousMutation.error)
   const dangerLabel =
     dangerousAction === "ban"
       ? config.localization.banUser
@@ -1011,17 +1040,24 @@ function UserInspector({
       />
       <AlertDialog
         open={Boolean(dangerousAction)}
-        onOpenChange={(value) => !value && setDangerousAction(undefined)}
+        onOpenChange={(value) => !value && closeDangerousAction()}
       >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{dangerLabel}</AlertDialogTitle>
-            <AlertDialogDescription>{user?.email}</AlertDialogDescription>
+            <AlertDialogDescription className="flex flex-col gap-2">
+              <span>{user?.email}</span>
+              {dangerousError ? (
+                <span className="text-destructive" role="alert">
+                  {dangerousError}
+                </span>
+              ) : null}
+            </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{config.localization.cancel}</AlertDialogCancel>
             <AlertDialogAction
-              disabled={isSelf}
+              disabled={isSelf || dangerousMutation.isPending}
               onClick={confirm}
               variant={dangerousAction === "delete" ? "destructive" : "default"}
             >
@@ -1046,18 +1082,28 @@ function PasswordDialog({
   const auth = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
   const [password, setPassword] = useState("")
-  const mutation = useMutation(setAdminUserPasswordOptions(auth.authClient))
+  const [errorMessage, setErrorMessage] = useState<string>()
+  const mutation = useMutation(
+    setAdminUserPasswordOptions(auth.authClient, () => {
+      setTimeout(() => mutation.reset(), 0)
+    })
+  )
   const close = () => {
     setPassword("")
+    setErrorMessage(undefined)
     mutation.reset()
     onOpenChange(false)
   }
   const submit = (event: FormEvent) => {
     event.preventDefault()
+    setErrorMessage(undefined)
     if (userId)
       mutation.mutate(
         { userId, newPassword: password },
-        { onSuccess: close, onSettled: () => setPassword("") }
+        {
+          onError: (error) => setErrorMessage(getAdminErrorMessage(error)),
+          onSuccess: close
+        }
       )
   }
   return (
@@ -1073,12 +1119,13 @@ function PasswordDialog({
               {config.localization.userDetails}
             </DialogDescription>
           </DialogHeader>
-          <Field>
+          <Field data-invalid={Boolean(errorMessage)}>
             <FieldLabel htmlFor="admin-new-password">
               {config.localization.password}
             </FieldLabel>
             <InputGroup>
               <InputGroupInput
+                aria-invalid={Boolean(errorMessage)}
                 autoComplete="new-password"
                 id="admin-new-password"
                 onChange={(event) => setPassword(event.target.value)}
@@ -1087,6 +1134,7 @@ function PasswordDialog({
                 value={password}
               />
             </InputGroup>
+            <FieldError>{errorMessage}</FieldError>
           </Field>
           <DialogFooter>
             <Button onClick={close} type="button" variant="outline">

--- a/apps/docs/src/components/auth/admin/admin.tsx
+++ b/apps/docs/src/components/auth/admin/admin.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import type { AdminView } from "@better-auth-ui/core"
+import { useAuth, useAuthenticate, useAuthPlugin } from "@better-auth-ui/react"
+import { ShieldAlertIcon, UsersIcon } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { adminPlugin } from "@/lib/auth/admin-plugin"
+import { cn } from "@/lib/utils"
+
+import { AdminUsers } from "./admin-users"
+
+export type AdminProps = {
+  className?: string
+  hideNav?: boolean
+  path?: string
+  view?: AdminView | string
+}
+
+/** Render a finite, static administration route and plugin-contributed tabs. */
+export function Admin({ className, hideNav, path, view }: AdminProps) {
+  const { authClient, basePaths, plugins, viewPaths } = useAuth()
+  const { localization } = useAuthPlugin(adminPlugin)
+  useAuthenticate(authClient)
+
+  if (!view && !path) {
+    throw new Error("[Better Auth UI] Either `view` or `path` must be provided")
+  }
+
+  const contributedTabs = plugins.flatMap((plugin) => plugin.adminTabs ?? [])
+  const currentView =
+    view ??
+    (viewPaths.admin.users === path ? "users" : undefined) ??
+    contributedTabs.find((tab) => tab.path === path)?.id
+  const contributedView = contributedTabs.find((tab) => tab.id === currentView)
+
+  return (
+    <div className={cn("flex w-full flex-col gap-6", className)}>
+      {!hideNav && (
+        <nav aria-label={localization.admin} className="flex gap-1 border-b">
+          <Button
+            aria-current={currentView === "users" ? "page" : undefined}
+            asChild
+            className="rounded-b-none"
+            variant={currentView === "users" ? "secondary" : "ghost"}
+          >
+            <a href={`${basePaths.admin}/${viewPaths.admin.users}`}>
+              <UsersIcon />
+              {localization.users}
+            </a>
+          </Button>
+
+          {contributedTabs.map((tab) => (
+            <Button
+              key={`${tab.id}-${tab.path}`}
+              aria-current={currentView === tab.id ? "page" : undefined}
+              asChild
+              className="rounded-b-none"
+              variant={currentView === tab.id ? "secondary" : "ghost"}
+            >
+              <a href={`${basePaths.admin}/${tab.path}`}>{tab.label}</a>
+            </Button>
+          ))}
+        </nav>
+      )}
+
+      {currentView === "users" ? (
+        <AdminUsers />
+      ) : contributedView ? (
+        <contributedView.component />
+      ) : (
+        <div className="flex min-h-64 flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-8 text-center">
+          <ShieldAlertIcon className="size-8 text-muted-foreground" />
+          <div className="flex flex-col gap-1">
+            <h2 className="font-medium">{localization.unknownView}</h2>
+            <p className="max-w-md text-sm text-muted-foreground">
+              {localization.unknownViewDescription} &quot;{path ?? view}&quot;
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/docs/src/components/ui/sheet.tsx
+++ b/apps/docs/src/components/ui/sheet.tsx
@@ -1,0 +1,137 @@
+"use client"
+
+import { XIcon } from "lucide-react"
+import * as React from "react"
+import { Dialog as SheetPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Sheet(props: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger(props: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose(props: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal(props: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        data-side={side}
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close asChild data-slot="sheet-close">
+            <Button
+              className="absolute top-3 right-3"
+              size="icon-sm"
+              variant="ghost"
+            >
+              <XIcon />
+              <span className="sr-only">Close</span>
+            </Button>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-0.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-base font-medium text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger
+}

--- a/examples/next-heroui-example/src/app/admin/users/page.tsx
+++ b/examples/next-heroui-example/src/app/admin/users/page.tsx
@@ -1,0 +1,25 @@
+import { ensureSessionServer } from "@better-auth-ui/core/server"
+import { Admin } from "@better-auth-ui/heroui"
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query"
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+
+import { auth } from "@/lib/auth"
+import { getQueryClient } from "@/lib/query-client"
+
+export default async function AdminUsersPage() {
+  const queryClient = getQueryClient()
+  const session = await ensureSessionServer(queryClient, auth, {
+    headers: await headers()
+  })
+
+  if (!session) redirect("/auth/sign-in?redirectTo=%2Fadmin%2Fusers")
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <main className="mx-auto w-full max-w-6xl p-4 md:p-6">
+        <Admin view="users" />
+      </main>
+    </HydrationBoundary>
+  )
+}

--- a/examples/next-shadcn-example/src/app/admin/users/page.tsx
+++ b/examples/next-shadcn-example/src/app/admin/users/page.tsx
@@ -1,0 +1,25 @@
+import { ensureSessionServer } from "@better-auth-ui/core/server"
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query"
+import { headers } from "next/headers"
+import { redirect } from "next/navigation"
+
+import { Admin } from "@/components/auth/admin/admin"
+import { auth } from "@/lib/auth"
+import { getQueryClient } from "@/lib/query-client"
+
+export default async function AdminUsersPage() {
+  const queryClient = getQueryClient()
+  const session = await ensureSessionServer(queryClient, auth, {
+    headers: await headers()
+  })
+
+  if (!session) redirect("/auth/sign-in?redirectTo=%2Fadmin%2Fusers")
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <main className="mx-auto w-full max-w-6xl p-4 md:p-6">
+        <Admin view="users" />
+      </main>
+    </HydrationBoundary>
+  )
+}

--- a/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -1,0 +1,1103 @@
+"use client"
+
+import {
+  type AdminAuthClient,
+  type AdminListUsersParams,
+  banAdminUserOptions,
+  createAdminUserOptions,
+  impersonateAdminUserOptions,
+  removeAdminUserOptions,
+  revokeAdminUserSessionOptions,
+  revokeAdminUserSessionsOptions,
+  setAdminUserPasswordOptions,
+  setAdminUserRoleOptions,
+  unbanAdminUserOptions
+} from "@better-auth-ui/core/plugins/admin"
+import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
+import {
+  useAdminPermission,
+  useAdminUser,
+  useAdminUserSessions,
+  useAdminUsers
+} from "@better-auth-ui/react/plugins/admin"
+import { keepPreviousData, useMutation } from "@tanstack/react-query"
+import {
+  BanIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CopyIcon,
+  KeyRoundIcon,
+  LogInIcon,
+  SearchIcon,
+  ShieldAlertIcon,
+  Trash2Icon,
+  UserPlusIcon
+} from "lucide-react"
+import {
+  type FormEvent,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState
+} from "react"
+import { UserAvatar } from "@/components/auth/user/user-avatar"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput
+} from "@/components/ui/input-group"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle
+} from "@/components/ui/sheet"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@/components/ui/table"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { adminPlugin } from "@/lib/auth/admin-plugin"
+
+type SearchField = "email" | "name"
+type StatusFilter = "all" | "active" | "banned"
+type SortDirection = "asc" | "desc"
+type DangerousAction = "ban" | "delete" | "impersonate" | "revokeAll"
+
+export type AdminUsersProps = {
+  className?: string
+  onSelectedUserIdChange?: (userId: string | undefined) => void
+  selectedUserId?: string
+}
+
+const formatDate = (value: Date | string | undefined | null) =>
+  value
+    ? new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(
+        new Date(value)
+      )
+    : "–"
+
+const asAdminRole = (role: string) => role as "user" | "admin"
+
+/** Server-paginated user management with optional controlled inspector state. */
+export function AdminUsers({
+  className,
+  onSelectedUserIdChange,
+  selectedUserId: controlledSelectedUserId
+}: AdminUsersProps) {
+  const auth = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const { localization } = config
+  const [localSelectedUserId, setLocalSelectedUserId] = useState<string>()
+  const [page, setPage] = useState(0)
+  const [search, setSearch] = useState("")
+  const [searchField, setSearchField] = useState<SearchField>("email")
+  const [status, setStatus] = useState<StatusFilter>("all")
+  const [sortBy, setSortBy] = useState("createdAt")
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc")
+  const [createOpen, setCreateOpen] = useState(false)
+  const deferredSearch = useDeferredValue(search.trim())
+  const isSelectionControlled = onSelectedUserIdChange !== undefined
+  const selectedUserId = isSelectionControlled
+    ? controlledSelectedUserId
+    : localSelectedUserId
+
+  const setSelectedUserId = (userId: string | undefined) => {
+    if (!isSelectionControlled) setLocalSelectedUserId(userId)
+    onSelectedUserIdChange?.(userId)
+  }
+
+  const params = useMemo<AdminListUsersParams>(
+    () => ({
+      limit: config.pageSize,
+      offset: page * config.pageSize,
+      searchField,
+      searchOperator: "contains",
+      searchValue: deferredSearch || undefined,
+      sortBy,
+      sortDirection,
+      ...(status === "all"
+        ? {}
+        : {
+            filterField: "banned",
+            filterOperator: "eq" as const,
+            filterValue: status === "banned"
+          })
+    }),
+    [
+      config.pageSize,
+      deferredSearch,
+      page,
+      searchField,
+      sortBy,
+      sortDirection,
+      status
+    ]
+  )
+  const permission = useAdminPermission(auth.authClient, { user: ["list"] })
+  const users = useAdminUsers(auth.authClient, {
+    enabled: permission.data?.success === true,
+    params,
+    placeholderData: keepPreviousData
+  })
+  const canCreate = useAdminPermission(auth.authClient, { user: ["create"] })
+
+  const changeSort = (field: string) => {
+    if (sortBy === field) {
+      setSortDirection((value) => (value === "asc" ? "desc" : "asc"))
+    } else {
+      setSortBy(field)
+      setSortDirection("asc")
+    }
+  }
+
+  const total = users.data?.total ?? 0
+  const from = total ? page * config.pageSize + 1 : 0
+  const to = Math.min(total, (page + 1) * config.pageSize)
+
+  return (
+    <section className={className}>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div className="flex flex-col gap-1">
+            <h1 className="text-xl font-semibold tracking-tight">
+              {localization.users}
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              {localization.usersDescription}
+            </p>
+          </div>
+          {canCreate.isPending ? (
+            <Skeleton className="h-8 w-28" />
+          ) : canCreate.data?.success ? (
+            <Button onClick={() => setCreateOpen(true)}>
+              <UserPlusIcon />
+              {localization.createUser}
+            </Button>
+          ) : null}
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Select
+            value={searchField}
+            onValueChange={(value) => {
+              setSearchField(value as SearchField)
+              setPage(0)
+            }}
+          >
+            <SelectTrigger
+              aria-label={localization.search}
+              className="w-full sm:w-36"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="email">{localization.email}</SelectItem>
+              <SelectItem value="name">{localization.name}</SelectItem>
+            </SelectContent>
+          </Select>
+          <InputGroup className="sm:max-w-md">
+            <InputGroupAddon>
+              <SearchIcon />
+            </InputGroupAddon>
+            <InputGroupInput
+              aria-label={
+                searchField === "email"
+                  ? localization.searchByEmail
+                  : localization.searchByName
+              }
+              onChange={(event) => {
+                setSearch(event.target.value)
+                setPage(0)
+              }}
+              placeholder={
+                searchField === "email"
+                  ? localization.searchByEmail
+                  : localization.searchByName
+              }
+              value={search}
+            />
+          </InputGroup>
+          <Select
+            value={status}
+            onValueChange={(value) => {
+              setStatus(value as StatusFilter)
+              setPage(0)
+            }}
+          >
+            <SelectTrigger
+              aria-label={localization.status}
+              className="w-full sm:w-36"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">{localization.status}</SelectItem>
+              <SelectItem value="active">{localization.active}</SelectItem>
+              <SelectItem value="banned">{localization.banned}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {permission.isPending ? (
+          <UserTableSkeleton />
+        ) : !permission.data?.success ? (
+          <AdminState
+            icon={<ShieldAlertIcon />}
+            title={localization.accessDenied}
+            description={localization.accessDeniedDescription}
+          />
+        ) : users.isError ? (
+          <AdminState
+            icon={<ShieldAlertIcon />}
+            title={localization.loadUsersError}
+            description={localization.loadUsersErrorDescription}
+            action={
+              <Button variant="outline" onClick={() => users.refetch()}>
+                {localization.retry}
+              </Button>
+            }
+          />
+        ) : (
+          <div className="overflow-hidden rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>
+                    <SortButton
+                      active={sortBy === "name"}
+                      direction={sortDirection}
+                      onClick={() => changeSort("name")}
+                    >
+                      {localization.name}
+                    </SortButton>
+                  </TableHead>
+                  <TableHead className="hidden md:table-cell">
+                    <SortButton
+                      active={sortBy === "role"}
+                      direction={sortDirection}
+                      onClick={() => changeSort("role")}
+                    >
+                      {localization.role}
+                    </SortButton>
+                  </TableHead>
+                  <TableHead>{localization.status}</TableHead>
+                  <TableHead className="hidden lg:table-cell">
+                    <SortButton
+                      active={sortBy === "createdAt"}
+                      direction={sortDirection}
+                      onClick={() => changeSort("createdAt")}
+                    >
+                      {localization.created}
+                    </SortButton>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {users.isPending ? (
+                  <UserRowsSkeleton />
+                ) : users.data?.users.length ? (
+                  users.data.users.map((user) => (
+                    <TableRow
+                      key={user.id}
+                      aria-selected={selectedUserId === user.id}
+                      className="cursor-pointer"
+                      onClick={() => setSelectedUserId(user.id)}
+                    >
+                      <TableCell>
+                        <div className="flex items-center gap-3">
+                          <UserAvatar className="size-8" user={user} />
+                          <div className="min-w-0">
+                            <div className="truncate font-medium">
+                              {user.name}
+                            </div>
+                            <div className="truncate text-xs text-muted-foreground">
+                              {user.email}
+                            </div>
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell className="hidden md:table-cell">
+                        <Badge variant="outline">
+                          {user.role ?? config.defaultRole}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={user.banned ? "destructive" : "secondary"}
+                        >
+                          {user.banned
+                            ? localization.banned
+                            : localization.active}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="hidden text-muted-foreground lg:table-cell">
+                        {formatDate(user.createdAt)}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={4} className="h-40 text-center">
+                      <strong className="block font-medium">
+                        {localization.noUsers}
+                      </strong>
+                      <span className="text-muted-foreground">
+                        {localization.noUsersDescription}
+                      </span>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+
+        <div className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
+          <span>
+            {localization.usersPaginationRange
+              .replace("{{from}}", String(from))
+              .replace("{{to}}", String(to))
+              .replace("{{total}}", String(total))}
+          </span>
+          <div className="flex gap-1">
+            <Button
+              aria-label={localization.previousPage}
+              disabled={page === 0 || users.isFetching}
+              onClick={() => setPage((value) => Math.max(0, value - 1))}
+              size="icon-sm"
+              variant="outline"
+            >
+              <ChevronLeftIcon />
+            </Button>
+            <Button
+              aria-label={localization.nextPage}
+              disabled={to >= total || users.isFetching}
+              onClick={() => setPage((value) => value + 1)}
+              size="icon-sm"
+              variant="outline"
+            >
+              <ChevronRightIcon />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <CreateUserDialog open={createOpen} onOpenChange={setCreateOpen} />
+      <UserInspector
+        open={Boolean(selectedUserId)}
+        onOpenChange={(open) => !open && setSelectedUserId(undefined)}
+        userId={selectedUserId}
+      />
+    </section>
+  )
+}
+
+function SortButton({
+  active,
+  children,
+  direction,
+  onClick
+}: {
+  active: boolean
+  children: React.ReactNode
+  direction: SortDirection
+  onClick: () => void
+}) {
+  return (
+    <button
+      className="inline-flex items-center gap-1 hover:text-foreground"
+      onClick={onClick}
+      type="button"
+    >
+      {children}
+      {active ? (direction === "asc" ? "↑" : "↓") : null}
+    </button>
+  )
+}
+
+function AdminState({
+  action,
+  description,
+  icon,
+  title
+}: {
+  action?: React.ReactNode
+  description: string
+  icon: React.ReactNode
+  title: string
+}) {
+  return (
+    <div className="flex min-h-64 flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-8 text-center">
+      <span className="text-muted-foreground [&>svg]:size-8">{icon}</span>
+      <div className="flex flex-col gap-1">
+        <h2 className="font-medium">{title}</h2>
+        <p className="max-w-md text-sm text-muted-foreground">{description}</p>
+      </div>
+      {action}
+    </div>
+  )
+}
+
+const skeletonRowIds = [
+  "admin-row-1",
+  "admin-row-2",
+  "admin-row-3",
+  "admin-row-4",
+  "admin-row-5"
+]
+
+function UserRowsSkeleton() {
+  return skeletonRowIds.map((id) => (
+    <TableRow key={id}>
+      <TableCell>
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-8 rounded-full" />
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-48" />
+          </div>
+        </div>
+      </TableCell>
+      <TableCell className="hidden md:table-cell">
+        <Skeleton className="h-5 w-16" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-5 w-16" />
+      </TableCell>
+      <TableCell className="hidden lg:table-cell">
+        <Skeleton className="h-4 w-24" />
+      </TableCell>
+    </TableRow>
+  ))
+}
+
+function UserTableSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-lg border">
+      <Table>
+        <TableBody>
+          <UserRowsSkeleton />
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+function CreateUserDialog({
+  open,
+  onOpenChange
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const auth = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const { data: session } = useSession(auth.authClient)
+  const [password, setPassword] = useState("")
+  const createUser = useMutation(
+    createAdminUserOptions(auth.authClient, session?.user.id)
+  )
+
+  const close = () => {
+    setPassword("")
+    createUser.reset()
+    onOpenChange(false)
+  }
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const data = new FormData(event.currentTarget)
+    createUser.mutate(
+      {
+        email: String(data.get("email")),
+        name: String(data.get("name")),
+        password,
+        role: asAdminRole(String(data.get("role") || config.defaultRole))
+      },
+      { onSuccess: close }
+    )
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(value) => (value ? onOpenChange(true) : close())}
+    >
+      <DialogContent>
+        <form className="flex flex-col gap-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{config.localization.createUser}</DialogTitle>
+            <DialogDescription>
+              {config.localization.usersDescription}
+            </DialogDescription>
+          </DialogHeader>
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor="admin-create-name">
+                {config.localization.name}
+              </FieldLabel>
+              <InputGroup>
+                <InputGroupInput id="admin-create-name" name="name" required />
+              </InputGroup>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="admin-create-email">
+                {config.localization.email}
+              </FieldLabel>
+              <InputGroup>
+                <InputGroupInput
+                  autoComplete="off"
+                  id="admin-create-email"
+                  name="email"
+                  required
+                  type="email"
+                />
+              </InputGroup>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="admin-create-password">
+                {config.localization.password}
+              </FieldLabel>
+              <InputGroup>
+                <InputGroupInput
+                  autoComplete="new-password"
+                  id="admin-create-password"
+                  onChange={(event) => setPassword(event.target.value)}
+                  required
+                  type="password"
+                  value={password}
+                />
+              </InputGroup>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="admin-create-role">
+                {config.localization.role}
+              </FieldLabel>
+              <select
+                className="h-8 rounded-lg border bg-transparent px-2 text-sm"
+                defaultValue={config.defaultRole}
+                id="admin-create-role"
+                name="role"
+              >
+                {config.roles.map((role) => (
+                  <option key={role} value={role}>
+                    {role}
+                  </option>
+                ))}
+              </select>
+            </Field>
+          </FieldGroup>
+          <DialogFooter>
+            <Button onClick={close} type="button" variant="outline">
+              {config.localization.cancel}
+            </Button>
+            <Button disabled={createUser.isPending} type="submit">
+              {config.localization.createUser}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function UserInspector({
+  open,
+  onOpenChange,
+  userId
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  userId?: string
+}) {
+  const auth = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const detail = useAdminUser(auth.authClient, userId)
+  const sessionsPermission = useAdminPermission(
+    auth.authClient,
+    {
+      session: ["list"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const sessions = useAdminUserSessions(auth.authClient, userId, {
+    enabled: sessionsPermission.data?.success === true
+  })
+  const { data: actor } = useSession(auth.authClient)
+  const canSetRole = useAdminPermission(
+    auth.authClient,
+    {
+      user: ["set-role"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const canSetPassword = useAdminPermission(
+    auth.authClient,
+    {
+      user: ["set-password"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const canBan = useAdminPermission(
+    auth.authClient,
+    { user: ["ban"] },
+    { enabled: Boolean(userId) }
+  )
+  const canImpersonate = useAdminPermission(
+    auth.authClient,
+    {
+      user: ["impersonate"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const canDelete = useAdminPermission(
+    auth.authClient,
+    { user: ["delete"] },
+    { enabled: Boolean(userId) }
+  )
+  const canRevoke = useAdminPermission(
+    auth.authClient,
+    {
+      session: ["revoke"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const [role, setRole] = useState(config.defaultRole)
+  const [passwordOpen, setPasswordOpen] = useState(false)
+  const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
+  const user = detail.data
+  const isSelf = user?.id === actor?.user.id
+  useEffect(() => {
+    if (user?.role) setRole(user.role)
+  }, [user?.role])
+
+  const setRoleMutation = useMutation(
+    setAdminUserRoleOptions(auth.authClient, actor?.user.id)
+  )
+  const ban = useMutation(banAdminUserOptions(auth.authClient, actor?.user.id))
+  const unban = useMutation(
+    unbanAdminUserOptions(auth.authClient, actor?.user.id)
+  )
+  const remove = useMutation(
+    removeAdminUserOptions(auth.authClient, actor?.user.id)
+  )
+  const impersonate = useMutation(
+    impersonateAdminUserOptions(auth.authClient, actor?.user.id)
+  )
+  const revokeSession = useMutation(
+    revokeAdminUserSessionOptions(auth.authClient, actor?.user.id, userId)
+  )
+  const revokeSessions = useMutation(
+    revokeAdminUserSessionsOptions(auth.authClient, actor?.user.id, userId)
+  )
+
+  const confirm = () => {
+    if (!user) return
+    if (dangerousAction === "ban")
+      ban.mutate(
+        { userId: user.id },
+        { onSuccess: () => setDangerousAction(undefined) }
+      )
+    if (dangerousAction === "delete")
+      remove.mutate(
+        { userId: user.id },
+        {
+          onSuccess: () => {
+            setDangerousAction(undefined)
+            onOpenChange(false)
+          }
+        }
+      )
+    if (dangerousAction === "revokeAll")
+      revokeSessions.mutate(
+        { userId: user.id },
+        { onSuccess: () => setDangerousAction(undefined) }
+      )
+    if (dangerousAction === "impersonate")
+      impersonate.mutate(
+        { userId: user.id },
+        {
+          onSuccess: () => {
+            setDangerousAction(undefined)
+            if (config.impersonationRedirectTo)
+              auth.navigate({ to: config.impersonationRedirectTo })
+          }
+        }
+      )
+  }
+  const dangerLabel =
+    dangerousAction === "ban"
+      ? config.localization.banUser
+      : dangerousAction === "delete"
+        ? config.localization.deleteUser
+        : dangerousAction === "revokeAll"
+          ? config.localization.revokeAllSessions
+          : config.localization.impersonateUser
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent className="w-full overflow-y-auto sm:max-w-lg">
+          <SheetHeader>
+            <SheetTitle>{config.localization.userDetails}</SheetTitle>
+            <SheetDescription>
+              {user?.email ?? config.localization.usersDescription}
+            </SheetDescription>
+          </SheetHeader>
+          {detail.isPending ? (
+            <div className="flex flex-col gap-3 p-4">
+              <Skeleton className="size-14 rounded-full" />
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-4 w-64" />
+            </div>
+          ) : user ? (
+            <Tabs className="px-4 pb-6" defaultValue="overview">
+              <TabsList>
+                <TabsTrigger value="overview">
+                  {config.localization.overview}
+                </TabsTrigger>
+                <TabsTrigger value="sessions">
+                  {config.localization.sessions}
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent
+                className="flex flex-col gap-6 pt-4"
+                value="overview"
+              >
+                <div className="flex items-center gap-3">
+                  <UserAvatar className="size-12" user={user} />
+                  <div>
+                    <div className="font-medium">{user.name}</div>
+                    <div className="text-sm text-muted-foreground">
+                      {user.email}
+                    </div>
+                  </div>
+                </div>
+                <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-3 text-sm">
+                  <dt className="text-muted-foreground">
+                    {config.localization.userId}
+                  </dt>
+                  <dd className="flex min-w-0 items-center gap-1">
+                    <code className="truncate text-xs">{user.id}</code>
+                    <Button
+                      aria-label={config.localization.copyUserId}
+                      onClick={() => navigator.clipboard.writeText(user.id)}
+                      size="icon-xs"
+                      variant="ghost"
+                    >
+                      <CopyIcon />
+                    </Button>
+                  </dd>
+                  <dt className="text-muted-foreground">
+                    {config.localization.created}
+                  </dt>
+                  <dd>{formatDate(user.createdAt)}</dd>
+                  <dt className="text-muted-foreground">
+                    {config.localization.status}
+                  </dt>
+                  <dd>
+                    <Badge variant={user.banned ? "destructive" : "secondary"}>
+                      {user.banned
+                        ? config.localization.banned
+                        : config.localization.active}
+                    </Badge>
+                  </dd>
+                </dl>
+                <div className="flex items-end gap-2">
+                  <Field className="flex-1">
+                    <FieldLabel>{config.localization.role}</FieldLabel>
+                    <Select value={role} onValueChange={setRole}>
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {config.roles.map((item) => (
+                          <SelectItem key={item} value={item}>
+                            {item}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </Field>
+                  <Button
+                    disabled={
+                      setRoleMutation.isPending ||
+                      canSetRole.isPending ||
+                      !canSetRole.data?.success ||
+                      isSelf
+                    }
+                    onClick={() =>
+                      setRoleMutation.mutate({
+                        userId: user.id,
+                        role: asAdminRole(role)
+                      })
+                    }
+                    variant="outline"
+                  >
+                    {config.localization.saveRole}
+                  </Button>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    disabled={
+                      canSetPassword.isPending || !canSetPassword.data?.success
+                    }
+                    onClick={() => setPasswordOpen(true)}
+                    variant="outline"
+                  >
+                    <KeyRoundIcon />
+                    {config.localization.setPassword}
+                  </Button>
+                  <Button
+                    disabled={
+                      canBan.isPending || !canBan.data?.success || isSelf
+                    }
+                    onClick={() =>
+                      user.banned
+                        ? unban.mutate({ userId: user.id })
+                        : setDangerousAction("ban")
+                    }
+                    variant="outline"
+                  >
+                    <BanIcon />
+                    {user.banned
+                      ? config.localization.unbanUser
+                      : config.localization.banUser}
+                  </Button>
+                  <Button
+                    disabled={
+                      canImpersonate.isPending ||
+                      !canImpersonate.data?.success ||
+                      isSelf
+                    }
+                    onClick={() => setDangerousAction("impersonate")}
+                    variant="outline"
+                  >
+                    <LogInIcon />
+                    {config.localization.impersonateUser}
+                  </Button>
+                  <Button
+                    disabled={
+                      canDelete.isPending || !canDelete.data?.success || isSelf
+                    }
+                    onClick={() => setDangerousAction("delete")}
+                    variant="destructive"
+                  >
+                    <Trash2Icon />
+                    {config.localization.deleteUser}
+                  </Button>
+                </div>
+              </TabsContent>
+              <TabsContent
+                className="flex flex-col gap-3 pt-4"
+                value="sessions"
+              >
+                {sessionsPermission.isPending || sessions.isPending ? (
+                  skeletonRowIds
+                    .slice(0, 3)
+                    .map((id) => (
+                      <Skeleton className="h-20 w-full" key={`session-${id}`} />
+                    ))
+                ) : !sessionsPermission.data?.success ? (
+                  <p className="text-sm text-muted-foreground">
+                    {config.localization.accessDeniedDescription}
+                  </p>
+                ) : sessions.data?.sessions.length ? (
+                  <>
+                    <Button
+                      className="self-end"
+                      disabled={
+                        canRevoke.isPending ||
+                        !canRevoke.data?.success ||
+                        isSelf
+                      }
+                      onClick={() => setDangerousAction("revokeAll")}
+                      variant="outline"
+                    >
+                      {config.localization.revokeAllSessions}
+                    </Button>
+                    {sessions.data.sessions.map((item) => (
+                      <div
+                        className="flex items-start justify-between gap-3 rounded-lg border p-3"
+                        key={item.id}
+                      >
+                        <div className="min-w-0 text-sm">
+                          <div className="truncate font-medium">
+                            {item.userAgent || config.localization.sessions}
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            {formatDate(item.createdAt)} ·{" "}
+                            {formatDate(item.expiresAt)}
+                          </div>
+                          {config.showIpAddress && item.ipAddress ? (
+                            <div className="mt-1 font-mono text-xs text-muted-foreground">
+                              {item.ipAddress}
+                            </div>
+                          ) : null}
+                        </div>
+                        <Button
+                          aria-label={config.localization.revoke}
+                          disabled={
+                            revokeSession.isPending ||
+                            canRevoke.isPending ||
+                            !canRevoke.data?.success ||
+                            isSelf
+                          }
+                          onClick={() =>
+                            revokeSession.mutate({ sessionToken: item.token })
+                          }
+                          size="icon-sm"
+                          variant="ghost"
+                        >
+                          <Trash2Icon />
+                        </Button>
+                      </div>
+                    ))}
+                  </>
+                ) : (
+                  <p className="py-8 text-center text-sm text-muted-foreground">
+                    {config.localization.noSessions}
+                  </p>
+                )}
+              </TabsContent>
+            </Tabs>
+          ) : (
+            <AdminState
+              icon={<ShieldAlertIcon />}
+              title={config.localization.loadUsersError}
+              description={config.localization.loadUsersErrorDescription}
+            />
+          )}
+        </SheetContent>
+      </Sheet>
+      <PasswordDialog
+        open={passwordOpen}
+        onOpenChange={setPasswordOpen}
+        userId={user?.id}
+      />
+      <AlertDialog
+        open={Boolean(dangerousAction)}
+        onOpenChange={(value) => !value && setDangerousAction(undefined)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{dangerLabel}</AlertDialogTitle>
+            <AlertDialogDescription>{user?.email}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{config.localization.cancel}</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isSelf}
+              onClick={confirm}
+              variant={dangerousAction === "delete" ? "destructive" : "default"}
+            >
+              {dangerLabel}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}
+
+function PasswordDialog({
+  open,
+  onOpenChange,
+  userId
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  userId?: string
+}) {
+  const auth = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const [password, setPassword] = useState("")
+  const mutation = useMutation(setAdminUserPasswordOptions(auth.authClient))
+  const close = () => {
+    setPassword("")
+    mutation.reset()
+    onOpenChange(false)
+  }
+  const submit = (event: FormEvent) => {
+    event.preventDefault()
+    if (userId)
+      mutation.mutate(
+        { userId, newPassword: password },
+        { onSuccess: close, onSettled: () => setPassword("") }
+      )
+  }
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(value) => (value ? onOpenChange(true) : close())}
+    >
+      <DialogContent>
+        <form className="flex flex-col gap-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{config.localization.setPassword}</DialogTitle>
+            <DialogDescription>
+              {config.localization.userDetails}
+            </DialogDescription>
+          </DialogHeader>
+          <Field>
+            <FieldLabel htmlFor="admin-new-password">
+              {config.localization.password}
+            </FieldLabel>
+            <InputGroup>
+              <InputGroupInput
+                autoComplete="new-password"
+                id="admin-new-password"
+                onChange={(event) => setPassword(event.target.value)}
+                required
+                type="password"
+                value={password}
+              />
+            </InputGroup>
+          </Field>
+          <DialogFooter>
+            <Button onClick={close} type="button" variant="outline">
+              {config.localization.cancel}
+            </Button>
+            <Button disabled={!password || mutation.isPending} type="submit">
+              {config.localization.setPassword}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -354,9 +354,16 @@ export function AdminUsers({
                         <div className="flex items-center gap-3">
                           <UserAvatar className="size-8" user={user} />
                           <div className="min-w-0">
-                            <div className="truncate font-medium">
-                              {user.name}
-                            </div>
+                            <Button
+                              className="h-auto min-w-0 justify-start p-0 font-medium"
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                setSelectedUserId(user.id)
+                              }}
+                              variant="link"
+                            >
+                              <span className="truncate">{user.name}</span>
+                            </Button>
                             <div className="truncate text-xs text-muted-foreground">
                               {user.email}
                             </div>
@@ -881,6 +888,11 @@ function UserInspector({
                         ))}
                       </SelectContent>
                     </Select>
+                    {setRoleMutation.error ? (
+                      <FieldError>
+                        {getAdminErrorMessage(setRoleMutation.error)}
+                      </FieldError>
+                    ) : null}
                   </Field>
                   <Button
                     disabled={
@@ -950,6 +962,9 @@ function UserInspector({
                     {config.localization.deleteUser}
                   </Button>
                 </div>
+                {unban.error ? (
+                  <FieldError>{getAdminErrorMessage(unban.error)}</FieldError>
+                ) : null}
               </TabsContent>
               <TabsContent
                 className="flex flex-col gap-3 pt-4"
@@ -1058,7 +1073,10 @@ function UserInspector({
             <AlertDialogCancel>{config.localization.cancel}</AlertDialogCancel>
             <AlertDialogAction
               disabled={isSelf || dangerousMutation.isPending}
-              onClick={confirm}
+              onClick={(event) => {
+                event.preventDefault()
+                confirm()
+              }}
               variant={dangerousAction === "delete" ? "destructive" : "default"}
             >
               {dangerLabel}

--- a/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -21,6 +21,7 @@ import {
   useAdminUsers
 } from "@better-auth-ui/react/plugins/admin"
 import { keepPreviousData, useMutation } from "@tanstack/react-query"
+import type { BetterFetchError } from "better-auth/react"
 import {
   BanIcon,
   ChevronLeftIcon,
@@ -61,7 +62,12 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel
+} from "@/components/ui/field"
 import {
   InputGroup,
   InputGroupAddon,
@@ -112,6 +118,11 @@ const formatDate = (value: Date | string | undefined | null) =>
     : "–"
 
 const asAdminRole = (role: string) => role as "user" | "admin"
+
+const getAdminErrorMessage = (error: Error | null) => {
+  const authError = error as BetterFetchError | null
+  return authError?.error?.message ?? authError?.message
+}
 
 /** Server-paginated user management with optional controlled inspector state. */
 export function AdminUsers({
@@ -177,6 +188,7 @@ export function AdminUsers({
   const canCreate = useAdminPermission(auth.authClient, { user: ["create"] })
 
   const changeSort = (field: string) => {
+    setPage(0)
     if (sortBy === field) {
       setSortDirection((value) => (value === "asc" ? "desc" : "asc"))
     } else {
@@ -621,6 +633,7 @@ function CreateUserDialog({
               </select>
             </Field>
           </FieldGroup>
+          <FieldError>{getAdminErrorMessage(createUser.error)}</FieldError>
           <DialogFooter>
             <Button onClick={close} type="button" variant="outline">
               {config.localization.cancel}
@@ -759,6 +772,22 @@ function UserInspector({
         }
       )
   }
+  const closeDangerousAction = () => {
+    ban.reset()
+    remove.reset()
+    revokeSessions.reset()
+    impersonate.reset()
+    setDangerousAction(undefined)
+  }
+  const dangerousMutation =
+    dangerousAction === "ban"
+      ? ban
+      : dangerousAction === "delete"
+        ? remove
+        : dangerousAction === "revokeAll"
+          ? revokeSessions
+          : impersonate
+  const dangerousError = getAdminErrorMessage(dangerousMutation.error)
   const dangerLabel =
     dangerousAction === "ban"
       ? config.localization.banUser
@@ -1011,17 +1040,24 @@ function UserInspector({
       />
       <AlertDialog
         open={Boolean(dangerousAction)}
-        onOpenChange={(value) => !value && setDangerousAction(undefined)}
+        onOpenChange={(value) => !value && closeDangerousAction()}
       >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{dangerLabel}</AlertDialogTitle>
-            <AlertDialogDescription>{user?.email}</AlertDialogDescription>
+            <AlertDialogDescription className="flex flex-col gap-2">
+              <span>{user?.email}</span>
+              {dangerousError ? (
+                <span className="text-destructive" role="alert">
+                  {dangerousError}
+                </span>
+              ) : null}
+            </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{config.localization.cancel}</AlertDialogCancel>
             <AlertDialogAction
-              disabled={isSelf}
+              disabled={isSelf || dangerousMutation.isPending}
               onClick={confirm}
               variant={dangerousAction === "delete" ? "destructive" : "default"}
             >
@@ -1046,18 +1082,28 @@ function PasswordDialog({
   const auth = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
   const [password, setPassword] = useState("")
-  const mutation = useMutation(setAdminUserPasswordOptions(auth.authClient))
+  const [errorMessage, setErrorMessage] = useState<string>()
+  const mutation = useMutation(
+    setAdminUserPasswordOptions(auth.authClient, () => {
+      setTimeout(() => mutation.reset(), 0)
+    })
+  )
   const close = () => {
     setPassword("")
+    setErrorMessage(undefined)
     mutation.reset()
     onOpenChange(false)
   }
   const submit = (event: FormEvent) => {
     event.preventDefault()
+    setErrorMessage(undefined)
     if (userId)
       mutation.mutate(
         { userId, newPassword: password },
-        { onSuccess: close, onSettled: () => setPassword("") }
+        {
+          onError: (error) => setErrorMessage(getAdminErrorMessage(error)),
+          onSuccess: close
+        }
       )
   }
   return (
@@ -1073,12 +1119,13 @@ function PasswordDialog({
               {config.localization.userDetails}
             </DialogDescription>
           </DialogHeader>
-          <Field>
+          <Field data-invalid={Boolean(errorMessage)}>
             <FieldLabel htmlFor="admin-new-password">
               {config.localization.password}
             </FieldLabel>
             <InputGroup>
               <InputGroupInput
+                aria-invalid={Boolean(errorMessage)}
                 autoComplete="new-password"
                 id="admin-new-password"
                 onChange={(event) => setPassword(event.target.value)}
@@ -1087,6 +1134,7 @@ function PasswordDialog({
                 value={password}
               />
             </InputGroup>
+            <FieldError>{errorMessage}</FieldError>
           </Field>
           <DialogFooter>
             <Button onClick={close} type="button" variant="outline">

--- a/examples/next-shadcn-example/src/components/auth/admin/admin.tsx
+++ b/examples/next-shadcn-example/src/components/auth/admin/admin.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import type { AdminView } from "@better-auth-ui/core"
+import { useAuth, useAuthenticate, useAuthPlugin } from "@better-auth-ui/react"
+import { ShieldAlertIcon, UsersIcon } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { adminPlugin } from "@/lib/auth/admin-plugin"
+import { cn } from "@/lib/utils"
+
+import { AdminUsers } from "./admin-users"
+
+export type AdminProps = {
+  className?: string
+  hideNav?: boolean
+  path?: string
+  view?: AdminView | string
+}
+
+/** Render a finite, static administration route and plugin-contributed tabs. */
+export function Admin({ className, hideNav, path, view }: AdminProps) {
+  const { authClient, basePaths, plugins, viewPaths } = useAuth()
+  const { localization } = useAuthPlugin(adminPlugin)
+  useAuthenticate(authClient)
+
+  if (!view && !path) {
+    throw new Error("[Better Auth UI] Either `view` or `path` must be provided")
+  }
+
+  const contributedTabs = plugins.flatMap((plugin) => plugin.adminTabs ?? [])
+  const currentView =
+    view ??
+    (viewPaths.admin.users === path ? "users" : undefined) ??
+    contributedTabs.find((tab) => tab.path === path)?.id
+  const contributedView = contributedTabs.find((tab) => tab.id === currentView)
+
+  return (
+    <div className={cn("flex w-full flex-col gap-6", className)}>
+      {!hideNav && (
+        <nav aria-label={localization.admin} className="flex gap-1 border-b">
+          <Button
+            aria-current={currentView === "users" ? "page" : undefined}
+            asChild
+            className="rounded-b-none"
+            variant={currentView === "users" ? "secondary" : "ghost"}
+          >
+            <a href={`${basePaths.admin}/${viewPaths.admin.users}`}>
+              <UsersIcon />
+              {localization.users}
+            </a>
+          </Button>
+
+          {contributedTabs.map((tab) => (
+            <Button
+              key={`${tab.id}-${tab.path}`}
+              aria-current={currentView === tab.id ? "page" : undefined}
+              asChild
+              className="rounded-b-none"
+              variant={currentView === tab.id ? "secondary" : "ghost"}
+            >
+              <a href={`${basePaths.admin}/${tab.path}`}>{tab.label}</a>
+            </Button>
+          ))}
+        </nav>
+      )}
+
+      {currentView === "users" ? (
+        <AdminUsers />
+      ) : contributedView ? (
+        <contributedView.component />
+      ) : (
+        <div className="flex min-h-64 flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-8 text-center">
+          <ShieldAlertIcon className="size-8 text-muted-foreground" />
+          <div className="flex flex-col gap-1">
+            <h2 className="font-medium">{localization.unknownView}</h2>
+            <p className="max-w-md text-sm text-muted-foreground">
+              {localization.unknownViewDescription} &quot;{path ?? view}&quot;
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/examples/next-shadcn-example/src/components/ui/sheet.tsx
+++ b/examples/next-shadcn-example/src/components/ui/sheet.tsx
@@ -1,0 +1,137 @@
+"use client"
+
+import { XIcon } from "lucide-react"
+import * as React from "react"
+import { Dialog as SheetPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Sheet(props: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger(props: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose(props: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal(props: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        data-side={side}
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close asChild data-slot="sheet-close">
+            <Button
+              className="absolute top-3 right-3"
+              size="icon-sm"
+              variant="ghost"
+            >
+              <XIcon />
+              <span className="sr-only">Close</span>
+            </Button>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-0.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-base font-medium text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger
+}

--- a/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
@@ -354,9 +354,16 @@ export function AdminUsers({
                         <div className="flex items-center gap-3">
                           <UserAvatar className="size-8" user={user} />
                           <div className="min-w-0">
-                            <div className="truncate font-medium">
-                              {user.name}
-                            </div>
+                            <Button
+                              className="h-auto min-w-0 justify-start p-0 font-medium"
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                setSelectedUserId(user.id)
+                              }}
+                              variant="link"
+                            >
+                              <span className="truncate">{user.name}</span>
+                            </Button>
                             <div className="truncate text-xs text-muted-foreground">
                               {user.email}
                             </div>
@@ -884,6 +891,11 @@ function UserInspector({
                         ))}
                       </SelectContent>
                     </Select>
+                    {setRoleMutation.error ? (
+                      <FieldError>
+                        {getAdminErrorMessage(setRoleMutation.error)}
+                      </FieldError>
+                    ) : null}
                   </Field>
                   <Button
                     disabled={
@@ -953,6 +965,9 @@ function UserInspector({
                     {config.localization.deleteUser}
                   </Button>
                 </div>
+                {unban.error ? (
+                  <FieldError>{getAdminErrorMessage(unban.error)}</FieldError>
+                ) : null}
               </TabsContent>
               <TabsContent
                 className="flex flex-col gap-3 pt-4"
@@ -1061,7 +1076,10 @@ function UserInspector({
             <AlertDialogCancel>{config.localization.cancel}</AlertDialogCancel>
             <AlertDialogAction
               disabled={isSelf || dangerousMutation.isPending}
-              onClick={confirm}
+              onClick={(event) => {
+                event.preventDefault()
+                confirm()
+              }}
               variant={dangerousAction === "delete" ? "destructive" : "default"}
             >
               {dangerLabel}

--- a/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
@@ -1,0 +1,1106 @@
+"use client"
+
+import {
+  type AdminAuthClient,
+  type AdminListUsersParams,
+  banAdminUserOptions,
+  createAdminUserOptions,
+  impersonateAdminUserOptions,
+  removeAdminUserOptions,
+  revokeAdminUserSessionOptions,
+  revokeAdminUserSessionsOptions,
+  setAdminUserPasswordOptions,
+  setAdminUserRoleOptions,
+  unbanAdminUserOptions
+} from "@better-auth-ui/core/plugins/admin"
+import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
+import {
+  useAdminPermission,
+  useAdminUser,
+  useAdminUserSessions,
+  useAdminUsers
+} from "@better-auth-ui/react/plugins/admin"
+import { keepPreviousData, useMutation } from "@tanstack/react-query"
+import {
+  BanIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CopyIcon,
+  KeyRoundIcon,
+  LogInIcon,
+  SearchIcon,
+  ShieldAlertIcon,
+  Trash2Icon,
+  UserPlusIcon
+} from "lucide-react"
+import {
+  type FormEvent,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState
+} from "react"
+import { UserAvatar } from "@/components/auth/user/user-avatar"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput
+} from "@/components/ui/input-group"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle
+} from "@/components/ui/sheet"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@/components/ui/table"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { adminPlugin } from "@/lib/auth/admin-plugin"
+
+type SearchField = "email" | "name"
+type StatusFilter = "all" | "active" | "banned"
+type SortDirection = "asc" | "desc"
+type DangerousAction = "ban" | "delete" | "impersonate" | "revokeAll"
+
+export type AdminUsersProps = {
+  className?: string
+  onSelectedUserIdChange?: (userId: string | undefined) => void
+  selectedUserId?: string
+}
+
+const formatDate = (value: Date | string | undefined | null) =>
+  value
+    ? new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(
+        new Date(value)
+      )
+    : "–"
+
+const asAdminRole = (role: string) => role as "user" | "admin"
+
+/** Server-paginated user management with optional controlled inspector state. */
+export function AdminUsers({
+  className,
+  onSelectedUserIdChange,
+  selectedUserId: controlledSelectedUserId
+}: AdminUsersProps) {
+  const auth = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const { localization } = config
+  const [localSelectedUserId, setLocalSelectedUserId] = useState<string>()
+  const [page, setPage] = useState(0)
+  const [search, setSearch] = useState("")
+  const [searchField, setSearchField] = useState<SearchField>("email")
+  const [status, setStatus] = useState<StatusFilter>("all")
+  const [sortBy, setSortBy] = useState("createdAt")
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc")
+  const [createOpen, setCreateOpen] = useState(false)
+  const deferredSearch = useDeferredValue(search.trim())
+  const isSelectionControlled = onSelectedUserIdChange !== undefined
+  const selectedUserId = isSelectionControlled
+    ? controlledSelectedUserId
+    : localSelectedUserId
+
+  const setSelectedUserId = (userId: string | undefined) => {
+    if (!isSelectionControlled) setLocalSelectedUserId(userId)
+    onSelectedUserIdChange?.(userId)
+  }
+
+  const params = useMemo<AdminListUsersParams>(
+    () => ({
+      limit: config.pageSize,
+      offset: page * config.pageSize,
+      searchField,
+      searchOperator: "contains",
+      searchValue: deferredSearch || undefined,
+      sortBy,
+      sortDirection,
+      ...(status === "all"
+        ? {}
+        : {
+            filterField: "banned",
+            filterOperator: "eq" as const,
+            filterValue: status === "banned"
+          })
+    }),
+    [
+      config.pageSize,
+      deferredSearch,
+      page,
+      searchField,
+      sortBy,
+      sortDirection,
+      status
+    ]
+  )
+  const permission = useAdminPermission(auth.authClient, { user: ["list"] })
+  const users = useAdminUsers(auth.authClient, {
+    enabled: permission.data?.success === true,
+    params,
+    placeholderData: keepPreviousData
+  })
+  const canCreate = useAdminPermission(auth.authClient, { user: ["create"] })
+
+  const changeSort = (field: string) => {
+    if (sortBy === field) {
+      setSortDirection((value) => (value === "asc" ? "desc" : "asc"))
+    } else {
+      setSortBy(field)
+      setSortDirection("asc")
+    }
+  }
+
+  const total = users.data?.total ?? 0
+  const from = total ? page * config.pageSize + 1 : 0
+  const to = Math.min(total, (page + 1) * config.pageSize)
+
+  return (
+    <section className={className}>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div className="flex flex-col gap-1">
+            <h1 className="text-xl font-semibold tracking-tight">
+              {localization.users}
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              {localization.usersDescription}
+            </p>
+          </div>
+          {canCreate.isPending ? (
+            <Skeleton className="h-8 w-28" />
+          ) : canCreate.data?.success ? (
+            <Button onClick={() => setCreateOpen(true)}>
+              <UserPlusIcon />
+              {localization.createUser}
+            </Button>
+          ) : null}
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Select
+            value={searchField}
+            onValueChange={(value) => {
+              setSearchField(value as SearchField)
+              setPage(0)
+            }}
+          >
+            <SelectTrigger
+              aria-label={localization.search}
+              className="w-full sm:w-36"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="email">{localization.email}</SelectItem>
+              <SelectItem value="name">{localization.name}</SelectItem>
+            </SelectContent>
+          </Select>
+          <InputGroup className="sm:max-w-md">
+            <InputGroupAddon>
+              <SearchIcon />
+            </InputGroupAddon>
+            <InputGroupInput
+              aria-label={
+                searchField === "email"
+                  ? localization.searchByEmail
+                  : localization.searchByName
+              }
+              onChange={(event) => {
+                setSearch(event.target.value)
+                setPage(0)
+              }}
+              placeholder={
+                searchField === "email"
+                  ? localization.searchByEmail
+                  : localization.searchByName
+              }
+              value={search}
+            />
+          </InputGroup>
+          <Select
+            value={status}
+            onValueChange={(value) => {
+              setStatus(value as StatusFilter)
+              setPage(0)
+            }}
+          >
+            <SelectTrigger
+              aria-label={localization.status}
+              className="w-full sm:w-36"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">{localization.status}</SelectItem>
+              <SelectItem value="active">{localization.active}</SelectItem>
+              <SelectItem value="banned">{localization.banned}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {permission.isPending ? (
+          <UserTableSkeleton />
+        ) : !permission.data?.success ? (
+          <AdminState
+            icon={<ShieldAlertIcon />}
+            title={localization.accessDenied}
+            description={localization.accessDeniedDescription}
+          />
+        ) : users.isError ? (
+          <AdminState
+            icon={<ShieldAlertIcon />}
+            title={localization.loadUsersError}
+            description={localization.loadUsersErrorDescription}
+            action={
+              <Button variant="outline" onClick={() => users.refetch()}>
+                {localization.retry}
+              </Button>
+            }
+          />
+        ) : (
+          <div className="overflow-hidden rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>
+                    <SortButton
+                      active={sortBy === "name"}
+                      direction={sortDirection}
+                      onClick={() => changeSort("name")}
+                    >
+                      {localization.name}
+                    </SortButton>
+                  </TableHead>
+                  <TableHead className="hidden md:table-cell">
+                    <SortButton
+                      active={sortBy === "role"}
+                      direction={sortDirection}
+                      onClick={() => changeSort("role")}
+                    >
+                      {localization.role}
+                    </SortButton>
+                  </TableHead>
+                  <TableHead>{localization.status}</TableHead>
+                  <TableHead className="hidden lg:table-cell">
+                    <SortButton
+                      active={sortBy === "createdAt"}
+                      direction={sortDirection}
+                      onClick={() => changeSort("createdAt")}
+                    >
+                      {localization.created}
+                    </SortButton>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {users.isPending ? (
+                  <UserRowsSkeleton />
+                ) : users.data?.users.length ? (
+                  users.data.users.map((user) => (
+                    <TableRow
+                      key={user.id}
+                      aria-selected={selectedUserId === user.id}
+                      className="cursor-pointer"
+                      onClick={() => setSelectedUserId(user.id)}
+                    >
+                      <TableCell>
+                        <div className="flex items-center gap-3">
+                          <UserAvatar className="size-8" user={user} />
+                          <div className="min-w-0">
+                            <div className="truncate font-medium">
+                              {user.name}
+                            </div>
+                            <div className="truncate text-xs text-muted-foreground">
+                              {user.email}
+                            </div>
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell className="hidden md:table-cell">
+                        <Badge variant="outline">
+                          {user.role ?? config.defaultRole}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={user.banned ? "destructive" : "secondary"}
+                        >
+                          {user.banned
+                            ? localization.banned
+                            : localization.active}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="hidden text-muted-foreground lg:table-cell">
+                        {formatDate(user.createdAt)}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={4} className="h-40 text-center">
+                      <strong className="block font-medium">
+                        {localization.noUsers}
+                      </strong>
+                      <span className="text-muted-foreground">
+                        {localization.noUsersDescription}
+                      </span>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+
+        <div className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
+          <span>
+            {localization.usersPaginationRange
+              .replace("{{from}}", String(from))
+              .replace("{{to}}", String(to))
+              .replace("{{total}}", String(total))}
+          </span>
+          <div className="flex gap-1">
+            <Button
+              aria-label={localization.previousPage}
+              disabled={page === 0 || users.isFetching}
+              onClick={() => setPage((value) => Math.max(0, value - 1))}
+              size="icon-sm"
+              variant="outline"
+            >
+              <ChevronLeftIcon />
+            </Button>
+            <Button
+              aria-label={localization.nextPage}
+              disabled={to >= total || users.isFetching}
+              onClick={() => setPage((value) => value + 1)}
+              size="icon-sm"
+              variant="outline"
+            >
+              <ChevronRightIcon />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <CreateUserDialog open={createOpen} onOpenChange={setCreateOpen} />
+      <UserInspector
+        open={Boolean(selectedUserId)}
+        onOpenChange={(open) => !open && setSelectedUserId(undefined)}
+        userId={selectedUserId}
+      />
+    </section>
+  )
+}
+
+function SortButton({
+  active,
+  children,
+  direction,
+  onClick
+}: {
+  active: boolean
+  children: React.ReactNode
+  direction: SortDirection
+  onClick: () => void
+}) {
+  return (
+    <button
+      className="inline-flex items-center gap-1 hover:text-foreground"
+      onClick={onClick}
+      type="button"
+    >
+      {children}
+      {active ? (direction === "asc" ? "↑" : "↓") : null}
+    </button>
+  )
+}
+
+function AdminState({
+  action,
+  description,
+  icon,
+  title
+}: {
+  action?: React.ReactNode
+  description: string
+  icon: React.ReactNode
+  title: string
+}) {
+  return (
+    <div className="flex min-h-64 flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-8 text-center">
+      <span className="text-muted-foreground [&>svg]:size-8">{icon}</span>
+      <div className="flex flex-col gap-1">
+        <h2 className="font-medium">{title}</h2>
+        <p className="max-w-md text-sm text-muted-foreground">{description}</p>
+      </div>
+      {action}
+    </div>
+  )
+}
+
+const skeletonRowIds = [
+  "admin-row-1",
+  "admin-row-2",
+  "admin-row-3",
+  "admin-row-4",
+  "admin-row-5"
+]
+
+function UserRowsSkeleton() {
+  return skeletonRowIds.map((id) => (
+    <TableRow key={id}>
+      <TableCell>
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-8 rounded-full" />
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-48" />
+          </div>
+        </div>
+      </TableCell>
+      <TableCell className="hidden md:table-cell">
+        <Skeleton className="h-5 w-16" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-5 w-16" />
+      </TableCell>
+      <TableCell className="hidden lg:table-cell">
+        <Skeleton className="h-4 w-24" />
+      </TableCell>
+    </TableRow>
+  ))
+}
+
+function UserTableSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-lg border">
+      <Table>
+        <TableBody>
+          <UserRowsSkeleton />
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+function CreateUserDialog({
+  open,
+  onOpenChange
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const auth = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const { data: session } = useSession(auth.authClient)
+  const [password, setPassword] = useState("")
+  const createUser = useMutation(
+    createAdminUserOptions(auth.authClient, session?.user.id)
+  )
+
+  const close = () => {
+    setPassword("")
+    createUser.reset()
+    onOpenChange(false)
+  }
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const data = new FormData(event.currentTarget)
+    createUser.mutate(
+      {
+        email: String(data.get("email")),
+        name: String(data.get("name")),
+        password,
+        role: asAdminRole(String(data.get("role") || config.defaultRole))
+      },
+      { onSuccess: close }
+    )
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(value) => (value ? onOpenChange(true) : close())}
+    >
+      <DialogContent>
+        <form className="flex flex-col gap-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{config.localization.createUser}</DialogTitle>
+            <DialogDescription>
+              {config.localization.usersDescription}
+            </DialogDescription>
+          </DialogHeader>
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor="admin-create-name">
+                {config.localization.name}
+              </FieldLabel>
+              <InputGroup>
+                <InputGroupInput id="admin-create-name" name="name" required />
+              </InputGroup>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="admin-create-email">
+                {config.localization.email}
+              </FieldLabel>
+              <InputGroup>
+                <InputGroupInput
+                  autoComplete="off"
+                  id="admin-create-email"
+                  name="email"
+                  required
+                  type="email"
+                />
+              </InputGroup>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="admin-create-password">
+                {config.localization.password}
+              </FieldLabel>
+              <InputGroup>
+                <InputGroupInput
+                  autoComplete="new-password"
+                  id="admin-create-password"
+                  onChange={(event) => setPassword(event.target.value)}
+                  required
+                  type="password"
+                  value={password}
+                />
+              </InputGroup>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="admin-create-role">
+                {config.localization.role}
+              </FieldLabel>
+              <select
+                className="h-8 rounded-lg border bg-transparent px-2 text-sm"
+                defaultValue={config.defaultRole}
+                id="admin-create-role"
+                name="role"
+              >
+                {config.roles.map((role) => (
+                  <option key={role} value={role}>
+                    {role}
+                  </option>
+                ))}
+              </select>
+            </Field>
+          </FieldGroup>
+          <DialogFooter>
+            <Button onClick={close} type="button" variant="outline">
+              {config.localization.cancel}
+            </Button>
+            <Button disabled={createUser.isPending} type="submit">
+              {config.localization.createUser}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function UserInspector({
+  open,
+  onOpenChange,
+  userId
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  userId?: string
+}) {
+  const auth = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const detail = useAdminUser(auth.authClient, userId)
+  const sessionsPermission = useAdminPermission(
+    auth.authClient,
+    {
+      session: ["list"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const sessions = useAdminUserSessions(auth.authClient, userId, {
+    enabled: sessionsPermission.data?.success === true
+  })
+  const { data: actor } = useSession(auth.authClient)
+  const canSetRole = useAdminPermission(
+    auth.authClient,
+    {
+      user: ["set-role"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const canSetPassword = useAdminPermission(
+    auth.authClient,
+    {
+      user: ["set-password"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const canBan = useAdminPermission(
+    auth.authClient,
+    { user: ["ban"] },
+    { enabled: Boolean(userId) }
+  )
+  const canImpersonate = useAdminPermission(
+    auth.authClient,
+    {
+      user: ["impersonate"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const canDelete = useAdminPermission(
+    auth.authClient,
+    { user: ["delete"] },
+    { enabled: Boolean(userId) }
+  )
+  const canRevoke = useAdminPermission(
+    auth.authClient,
+    {
+      session: ["revoke"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const [role, setRole] = useState(config.defaultRole)
+  const [passwordOpen, setPasswordOpen] = useState(false)
+  const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
+  const user = detail.data
+  const isSelf = user?.id === actor?.user.id
+  useEffect(() => {
+    if (user?.role) setRole(user.role)
+  }, [user?.role])
+
+  const setRoleMutation = useMutation(
+    setAdminUserRoleOptions(auth.authClient, actor?.user.id)
+  )
+  const ban = useMutation(banAdminUserOptions(auth.authClient, actor?.user.id))
+  const unban = useMutation(
+    unbanAdminUserOptions(auth.authClient, actor?.user.id)
+  )
+  const remove = useMutation(
+    removeAdminUserOptions(auth.authClient, actor?.user.id)
+  )
+  const impersonate = useMutation(
+    impersonateAdminUserOptions(auth.authClient, actor?.user.id)
+  )
+  const revokeSession = useMutation(
+    revokeAdminUserSessionOptions(auth.authClient, actor?.user.id, userId)
+  )
+  const revokeSessions = useMutation(
+    revokeAdminUserSessionsOptions(auth.authClient, actor?.user.id, userId)
+  )
+
+  const confirm = () => {
+    if (!user) return
+    if (dangerousAction === "ban")
+      ban.mutate(
+        { userId: user.id },
+        { onSuccess: () => setDangerousAction(undefined) }
+      )
+    if (dangerousAction === "delete")
+      remove.mutate(
+        { userId: user.id },
+        {
+          onSuccess: () => {
+            setDangerousAction(undefined)
+            onOpenChange(false)
+          }
+        }
+      )
+    if (dangerousAction === "revokeAll")
+      revokeSessions.mutate(
+        { userId: user.id },
+        { onSuccess: () => setDangerousAction(undefined) }
+      )
+    if (dangerousAction === "impersonate")
+      impersonate.mutate(
+        { userId: user.id },
+        {
+          onSuccess: () => {
+            setDangerousAction(undefined)
+            if (config.impersonationRedirectTo)
+              auth.navigate({ to: config.impersonationRedirectTo })
+          }
+        }
+      )
+  }
+  const dangerLabel =
+    dangerousAction === "ban"
+      ? config.localization.banUser
+      : dangerousAction === "delete"
+        ? config.localization.deleteUser
+        : dangerousAction === "revokeAll"
+          ? config.localization.revokeAllSessions
+          : config.localization.impersonateUser
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent className="w-full overflow-y-auto sm:max-w-lg">
+          <SheetHeader>
+            <SheetTitle>{config.localization.userDetails}</SheetTitle>
+            <SheetDescription>
+              {user?.email ?? config.localization.usersDescription}
+            </SheetDescription>
+          </SheetHeader>
+          {detail.isPending ? (
+            <div className="flex flex-col gap-3 p-4">
+              <Skeleton className="size-14 rounded-full" />
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-4 w-64" />
+            </div>
+          ) : user ? (
+            <Tabs className="px-4 pb-6" defaultValue="overview">
+              <TabsList>
+                <TabsTrigger value="overview">
+                  {config.localization.overview}
+                </TabsTrigger>
+                <TabsTrigger value="sessions">
+                  {config.localization.sessions}
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent
+                className="flex flex-col gap-6 pt-4"
+                value="overview"
+              >
+                <div className="flex items-center gap-3">
+                  <UserAvatar className="size-12" user={user} />
+                  <div>
+                    <div className="font-medium">{user.name}</div>
+                    <div className="text-sm text-muted-foreground">
+                      {user.email}
+                    </div>
+                  </div>
+                </div>
+                <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-3 text-sm">
+                  <dt className="text-muted-foreground">
+                    {config.localization.userId}
+                  </dt>
+                  <dd className="flex min-w-0 items-center gap-1">
+                    <code className="truncate text-xs">{user.id}</code>
+                    <Button
+                      aria-label={config.localization.copyUserId}
+                      onClick={() => navigator.clipboard.writeText(user.id)}
+                      size="icon-xs"
+                      variant="ghost"
+                    >
+                      <CopyIcon />
+                    </Button>
+                  </dd>
+                  <dt className="text-muted-foreground">
+                    {config.localization.created}
+                  </dt>
+                  <dd>{formatDate(user.createdAt)}</dd>
+                  <dt className="text-muted-foreground">
+                    {config.localization.status}
+                  </dt>
+                  <dd>
+                    <Badge variant={user.banned ? "destructive" : "secondary"}>
+                      {user.banned
+                        ? config.localization.banned
+                        : config.localization.active}
+                    </Badge>
+                  </dd>
+                </dl>
+                <div className="flex items-end gap-2">
+                  <Field className="flex-1">
+                    <FieldLabel>{config.localization.role}</FieldLabel>
+                    <Select
+                      value={role}
+                      onValueChange={(value) => value && setRole(value)}
+                    >
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {config.roles.map((item) => (
+                          <SelectItem key={item} value={item}>
+                            {item}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </Field>
+                  <Button
+                    disabled={
+                      setRoleMutation.isPending ||
+                      canSetRole.isPending ||
+                      !canSetRole.data?.success ||
+                      isSelf
+                    }
+                    onClick={() =>
+                      setRoleMutation.mutate({
+                        userId: user.id,
+                        role: asAdminRole(role)
+                      })
+                    }
+                    variant="outline"
+                  >
+                    {config.localization.saveRole}
+                  </Button>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    disabled={
+                      canSetPassword.isPending || !canSetPassword.data?.success
+                    }
+                    onClick={() => setPasswordOpen(true)}
+                    variant="outline"
+                  >
+                    <KeyRoundIcon />
+                    {config.localization.setPassword}
+                  </Button>
+                  <Button
+                    disabled={
+                      canBan.isPending || !canBan.data?.success || isSelf
+                    }
+                    onClick={() =>
+                      user.banned
+                        ? unban.mutate({ userId: user.id })
+                        : setDangerousAction("ban")
+                    }
+                    variant="outline"
+                  >
+                    <BanIcon />
+                    {user.banned
+                      ? config.localization.unbanUser
+                      : config.localization.banUser}
+                  </Button>
+                  <Button
+                    disabled={
+                      canImpersonate.isPending ||
+                      !canImpersonate.data?.success ||
+                      isSelf
+                    }
+                    onClick={() => setDangerousAction("impersonate")}
+                    variant="outline"
+                  >
+                    <LogInIcon />
+                    {config.localization.impersonateUser}
+                  </Button>
+                  <Button
+                    disabled={
+                      canDelete.isPending || !canDelete.data?.success || isSelf
+                    }
+                    onClick={() => setDangerousAction("delete")}
+                    variant="destructive"
+                  >
+                    <Trash2Icon />
+                    {config.localization.deleteUser}
+                  </Button>
+                </div>
+              </TabsContent>
+              <TabsContent
+                className="flex flex-col gap-3 pt-4"
+                value="sessions"
+              >
+                {sessionsPermission.isPending || sessions.isPending ? (
+                  skeletonRowIds
+                    .slice(0, 3)
+                    .map((id) => (
+                      <Skeleton className="h-20 w-full" key={`session-${id}`} />
+                    ))
+                ) : !sessionsPermission.data?.success ? (
+                  <p className="text-sm text-muted-foreground">
+                    {config.localization.accessDeniedDescription}
+                  </p>
+                ) : sessions.data?.sessions.length ? (
+                  <>
+                    <Button
+                      className="self-end"
+                      disabled={
+                        canRevoke.isPending ||
+                        !canRevoke.data?.success ||
+                        isSelf
+                      }
+                      onClick={() => setDangerousAction("revokeAll")}
+                      variant="outline"
+                    >
+                      {config.localization.revokeAllSessions}
+                    </Button>
+                    {sessions.data.sessions.map((item) => (
+                      <div
+                        className="flex items-start justify-between gap-3 rounded-lg border p-3"
+                        key={item.id}
+                      >
+                        <div className="min-w-0 text-sm">
+                          <div className="truncate font-medium">
+                            {item.userAgent || config.localization.sessions}
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            {formatDate(item.createdAt)} ·{" "}
+                            {formatDate(item.expiresAt)}
+                          </div>
+                          {config.showIpAddress && item.ipAddress ? (
+                            <div className="mt-1 font-mono text-xs text-muted-foreground">
+                              {item.ipAddress}
+                            </div>
+                          ) : null}
+                        </div>
+                        <Button
+                          aria-label={config.localization.revoke}
+                          disabled={
+                            revokeSession.isPending ||
+                            canRevoke.isPending ||
+                            !canRevoke.data?.success ||
+                            isSelf
+                          }
+                          onClick={() =>
+                            revokeSession.mutate({ sessionToken: item.token })
+                          }
+                          size="icon-sm"
+                          variant="ghost"
+                        >
+                          <Trash2Icon />
+                        </Button>
+                      </div>
+                    ))}
+                  </>
+                ) : (
+                  <p className="py-8 text-center text-sm text-muted-foreground">
+                    {config.localization.noSessions}
+                  </p>
+                )}
+              </TabsContent>
+            </Tabs>
+          ) : (
+            <AdminState
+              icon={<ShieldAlertIcon />}
+              title={config.localization.loadUsersError}
+              description={config.localization.loadUsersErrorDescription}
+            />
+          )}
+        </SheetContent>
+      </Sheet>
+      <PasswordDialog
+        open={passwordOpen}
+        onOpenChange={setPasswordOpen}
+        userId={user?.id}
+      />
+      <AlertDialog
+        open={Boolean(dangerousAction)}
+        onOpenChange={(value) => !value && setDangerousAction(undefined)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{dangerLabel}</AlertDialogTitle>
+            <AlertDialogDescription>{user?.email}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{config.localization.cancel}</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isSelf}
+              onClick={confirm}
+              variant={dangerousAction === "delete" ? "destructive" : "default"}
+            >
+              {dangerLabel}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}
+
+function PasswordDialog({
+  open,
+  onOpenChange,
+  userId
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  userId?: string
+}) {
+  const auth = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const [password, setPassword] = useState("")
+  const mutation = useMutation(setAdminUserPasswordOptions(auth.authClient))
+  const close = () => {
+    setPassword("")
+    mutation.reset()
+    onOpenChange(false)
+  }
+  const submit = (event: FormEvent) => {
+    event.preventDefault()
+    if (userId)
+      mutation.mutate(
+        { userId, newPassword: password },
+        { onSuccess: close, onSettled: () => setPassword("") }
+      )
+  }
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(value) => (value ? onOpenChange(true) : close())}
+    >
+      <DialogContent>
+        <form className="flex flex-col gap-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{config.localization.setPassword}</DialogTitle>
+            <DialogDescription>
+              {config.localization.userDetails}
+            </DialogDescription>
+          </DialogHeader>
+          <Field>
+            <FieldLabel htmlFor="admin-new-password">
+              {config.localization.password}
+            </FieldLabel>
+            <InputGroup>
+              <InputGroupInput
+                autoComplete="new-password"
+                id="admin-new-password"
+                onChange={(event) => setPassword(event.target.value)}
+                required
+                type="password"
+                value={password}
+              />
+            </InputGroup>
+          </Field>
+          <DialogFooter>
+            <Button onClick={close} type="button" variant="outline">
+              {config.localization.cancel}
+            </Button>
+            <Button disabled={!password || mutation.isPending} type="submit">
+              {config.localization.setPassword}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
@@ -21,6 +21,7 @@ import {
   useAdminUsers
 } from "@better-auth-ui/react/plugins/admin"
 import { keepPreviousData, useMutation } from "@tanstack/react-query"
+import type { BetterFetchError } from "better-auth/react"
 import {
   BanIcon,
   ChevronLeftIcon,
@@ -61,7 +62,12 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel
+} from "@/components/ui/field"
 import {
   InputGroup,
   InputGroupAddon,
@@ -112,6 +118,11 @@ const formatDate = (value: Date | string | undefined | null) =>
     : "–"
 
 const asAdminRole = (role: string) => role as "user" | "admin"
+
+const getAdminErrorMessage = (error: Error | null) => {
+  const authError = error as BetterFetchError | null
+  return authError?.error?.message ?? authError?.message
+}
 
 /** Server-paginated user management with optional controlled inspector state. */
 export function AdminUsers({
@@ -177,6 +188,7 @@ export function AdminUsers({
   const canCreate = useAdminPermission(auth.authClient, { user: ["create"] })
 
   const changeSort = (field: string) => {
+    setPage(0)
     if (sortBy === field) {
       setSortDirection((value) => (value === "asc" ? "desc" : "asc"))
     } else {
@@ -621,6 +633,7 @@ function CreateUserDialog({
               </select>
             </Field>
           </FieldGroup>
+          <FieldError>{getAdminErrorMessage(createUser.error)}</FieldError>
           <DialogFooter>
             <Button onClick={close} type="button" variant="outline">
               {config.localization.cancel}
@@ -759,6 +772,22 @@ function UserInspector({
         }
       )
   }
+  const closeDangerousAction = () => {
+    ban.reset()
+    remove.reset()
+    revokeSessions.reset()
+    impersonate.reset()
+    setDangerousAction(undefined)
+  }
+  const dangerousMutation =
+    dangerousAction === "ban"
+      ? ban
+      : dangerousAction === "delete"
+        ? remove
+        : dangerousAction === "revokeAll"
+          ? revokeSessions
+          : impersonate
+  const dangerousError = getAdminErrorMessage(dangerousMutation.error)
   const dangerLabel =
     dangerousAction === "ban"
       ? config.localization.banUser
@@ -1014,17 +1043,24 @@ function UserInspector({
       />
       <AlertDialog
         open={Boolean(dangerousAction)}
-        onOpenChange={(value) => !value && setDangerousAction(undefined)}
+        onOpenChange={(value) => !value && closeDangerousAction()}
       >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{dangerLabel}</AlertDialogTitle>
-            <AlertDialogDescription>{user?.email}</AlertDialogDescription>
+            <AlertDialogDescription className="flex flex-col gap-2">
+              <span>{user?.email}</span>
+              {dangerousError ? (
+                <span className="text-destructive" role="alert">
+                  {dangerousError}
+                </span>
+              ) : null}
+            </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{config.localization.cancel}</AlertDialogCancel>
             <AlertDialogAction
-              disabled={isSelf}
+              disabled={isSelf || dangerousMutation.isPending}
               onClick={confirm}
               variant={dangerousAction === "delete" ? "destructive" : "default"}
             >
@@ -1049,18 +1085,28 @@ function PasswordDialog({
   const auth = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
   const [password, setPassword] = useState("")
-  const mutation = useMutation(setAdminUserPasswordOptions(auth.authClient))
+  const [errorMessage, setErrorMessage] = useState<string>()
+  const mutation = useMutation(
+    setAdminUserPasswordOptions(auth.authClient, () => {
+      setTimeout(() => mutation.reset(), 0)
+    })
+  )
   const close = () => {
     setPassword("")
+    setErrorMessage(undefined)
     mutation.reset()
     onOpenChange(false)
   }
   const submit = (event: FormEvent) => {
     event.preventDefault()
+    setErrorMessage(undefined)
     if (userId)
       mutation.mutate(
         { userId, newPassword: password },
-        { onSuccess: close, onSettled: () => setPassword("") }
+        {
+          onError: (error) => setErrorMessage(getAdminErrorMessage(error)),
+          onSuccess: close
+        }
       )
   }
   return (
@@ -1076,12 +1122,13 @@ function PasswordDialog({
               {config.localization.userDetails}
             </DialogDescription>
           </DialogHeader>
-          <Field>
+          <Field data-invalid={Boolean(errorMessage)}>
             <FieldLabel htmlFor="admin-new-password">
               {config.localization.password}
             </FieldLabel>
             <InputGroup>
               <InputGroupInput
+                aria-invalid={Boolean(errorMessage)}
                 autoComplete="new-password"
                 id="admin-new-password"
                 onChange={(event) => setPassword(event.target.value)}
@@ -1090,6 +1137,7 @@ function PasswordDialog({
                 value={password}
               />
             </InputGroup>
+            <FieldError>{errorMessage}</FieldError>
           </Field>
           <DialogFooter>
             <Button onClick={close} type="button" variant="outline">

--- a/examples/start-shadcn-baseui-example/src/components/auth/admin/admin.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/admin/admin.tsx
@@ -1,0 +1,82 @@
+"use client"
+
+import type { AdminView } from "@better-auth-ui/core"
+import { useAuth, useAuthenticate, useAuthPlugin } from "@better-auth-ui/react"
+import { ShieldAlertIcon, UsersIcon } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { adminPlugin } from "@/lib/auth/admin-plugin"
+import { cn } from "@/lib/utils"
+
+import { AdminUsers } from "./admin-users"
+
+export type AdminProps = {
+  className?: string
+  hideNav?: boolean
+  path?: string
+  view?: AdminView | string
+}
+
+/** Render a finite, static administration route and plugin-contributed tabs. */
+export function Admin({ className, hideNav, path, view }: AdminProps) {
+  const { authClient, basePaths, plugins, viewPaths } = useAuth()
+  const { localization } = useAuthPlugin(adminPlugin)
+  useAuthenticate(authClient)
+
+  if (!view && !path) {
+    throw new Error("[Better Auth UI] Either `view` or `path` must be provided")
+  }
+
+  const contributedTabs = plugins.flatMap((plugin) => plugin.adminTabs ?? [])
+  const currentView =
+    view ??
+    (viewPaths.admin.users === path ? "users" : undefined) ??
+    contributedTabs.find((tab) => tab.path === path)?.id
+  const contributedView = contributedTabs.find((tab) => tab.id === currentView)
+
+  return (
+    <div className={cn("flex w-full flex-col gap-6", className)}>
+      {!hideNav && (
+        <nav aria-label={localization.admin} className="flex gap-1 border-b">
+          <Button
+            aria-current={currentView === "users" ? "page" : undefined}
+            className="rounded-b-none"
+            render={<a href={`${basePaths.admin}/${viewPaths.admin.users}`} />}
+            variant={currentView === "users" ? "secondary" : "ghost"}
+          >
+            <UsersIcon />
+            {localization.users}
+          </Button>
+
+          {contributedTabs.map((tab) => (
+            <Button
+              key={`${tab.id}-${tab.path}`}
+              aria-current={currentView === tab.id ? "page" : undefined}
+              className="rounded-b-none"
+              render={<a href={`${basePaths.admin}/${tab.path}`} />}
+              variant={currentView === tab.id ? "secondary" : "ghost"}
+            >
+              {tab.label}
+            </Button>
+          ))}
+        </nav>
+      )}
+
+      {currentView === "users" ? (
+        <AdminUsers />
+      ) : contributedView ? (
+        <contributedView.component />
+      ) : (
+        <div className="flex min-h-64 flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-8 text-center">
+          <ShieldAlertIcon className="size-8 text-muted-foreground" />
+          <div className="flex flex-col gap-1">
+            <h2 className="font-medium">{localization.unknownView}</h2>
+            <p className="max-w-md text-sm text-muted-foreground">
+              {localization.unknownViewDescription} &quot;{path ?? view}&quot;
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/examples/start-shadcn-baseui-example/src/components/ui/sheet.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/ui/sheet.tsx
@@ -1,0 +1,137 @@
+"use client"
+
+import { Dialog as SheetPrimitive } from "@base-ui/react/dialog"
+import { XIcon } from "lucide-react"
+import * as React from "react"
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+function Sheet(props: SheetPrimitive.Root.Props) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger(props: SheetPrimitive.Trigger.Props) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose(props: SheetPrimitive.Close.Props) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal(props: SheetPrimitive.Portal.Props) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: SheetPrimitive.Backdrop.Props) {
+  return (
+    <SheetPrimitive.Backdrop
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/10 transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: SheetPrimitive.Popup.Props & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Popup
+        data-slot="sheet-content"
+        data-side={side}
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-ending-style:opacity-0 data-starting-style:opacity-0 data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=bottom]:data-ending-style:translate-y-10 data-[side=bottom]:data-starting-style:translate-y-10 data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=left]:data-ending-style:-translate-x-10 data-[side=left]:data-starting-style:-translate-x-10 data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=right]:data-ending-style:translate-x-10 data-[side=right]:data-starting-style:translate-x-10 data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=top]:data-ending-style:-translate-y-10 data-[side=top]:data-starting-style:-translate-y-10 data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close
+            data-slot="sheet-close"
+            render={
+              <Button
+                className="absolute top-3 right-3"
+                size="icon-sm"
+                variant="ghost"
+              />
+            }
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Popup>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-0.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({ className, ...props }: SheetPrimitive.Title.Props) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-base font-medium text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: SheetPrimitive.Description.Props) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger
+}

--- a/examples/start-shadcn-example/registry.json
+++ b/examples/start-shadcn-example/registry.json
@@ -1209,7 +1209,7 @@
       "name": "admin",
       "type": "registry:component",
       "title": "Admin",
-      "description": "Admin plugin integration that adds a stop-impersonating action to the user button while an administrator is impersonating another user.",
+      "description": "Static administration shell with user management, a user inspector, session controls, and the stop-impersonating action.",
       "dependencies": [
         "@better-auth-ui/react@latest",
         "@better-auth-ui/core@latest",
@@ -1217,8 +1217,19 @@
         "lucide-react"
       ],
       "registryDependencies": [
+        "alert-dialog",
+        "badge",
+        "button",
+        "dialog",
         "dropdown-menu",
+        "field",
+        "input-group",
+        "select",
+        "sheet",
+        "skeleton",
         "spinner",
+        "table",
+        "tabs",
         "https://better-auth-ui.com/r/radix-nova/user-button.json"
       ],
       "files": [
@@ -1236,6 +1247,16 @@
           "path": "src/components/auth/admin/stop-impersonating.tsx",
           "type": "registry:component",
           "target": "@components/auth/admin/stop-impersonating.tsx"
+        },
+        {
+          "path": "src/components/auth/admin/admin.tsx",
+          "type": "registry:component",
+          "target": "@components/auth/admin/admin.tsx"
+        },
+        {
+          "path": "src/components/auth/admin/admin-users.tsx",
+          "type": "registry:component",
+          "target": "@components/auth/admin/admin-users.tsx"
         }
       ]
     },

--- a/examples/start-shadcn-example/scripts/build-registry.ts
+++ b/examples/start-shadcn-example/scripts/build-registry.ts
@@ -23,6 +23,8 @@ const STYLE_NAMES = [
 
 const EXPECTED_BASE_UI_OVERRIDES = [
   "src/components/auth/additional-field.tsx",
+  "src/components/auth/admin/admin-users.tsx",
+  "src/components/auth/admin/admin.tsx",
   "src/components/auth/api-key/api-keys.tsx",
   "src/components/auth/api-key/create-api-key-dialog.tsx",
   "src/components/auth/api-key/edit-api-key-dialog.tsx",

--- a/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -1,0 +1,1103 @@
+"use client"
+
+import {
+  type AdminAuthClient,
+  type AdminListUsersParams,
+  banAdminUserOptions,
+  createAdminUserOptions,
+  impersonateAdminUserOptions,
+  removeAdminUserOptions,
+  revokeAdminUserSessionOptions,
+  revokeAdminUserSessionsOptions,
+  setAdminUserPasswordOptions,
+  setAdminUserRoleOptions,
+  unbanAdminUserOptions
+} from "@better-auth-ui/core/plugins/admin"
+import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
+import {
+  useAdminPermission,
+  useAdminUser,
+  useAdminUserSessions,
+  useAdminUsers
+} from "@better-auth-ui/react/plugins/admin"
+import { keepPreviousData, useMutation } from "@tanstack/react-query"
+import {
+  BanIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CopyIcon,
+  KeyRoundIcon,
+  LogInIcon,
+  SearchIcon,
+  ShieldAlertIcon,
+  Trash2Icon,
+  UserPlusIcon
+} from "lucide-react"
+import {
+  type FormEvent,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState
+} from "react"
+import { UserAvatar } from "@/components/auth/user/user-avatar"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput
+} from "@/components/ui/input-group"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle
+} from "@/components/ui/sheet"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@/components/ui/table"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { adminPlugin } from "@/lib/auth/admin-plugin"
+
+type SearchField = "email" | "name"
+type StatusFilter = "all" | "active" | "banned"
+type SortDirection = "asc" | "desc"
+type DangerousAction = "ban" | "delete" | "impersonate" | "revokeAll"
+
+export type AdminUsersProps = {
+  className?: string
+  onSelectedUserIdChange?: (userId: string | undefined) => void
+  selectedUserId?: string
+}
+
+const formatDate = (value: Date | string | undefined | null) =>
+  value
+    ? new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(
+        new Date(value)
+      )
+    : "–"
+
+const asAdminRole = (role: string) => role as "user" | "admin"
+
+/** Server-paginated user management with optional controlled inspector state. */
+export function AdminUsers({
+  className,
+  onSelectedUserIdChange,
+  selectedUserId: controlledSelectedUserId
+}: AdminUsersProps) {
+  const auth = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const { localization } = config
+  const [localSelectedUserId, setLocalSelectedUserId] = useState<string>()
+  const [page, setPage] = useState(0)
+  const [search, setSearch] = useState("")
+  const [searchField, setSearchField] = useState<SearchField>("email")
+  const [status, setStatus] = useState<StatusFilter>("all")
+  const [sortBy, setSortBy] = useState("createdAt")
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc")
+  const [createOpen, setCreateOpen] = useState(false)
+  const deferredSearch = useDeferredValue(search.trim())
+  const isSelectionControlled = onSelectedUserIdChange !== undefined
+  const selectedUserId = isSelectionControlled
+    ? controlledSelectedUserId
+    : localSelectedUserId
+
+  const setSelectedUserId = (userId: string | undefined) => {
+    if (!isSelectionControlled) setLocalSelectedUserId(userId)
+    onSelectedUserIdChange?.(userId)
+  }
+
+  const params = useMemo<AdminListUsersParams>(
+    () => ({
+      limit: config.pageSize,
+      offset: page * config.pageSize,
+      searchField,
+      searchOperator: "contains",
+      searchValue: deferredSearch || undefined,
+      sortBy,
+      sortDirection,
+      ...(status === "all"
+        ? {}
+        : {
+            filterField: "banned",
+            filterOperator: "eq" as const,
+            filterValue: status === "banned"
+          })
+    }),
+    [
+      config.pageSize,
+      deferredSearch,
+      page,
+      searchField,
+      sortBy,
+      sortDirection,
+      status
+    ]
+  )
+  const permission = useAdminPermission(auth.authClient, { user: ["list"] })
+  const users = useAdminUsers(auth.authClient, {
+    enabled: permission.data?.success === true,
+    params,
+    placeholderData: keepPreviousData
+  })
+  const canCreate = useAdminPermission(auth.authClient, { user: ["create"] })
+
+  const changeSort = (field: string) => {
+    if (sortBy === field) {
+      setSortDirection((value) => (value === "asc" ? "desc" : "asc"))
+    } else {
+      setSortBy(field)
+      setSortDirection("asc")
+    }
+  }
+
+  const total = users.data?.total ?? 0
+  const from = total ? page * config.pageSize + 1 : 0
+  const to = Math.min(total, (page + 1) * config.pageSize)
+
+  return (
+    <section className={className}>
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div className="flex flex-col gap-1">
+            <h1 className="text-xl font-semibold tracking-tight">
+              {localization.users}
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              {localization.usersDescription}
+            </p>
+          </div>
+          {canCreate.isPending ? (
+            <Skeleton className="h-8 w-28" />
+          ) : canCreate.data?.success ? (
+            <Button onClick={() => setCreateOpen(true)}>
+              <UserPlusIcon />
+              {localization.createUser}
+            </Button>
+          ) : null}
+        </div>
+
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <Select
+            value={searchField}
+            onValueChange={(value) => {
+              setSearchField(value as SearchField)
+              setPage(0)
+            }}
+          >
+            <SelectTrigger
+              aria-label={localization.search}
+              className="w-full sm:w-36"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="email">{localization.email}</SelectItem>
+              <SelectItem value="name">{localization.name}</SelectItem>
+            </SelectContent>
+          </Select>
+          <InputGroup className="sm:max-w-md">
+            <InputGroupAddon>
+              <SearchIcon />
+            </InputGroupAddon>
+            <InputGroupInput
+              aria-label={
+                searchField === "email"
+                  ? localization.searchByEmail
+                  : localization.searchByName
+              }
+              onChange={(event) => {
+                setSearch(event.target.value)
+                setPage(0)
+              }}
+              placeholder={
+                searchField === "email"
+                  ? localization.searchByEmail
+                  : localization.searchByName
+              }
+              value={search}
+            />
+          </InputGroup>
+          <Select
+            value={status}
+            onValueChange={(value) => {
+              setStatus(value as StatusFilter)
+              setPage(0)
+            }}
+          >
+            <SelectTrigger
+              aria-label={localization.status}
+              className="w-full sm:w-36"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">{localization.status}</SelectItem>
+              <SelectItem value="active">{localization.active}</SelectItem>
+              <SelectItem value="banned">{localization.banned}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {permission.isPending ? (
+          <UserTableSkeleton />
+        ) : !permission.data?.success ? (
+          <AdminState
+            icon={<ShieldAlertIcon />}
+            title={localization.accessDenied}
+            description={localization.accessDeniedDescription}
+          />
+        ) : users.isError ? (
+          <AdminState
+            icon={<ShieldAlertIcon />}
+            title={localization.loadUsersError}
+            description={localization.loadUsersErrorDescription}
+            action={
+              <Button variant="outline" onClick={() => users.refetch()}>
+                {localization.retry}
+              </Button>
+            }
+          />
+        ) : (
+          <div className="overflow-hidden rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>
+                    <SortButton
+                      active={sortBy === "name"}
+                      direction={sortDirection}
+                      onClick={() => changeSort("name")}
+                    >
+                      {localization.name}
+                    </SortButton>
+                  </TableHead>
+                  <TableHead className="hidden md:table-cell">
+                    <SortButton
+                      active={sortBy === "role"}
+                      direction={sortDirection}
+                      onClick={() => changeSort("role")}
+                    >
+                      {localization.role}
+                    </SortButton>
+                  </TableHead>
+                  <TableHead>{localization.status}</TableHead>
+                  <TableHead className="hidden lg:table-cell">
+                    <SortButton
+                      active={sortBy === "createdAt"}
+                      direction={sortDirection}
+                      onClick={() => changeSort("createdAt")}
+                    >
+                      {localization.created}
+                    </SortButton>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {users.isPending ? (
+                  <UserRowsSkeleton />
+                ) : users.data?.users.length ? (
+                  users.data.users.map((user) => (
+                    <TableRow
+                      key={user.id}
+                      aria-selected={selectedUserId === user.id}
+                      className="cursor-pointer"
+                      onClick={() => setSelectedUserId(user.id)}
+                    >
+                      <TableCell>
+                        <div className="flex items-center gap-3">
+                          <UserAvatar className="size-8" user={user} />
+                          <div className="min-w-0">
+                            <div className="truncate font-medium">
+                              {user.name}
+                            </div>
+                            <div className="truncate text-xs text-muted-foreground">
+                              {user.email}
+                            </div>
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell className="hidden md:table-cell">
+                        <Badge variant="outline">
+                          {user.role ?? config.defaultRole}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={user.banned ? "destructive" : "secondary"}
+                        >
+                          {user.banned
+                            ? localization.banned
+                            : localization.active}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="hidden text-muted-foreground lg:table-cell">
+                        {formatDate(user.createdAt)}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={4} className="h-40 text-center">
+                      <strong className="block font-medium">
+                        {localization.noUsers}
+                      </strong>
+                      <span className="text-muted-foreground">
+                        {localization.noUsersDescription}
+                      </span>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+
+        <div className="flex items-center justify-between gap-3 text-sm text-muted-foreground">
+          <span>
+            {localization.usersPaginationRange
+              .replace("{{from}}", String(from))
+              .replace("{{to}}", String(to))
+              .replace("{{total}}", String(total))}
+          </span>
+          <div className="flex gap-1">
+            <Button
+              aria-label={localization.previousPage}
+              disabled={page === 0 || users.isFetching}
+              onClick={() => setPage((value) => Math.max(0, value - 1))}
+              size="icon-sm"
+              variant="outline"
+            >
+              <ChevronLeftIcon />
+            </Button>
+            <Button
+              aria-label={localization.nextPage}
+              disabled={to >= total || users.isFetching}
+              onClick={() => setPage((value) => value + 1)}
+              size="icon-sm"
+              variant="outline"
+            >
+              <ChevronRightIcon />
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <CreateUserDialog open={createOpen} onOpenChange={setCreateOpen} />
+      <UserInspector
+        open={Boolean(selectedUserId)}
+        onOpenChange={(open) => !open && setSelectedUserId(undefined)}
+        userId={selectedUserId}
+      />
+    </section>
+  )
+}
+
+function SortButton({
+  active,
+  children,
+  direction,
+  onClick
+}: {
+  active: boolean
+  children: React.ReactNode
+  direction: SortDirection
+  onClick: () => void
+}) {
+  return (
+    <button
+      className="inline-flex items-center gap-1 hover:text-foreground"
+      onClick={onClick}
+      type="button"
+    >
+      {children}
+      {active ? (direction === "asc" ? "↑" : "↓") : null}
+    </button>
+  )
+}
+
+function AdminState({
+  action,
+  description,
+  icon,
+  title
+}: {
+  action?: React.ReactNode
+  description: string
+  icon: React.ReactNode
+  title: string
+}) {
+  return (
+    <div className="flex min-h-64 flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-8 text-center">
+      <span className="text-muted-foreground [&>svg]:size-8">{icon}</span>
+      <div className="flex flex-col gap-1">
+        <h2 className="font-medium">{title}</h2>
+        <p className="max-w-md text-sm text-muted-foreground">{description}</p>
+      </div>
+      {action}
+    </div>
+  )
+}
+
+const skeletonRowIds = [
+  "admin-row-1",
+  "admin-row-2",
+  "admin-row-3",
+  "admin-row-4",
+  "admin-row-5"
+]
+
+function UserRowsSkeleton() {
+  return skeletonRowIds.map((id) => (
+    <TableRow key={id}>
+      <TableCell>
+        <div className="flex items-center gap-3">
+          <Skeleton className="size-8 rounded-full" />
+          <div className="flex flex-col gap-1">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-48" />
+          </div>
+        </div>
+      </TableCell>
+      <TableCell className="hidden md:table-cell">
+        <Skeleton className="h-5 w-16" />
+      </TableCell>
+      <TableCell>
+        <Skeleton className="h-5 w-16" />
+      </TableCell>
+      <TableCell className="hidden lg:table-cell">
+        <Skeleton className="h-4 w-24" />
+      </TableCell>
+    </TableRow>
+  ))
+}
+
+function UserTableSkeleton() {
+  return (
+    <div className="overflow-hidden rounded-lg border">
+      <Table>
+        <TableBody>
+          <UserRowsSkeleton />
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+function CreateUserDialog({
+  open,
+  onOpenChange
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const auth = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const { data: session } = useSession(auth.authClient)
+  const [password, setPassword] = useState("")
+  const createUser = useMutation(
+    createAdminUserOptions(auth.authClient, session?.user.id)
+  )
+
+  const close = () => {
+    setPassword("")
+    createUser.reset()
+    onOpenChange(false)
+  }
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const data = new FormData(event.currentTarget)
+    createUser.mutate(
+      {
+        email: String(data.get("email")),
+        name: String(data.get("name")),
+        password,
+        role: asAdminRole(String(data.get("role") || config.defaultRole))
+      },
+      { onSuccess: close }
+    )
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(value) => (value ? onOpenChange(true) : close())}
+    >
+      <DialogContent>
+        <form className="flex flex-col gap-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{config.localization.createUser}</DialogTitle>
+            <DialogDescription>
+              {config.localization.usersDescription}
+            </DialogDescription>
+          </DialogHeader>
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor="admin-create-name">
+                {config.localization.name}
+              </FieldLabel>
+              <InputGroup>
+                <InputGroupInput id="admin-create-name" name="name" required />
+              </InputGroup>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="admin-create-email">
+                {config.localization.email}
+              </FieldLabel>
+              <InputGroup>
+                <InputGroupInput
+                  autoComplete="off"
+                  id="admin-create-email"
+                  name="email"
+                  required
+                  type="email"
+                />
+              </InputGroup>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="admin-create-password">
+                {config.localization.password}
+              </FieldLabel>
+              <InputGroup>
+                <InputGroupInput
+                  autoComplete="new-password"
+                  id="admin-create-password"
+                  onChange={(event) => setPassword(event.target.value)}
+                  required
+                  type="password"
+                  value={password}
+                />
+              </InputGroup>
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="admin-create-role">
+                {config.localization.role}
+              </FieldLabel>
+              <select
+                className="h-8 rounded-lg border bg-transparent px-2 text-sm"
+                defaultValue={config.defaultRole}
+                id="admin-create-role"
+                name="role"
+              >
+                {config.roles.map((role) => (
+                  <option key={role} value={role}>
+                    {role}
+                  </option>
+                ))}
+              </select>
+            </Field>
+          </FieldGroup>
+          <DialogFooter>
+            <Button onClick={close} type="button" variant="outline">
+              {config.localization.cancel}
+            </Button>
+            <Button disabled={createUser.isPending} type="submit">
+              {config.localization.createUser}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function UserInspector({
+  open,
+  onOpenChange,
+  userId
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  userId?: string
+}) {
+  const auth = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const detail = useAdminUser(auth.authClient, userId)
+  const sessionsPermission = useAdminPermission(
+    auth.authClient,
+    {
+      session: ["list"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const sessions = useAdminUserSessions(auth.authClient, userId, {
+    enabled: sessionsPermission.data?.success === true
+  })
+  const { data: actor } = useSession(auth.authClient)
+  const canSetRole = useAdminPermission(
+    auth.authClient,
+    {
+      user: ["set-role"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const canSetPassword = useAdminPermission(
+    auth.authClient,
+    {
+      user: ["set-password"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const canBan = useAdminPermission(
+    auth.authClient,
+    { user: ["ban"] },
+    { enabled: Boolean(userId) }
+  )
+  const canImpersonate = useAdminPermission(
+    auth.authClient,
+    {
+      user: ["impersonate"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const canDelete = useAdminPermission(
+    auth.authClient,
+    { user: ["delete"] },
+    { enabled: Boolean(userId) }
+  )
+  const canRevoke = useAdminPermission(
+    auth.authClient,
+    {
+      session: ["revoke"]
+    },
+    { enabled: Boolean(userId) }
+  )
+  const [role, setRole] = useState(config.defaultRole)
+  const [passwordOpen, setPasswordOpen] = useState(false)
+  const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
+  const user = detail.data
+  const isSelf = user?.id === actor?.user.id
+  useEffect(() => {
+    if (user?.role) setRole(user.role)
+  }, [user?.role])
+
+  const setRoleMutation = useMutation(
+    setAdminUserRoleOptions(auth.authClient, actor?.user.id)
+  )
+  const ban = useMutation(banAdminUserOptions(auth.authClient, actor?.user.id))
+  const unban = useMutation(
+    unbanAdminUserOptions(auth.authClient, actor?.user.id)
+  )
+  const remove = useMutation(
+    removeAdminUserOptions(auth.authClient, actor?.user.id)
+  )
+  const impersonate = useMutation(
+    impersonateAdminUserOptions(auth.authClient, actor?.user.id)
+  )
+  const revokeSession = useMutation(
+    revokeAdminUserSessionOptions(auth.authClient, actor?.user.id, userId)
+  )
+  const revokeSessions = useMutation(
+    revokeAdminUserSessionsOptions(auth.authClient, actor?.user.id, userId)
+  )
+
+  const confirm = () => {
+    if (!user) return
+    if (dangerousAction === "ban")
+      ban.mutate(
+        { userId: user.id },
+        { onSuccess: () => setDangerousAction(undefined) }
+      )
+    if (dangerousAction === "delete")
+      remove.mutate(
+        { userId: user.id },
+        {
+          onSuccess: () => {
+            setDangerousAction(undefined)
+            onOpenChange(false)
+          }
+        }
+      )
+    if (dangerousAction === "revokeAll")
+      revokeSessions.mutate(
+        { userId: user.id },
+        { onSuccess: () => setDangerousAction(undefined) }
+      )
+    if (dangerousAction === "impersonate")
+      impersonate.mutate(
+        { userId: user.id },
+        {
+          onSuccess: () => {
+            setDangerousAction(undefined)
+            if (config.impersonationRedirectTo)
+              auth.navigate({ to: config.impersonationRedirectTo })
+          }
+        }
+      )
+  }
+  const dangerLabel =
+    dangerousAction === "ban"
+      ? config.localization.banUser
+      : dangerousAction === "delete"
+        ? config.localization.deleteUser
+        : dangerousAction === "revokeAll"
+          ? config.localization.revokeAllSessions
+          : config.localization.impersonateUser
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent className="w-full overflow-y-auto sm:max-w-lg">
+          <SheetHeader>
+            <SheetTitle>{config.localization.userDetails}</SheetTitle>
+            <SheetDescription>
+              {user?.email ?? config.localization.usersDescription}
+            </SheetDescription>
+          </SheetHeader>
+          {detail.isPending ? (
+            <div className="flex flex-col gap-3 p-4">
+              <Skeleton className="size-14 rounded-full" />
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-4 w-64" />
+            </div>
+          ) : user ? (
+            <Tabs className="px-4 pb-6" defaultValue="overview">
+              <TabsList>
+                <TabsTrigger value="overview">
+                  {config.localization.overview}
+                </TabsTrigger>
+                <TabsTrigger value="sessions">
+                  {config.localization.sessions}
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent
+                className="flex flex-col gap-6 pt-4"
+                value="overview"
+              >
+                <div className="flex items-center gap-3">
+                  <UserAvatar className="size-12" user={user} />
+                  <div>
+                    <div className="font-medium">{user.name}</div>
+                    <div className="text-sm text-muted-foreground">
+                      {user.email}
+                    </div>
+                  </div>
+                </div>
+                <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-3 text-sm">
+                  <dt className="text-muted-foreground">
+                    {config.localization.userId}
+                  </dt>
+                  <dd className="flex min-w-0 items-center gap-1">
+                    <code className="truncate text-xs">{user.id}</code>
+                    <Button
+                      aria-label={config.localization.copyUserId}
+                      onClick={() => navigator.clipboard.writeText(user.id)}
+                      size="icon-xs"
+                      variant="ghost"
+                    >
+                      <CopyIcon />
+                    </Button>
+                  </dd>
+                  <dt className="text-muted-foreground">
+                    {config.localization.created}
+                  </dt>
+                  <dd>{formatDate(user.createdAt)}</dd>
+                  <dt className="text-muted-foreground">
+                    {config.localization.status}
+                  </dt>
+                  <dd>
+                    <Badge variant={user.banned ? "destructive" : "secondary"}>
+                      {user.banned
+                        ? config.localization.banned
+                        : config.localization.active}
+                    </Badge>
+                  </dd>
+                </dl>
+                <div className="flex items-end gap-2">
+                  <Field className="flex-1">
+                    <FieldLabel>{config.localization.role}</FieldLabel>
+                    <Select value={role} onValueChange={setRole}>
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {config.roles.map((item) => (
+                          <SelectItem key={item} value={item}>
+                            {item}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </Field>
+                  <Button
+                    disabled={
+                      setRoleMutation.isPending ||
+                      canSetRole.isPending ||
+                      !canSetRole.data?.success ||
+                      isSelf
+                    }
+                    onClick={() =>
+                      setRoleMutation.mutate({
+                        userId: user.id,
+                        role: asAdminRole(role)
+                      })
+                    }
+                    variant="outline"
+                  >
+                    {config.localization.saveRole}
+                  </Button>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    disabled={
+                      canSetPassword.isPending || !canSetPassword.data?.success
+                    }
+                    onClick={() => setPasswordOpen(true)}
+                    variant="outline"
+                  >
+                    <KeyRoundIcon />
+                    {config.localization.setPassword}
+                  </Button>
+                  <Button
+                    disabled={
+                      canBan.isPending || !canBan.data?.success || isSelf
+                    }
+                    onClick={() =>
+                      user.banned
+                        ? unban.mutate({ userId: user.id })
+                        : setDangerousAction("ban")
+                    }
+                    variant="outline"
+                  >
+                    <BanIcon />
+                    {user.banned
+                      ? config.localization.unbanUser
+                      : config.localization.banUser}
+                  </Button>
+                  <Button
+                    disabled={
+                      canImpersonate.isPending ||
+                      !canImpersonate.data?.success ||
+                      isSelf
+                    }
+                    onClick={() => setDangerousAction("impersonate")}
+                    variant="outline"
+                  >
+                    <LogInIcon />
+                    {config.localization.impersonateUser}
+                  </Button>
+                  <Button
+                    disabled={
+                      canDelete.isPending || !canDelete.data?.success || isSelf
+                    }
+                    onClick={() => setDangerousAction("delete")}
+                    variant="destructive"
+                  >
+                    <Trash2Icon />
+                    {config.localization.deleteUser}
+                  </Button>
+                </div>
+              </TabsContent>
+              <TabsContent
+                className="flex flex-col gap-3 pt-4"
+                value="sessions"
+              >
+                {sessionsPermission.isPending || sessions.isPending ? (
+                  skeletonRowIds
+                    .slice(0, 3)
+                    .map((id) => (
+                      <Skeleton className="h-20 w-full" key={`session-${id}`} />
+                    ))
+                ) : !sessionsPermission.data?.success ? (
+                  <p className="text-sm text-muted-foreground">
+                    {config.localization.accessDeniedDescription}
+                  </p>
+                ) : sessions.data?.sessions.length ? (
+                  <>
+                    <Button
+                      className="self-end"
+                      disabled={
+                        canRevoke.isPending ||
+                        !canRevoke.data?.success ||
+                        isSelf
+                      }
+                      onClick={() => setDangerousAction("revokeAll")}
+                      variant="outline"
+                    >
+                      {config.localization.revokeAllSessions}
+                    </Button>
+                    {sessions.data.sessions.map((item) => (
+                      <div
+                        className="flex items-start justify-between gap-3 rounded-lg border p-3"
+                        key={item.id}
+                      >
+                        <div className="min-w-0 text-sm">
+                          <div className="truncate font-medium">
+                            {item.userAgent || config.localization.sessions}
+                          </div>
+                          <div className="text-xs text-muted-foreground">
+                            {formatDate(item.createdAt)} ·{" "}
+                            {formatDate(item.expiresAt)}
+                          </div>
+                          {config.showIpAddress && item.ipAddress ? (
+                            <div className="mt-1 font-mono text-xs text-muted-foreground">
+                              {item.ipAddress}
+                            </div>
+                          ) : null}
+                        </div>
+                        <Button
+                          aria-label={config.localization.revoke}
+                          disabled={
+                            revokeSession.isPending ||
+                            canRevoke.isPending ||
+                            !canRevoke.data?.success ||
+                            isSelf
+                          }
+                          onClick={() =>
+                            revokeSession.mutate({ sessionToken: item.token })
+                          }
+                          size="icon-sm"
+                          variant="ghost"
+                        >
+                          <Trash2Icon />
+                        </Button>
+                      </div>
+                    ))}
+                  </>
+                ) : (
+                  <p className="py-8 text-center text-sm text-muted-foreground">
+                    {config.localization.noSessions}
+                  </p>
+                )}
+              </TabsContent>
+            </Tabs>
+          ) : (
+            <AdminState
+              icon={<ShieldAlertIcon />}
+              title={config.localization.loadUsersError}
+              description={config.localization.loadUsersErrorDescription}
+            />
+          )}
+        </SheetContent>
+      </Sheet>
+      <PasswordDialog
+        open={passwordOpen}
+        onOpenChange={setPasswordOpen}
+        userId={user?.id}
+      />
+      <AlertDialog
+        open={Boolean(dangerousAction)}
+        onOpenChange={(value) => !value && setDangerousAction(undefined)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{dangerLabel}</AlertDialogTitle>
+            <AlertDialogDescription>{user?.email}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{config.localization.cancel}</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isSelf}
+              onClick={confirm}
+              variant={dangerousAction === "delete" ? "destructive" : "default"}
+            >
+              {dangerLabel}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}
+
+function PasswordDialog({
+  open,
+  onOpenChange,
+  userId
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  userId?: string
+}) {
+  const auth = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const [password, setPassword] = useState("")
+  const mutation = useMutation(setAdminUserPasswordOptions(auth.authClient))
+  const close = () => {
+    setPassword("")
+    mutation.reset()
+    onOpenChange(false)
+  }
+  const submit = (event: FormEvent) => {
+    event.preventDefault()
+    if (userId)
+      mutation.mutate(
+        { userId, newPassword: password },
+        { onSuccess: close, onSettled: () => setPassword("") }
+      )
+  }
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(value) => (value ? onOpenChange(true) : close())}
+    >
+      <DialogContent>
+        <form className="flex flex-col gap-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{config.localization.setPassword}</DialogTitle>
+            <DialogDescription>
+              {config.localization.userDetails}
+            </DialogDescription>
+          </DialogHeader>
+          <Field>
+            <FieldLabel htmlFor="admin-new-password">
+              {config.localization.password}
+            </FieldLabel>
+            <InputGroup>
+              <InputGroupInput
+                autoComplete="new-password"
+                id="admin-new-password"
+                onChange={(event) => setPassword(event.target.value)}
+                required
+                type="password"
+                value={password}
+              />
+            </InputGroup>
+          </Field>
+          <DialogFooter>
+            <Button onClick={close} type="button" variant="outline">
+              {config.localization.cancel}
+            </Button>
+            <Button disabled={!password || mutation.isPending} type="submit">
+              {config.localization.setPassword}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -354,9 +354,16 @@ export function AdminUsers({
                         <div className="flex items-center gap-3">
                           <UserAvatar className="size-8" user={user} />
                           <div className="min-w-0">
-                            <div className="truncate font-medium">
-                              {user.name}
-                            </div>
+                            <Button
+                              className="h-auto min-w-0 justify-start p-0 font-medium"
+                              onClick={(event) => {
+                                event.stopPropagation()
+                                setSelectedUserId(user.id)
+                              }}
+                              variant="link"
+                            >
+                              <span className="truncate">{user.name}</span>
+                            </Button>
                             <div className="truncate text-xs text-muted-foreground">
                               {user.email}
                             </div>
@@ -881,6 +888,11 @@ function UserInspector({
                         ))}
                       </SelectContent>
                     </Select>
+                    {setRoleMutation.error ? (
+                      <FieldError>
+                        {getAdminErrorMessage(setRoleMutation.error)}
+                      </FieldError>
+                    ) : null}
                   </Field>
                   <Button
                     disabled={
@@ -950,6 +962,9 @@ function UserInspector({
                     {config.localization.deleteUser}
                   </Button>
                 </div>
+                {unban.error ? (
+                  <FieldError>{getAdminErrorMessage(unban.error)}</FieldError>
+                ) : null}
               </TabsContent>
               <TabsContent
                 className="flex flex-col gap-3 pt-4"
@@ -1058,7 +1073,10 @@ function UserInspector({
             <AlertDialogCancel>{config.localization.cancel}</AlertDialogCancel>
             <AlertDialogAction
               disabled={isSelf || dangerousMutation.isPending}
-              onClick={confirm}
+              onClick={(event) => {
+                event.preventDefault()
+                confirm()
+              }}
               variant={dangerousAction === "delete" ? "destructive" : "default"}
             >
               {dangerLabel}

--- a/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -21,6 +21,7 @@ import {
   useAdminUsers
 } from "@better-auth-ui/react/plugins/admin"
 import { keepPreviousData, useMutation } from "@tanstack/react-query"
+import type { BetterFetchError } from "better-auth/react"
 import {
   BanIcon,
   ChevronLeftIcon,
@@ -61,7 +62,12 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel
+} from "@/components/ui/field"
 import {
   InputGroup,
   InputGroupAddon,
@@ -112,6 +118,11 @@ const formatDate = (value: Date | string | undefined | null) =>
     : "–"
 
 const asAdminRole = (role: string) => role as "user" | "admin"
+
+const getAdminErrorMessage = (error: Error | null) => {
+  const authError = error as BetterFetchError | null
+  return authError?.error?.message ?? authError?.message
+}
 
 /** Server-paginated user management with optional controlled inspector state. */
 export function AdminUsers({
@@ -177,6 +188,7 @@ export function AdminUsers({
   const canCreate = useAdminPermission(auth.authClient, { user: ["create"] })
 
   const changeSort = (field: string) => {
+    setPage(0)
     if (sortBy === field) {
       setSortDirection((value) => (value === "asc" ? "desc" : "asc"))
     } else {
@@ -621,6 +633,7 @@ function CreateUserDialog({
               </select>
             </Field>
           </FieldGroup>
+          <FieldError>{getAdminErrorMessage(createUser.error)}</FieldError>
           <DialogFooter>
             <Button onClick={close} type="button" variant="outline">
               {config.localization.cancel}
@@ -759,6 +772,22 @@ function UserInspector({
         }
       )
   }
+  const closeDangerousAction = () => {
+    ban.reset()
+    remove.reset()
+    revokeSessions.reset()
+    impersonate.reset()
+    setDangerousAction(undefined)
+  }
+  const dangerousMutation =
+    dangerousAction === "ban"
+      ? ban
+      : dangerousAction === "delete"
+        ? remove
+        : dangerousAction === "revokeAll"
+          ? revokeSessions
+          : impersonate
+  const dangerousError = getAdminErrorMessage(dangerousMutation.error)
   const dangerLabel =
     dangerousAction === "ban"
       ? config.localization.banUser
@@ -1011,17 +1040,24 @@ function UserInspector({
       />
       <AlertDialog
         open={Boolean(dangerousAction)}
-        onOpenChange={(value) => !value && setDangerousAction(undefined)}
+        onOpenChange={(value) => !value && closeDangerousAction()}
       >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{dangerLabel}</AlertDialogTitle>
-            <AlertDialogDescription>{user?.email}</AlertDialogDescription>
+            <AlertDialogDescription className="flex flex-col gap-2">
+              <span>{user?.email}</span>
+              {dangerousError ? (
+                <span className="text-destructive" role="alert">
+                  {dangerousError}
+                </span>
+              ) : null}
+            </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>{config.localization.cancel}</AlertDialogCancel>
             <AlertDialogAction
-              disabled={isSelf}
+              disabled={isSelf || dangerousMutation.isPending}
               onClick={confirm}
               variant={dangerousAction === "delete" ? "destructive" : "default"}
             >
@@ -1046,18 +1082,28 @@ function PasswordDialog({
   const auth = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
   const [password, setPassword] = useState("")
-  const mutation = useMutation(setAdminUserPasswordOptions(auth.authClient))
+  const [errorMessage, setErrorMessage] = useState<string>()
+  const mutation = useMutation(
+    setAdminUserPasswordOptions(auth.authClient, () => {
+      setTimeout(() => mutation.reset(), 0)
+    })
+  )
   const close = () => {
     setPassword("")
+    setErrorMessage(undefined)
     mutation.reset()
     onOpenChange(false)
   }
   const submit = (event: FormEvent) => {
     event.preventDefault()
+    setErrorMessage(undefined)
     if (userId)
       mutation.mutate(
         { userId, newPassword: password },
-        { onSuccess: close, onSettled: () => setPassword("") }
+        {
+          onError: (error) => setErrorMessage(getAdminErrorMessage(error)),
+          onSuccess: close
+        }
       )
   }
   return (
@@ -1073,12 +1119,13 @@ function PasswordDialog({
               {config.localization.userDetails}
             </DialogDescription>
           </DialogHeader>
-          <Field>
+          <Field data-invalid={Boolean(errorMessage)}>
             <FieldLabel htmlFor="admin-new-password">
               {config.localization.password}
             </FieldLabel>
             <InputGroup>
               <InputGroupInput
+                aria-invalid={Boolean(errorMessage)}
                 autoComplete="new-password"
                 id="admin-new-password"
                 onChange={(event) => setPassword(event.target.value)}
@@ -1087,6 +1134,7 @@ function PasswordDialog({
                 value={password}
               />
             </InputGroup>
+            <FieldError>{errorMessage}</FieldError>
           </Field>
           <DialogFooter>
             <Button onClick={close} type="button" variant="outline">

--- a/examples/start-shadcn-example/src/components/auth/admin/admin.tsx
+++ b/examples/start-shadcn-example/src/components/auth/admin/admin.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import type { AdminView } from "@better-auth-ui/core"
+import { useAuth, useAuthenticate, useAuthPlugin } from "@better-auth-ui/react"
+import { ShieldAlertIcon, UsersIcon } from "lucide-react"
+
+import { Button } from "@/components/ui/button"
+import { adminPlugin } from "@/lib/auth/admin-plugin"
+import { cn } from "@/lib/utils"
+
+import { AdminUsers } from "./admin-users"
+
+export type AdminProps = {
+  className?: string
+  hideNav?: boolean
+  path?: string
+  view?: AdminView | string
+}
+
+/** Render a finite, static administration route and plugin-contributed tabs. */
+export function Admin({ className, hideNav, path, view }: AdminProps) {
+  const { authClient, basePaths, plugins, viewPaths } = useAuth()
+  const { localization } = useAuthPlugin(adminPlugin)
+  useAuthenticate(authClient)
+
+  if (!view && !path) {
+    throw new Error("[Better Auth UI] Either `view` or `path` must be provided")
+  }
+
+  const contributedTabs = plugins.flatMap((plugin) => plugin.adminTabs ?? [])
+  const currentView =
+    view ??
+    (viewPaths.admin.users === path ? "users" : undefined) ??
+    contributedTabs.find((tab) => tab.path === path)?.id
+  const contributedView = contributedTabs.find((tab) => tab.id === currentView)
+
+  return (
+    <div className={cn("flex w-full flex-col gap-6", className)}>
+      {!hideNav && (
+        <nav aria-label={localization.admin} className="flex gap-1 border-b">
+          <Button
+            aria-current={currentView === "users" ? "page" : undefined}
+            asChild
+            className="rounded-b-none"
+            variant={currentView === "users" ? "secondary" : "ghost"}
+          >
+            <a href={`${basePaths.admin}/${viewPaths.admin.users}`}>
+              <UsersIcon />
+              {localization.users}
+            </a>
+          </Button>
+
+          {contributedTabs.map((tab) => (
+            <Button
+              key={`${tab.id}-${tab.path}`}
+              aria-current={currentView === tab.id ? "page" : undefined}
+              asChild
+              className="rounded-b-none"
+              variant={currentView === tab.id ? "secondary" : "ghost"}
+            >
+              <a href={`${basePaths.admin}/${tab.path}`}>{tab.label}</a>
+            </Button>
+          ))}
+        </nav>
+      )}
+
+      {currentView === "users" ? (
+        <AdminUsers />
+      ) : contributedView ? (
+        <contributedView.component />
+      ) : (
+        <div className="flex min-h-64 flex-col items-center justify-center gap-3 rounded-lg border border-dashed p-8 text-center">
+          <ShieldAlertIcon className="size-8 text-muted-foreground" />
+          <div className="flex flex-col gap-1">
+            <h2 className="font-medium">{localization.unknownView}</h2>
+            <p className="max-w-md text-sm text-muted-foreground">
+              {localization.unknownViewDescription} &quot;{path ?? view}&quot;
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/examples/start-shadcn-example/src/components/ui/sheet.tsx
+++ b/examples/start-shadcn-example/src/components/ui/sheet.tsx
@@ -1,0 +1,137 @@
+"use client"
+
+import { XIcon } from "lucide-react"
+import * as React from "react"
+import { Dialog as SheetPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function Sheet(props: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger(props: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose(props: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal(props: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        data-side={side}
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-popover bg-clip-padding text-sm text-popover-foreground shadow-lg transition duration-200 ease-in-out data-[side=bottom]:inset-x-0 data-[side=bottom]:bottom-0 data-[side=bottom]:h-auto data-[side=bottom]:border-t data-[side=left]:inset-y-0 data-[side=left]:left-0 data-[side=left]:h-full data-[side=left]:w-3/4 data-[side=left]:border-r data-[side=right]:inset-y-0 data-[side=right]:right-0 data-[side=right]:h-full data-[side=right]:w-3/4 data-[side=right]:border-l data-[side=top]:inset-x-0 data-[side=top]:top-0 data-[side=top]:h-auto data-[side=top]:border-b data-[side=left]:sm:max-w-sm data-[side=right]:sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-[side=bottom]:data-open:slide-in-from-bottom-10 data-[side=left]:data-open:slide-in-from-left-10 data-[side=right]:data-open:slide-in-from-right-10 data-[side=top]:data-open:slide-in-from-top-10 data-closed:animate-out data-closed:fade-out-0 data-[side=bottom]:data-closed:slide-out-to-bottom-10 data-[side=left]:data-closed:slide-out-to-left-10 data-[side=right]:data-closed:slide-out-to-right-10 data-[side=top]:data-closed:slide-out-to-top-10",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close asChild data-slot="sheet-close">
+            <Button
+              className="absolute top-3 right-3"
+              size="icon-sm"
+              variant="ghost"
+            >
+              <XIcon />
+              <span className="sr-only">Close</span>
+            </Button>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-0.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("text-base font-medium text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger
+}

--- a/examples/start-shadcn-example/src/routeTree.gen.ts
+++ b/examples/start-shadcn-example/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AdminUsersRouteImport } from './routes/admin/users'
 import { Route as AuthPathRouteImport } from './routes/auth/$path'
 import { Route as SettingsPathRouteImport } from './routes/settings/$path'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
@@ -18,6 +19,11 @@ import { Route as OrganizationAtChar123slugChar125PathRouteImport } from './rout
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AdminUsersRoute = AdminUsersRouteImport.update({
+  id: '/admin/users',
+  path: '/admin/users',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthPathRoute = AuthPathRouteImport.update({
@@ -44,6 +50,7 @@ const OrganizationAtChar123slugChar125PathRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/admin/users': typeof AdminUsersRoute
   '/auth/$path': typeof AuthPathRoute
   '/settings/$path': typeof SettingsPathRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
@@ -51,6 +58,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/admin/users': typeof AdminUsersRoute
   '/auth/$path': typeof AuthPathRoute
   '/settings/$path': typeof SettingsPathRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
@@ -59,6 +67,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/admin/users': typeof AdminUsersRoute
   '/auth/$path': typeof AuthPathRoute
   '/settings/$path': typeof SettingsPathRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
@@ -68,6 +77,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/admin/users'
     | '/auth/$path'
     | '/settings/$path'
     | '/api/auth/$'
@@ -75,6 +85,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/admin/users'
     | '/auth/$path'
     | '/settings/$path'
     | '/api/auth/$'
@@ -82,6 +93,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/admin/users'
     | '/auth/$path'
     | '/settings/$path'
     | '/api/auth/$'
@@ -90,6 +102,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AdminUsersRoute: typeof AdminUsersRoute
   AuthPathRoute: typeof AuthPathRoute
   SettingsPathRoute: typeof SettingsPathRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
@@ -103,6 +116,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/admin/users': {
+      id: '/admin/users'
+      path: '/admin/users'
+      fullPath: '/admin/users'
+      preLoaderRoute: typeof AdminUsersRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/auth/$path': {
@@ -138,6 +158,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AdminUsersRoute: AdminUsersRoute,
   AuthPathRoute: AuthPathRoute,
   SettingsPathRoute: SettingsPathRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,

--- a/examples/start-shadcn-example/src/routes/admin/users.tsx
+++ b/examples/start-shadcn-example/src/routes/admin/users.tsx
@@ -1,0 +1,36 @@
+import { ensureSession } from "@better-auth-ui/core"
+import { ensureSessionServer } from "@better-auth-ui/core/server"
+import { createFileRoute, redirect } from "@tanstack/react-router"
+import { createIsomorphicFn } from "@tanstack/react-start"
+import { getRequestHeaders } from "@tanstack/react-start/server"
+
+import { Admin } from "@/components/auth/admin/admin"
+import { auth } from "@/lib/auth"
+import { authClient } from "@/lib/auth-client"
+
+export const Route = createFileRoute("/admin/users")({
+  async beforeLoad({ context: { queryClient }, location }) {
+    const session = await createIsomorphicFn()
+      .server(() =>
+        ensureSessionServer(queryClient, auth, { headers: getRequestHeaders() })
+      )
+      .client(() => ensureSession(queryClient, authClient))()
+
+    if (!session) {
+      throw redirect({
+        to: "/auth/$path",
+        params: { path: "sign-in" },
+        search: { redirectTo: location.href }
+      })
+    }
+  },
+  component: AdminUsersPage
+})
+
+function AdminUsersPage() {
+  return (
+    <main className="mx-auto w-full max-w-6xl p-4 md:p-6">
+      <Admin view="users" />
+    </main>
+  )
+}

--- a/examples/start-solid-zaidan-example/registry.manifest.ts
+++ b/examples/start-solid-zaidan-example/registry.manifest.ts
@@ -967,15 +967,24 @@ export const solidRegistryManifest = {
       type: "registry:component",
       title: "Solid Admin",
       description:
-        "Adds a stop-impersonating action to the Solid user button while an administrator is impersonating another user.",
+        "Static administration shell with user management, a user inspector, session details, and the stop-impersonating action.",
       registryDependencies: [
         betterAuthSolidRegistryDependency("auth-provider"),
         betterAuthSolidRegistryDependency("user-button"),
+        "@zaidan/badge",
+        "@zaidan/button",
+        "@zaidan/dialog",
         "@zaidan/dropdown-menu",
-        "@zaidan/spinner"
+        "@zaidan/input-group",
+        "@zaidan/skeleton",
+        "@zaidan/spinner",
+        "@zaidan/table",
+        "@zaidan/tabs"
       ],
       files: [
         libFile("src/lib/auth/admin-plugin.ts"),
+        componentFile("src/components/auth/admin/admin.tsx"),
+        componentFile("src/components/auth/admin/admin-users.tsx"),
         componentFile("src/components/auth/admin/stop-impersonating.tsx"),
         ...zaidanInteractiveSupportFiles
       ]

--- a/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
@@ -10,8 +10,9 @@ import {
   useAdminUserSessions,
   useAdminUsers
 } from "@better-auth-ui/solid/plugins/admin"
+import { createDebounce } from "@solid-primitives/debounce"
 import { Search } from "lucide-solid"
-import { createEffect, createMemo, createSignal, For, Show } from "solid-js"
+import { createMemo, createSignal, For, Show } from "solid-js"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -23,6 +24,12 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle
+} from "@/components/ui/empty"
 import {
   InputGroup,
   InputGroupAddon,
@@ -68,7 +75,9 @@ export function AdminUsers(props: AdminUsersProps) {
   const [localSelectedUserId, setLocalSelectedUserId] = createSignal<string>()
   const [page, setPage] = createSignal(0)
   const [search, setSearch] = createSignal("")
+  const [debouncedSearch, setDebouncedSearch] = createSignal("")
   const [searchField, setSearchField] = createSignal<"email" | "name">("email")
+  const updateDebouncedSearch = createDebounce(setDebouncedSearch, 300)
   const selectedUserId = () =>
     props.onSelectedUserIdChange ? props.selectedUserId : localSelectedUserId()
   const permission = useAdminPermission(authClient, () => ({ user: ["list"] }))
@@ -77,7 +86,7 @@ export function AdminUsers(props: AdminUsersProps) {
     offset: page() * config().pageSize,
     searchField: searchField(),
     searchOperator: "contains",
-    searchValue: search().trim() || undefined,
+    searchValue: debouncedSearch() || undefined,
     sortBy: "createdAt",
     sortDirection: "desc"
   }))
@@ -85,12 +94,6 @@ export function AdminUsers(props: AdminUsersProps) {
     enabled: permission.data?.success === true,
     params: params()
   }))
-
-  createEffect(() => {
-    search()
-    searchField()
-    setPage(0)
-  })
 
   const selectUser = (userId: string | undefined) => {
     if (!props.onSelectedUserIdChange) setLocalSelectedUserId(userId)
@@ -111,9 +114,10 @@ export function AdminUsers(props: AdminUsersProps) {
         <select
           aria-label={config().localization.search}
           class="h-8 rounded-lg border bg-transparent px-2 text-sm sm:w-36"
-          onChange={(event) =>
+          onChange={(event) => {
             setSearchField(event.currentTarget.value as "email" | "name")
-          }
+            setPage(0)
+          }}
           value={searchField()}
         >
           <option value="email">{config().localization.email}</option>
@@ -125,7 +129,12 @@ export function AdminUsers(props: AdminUsersProps) {
           </InputGroupAddon>
           <InputGroupInput
             aria-label={config().localization.search}
-            onInput={(event) => setSearch(event.currentTarget.value)}
+            onInput={(event) => {
+              const value = event.currentTarget.value
+              setSearch(value)
+              setPage(0)
+              updateDebouncedSearch(value.trim())
+            }}
             placeholder={
               searchField() === "email"
                 ? config().localization.searchByEmail
@@ -167,45 +176,65 @@ export function AdminUsers(props: AdminUsersProps) {
               <TableBody>
                 <Show
                   fallback={
-                    <For each={users.data?.users}>
-                      {(user) => (
-                        <TableRow
-                          class="cursor-pointer"
-                          onClick={() => selectUser(user.id)}
-                        >
-                          <TableCell>
-                            <div class="flex items-center gap-3">
-                              <UserAvatar user={user} />
-                              <div class="min-w-0">
-                                <div class="truncate font-medium">
-                                  {user.name}
-                                </div>
-                                <div class="truncate text-xs text-muted-foreground">
-                                  {user.email}
+                    <Show
+                      fallback={
+                        <TableRow>
+                          <TableCell colspan="4">
+                            <Empty class="min-h-48 gap-2 p-4">
+                              <EmptyHeader class="gap-1">
+                                <EmptyTitle>
+                                  {config().localization.noUsers}
+                                </EmptyTitle>
+                                <EmptyDescription>
+                                  {config().localization.noUsersDescription}
+                                </EmptyDescription>
+                              </EmptyHeader>
+                            </Empty>
+                          </TableCell>
+                        </TableRow>
+                      }
+                      when={users.data?.users.length}
+                    >
+                      <For each={users.data?.users}>
+                        {(user) => (
+                          <TableRow
+                            class="cursor-pointer"
+                            onClick={() => selectUser(user.id)}
+                          >
+                            <TableCell>
+                              <div class="flex items-center gap-3">
+                                <UserAvatar user={user} />
+                                <div class="min-w-0">
+                                  <div class="truncate font-medium">
+                                    {user.name}
+                                  </div>
+                                  <div class="truncate text-xs text-muted-foreground">
+                                    {user.email}
+                                  </div>
                                 </div>
                               </div>
-                            </div>
-                          </TableCell>
-                          <TableCell>
-                            <Badge variant="outline">
-                              {user.role ?? config().defaultRole}
-                            </Badge>
-                          </TableCell>
-                          <TableCell>
-                            <Badge
-                              variant={
-                                user.banned ? "destructive" : "secondary"
-                              }
-                            >
-                              {user.banned
-                                ? config().localization.banned
-                                : config().localization.active}
-                            </Badge>
-                          </TableCell>
-                          <TableCell>{formatDate(user.createdAt)}</TableCell>
-                        </TableRow>
-                      )}
-                    </For>
+                            </TableCell>
+                            <TableCell>
+                              <Badge variant="outline">
+                                {user.role ?? config().defaultRole}
+                              </Badge>
+                            </TableCell>
+                            <TableCell>
+                              <Badge
+                                variant={
+                                  user.banned ? "destructive" : "secondary"
+                                }
+                              >
+                                {user.banned
+                                  ? config().localization.banned
+                                  : config().localization.active}
+                              </Badge>
+                            </TableCell>
+                            <TableCell>{formatDate(user.createdAt)}</TableCell>
+                          </TableRow>
+                        )}
+                      </For>
+                    </Show>
                   }
                   when={permission.isPending || users.isPending}
                 >
@@ -301,75 +330,89 @@ function UserDialog(props: {
             {user.data?.email ?? config().localization.usersDescription}
           </DialogDescription>
         </DialogHeader>
-        <Show fallback={<Skeleton class="mt-4 h-40 w-full" />} when={user.data}>
-          {(detail) => (
-            <Tabs class="mt-4" defaultValue="overview">
-              <TabsList>
-                <TabsTrigger value="overview">
-                  {config().localization.overview}
-                </TabsTrigger>
-                <TabsTrigger value="sessions">
-                  {config().localization.sessions}
-                </TabsTrigger>
-              </TabsList>
-              <TabsContent class="flex flex-col gap-4 pt-4" value="overview">
-                <div class="flex items-center gap-3">
-                  <UserAvatar class="size-12" user={detail()} />
-                  <div>
-                    <div class="font-medium">{detail().name}</div>
-                    <div class="text-sm text-muted-foreground">
-                      {detail().email}
+        <Show
+          fallback={
+            <AdminMessage
+              title={config().localization.loadUsersError}
+              description={config().localization.loadUsersErrorDescription}
+            />
+          }
+          when={!user.isError}
+        >
+          <Show
+            fallback={<Skeleton class="mt-4 h-40 w-full" />}
+            when={user.data}
+          >
+            {(detail) => (
+              <Tabs class="mt-4" defaultValue="overview">
+                <TabsList>
+                  <TabsTrigger value="overview">
+                    {config().localization.overview}
+                  </TabsTrigger>
+                  <TabsTrigger value="sessions">
+                    {config().localization.sessions}
+                  </TabsTrigger>
+                </TabsList>
+                <TabsContent class="flex flex-col gap-4 pt-4" value="overview">
+                  <div class="flex items-center gap-3">
+                    <UserAvatar class="size-12" user={detail()} />
+                    <div>
+                      <div class="font-medium">{detail().name}</div>
+                      <div class="text-sm text-muted-foreground">
+                        {detail().email}
+                      </div>
                     </div>
                   </div>
-                </div>
-                <dl class="grid grid-cols-[auto_1fr] gap-3 text-sm">
-                  <dt class="text-muted-foreground">
-                    {config().localization.userId}
-                  </dt>
-                  <dd class="font-mono text-xs">{detail().id}</dd>
-                  <dt class="text-muted-foreground">
-                    {config().localization.role}
-                  </dt>
-                  <dd>{detail().role ?? config().defaultRole}</dd>
-                  <dt class="text-muted-foreground">
-                    {config().localization.created}
-                  </dt>
-                  <dd>{formatDate(detail().createdAt)}</dd>
-                </dl>
-              </TabsContent>
-              <TabsContent class="flex flex-col gap-2 pt-4" value="sessions">
-                <Show
-                  fallback={
-                    <p class="py-8 text-center text-sm text-muted-foreground">
-                      {config().localization.noSessions}
-                    </p>
-                  }
-                  when={sessions.data?.sessions.length}
-                >
-                  <For each={sessions.data?.sessions}>
-                    {(session) => (
-                      <div class="rounded-lg border p-3">
-                        <div class="truncate text-sm font-medium">
-                          {session.userAgent || config().localization.sessions}
-                        </div>
-                        <div class="text-xs text-muted-foreground">
-                          {formatDate(session.createdAt)} ·{" "}
-                          {formatDate(session.expiresAt)}
-                        </div>
-                        <Show
-                          when={config().showIpAddress && session.ipAddress}
-                        >
-                          <div class="mt-1 font-mono text-xs text-muted-foreground">
-                            {session.ipAddress}
+                  <dl class="grid grid-cols-[auto_1fr] gap-3 text-sm">
+                    <dt class="text-muted-foreground">
+                      {config().localization.userId}
+                    </dt>
+                    <dd class="font-mono text-xs">{detail().id}</dd>
+                    <dt class="text-muted-foreground">
+                      {config().localization.role}
+                    </dt>
+                    <dd>{detail().role ?? config().defaultRole}</dd>
+                    <dt class="text-muted-foreground">
+                      {config().localization.created}
+                    </dt>
+                    <dd>{formatDate(detail().createdAt)}</dd>
+                  </dl>
+                </TabsContent>
+                <TabsContent class="flex flex-col gap-2 pt-4" value="sessions">
+                  <Show
+                    fallback={
+                      <p class="py-8 text-center text-sm text-muted-foreground">
+                        {config().localization.noSessions}
+                      </p>
+                    }
+                    when={sessions.data?.sessions.length}
+                  >
+                    <For each={sessions.data?.sessions}>
+                      {(session) => (
+                        <div class="rounded-lg border p-3">
+                          <div class="truncate text-sm font-medium">
+                            {session.userAgent ||
+                              config().localization.sessions}
                           </div>
-                        </Show>
-                      </div>
-                    )}
-                  </For>
-                </Show>
-              </TabsContent>
-            </Tabs>
-          )}
+                          <div class="text-xs text-muted-foreground">
+                            {formatDate(session.createdAt)} ·{" "}
+                            {formatDate(session.expiresAt)}
+                          </div>
+                          <Show
+                            when={config().showIpAddress && session.ipAddress}
+                          >
+                            <div class="mt-1 font-mono text-xs text-muted-foreground">
+                              {session.ipAddress}
+                            </div>
+                          </Show>
+                        </div>
+                      )}
+                    </For>
+                  </Show>
+                </TabsContent>
+              </Tabs>
+            )}
+          </Show>
         </Show>
         <DialogFooter showCloseButton />
       </DialogContent>

--- a/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
@@ -198,6 +198,7 @@ export function AdminUsers(props: AdminUsersProps) {
                       <For each={users.data?.users}>
                         {(user) => (
                           <TableRow
+                            aria-selected={selectedUserId() === user.id}
                             class="cursor-pointer"
                             onClick={() => selectUser(user.id)}
                           >
@@ -205,9 +206,16 @@ export function AdminUsers(props: AdminUsersProps) {
                               <div class="flex items-center gap-3">
                                 <UserAvatar user={user} />
                                 <div class="min-w-0">
-                                  <div class="truncate font-medium">
-                                    {user.name}
-                                  </div>
+                                  <Button
+                                    class="h-auto min-w-0 justify-start p-0 font-medium"
+                                    onClick={(event) => {
+                                      event.stopPropagation()
+                                      selectUser(user.id)
+                                    }}
+                                    variant="link"
+                                  >
+                                    <span class="truncate">{user.name}</span>
+                                  </Button>
                                   <div class="truncate text-xs text-muted-foreground">
                                     {user.email}
                                   </div>
@@ -303,6 +311,14 @@ function AdminMessage(props: { description: string; title: string }) {
   )
 }
 
+function SessionRowsSkeleton() {
+  return (
+    <For each={skeletonIds}>
+      {(id) => <Skeleton class="h-20 w-full" data-id={`session-${id}`} />}
+    </For>
+  )
+}
+
 function UserDialog(props: {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -380,34 +396,55 @@ function UserDialog(props: {
                 </TabsContent>
                 <TabsContent class="flex flex-col gap-2 pt-4" value="sessions">
                   <Show
-                    fallback={
-                      <p class="py-8 text-center text-sm text-muted-foreground">
-                        {config().localization.noSessions}
-                      </p>
-                    }
-                    when={sessions.data?.sessions.length}
+                    fallback={<SessionRowsSkeleton />}
+                    when={!sessionsPermission.isPending}
                   >
-                    <For each={sessions.data?.sessions}>
-                      {(session) => (
-                        <div class="rounded-lg border p-3">
-                          <div class="truncate text-sm font-medium">
-                            {session.userAgent ||
-                              config().localization.sessions}
-                          </div>
-                          <div class="text-xs text-muted-foreground">
-                            {formatDate(session.createdAt)} ·{" "}
-                            {formatDate(session.expiresAt)}
-                          </div>
-                          <Show
-                            when={config().showIpAddress && session.ipAddress}
-                          >
-                            <div class="mt-1 font-mono text-xs text-muted-foreground">
-                              {session.ipAddress}
-                            </div>
-                          </Show>
-                        </div>
-                      )}
-                    </For>
+                    <Show
+                      fallback={
+                        <p class="py-8 text-center text-sm text-muted-foreground">
+                          {config().localization.accessDeniedDescription}
+                        </p>
+                      }
+                      when={sessionsPermission.data?.success}
+                    >
+                      <Show
+                        fallback={<SessionRowsSkeleton />}
+                        when={!sessions.isPending}
+                      >
+                        <Show
+                          fallback={
+                            <p class="py-8 text-center text-sm text-muted-foreground">
+                              {config().localization.noSessions}
+                            </p>
+                          }
+                          when={sessions.data?.sessions.length}
+                        >
+                          <For each={sessions.data?.sessions}>
+                            {(session) => (
+                              <div class="rounded-lg border p-3">
+                                <div class="truncate text-sm font-medium">
+                                  {session.userAgent ||
+                                    config().localization.sessions}
+                                </div>
+                                <div class="text-xs text-muted-foreground">
+                                  {formatDate(session.createdAt)} ·{" "}
+                                  {formatDate(session.expiresAt)}
+                                </div>
+                                <Show
+                                  when={
+                                    config().showIpAddress && session.ipAddress
+                                  }
+                                >
+                                  <div class="mt-1 font-mono text-xs text-muted-foreground">
+                                    {session.ipAddress}
+                                  </div>
+                                </Show>
+                              </div>
+                            )}
+                          </For>
+                        </Show>
+                      </Show>
+                    </Show>
                   </Show>
                 </TabsContent>
               </Tabs>

--- a/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
@@ -1,0 +1,378 @@
+import {
+  type AdminAuthClient,
+  type AdminListUsersParams,
+  adminPlugin
+} from "@better-auth-ui/core/plugins/admin"
+import { useAuth } from "@better-auth-ui/solid"
+import {
+  useAdminPermission,
+  useAdminUser,
+  useAdminUserSessions,
+  useAdminUsers
+} from "@better-auth-ui/solid/plugins/admin"
+import { Search } from "lucide-solid"
+import { createEffect, createMemo, createSignal, For, Show } from "solid-js"
+
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput
+} from "@/components/ui/input-group"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@/components/ui/table"
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
+import { cn } from "@/lib/utils"
+
+import { UserAvatar } from "../user/user-avatar"
+
+export type AdminUsersProps = {
+  class?: string
+  onSelectedUserIdChange?: (userId: string | undefined) => void
+  selectedUserId?: string
+}
+
+const skeletonIds = ["solid-admin-1", "solid-admin-2", "solid-admin-3"]
+
+const formatDate = (value: Date | string | undefined | null) =>
+  value
+    ? new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(
+        new Date(value)
+      )
+    : "–"
+
+/** Zaidan presentation for the static Admin users view. */
+export function AdminUsers(props: AdminUsersProps) {
+  const auth = useAuth()
+  const authClient = auth.authClient as AdminAuthClient
+  const defaults = adminPlugin()
+  const config = () =>
+    (auth.plugins.find((plugin) => plugin.id === adminPlugin.id) ??
+      defaults) as typeof defaults
+  const [localSelectedUserId, setLocalSelectedUserId] = createSignal<string>()
+  const [page, setPage] = createSignal(0)
+  const [search, setSearch] = createSignal("")
+  const [searchField, setSearchField] = createSignal<"email" | "name">("email")
+  const selectedUserId = () =>
+    props.onSelectedUserIdChange ? props.selectedUserId : localSelectedUserId()
+  const permission = useAdminPermission(authClient, () => ({ user: ["list"] }))
+  const params = createMemo<AdminListUsersParams>(() => ({
+    limit: config().pageSize,
+    offset: page() * config().pageSize,
+    searchField: searchField(),
+    searchOperator: "contains",
+    searchValue: search().trim() || undefined,
+    sortBy: "createdAt",
+    sortDirection: "desc"
+  }))
+  const users = useAdminUsers(authClient, () => ({
+    enabled: permission.data?.success === true,
+    params: params()
+  }))
+
+  createEffect(() => {
+    search()
+    searchField()
+    setPage(0)
+  })
+
+  const selectUser = (userId: string | undefined) => {
+    if (!props.onSelectedUserIdChange) setLocalSelectedUserId(userId)
+    props.onSelectedUserIdChange?.(userId)
+  }
+  const total = () => users.data?.total ?? 0
+
+  return (
+    <section class={cn("flex flex-col gap-4", props.class)}>
+      <header class="flex flex-col gap-1">
+        <h1 class="text-xl font-semibold">{config().localization.users}</h1>
+        <p class="text-sm text-muted-foreground">
+          {config().localization.usersDescription}
+        </p>
+      </header>
+
+      <div class="flex flex-col gap-2 sm:flex-row">
+        <select
+          aria-label={config().localization.search}
+          class="h-8 rounded-lg border bg-transparent px-2 text-sm sm:w-36"
+          onChange={(event) =>
+            setSearchField(event.currentTarget.value as "email" | "name")
+          }
+          value={searchField()}
+        >
+          <option value="email">{config().localization.email}</option>
+          <option value="name">{config().localization.name}</option>
+        </select>
+        <InputGroup class="sm:max-w-md">
+          <InputGroupAddon>
+            <Search />
+          </InputGroupAddon>
+          <InputGroupInput
+            aria-label={config().localization.search}
+            onInput={(event) => setSearch(event.currentTarget.value)}
+            placeholder={
+              searchField() === "email"
+                ? config().localization.searchByEmail
+                : config().localization.searchByName
+            }
+            value={search()}
+          />
+        </InputGroup>
+      </div>
+
+      <Show
+        fallback={
+          <AdminMessage
+            title={config().localization.accessDenied}
+            description={config().localization.accessDeniedDescription}
+          />
+        }
+        when={permission.isPending || permission.data?.success}
+      >
+        <Show
+          fallback={
+            <AdminMessage
+              title={config().localization.loadUsersError}
+              description={config().localization.loadUsersErrorDescription}
+            />
+          }
+          when={!users.isError}
+        >
+          <div class="overflow-hidden rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{config().localization.name}</TableHead>
+                  <TableHead>{config().localization.role}</TableHead>
+                  <TableHead>{config().localization.status}</TableHead>
+                  <TableHead>{config().localization.created}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                <Show
+                  fallback={
+                    <For each={users.data?.users}>
+                      {(user) => (
+                        <TableRow
+                          class="cursor-pointer"
+                          onClick={() => selectUser(user.id)}
+                        >
+                          <TableCell>
+                            <div class="flex items-center gap-3">
+                              <UserAvatar user={user} />
+                              <div class="min-w-0">
+                                <div class="truncate font-medium">
+                                  {user.name}
+                                </div>
+                                <div class="truncate text-xs text-muted-foreground">
+                                  {user.email}
+                                </div>
+                              </div>
+                            </div>
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant="outline">
+                              {user.role ?? config().defaultRole}
+                            </Badge>
+                          </TableCell>
+                          <TableCell>
+                            <Badge
+                              variant={
+                                user.banned ? "destructive" : "secondary"
+                              }
+                            >
+                              {user.banned
+                                ? config().localization.banned
+                                : config().localization.active}
+                            </Badge>
+                          </TableCell>
+                          <TableCell>{formatDate(user.createdAt)}</TableCell>
+                        </TableRow>
+                      )}
+                    </For>
+                  }
+                  when={permission.isPending || users.isPending}
+                >
+                  <For each={skeletonIds}>
+                    {(id) => (
+                      <TableRow>
+                        <TableCell colspan="4">
+                          <Skeleton class="h-10 w-full" data-id={id} />
+                        </TableCell>
+                      </TableRow>
+                    )}
+                  </For>
+                </Show>
+              </TableBody>
+            </Table>
+          </div>
+        </Show>
+      </Show>
+
+      <footer class="flex items-center justify-between gap-2 text-sm text-muted-foreground">
+        <span>
+          {config()
+            .localization.usersPaginationRange.replace(
+              "{{from}}",
+              String(total() ? page() * config().pageSize + 1 : 0)
+            )
+            .replace(
+              "{{to}}",
+              String(Math.min(total(), (page() + 1) * config().pageSize))
+            )
+            .replace("{{total}}", String(total()))}
+        </span>
+        <div class="flex gap-2">
+          <Button
+            disabled={page() === 0}
+            onClick={() => setPage((value) => Math.max(0, value - 1))}
+            variant="outline"
+          >
+            {config().localization.previousPage}
+          </Button>
+          <Button
+            disabled={(page() + 1) * config().pageSize >= total()}
+            onClick={() => setPage((value) => value + 1)}
+            variant="outline"
+          >
+            {config().localization.nextPage}
+          </Button>
+        </div>
+      </footer>
+
+      <UserDialog
+        open={Boolean(selectedUserId())}
+        onOpenChange={(open) => !open && selectUser(undefined)}
+        userId={selectedUserId}
+      />
+    </section>
+  )
+}
+
+function AdminMessage(props: { description: string; title: string }) {
+  return (
+    <div class="flex min-h-64 flex-col items-center justify-center gap-1 rounded-lg border border-dashed p-8 text-center">
+      <h2 class="font-medium">{props.title}</h2>
+      <p class="text-sm text-muted-foreground">{props.description}</p>
+    </div>
+  )
+}
+
+function UserDialog(props: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  userId: () => string | undefined
+}) {
+  const auth = useAuth()
+  const authClient = auth.authClient as AdminAuthClient
+  const config = () =>
+    (auth.plugins.find((plugin) => plugin.id === adminPlugin.id) ??
+      adminPlugin()) as ReturnType<typeof adminPlugin>
+  const user = useAdminUser(authClient, props.userId)
+  const sessionsPermission = useAdminPermission(authClient, () => ({
+    session: ["list"]
+  }))
+  const sessions = useAdminUserSessions(authClient, props.userId, () => ({
+    enabled: sessionsPermission.data?.success === true
+  }))
+
+  return (
+    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+      <DialogContent class="max-h-[90vh] max-w-lg overflow-y-auto rounded-xl border bg-popover p-4">
+        <DialogHeader>
+          <DialogTitle>{config().localization.userDetails}</DialogTitle>
+          <DialogDescription>
+            {user.data?.email ?? config().localization.usersDescription}
+          </DialogDescription>
+        </DialogHeader>
+        <Show fallback={<Skeleton class="mt-4 h-40 w-full" />} when={user.data}>
+          {(detail) => (
+            <Tabs class="mt-4" defaultValue="overview">
+              <TabsList>
+                <TabsTrigger value="overview">
+                  {config().localization.overview}
+                </TabsTrigger>
+                <TabsTrigger value="sessions">
+                  {config().localization.sessions}
+                </TabsTrigger>
+              </TabsList>
+              <TabsContent class="flex flex-col gap-4 pt-4" value="overview">
+                <div class="flex items-center gap-3">
+                  <UserAvatar class="size-12" user={detail()} />
+                  <div>
+                    <div class="font-medium">{detail().name}</div>
+                    <div class="text-sm text-muted-foreground">
+                      {detail().email}
+                    </div>
+                  </div>
+                </div>
+                <dl class="grid grid-cols-[auto_1fr] gap-3 text-sm">
+                  <dt class="text-muted-foreground">
+                    {config().localization.userId}
+                  </dt>
+                  <dd class="font-mono text-xs">{detail().id}</dd>
+                  <dt class="text-muted-foreground">
+                    {config().localization.role}
+                  </dt>
+                  <dd>{detail().role ?? config().defaultRole}</dd>
+                  <dt class="text-muted-foreground">
+                    {config().localization.created}
+                  </dt>
+                  <dd>{formatDate(detail().createdAt)}</dd>
+                </dl>
+              </TabsContent>
+              <TabsContent class="flex flex-col gap-2 pt-4" value="sessions">
+                <Show
+                  fallback={
+                    <p class="py-8 text-center text-sm text-muted-foreground">
+                      {config().localization.noSessions}
+                    </p>
+                  }
+                  when={sessions.data?.sessions.length}
+                >
+                  <For each={sessions.data?.sessions}>
+                    {(session) => (
+                      <div class="rounded-lg border p-3">
+                        <div class="truncate text-sm font-medium">
+                          {session.userAgent || config().localization.sessions}
+                        </div>
+                        <div class="text-xs text-muted-foreground">
+                          {formatDate(session.createdAt)} ·{" "}
+                          {formatDate(session.expiresAt)}
+                        </div>
+                        <Show
+                          when={config().showIpAddress && session.ipAddress}
+                        >
+                          <div class="mt-1 font-mono text-xs text-muted-foreground">
+                            {session.ipAddress}
+                          </div>
+                        </Show>
+                      </div>
+                    )}
+                  </For>
+                </Show>
+              </TabsContent>
+            </Tabs>
+          )}
+        </Show>
+        <DialogFooter showCloseButton />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/examples/start-solid-zaidan-example/src/components/auth/admin/admin.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/admin/admin.tsx
@@ -1,0 +1,89 @@
+import type { AdminView } from "@better-auth-ui/core"
+import { adminPlugin as coreAdminPlugin } from "@better-auth-ui/core/plugins/admin"
+import { useAuth, useAuthenticate } from "@better-auth-ui/solid"
+import { For, Show } from "solid-js"
+import { Dynamic } from "solid-js/web"
+
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+import { AdminUsers } from "./admin-users"
+
+export type AdminProps = {
+  class?: string
+  hideNav?: boolean
+  path?: string
+  view?: AdminView | string
+}
+
+/** Render a finite static administration route and plugin-contributed tabs. */
+export function Admin(props: AdminProps) {
+  const auth = useAuth()
+  useAuthenticate(auth.authClient)
+  const defaults = coreAdminPlugin()
+  const config = () =>
+    (auth.plugins.find((plugin) => plugin.id === coreAdminPlugin.id) ??
+      defaults) as typeof defaults
+  const tabs = () => auth.plugins.flatMap((plugin) => plugin.adminTabs ?? [])
+  const currentView = () =>
+    props.view ??
+    (auth.viewPaths.admin.users === props.path ? "users" : undefined) ??
+    tabs().find((tab) => tab.path === props.path)?.id
+  const contribution = () => tabs().find((tab) => tab.id === currentView())
+
+  if (!props.view && !props.path) {
+    throw new Error("[Better Auth UI] Either `view` or `path` must be provided")
+  }
+
+  return (
+    <div class={cn("flex w-full flex-col gap-6", props.class)}>
+      <Show when={!props.hideNav}>
+        <nav
+          aria-label={config().localization.admin}
+          class="flex gap-1 border-b"
+        >
+          <Button
+            as="a"
+            href={`${auth.basePaths.admin}/${auth.viewPaths.admin.users}`}
+            variant={currentView() === "users" ? "secondary" : "ghost"}
+          >
+            {config().localization.users}
+          </Button>
+          <For each={tabs()}>
+            {(tab) => (
+              <Button
+                as="a"
+                href={`${auth.basePaths.admin}/${tab.path}`}
+                variant={currentView() === tab.id ? "secondary" : "ghost"}
+              >
+                <Dynamic component={tab.label} />
+              </Button>
+            )}
+          </For>
+        </nav>
+      </Show>
+
+      <Show
+        fallback={
+          <Show
+            fallback={
+              <div class="flex min-h-64 flex-col items-center justify-center gap-1 rounded-lg border border-dashed p-8 text-center">
+                <h2 class="font-medium">{config().localization.unknownView}</h2>
+                <p class="text-sm text-muted-foreground">
+                  {config().localization.unknownViewDescription} &quot;
+                  {props.path ?? props.view}&quot;
+                </p>
+              </div>
+            }
+            when={contribution()}
+          >
+            {(tab) => <Dynamic component={tab().component} />}
+          </Show>
+        }
+        when={currentView() === "users"}
+      >
+        <AdminUsers />
+      </Show>
+    </div>
+  )
+}

--- a/examples/start-solid-zaidan-example/src/routeTree.gen.ts
+++ b/examples/start-solid-zaidan-example/src/routeTree.gen.ts
@@ -10,6 +10,7 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AdminUsersRouteImport } from './routes/admin/users'
 import { Route as AuthPathRouteImport } from './routes/auth/$path'
 import { Route as SettingsPathRouteImport } from './routes/settings/$path'
 import { Route as ApiAuthSplatRouteImport } from './routes/api/auth/$'
@@ -18,6 +19,11 @@ import { Route as OrganizationAtChar123slugChar125PathRouteImport } from './rout
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AdminUsersRoute = AdminUsersRouteImport.update({
+  id: '/admin/users',
+  path: '/admin/users',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthPathRoute = AuthPathRouteImport.update({
@@ -44,6 +50,7 @@ const OrganizationAtChar123slugChar125PathRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/admin/users': typeof AdminUsersRoute
   '/auth/$path': typeof AuthPathRoute
   '/settings/$path': typeof SettingsPathRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
@@ -51,6 +58,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/admin/users': typeof AdminUsersRoute
   '/auth/$path': typeof AuthPathRoute
   '/settings/$path': typeof SettingsPathRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
@@ -59,6 +67,7 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/admin/users': typeof AdminUsersRoute
   '/auth/$path': typeof AuthPathRoute
   '/settings/$path': typeof SettingsPathRoute
   '/api/auth/$': typeof ApiAuthSplatRoute
@@ -68,6 +77,7 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
+    | '/admin/users'
     | '/auth/$path'
     | '/settings/$path'
     | '/api/auth/$'
@@ -75,6 +85,7 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
+    | '/admin/users'
     | '/auth/$path'
     | '/settings/$path'
     | '/api/auth/$'
@@ -82,6 +93,7 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
+    | '/admin/users'
     | '/auth/$path'
     | '/settings/$path'
     | '/api/auth/$'
@@ -90,6 +102,7 @@ export interface FileRouteTypes {
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AdminUsersRoute: typeof AdminUsersRoute
   AuthPathRoute: typeof AuthPathRoute
   SettingsPathRoute: typeof SettingsPathRoute
   ApiAuthSplatRoute: typeof ApiAuthSplatRoute
@@ -103,6 +116,13 @@ declare module '@tanstack/solid-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/admin/users': {
+      id: '/admin/users'
+      path: '/admin/users'
+      fullPath: '/admin/users'
+      preLoaderRoute: typeof AdminUsersRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/auth/$path': {
@@ -138,6 +158,7 @@ declare module '@tanstack/solid-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AdminUsersRoute: AdminUsersRoute,
   AuthPathRoute: AuthPathRoute,
   SettingsPathRoute: SettingsPathRoute,
   ApiAuthSplatRoute: ApiAuthSplatRoute,

--- a/examples/start-solid-zaidan-example/src/routes/admin/users.tsx
+++ b/examples/start-solid-zaidan-example/src/routes/admin/users.tsx
@@ -1,0 +1,36 @@
+import { ensureSession } from "@better-auth-ui/core"
+import { ensureSessionServer } from "@better-auth-ui/core/server"
+import { createFileRoute, redirect } from "@tanstack/solid-router"
+import { createIsomorphicFn } from "@tanstack/solid-start"
+import { getRequestHeaders } from "@tanstack/solid-start/server"
+
+import { Admin } from "@/components/auth/admin/admin"
+import { auth } from "@/lib/auth"
+import { authClient } from "@/lib/auth-client"
+
+export const Route = createFileRoute("/admin/users")({
+  async beforeLoad({ context: { queryClient }, location }) {
+    const session = await createIsomorphicFn()
+      .server(() =>
+        ensureSessionServer(queryClient, auth, { headers: getRequestHeaders() })
+      )
+      .client(() => ensureSession(queryClient, authClient))()
+
+    if (!session) {
+      throw redirect({
+        to: "/auth/$path",
+        params: { path: "sign-in" },
+        search: { redirectTo: location.href }
+      })
+    }
+  },
+  component: AdminUsersPage
+})
+
+function AdminUsersPage() {
+  return (
+    <main class="mx-auto w-full max-w-6xl p-4 md:p-6">
+      <Admin view="users" />
+    </main>
+  )
+}

--- a/packages/heroui/src/components/auth/admin/admin-users.tsx
+++ b/packages/heroui/src/components/auth/admin/admin-users.tsx
@@ -1,0 +1,409 @@
+"use client"
+
+import type {
+  AdminAuthClient,
+  AdminListUsersParams
+} from "@better-auth-ui/core/plugins/admin"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
+import {
+  useAdminPermission,
+  useAdminUser,
+  useAdminUserSessions,
+  useAdminUsers
+} from "@better-auth-ui/react/plugins/admin"
+import {
+  Button,
+  Chip,
+  cn,
+  Drawer,
+  Label,
+  ListBox,
+  SearchField,
+  Select,
+  Skeleton,
+  Table,
+  Tabs
+} from "@heroui/react"
+import { keepPreviousData } from "@tanstack/react-query"
+import { useDeferredValue, useMemo, useState } from "react"
+
+import { adminPlugin } from "../../../lib/auth/admin-plugin"
+import { UserAvatar } from "../user/user-avatar"
+
+type SearchFieldName = "email" | "name"
+
+export type AdminUsersProps = {
+  className?: string
+  onSelectedUserIdChange?: (userId: string | undefined) => void
+  selectedUserId?: string
+}
+
+const rowSkeletonIds = ["hero-admin-1", "hero-admin-2", "hero-admin-3"]
+
+const formatDate = (value: Date | string | undefined | null) =>
+  value
+    ? new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(
+        new Date(value)
+      )
+    : "–"
+
+/** HeroUI presentation for the static Admin users view. */
+export function AdminUsers({
+  className,
+  onSelectedUserIdChange,
+  selectedUserId: controlledSelectedUserId
+}: AdminUsersProps) {
+  const { authClient } = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const [localSelectedUserId, setLocalSelectedUserId] = useState<string>()
+  const [page, setPage] = useState(0)
+  const [search, setSearch] = useState("")
+  const [searchField, setSearchField] = useState<SearchFieldName>("email")
+  const deferredSearch = useDeferredValue(search.trim())
+  const isSelectionControlled = onSelectedUserIdChange !== undefined
+  const selectedUserId = isSelectionControlled
+    ? controlledSelectedUserId
+    : localSelectedUserId
+  const permission = useAdminPermission(authClient, { user: ["list"] })
+  const params = useMemo<AdminListUsersParams>(
+    () => ({
+      limit: config.pageSize,
+      offset: page * config.pageSize,
+      searchField,
+      searchOperator: "contains",
+      searchValue: deferredSearch || undefined,
+      sortBy: "createdAt",
+      sortDirection: "desc"
+    }),
+    [config.pageSize, deferredSearch, page, searchField]
+  )
+  const users = useAdminUsers(authClient, {
+    enabled: permission.data?.success === true,
+    params,
+    placeholderData: keepPreviousData
+  })
+
+  const selectUser = (userId: string | undefined) => {
+    if (!isSelectionControlled) setLocalSelectedUserId(userId)
+    onSelectedUserIdChange?.(userId)
+  }
+  const total = users.data?.total ?? 0
+
+  return (
+    <section className={cn("flex flex-col gap-4", className)}>
+      <header className="flex flex-col gap-1">
+        <h1 className="text-xl font-semibold">{config.localization.users}</h1>
+        <p className="text-sm text-muted">
+          {config.localization.usersDescription}
+        </p>
+      </header>
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
+        <Select
+          className="sm:w-36"
+          value={searchField}
+          onChange={(value) => {
+            setSearchField(String(value) as SearchFieldName)
+            setPage(0)
+          }}
+        >
+          <Label>{config.localization.search}</Label>
+          <Select.Trigger>
+            <Select.Value />
+            <Select.Indicator />
+          </Select.Trigger>
+          <Select.Popover>
+            <ListBox>
+              <ListBox.Item id="email">
+                {config.localization.email}
+              </ListBox.Item>
+              <ListBox.Item id="name">{config.localization.name}</ListBox.Item>
+            </ListBox>
+          </Select.Popover>
+        </Select>
+        <SearchField
+          className="w-full sm:max-w-md"
+          value={search}
+          onChange={(value) => {
+            setSearch(value)
+            setPage(0)
+          }}
+        >
+          <SearchField.Group>
+            <SearchField.SearchIcon />
+            <SearchField.Input
+              placeholder={
+                searchField === "email"
+                  ? config.localization.searchByEmail
+                  : config.localization.searchByName
+              }
+            />
+            <SearchField.ClearButton />
+          </SearchField.Group>
+        </SearchField>
+      </div>
+
+      {permission.isPending ? (
+        <AdminTableSkeleton />
+      ) : !permission.data?.success ? (
+        <AdminMessage
+          description={config.localization.accessDeniedDescription}
+          title={config.localization.accessDenied}
+        />
+      ) : users.isError ? (
+        <AdminMessage
+          description={config.localization.loadUsersErrorDescription}
+          title={config.localization.loadUsersError}
+        />
+      ) : (
+        <Table>
+          <Table.ScrollContainer>
+            <Table.Content aria-label={config.localization.users}>
+              <Table.Header>
+                <Table.Column isRowHeader>
+                  {config.localization.name}
+                </Table.Column>
+                <Table.Column>{config.localization.role}</Table.Column>
+                <Table.Column>{config.localization.status}</Table.Column>
+                <Table.Column>{config.localization.created}</Table.Column>
+              </Table.Header>
+              <Table.Body>
+                {users.isPending
+                  ? rowSkeletonIds.map((id) => (
+                      <Table.Row id={id} key={id}>
+                        <Table.Cell>
+                          <Skeleton className="h-8 w-52" />
+                        </Table.Cell>
+                        <Table.Cell>
+                          <Skeleton className="h-5 w-16" />
+                        </Table.Cell>
+                        <Table.Cell>
+                          <Skeleton className="h-5 w-16" />
+                        </Table.Cell>
+                        <Table.Cell>
+                          <Skeleton className="h-4 w-24" />
+                        </Table.Cell>
+                      </Table.Row>
+                    ))
+                  : users.data?.users.map((user) => (
+                      <Table.Row id={user.id} key={user.id}>
+                        <Table.Cell>
+                          <Button
+                            className="h-auto justify-start px-0"
+                            variant="tertiary"
+                            onPress={() => selectUser(user.id)}
+                          >
+                            <UserAvatar user={user} />
+                            <span className="min-w-0 text-start">
+                              <span className="block truncate font-medium">
+                                {user.name}
+                              </span>
+                              <span className="block truncate text-xs text-muted">
+                                {user.email}
+                              </span>
+                            </span>
+                          </Button>
+                        </Table.Cell>
+                        <Table.Cell>
+                          <Chip size="sm">
+                            {user.role ?? config.defaultRole}
+                          </Chip>
+                        </Table.Cell>
+                        <Table.Cell>
+                          <Chip
+                            color={user.banned ? "danger" : "default"}
+                            size="sm"
+                          >
+                            {user.banned
+                              ? config.localization.banned
+                              : config.localization.active}
+                          </Chip>
+                        </Table.Cell>
+                        <Table.Cell>{formatDate(user.createdAt)}</Table.Cell>
+                      </Table.Row>
+                    ))}
+              </Table.Body>
+            </Table.Content>
+          </Table.ScrollContainer>
+        </Table>
+      )}
+
+      <footer className="flex items-center justify-between gap-2 text-sm text-muted">
+        <span>
+          {config.localization.usersPaginationRange
+            .replace("{{from}}", String(total ? page * config.pageSize + 1 : 0))
+            .replace(
+              "{{to}}",
+              String(Math.min(total, (page + 1) * config.pageSize))
+            )
+            .replace("{{total}}", String(total))}
+        </span>
+        <div className="flex gap-2">
+          <Button
+            isDisabled={page === 0}
+            size="sm"
+            variant="outline"
+            onPress={() => setPage((value) => Math.max(0, value - 1))}
+          >
+            {config.localization.previousPage}
+          </Button>
+          <Button
+            isDisabled={(page + 1) * config.pageSize >= total}
+            size="sm"
+            variant="outline"
+            onPress={() => setPage((value) => value + 1)}
+          >
+            {config.localization.nextPage}
+          </Button>
+        </div>
+      </footer>
+
+      <UserDrawer
+        isOpen={Boolean(selectedUserId)}
+        onOpenChange={(open) => !open && selectUser(undefined)}
+        userId={selectedUserId}
+      />
+    </section>
+  )
+}
+
+function AdminMessage({
+  description,
+  title
+}: {
+  description: string
+  title: string
+}) {
+  return (
+    <div className="flex min-h-64 flex-col items-center justify-center gap-1 rounded-xl border border-dashed p-8 text-center">
+      <h2 className="font-semibold">{title}</h2>
+      <p className="text-sm text-muted">{description}</p>
+    </div>
+  )
+}
+
+function AdminTableSkeleton() {
+  return (
+    <div className="flex flex-col gap-2 rounded-xl border p-4">
+      {rowSkeletonIds.map((id) => (
+        <Skeleton className="h-12 w-full" key={id} />
+      ))}
+    </div>
+  )
+}
+
+function UserDrawer({
+  isOpen,
+  onOpenChange,
+  userId
+}: {
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+  userId?: string
+}) {
+  const { authClient } = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const user = useAdminUser(authClient, userId)
+  const sessionsPermission = useAdminPermission(authClient, {
+    session: ["list"]
+  })
+  const sessions = useAdminUserSessions(authClient, userId, {
+    enabled: sessionsPermission.data?.success === true
+  })
+
+  return (
+    <Drawer.Backdrop isOpen={isOpen} onOpenChange={onOpenChange}>
+      <Drawer.Content placement="right">
+        <Drawer.Dialog>
+          <Drawer.CloseTrigger />
+          <Drawer.Header>
+            <Drawer.Heading>{config.localization.userDetails}</Drawer.Heading>
+          </Drawer.Header>
+          <Drawer.Body>
+            {user.isPending ? (
+              <div className="flex flex-col gap-3">
+                <Skeleton className="size-12 rounded-full" />
+                <Skeleton className="h-5 w-40" />
+                <Skeleton className="h-4 w-64" />
+              </div>
+            ) : user.data ? (
+              <Tabs>
+                <Tabs.ListContainer>
+                  <Tabs.List aria-label={config.localization.userDetails}>
+                    <Tabs.Tab id="overview">
+                      {config.localization.overview}
+                      <Tabs.Indicator />
+                    </Tabs.Tab>
+                    <Tabs.Tab id="sessions">
+                      {config.localization.sessions}
+                      <Tabs.Indicator />
+                    </Tabs.Tab>
+                  </Tabs.List>
+                </Tabs.ListContainer>
+                <Tabs.Panel className="flex flex-col gap-4 pt-4" id="overview">
+                  <div className="flex items-center gap-3">
+                    <UserAvatar size="lg" user={user.data} />
+                    <div>
+                      <div className="font-medium">{user.data.name}</div>
+                      <div className="text-sm text-muted">
+                        {user.data.email}
+                      </div>
+                    </div>
+                  </div>
+                  <dl className="grid grid-cols-[auto_1fr] gap-3 text-sm">
+                    <dt className="text-muted">{config.localization.userId}</dt>
+                    <dd className="font-mono text-xs">{user.data.id}</dd>
+                    <dt className="text-muted">{config.localization.role}</dt>
+                    <dd>{user.data.role ?? config.defaultRole}</dd>
+                    <dt className="text-muted">
+                      {config.localization.created}
+                    </dt>
+                    <dd>{formatDate(user.data.createdAt)}</dd>
+                  </dl>
+                </Tabs.Panel>
+                <Tabs.Panel className="flex flex-col gap-2 pt-4" id="sessions">
+                  {sessions.isPending ? (
+                    rowSkeletonIds.map((id) => (
+                      <Skeleton className="h-16 w-full" key={`drawer-${id}`} />
+                    ))
+                  ) : sessions.data?.sessions.length ? (
+                    sessions.data.sessions.map((session) => (
+                      <div className="rounded-xl border p-3" key={session.id}>
+                        <div className="truncate text-sm font-medium">
+                          {session.userAgent || config.localization.sessions}
+                        </div>
+                        <div className="text-xs text-muted">
+                          {formatDate(session.createdAt)} ·{" "}
+                          {formatDate(session.expiresAt)}
+                        </div>
+                        {config.showIpAddress && session.ipAddress ? (
+                          <div className="mt-1 font-mono text-xs text-muted">
+                            {session.ipAddress}
+                          </div>
+                        ) : null}
+                      </div>
+                    ))
+                  ) : (
+                    <p className="py-8 text-center text-sm text-muted">
+                      {config.localization.noSessions}
+                    </p>
+                  )}
+                </Tabs.Panel>
+              </Tabs>
+            ) : (
+              <AdminMessage
+                title={config.localization.loadUsersError}
+                description={config.localization.loadUsersErrorDescription}
+              />
+            )}
+          </Drawer.Body>
+          <Drawer.Footer>
+            <Button slot="close" variant="secondary">
+              {config.localization.close}
+            </Button>
+          </Drawer.Footer>
+        </Drawer.Dialog>
+      </Drawer.Content>
+    </Drawer.Backdrop>
+  )
+}

--- a/packages/heroui/src/components/auth/admin/admin.tsx
+++ b/packages/heroui/src/components/auth/admin/admin.tsx
@@ -20,15 +20,15 @@ export function Admin({ className, hideNav, path, view }: AdminProps) {
   const { authClient, basePaths, plugins, viewPaths } = useAuth()
   const { localization } = useAuthPlugin(adminPlugin)
   useAuthenticate(authClient)
+  const tabs = useMemo(
+    () => plugins.flatMap((plugin) => plugin.adminTabs ?? []),
+    [plugins]
+  )
 
   if (!view && !path) {
     throw new Error("[Better Auth UI] Either `view` or `path` must be provided")
   }
 
-  const tabs = useMemo(
-    () => plugins.flatMap((plugin) => plugin.adminTabs ?? []),
-    [plugins]
-  )
   const currentView =
     view ??
     (viewPaths.admin.users === path ? "users" : undefined) ??

--- a/packages/heroui/src/components/auth/admin/admin.tsx
+++ b/packages/heroui/src/components/auth/admin/admin.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import type { AdminView } from "@better-auth-ui/core"
+import { useAuth, useAuthenticate, useAuthPlugin } from "@better-auth-ui/react"
+import { cn, Link } from "@heroui/react"
+import { useMemo } from "react"
+
+import { adminPlugin } from "../../../lib/auth/admin-plugin"
+import { AdminUsers } from "./admin-users"
+
+export type AdminProps = {
+  className?: string
+  hideNav?: boolean
+  path?: string
+  view?: AdminView | string
+}
+
+/** Render a finite static administration route and plugin-contributed tabs. */
+export function Admin({ className, hideNav, path, view }: AdminProps) {
+  const { authClient, basePaths, plugins, viewPaths } = useAuth()
+  const { localization } = useAuthPlugin(adminPlugin)
+  useAuthenticate(authClient)
+
+  if (!view && !path) {
+    throw new Error("[Better Auth UI] Either `view` or `path` must be provided")
+  }
+
+  const tabs = useMemo(
+    () => plugins.flatMap((plugin) => plugin.adminTabs ?? []),
+    [plugins]
+  )
+  const currentView =
+    view ??
+    (viewPaths.admin.users === path ? "users" : undefined) ??
+    tabs.find((tab) => tab.path === path)?.id
+  const contributedView = tabs.find((tab) => tab.id === currentView)
+
+  return (
+    <div className={cn("flex w-full flex-col gap-6", className)}>
+      {!hideNav && (
+        <nav aria-label={localization.admin} className="flex gap-1 border-b">
+          <Link
+            className={cn(
+              "rounded-lg px-3 py-2 text-sm",
+              currentView === "users" && "bg-default text-foreground"
+            )}
+            href={`${basePaths.admin}/${viewPaths.admin.users}`}
+          >
+            {localization.users}
+          </Link>
+          {tabs.map((tab) => (
+            <Link
+              key={`${tab.id}-${tab.path}`}
+              className={cn(
+                "rounded-lg px-3 py-2 text-sm",
+                currentView === tab.id && "bg-default text-foreground"
+              )}
+              href={`${basePaths.admin}/${tab.path}`}
+            >
+              {tab.label}
+            </Link>
+          ))}
+        </nav>
+      )}
+
+      {currentView === "users" ? (
+        <AdminUsers />
+      ) : contributedView ? (
+        <contributedView.component />
+      ) : (
+        <div className="flex min-h-64 flex-col items-center justify-center gap-2 rounded-xl border border-dashed p-8 text-center">
+          <h2 className="font-semibold">{localization.unknownView}</h2>
+          <p className="text-sm text-muted">
+            {localization.unknownViewDescription} &quot;{path ?? view}&quot;
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/heroui/src/index.tsx
+++ b/packages/heroui/src/index.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 export * from "./components/auth/additional-field"
+export * from "./components/auth/admin/admin"
+export * from "./components/auth/admin/admin-users"
 export * from "./components/auth/auth"
 export * from "./components/auth/auth-provider"
 export * from "./components/auth/auth-redirect"

--- a/packages/heroui/src/plugins/admin/index.ts
+++ b/packages/heroui/src/plugins/admin/index.ts
@@ -1,5 +1,7 @@
 "use client"
 
+export * from "../../components/auth/admin/admin"
+export * from "../../components/auth/admin/admin-users"
 export * from "../../components/auth/admin/stop-impersonating"
 export * from "../../lib/auth/admin-plugin"
 export * from "../../lib/auth/auth-plugin"


### PR DESCRIPTION
Add static /admin/users pages and controlled user inspectors across the supported presentations. Include permission-aware actions, registry artifacts, examples, and setup documentation.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin dashboards for managing and inspecting users.
  * Added user search, filtering, pagination, role and password management, banning, deletion, impersonation, and session controls.
  * Added the protected `/admin/users` route with authentication redirects.
  * Added responsive user-detail drawers and dialogs with permission-aware session and privacy controls.
  * Added configurable navigation, plugin-contributed admin views, localization, and loading, error, and empty states.
* **Documentation**
  * Expanded Admin plugin documentation across supported UI frameworks, covering setup, permissions, configuration, privacy, and supported functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->