### PR TITLE
feat(dash): add admin user activity tab

### DIFF
--- a/apps/docs/content/docs/heroui/plugins/admin.mdx
+++ b/apps/docs/content/docs/heroui/plugins/admin.mdx
@@ -89,6 +89,14 @@ Applications can control the drawer through `<AdminUsers />`:
 />
 ```
 
+## Inspector tabs
+
+The user inspector includes local Overview and Sessions tabs. Registered
+plugins can add more tabs without adding routes.
+
+The Dash integration adds an Activity tab when both UI plugins are registered.
+Dash applies its own organization owner or admin access rules to this tab.
+
 ## Permissions and privacy
 
 The users page calls the Better Auth permission API before it requests the

--- a/apps/docs/content/docs/heroui/plugins/dash.mdx
+++ b/apps/docs/content/docs/heroui/plugins/dash.mdx
@@ -7,7 +7,7 @@ description: Add personal activity and organization audit logs from Better Auth 
 import { Callout } from "fumadocs-ui/components/callout"
 import { Step, Steps } from "fumadocs-ui/components/steps"
 
-The Dash plugin adds an Activity tab to personal and organization settings. It reads audit logs through the public `dashClient()` API from `@better-auth/infra`.
+The Dash integration adds Activity tabs to personal settings, organization settings, and the Admin user inspector. It reads audit logs through the public `dashClient()` API from `@better-auth/infra`.
 
 Organization owners and admins see organization-wide activity. Other members see only their own activity in that organization. Every organization query uses the organization ID from the current route.
 
@@ -102,6 +102,14 @@ export const validOrganizationPaths = [
 
 Use the same Dash options in the provider and route configuration when you customize the segment.
 
+## Admin user activity
+
+If the Admin integration is present, Dash adds an Activity tab to its user inspector. The tab calls `getAllAuditLogs({ userId })` for the selected user.
+
+Dash authorizes this endpoint for organization owners and admins. A Better Auth application-admin role does not grant Dash access by itself.
+
+Set `admin: false` on `dashPlugin()` to remove this inspector tab.
+
 ## Access and privacy
 
 - Personal settings call `getAuditLogs` for the signed-in user.
@@ -118,13 +126,15 @@ The empty state says that no retained activity matches the view. It does not cla
 
 ```tsx
 import {
+  AdminUserActivity,
   OrganizationActivity,
   UserActivity
 } from "@better-auth-ui/heroui/plugins/dash"
 
 import {
   useDashAllAuditLogs,
-  useDashAuditLogs
+  useDashAuditLogs,
+  useDashUserAuditLogs
 } from "@better-auth-ui/react/plugins/dash"
 ```
 

--- a/apps/docs/content/docs/shadcn/plugins/admin.mdx
+++ b/apps/docs/content/docs/shadcn/plugins/admin.mdx
@@ -137,8 +137,11 @@ search across names, email addresses, and user IDs.
 
 ## User inspector
 
-Select a row to open the user inspector. The inspector uses local Overview and
-Sessions tabs. These tabs are not routes.
+Select a row to open the user inspector. The inspector includes local Overview
+and Sessions tabs. Registered plugins can add more tabs without adding routes.
+
+The Dash integration adds an Activity tab when both UI plugins are registered.
+Dash applies its own organization owner or admin access rules to this tab.
 
 The inspector can change roles, set passwords, ban users, impersonate users,
 remove users, and revoke sessions. Dangerous actions require confirmation.

--- a/apps/docs/content/docs/shadcn/plugins/dash.mdx
+++ b/apps/docs/content/docs/shadcn/plugins/dash.mdx
@@ -7,7 +7,7 @@ description: Add personal activity and organization audit logs from Better Auth 
 import { Callout } from "fumadocs-ui/components/callout"
 import { Step, Steps } from "fumadocs-ui/components/steps"
 
-The Dash registry item adds an Activity tab to personal and organization settings. It reads audit logs through the public `dashClient()` API from `@better-auth/infra`.
+The Dash integration adds Activity tabs to personal settings, organization settings, and the Admin user inspector. It reads audit logs through the public `dashClient()` API from `@better-auth/infra`.
 
 Organization owners and admins see organization-wide activity. Other members see only their own activity in that organization. Every organization query uses the organization ID from the current route.
 
@@ -111,6 +111,14 @@ export const validOrganizationPaths = [
 
 Use the same Dash options in the provider and route configuration when you customize the segment.
 
+## Admin user activity
+
+If the Admin integration is present, Dash adds an Activity tab to its user inspector. The tab calls `getAllAuditLogs({ userId })` for the selected user.
+
+Dash authorizes this endpoint for organization owners and admins. A Better Auth application-admin role does not grant Dash access by itself.
+
+Set `admin: false` on `dashPlugin()` to remove this inspector tab.
+
 ## Access and privacy
 
 - Personal settings call `getAuditLogs` for the signed-in user.
@@ -128,7 +136,8 @@ The empty state says that no retained activity matches the view. It does not cla
 ```tsx
 import {
   useDashAllAuditLogs,
-  useDashAuditLogs
+  useDashAuditLogs,
+  useDashUserAuditLogs
 } from "@better-auth-ui/react/plugins/dash"
 ```
 

--- a/apps/docs/content/docs/zaidan/plugins/admin.mdx
+++ b/apps/docs/content/docs/zaidan/plugins/admin.mdx
@@ -104,6 +104,14 @@ import { AdminUsers } from "@/components/auth/admin/admin-users"
 />
 ```
 
+## Inspector tabs
+
+The user inspector includes local Overview and Sessions tabs. Registered
+plugins can add more tabs without adding routes.
+
+The Dash integration adds an Activity tab when both UI plugins are registered.
+Dash applies its own organization owner or admin access rules to this tab.
+
 ## Permissions and privacy
 
 The users page calls the Better Auth permission API before it requests the

--- a/apps/docs/content/docs/zaidan/plugins/dash.mdx
+++ b/apps/docs/content/docs/zaidan/plugins/dash.mdx
@@ -7,7 +7,7 @@ description: Add personal activity and organization audit logs to Solid and Zaid
 import { Callout } from "fumadocs-ui/components/callout"
 import { Step, Steps } from "fumadocs-ui/components/steps"
 
-The Dash registry item adds an Activity tab to personal and organization settings. It reads audit logs through the public `dashClient()` API from `@better-auth/infra`.
+The Dash integration adds Activity tabs to personal settings, organization settings, and the Admin user inspector. It reads audit logs through the public `dashClient()` API from `@better-auth/infra`.
 
 Organization owners and admins see organization-wide activity. Other members see only their own activity in that organization. Every organization query uses the organization ID from the current route.
 
@@ -113,6 +113,14 @@ export const validOrganizationPaths = [
 
 Use the same Dash options in the provider and route configuration when you customize the segment.
 
+## Admin user activity
+
+If the Admin integration is present, Dash adds an Activity tab to its user inspector. The tab calls `getAllAuditLogs({ userId })` for the selected user.
+
+Dash authorizes this endpoint for organization owners and admins. A Better Auth application-admin role does not grant Dash access by itself.
+
+Set `admin: false` on `dashPlugin()` to remove this inspector tab.
+
 ## Access and privacy
 
 - Personal settings call `getAuditLogs` for the signed-in user.
@@ -130,7 +138,8 @@ The empty state says that no retained activity matches the view. It does not cla
 ```tsx
 import {
   useDashAllAuditLogs,
-  useDashAuditLogs
+  useDashAuditLogs,
+  useDashUserAuditLogs
 } from "@better-auth-ui/solid/plugins/dash"
 ```
 

--- a/apps/docs/src/components/auth/admin/admin-users.tsx
+++ b/apps/docs/src/components/auth/admin/admin-users.tsx
@@ -666,6 +666,12 @@ function UserInspector({
 }) {
   const auth = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
+  const contributedTabs = auth.plugins.flatMap((plugin) =>
+    (plugin.adminUserTabs ?? []).map((tab) => ({
+      ...tab,
+      value: `${plugin.id}:${tab.id}`
+    }))
+  )
   const detail = useAdminUser(auth.authClient, userId)
   const sessionsPermission = useAdminPermission(
     auth.authClient,
@@ -829,6 +835,11 @@ function UserInspector({
                 <TabsTrigger value="sessions">
                   {config.localization.sessions}
                 </TabsTrigger>
+                {contributedTabs.map((tab) => (
+                  <TabsTrigger key={tab.value} value={tab.value}>
+                    {tab.label}
+                  </TabsTrigger>
+                ))}
               </TabsList>
               <TabsContent
                 className="flex flex-col gap-6 pt-4"
@@ -1038,6 +1049,18 @@ function UserInspector({
                   </p>
                 )}
               </TabsContent>
+              {contributedTabs.map((tab) => {
+                const ContributedTab = tab.component
+                return (
+                  <TabsContent
+                    className="pt-4"
+                    key={tab.value}
+                    value={tab.value}
+                  >
+                    <ContributedTab userId={user.id} />
+                  </TabsContent>
+                )
+              })}
             </Tabs>
           ) : (
             <AdminState

--- a/apps/docs/src/components/auth/dash/activity.tsx
+++ b/apps/docs/src/components/auth/dash/activity.tsx
@@ -15,7 +15,8 @@ import {
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
   useDashAllAuditLogs,
-  useDashAuditLogs
+  useDashAuditLogs,
+  useDashUserAuditLogs
 } from "@better-auth-ui/react/plugins/dash"
 import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
 import { keepPreviousData } from "@tanstack/react-query"
@@ -56,13 +57,19 @@ import { Spinner } from "@/components/ui/spinner"
 import { dashPlugin } from "@/lib/auth/dash-plugin"
 import { cn } from "@/lib/utils"
 
-type ActivityAccess = "organization" | "user"
+type ActivityAccess = "admin-user" | "organization" | "user"
 
 type ActivityFeedProps = {
   access: ActivityAccess
   organizationId?: string
   ready?: boolean
   className?: string
+  userId?: string
+}
+
+export type AdminUserActivityProps = {
+  className?: string
+  userId: string
 }
 
 export type UserActivityProps = { className?: string }
@@ -182,7 +189,8 @@ function ActivityFeed({
   access,
   organizationId,
   ready = true,
-  className
+  className,
+  userId
 }: ActivityFeedProps) {
   const { authClient } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
@@ -199,7 +207,21 @@ function ActivityFeed({
     params,
     placeholderData: keepPreviousData
   })
-  const query = access === "organization" ? organizationQuery : userQuery
+  const adminUserQuery = useDashUserAuditLogs(
+    authClient as DashAuthClient,
+    userId,
+    {
+      enabled: ready && access === "admin-user",
+      params: { limit: pageSize, offset },
+      placeholderData: keepPreviousData
+    }
+  )
+  const query =
+    access === "organization"
+      ? organizationQuery
+      : access === "admin-user"
+        ? adminUserQuery
+        : userQuery
   const { data, error, isFetching, isPending } = query
   const showPending = !ready || isPending
   const pageEnd = offset + (data?.events.length ?? 0)
@@ -213,9 +235,11 @@ function ActivityFeed({
       <CardHeader>
         <CardTitle>{localization.activity}</CardTitle>
         <CardDescription>
-          {organizationId
-            ? localization.organizationActivityDescription
-            : localization.activityDescription}
+          {access === "admin-user"
+            ? localization.adminUserActivityDescription
+            : organizationId
+              ? localization.organizationActivityDescription
+              : localization.activityDescription}
         </CardDescription>
         {organizationId && (
           <CardAction>
@@ -318,6 +342,11 @@ function ActivityFeed({
       )}
     </Card>
   )
+}
+
+/** Authentication and account activity for a user selected by an administrator. */
+export function AdminUserActivity(props: AdminUserActivityProps) {
+  return <ActivityFeed access="admin-user" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/apps/docs/src/components/auth/dash/activity.tsx
+++ b/apps/docs/src/components/auth/dash/activity.tsx
@@ -212,8 +212,7 @@ function ActivityFeed({
     userId,
     {
       enabled: ready && access === "admin-user",
-      params: { limit: pageSize, offset },
-      placeholderData: keepPreviousData
+      params: { limit: pageSize, offset }
     }
   )
   const query =
@@ -346,7 +345,7 @@ function ActivityFeed({
 
 /** Authentication and account activity for a user selected by an administrator. */
 export function AdminUserActivity(props: AdminUserActivityProps) {
-  return <ActivityFeed access="admin-user" {...props} />
+  return <ActivityFeed key={props.userId} access="admin-user" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/apps/docs/src/lib/auth/dash-plugin.ts
+++ b/apps/docs/src/lib/auth/dash-plugin.ts
@@ -7,6 +7,7 @@ import { Activity } from "lucide-react"
 import { createElement } from "react"
 
 import {
+  AdminUserActivity,
   OrganizationActivity,
   UserActivity
 } from "@/components/auth/dash/activity"
@@ -25,6 +26,17 @@ export const dashPlugin = createAuthPlugin(
     const core = coreDashPlugin(options)
     return {
       ...core,
+      ...(core.admin
+        ? {
+            adminUserTabs: [
+              {
+                id: "activity",
+                label: activityLabel(core.localization.activity),
+                component: AdminUserActivity
+              }
+            ]
+          }
+        : {}),
       ...(core.user
         ? {
             settingsTabs: [

--- a/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -666,6 +666,12 @@ function UserInspector({
 }) {
   const auth = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
+  const contributedTabs = auth.plugins.flatMap((plugin) =>
+    (plugin.adminUserTabs ?? []).map((tab) => ({
+      ...tab,
+      value: `${plugin.id}:${tab.id}`
+    }))
+  )
   const detail = useAdminUser(auth.authClient, userId)
   const sessionsPermission = useAdminPermission(
     auth.authClient,
@@ -829,6 +835,11 @@ function UserInspector({
                 <TabsTrigger value="sessions">
                   {config.localization.sessions}
                 </TabsTrigger>
+                {contributedTabs.map((tab) => (
+                  <TabsTrigger key={tab.value} value={tab.value}>
+                    {tab.label}
+                  </TabsTrigger>
+                ))}
               </TabsList>
               <TabsContent
                 className="flex flex-col gap-6 pt-4"
@@ -1038,6 +1049,18 @@ function UserInspector({
                   </p>
                 )}
               </TabsContent>
+              {contributedTabs.map((tab) => {
+                const ContributedTab = tab.component
+                return (
+                  <TabsContent
+                    className="pt-4"
+                    key={tab.value}
+                    value={tab.value}
+                  >
+                    <ContributedTab userId={user.id} />
+                  </TabsContent>
+                )
+              })}
             </Tabs>
           ) : (
             <AdminState

--- a/examples/next-shadcn-example/src/components/auth/dash/activity.tsx
+++ b/examples/next-shadcn-example/src/components/auth/dash/activity.tsx
@@ -15,7 +15,8 @@ import {
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
   useDashAllAuditLogs,
-  useDashAuditLogs
+  useDashAuditLogs,
+  useDashUserAuditLogs
 } from "@better-auth-ui/react/plugins/dash"
 import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
 import { keepPreviousData } from "@tanstack/react-query"
@@ -56,13 +57,19 @@ import { Spinner } from "@/components/ui/spinner"
 import { dashPlugin } from "@/lib/auth/dash-plugin"
 import { cn } from "@/lib/utils"
 
-type ActivityAccess = "organization" | "user"
+type ActivityAccess = "admin-user" | "organization" | "user"
 
 type ActivityFeedProps = {
   access: ActivityAccess
   organizationId?: string
   ready?: boolean
   className?: string
+  userId?: string
+}
+
+export type AdminUserActivityProps = {
+  className?: string
+  userId: string
 }
 
 export type UserActivityProps = { className?: string }
@@ -182,7 +189,8 @@ function ActivityFeed({
   access,
   organizationId,
   ready = true,
-  className
+  className,
+  userId
 }: ActivityFeedProps) {
   const { authClient } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
@@ -199,7 +207,21 @@ function ActivityFeed({
     params,
     placeholderData: keepPreviousData
   })
-  const query = access === "organization" ? organizationQuery : userQuery
+  const adminUserQuery = useDashUserAuditLogs(
+    authClient as DashAuthClient,
+    userId,
+    {
+      enabled: ready && access === "admin-user",
+      params: { limit: pageSize, offset },
+      placeholderData: keepPreviousData
+    }
+  )
+  const query =
+    access === "organization"
+      ? organizationQuery
+      : access === "admin-user"
+        ? adminUserQuery
+        : userQuery
   const { data, error, isFetching, isPending } = query
   const showPending = !ready || isPending
   const pageEnd = offset + (data?.events.length ?? 0)
@@ -213,9 +235,11 @@ function ActivityFeed({
       <CardHeader>
         <CardTitle>{localization.activity}</CardTitle>
         <CardDescription>
-          {organizationId
-            ? localization.organizationActivityDescription
-            : localization.activityDescription}
+          {access === "admin-user"
+            ? localization.adminUserActivityDescription
+            : organizationId
+              ? localization.organizationActivityDescription
+              : localization.activityDescription}
         </CardDescription>
         {organizationId && (
           <CardAction>
@@ -318,6 +342,11 @@ function ActivityFeed({
       )}
     </Card>
   )
+}
+
+/** Authentication and account activity for a user selected by an administrator. */
+export function AdminUserActivity(props: AdminUserActivityProps) {
+  return <ActivityFeed access="admin-user" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/examples/next-shadcn-example/src/components/auth/dash/activity.tsx
+++ b/examples/next-shadcn-example/src/components/auth/dash/activity.tsx
@@ -212,8 +212,7 @@ function ActivityFeed({
     userId,
     {
       enabled: ready && access === "admin-user",
-      params: { limit: pageSize, offset },
-      placeholderData: keepPreviousData
+      params: { limit: pageSize, offset }
     }
   )
   const query =
@@ -346,7 +345,7 @@ function ActivityFeed({
 
 /** Authentication and account activity for a user selected by an administrator. */
 export function AdminUserActivity(props: AdminUserActivityProps) {
-  return <ActivityFeed access="admin-user" {...props} />
+  return <ActivityFeed key={props.userId} access="admin-user" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/examples/next-shadcn-example/src/lib/auth/dash-plugin.ts
+++ b/examples/next-shadcn-example/src/lib/auth/dash-plugin.ts
@@ -7,6 +7,7 @@ import { Activity } from "lucide-react"
 import { createElement } from "react"
 
 import {
+  AdminUserActivity,
   OrganizationActivity,
   UserActivity
 } from "@/components/auth/dash/activity"
@@ -25,6 +26,17 @@ export const dashPlugin = createAuthPlugin(
     const core = coreDashPlugin(options)
     return {
       ...core,
+      ...(core.admin
+        ? {
+            adminUserTabs: [
+              {
+                id: "activity",
+                label: activityLabel(core.localization.activity),
+                component: AdminUserActivity
+              }
+            ]
+          }
+        : {}),
       ...(core.user
         ? {
             settingsTabs: [

--- a/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
@@ -666,6 +666,12 @@ function UserInspector({
 }) {
   const auth = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
+  const contributedTabs = auth.plugins.flatMap((plugin) =>
+    (plugin.adminUserTabs ?? []).map((tab) => ({
+      ...tab,
+      value: `${plugin.id}:${tab.id}`
+    }))
+  )
   const detail = useAdminUser(auth.authClient, userId)
   const sessionsPermission = useAdminPermission(
     auth.authClient,
@@ -829,6 +835,11 @@ function UserInspector({
                 <TabsTrigger value="sessions">
                   {config.localization.sessions}
                 </TabsTrigger>
+                {contributedTabs.map((tab) => (
+                  <TabsTrigger key={tab.value} value={tab.value}>
+                    {tab.label}
+                  </TabsTrigger>
+                ))}
               </TabsList>
               <TabsContent
                 className="flex flex-col gap-6 pt-4"
@@ -1041,6 +1052,18 @@ function UserInspector({
                   </p>
                 )}
               </TabsContent>
+              {contributedTabs.map((tab) => {
+                const ContributedTab = tab.component
+                return (
+                  <TabsContent
+                    className="pt-4"
+                    key={tab.value}
+                    value={tab.value}
+                  >
+                    <ContributedTab userId={user.id} />
+                  </TabsContent>
+                )
+              })}
             </Tabs>
           ) : (
             <AdminState

--- a/examples/start-shadcn-baseui-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/dash/activity.tsx
@@ -15,7 +15,8 @@ import {
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
   useDashAllAuditLogs,
-  useDashAuditLogs
+  useDashAuditLogs,
+  useDashUserAuditLogs
 } from "@better-auth-ui/react/plugins/dash"
 import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
 import { keepPreviousData } from "@tanstack/react-query"
@@ -56,13 +57,19 @@ import { Spinner } from "@/components/ui/spinner"
 import { dashPlugin } from "@/lib/auth/dash-plugin"
 import { cn } from "@/lib/utils"
 
-type ActivityAccess = "organization" | "user"
+type ActivityAccess = "admin-user" | "organization" | "user"
 
 type ActivityFeedProps = {
   access: ActivityAccess
   organizationId?: string
   ready?: boolean
   className?: string
+  userId?: string
+}
+
+export type AdminUserActivityProps = {
+  className?: string
+  userId: string
 }
 
 export type UserActivityProps = { className?: string }
@@ -182,7 +189,8 @@ function ActivityFeed({
   access,
   organizationId,
   ready = true,
-  className
+  className,
+  userId
 }: ActivityFeedProps) {
   const { authClient } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
@@ -199,7 +207,21 @@ function ActivityFeed({
     params,
     placeholderData: keepPreviousData
   })
-  const query = access === "organization" ? organizationQuery : userQuery
+  const adminUserQuery = useDashUserAuditLogs(
+    authClient as DashAuthClient,
+    userId,
+    {
+      enabled: ready && access === "admin-user",
+      params: { limit: pageSize, offset },
+      placeholderData: keepPreviousData
+    }
+  )
+  const query =
+    access === "organization"
+      ? organizationQuery
+      : access === "admin-user"
+        ? adminUserQuery
+        : userQuery
   const { data, error, isFetching, isPending } = query
   const showPending = !ready || isPending
   const pageEnd = offset + (data?.events.length ?? 0)
@@ -213,9 +235,11 @@ function ActivityFeed({
       <CardHeader>
         <CardTitle>{localization.activity}</CardTitle>
         <CardDescription>
-          {organizationId
-            ? localization.organizationActivityDescription
-            : localization.activityDescription}
+          {access === "admin-user"
+            ? localization.adminUserActivityDescription
+            : organizationId
+              ? localization.organizationActivityDescription
+              : localization.activityDescription}
         </CardDescription>
         {organizationId && (
           <CardAction>
@@ -318,6 +342,11 @@ function ActivityFeed({
       )}
     </Card>
   )
+}
+
+/** Authentication and account activity for a user selected by an administrator. */
+export function AdminUserActivity(props: AdminUserActivityProps) {
+  return <ActivityFeed access="admin-user" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/examples/start-shadcn-baseui-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/dash/activity.tsx
@@ -212,8 +212,7 @@ function ActivityFeed({
     userId,
     {
       enabled: ready && access === "admin-user",
-      params: { limit: pageSize, offset },
-      placeholderData: keepPreviousData
+      params: { limit: pageSize, offset }
     }
   )
   const query =
@@ -346,7 +345,7 @@ function ActivityFeed({
 
 /** Authentication and account activity for a user selected by an administrator. */
 export function AdminUserActivity(props: AdminUserActivityProps) {
-  return <ActivityFeed access="admin-user" {...props} />
+  return <ActivityFeed key={props.userId} access="admin-user" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/examples/start-shadcn-baseui-example/src/lib/auth/dash-plugin.ts
+++ b/examples/start-shadcn-baseui-example/src/lib/auth/dash-plugin.ts
@@ -7,6 +7,7 @@ import { Activity } from "lucide-react"
 import { createElement } from "react"
 
 import {
+  AdminUserActivity,
   OrganizationActivity,
   UserActivity
 } from "@/components/auth/dash/activity"
@@ -25,6 +26,17 @@ export const dashPlugin = createAuthPlugin(
     const core = coreDashPlugin(options)
     return {
       ...core,
+      ...(core.admin
+        ? {
+            adminUserTabs: [
+              {
+                id: "activity",
+                label: activityLabel(core.localization.activity),
+                component: AdminUserActivity
+              }
+            ]
+          }
+        : {}),
       ...(core.user
         ? {
             settingsTabs: [

--- a/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -666,6 +666,12 @@ function UserInspector({
 }) {
   const auth = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
+  const contributedTabs = auth.plugins.flatMap((plugin) =>
+    (plugin.adminUserTabs ?? []).map((tab) => ({
+      ...tab,
+      value: `${plugin.id}:${tab.id}`
+    }))
+  )
   const detail = useAdminUser(auth.authClient, userId)
   const sessionsPermission = useAdminPermission(
     auth.authClient,
@@ -829,6 +835,11 @@ function UserInspector({
                 <TabsTrigger value="sessions">
                   {config.localization.sessions}
                 </TabsTrigger>
+                {contributedTabs.map((tab) => (
+                  <TabsTrigger key={tab.value} value={tab.value}>
+                    {tab.label}
+                  </TabsTrigger>
+                ))}
               </TabsList>
               <TabsContent
                 className="flex flex-col gap-6 pt-4"
@@ -1038,6 +1049,18 @@ function UserInspector({
                   </p>
                 )}
               </TabsContent>
+              {contributedTabs.map((tab) => {
+                const ContributedTab = tab.component
+                return (
+                  <TabsContent
+                    className="pt-4"
+                    key={tab.value}
+                    value={tab.value}
+                  >
+                    <ContributedTab userId={user.id} />
+                  </TabsContent>
+                )
+              })}
             </Tabs>
           ) : (
             <AdminState

--- a/examples/start-shadcn-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-shadcn-example/src/components/auth/dash/activity.tsx
@@ -15,7 +15,8 @@ import {
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
   useDashAllAuditLogs,
-  useDashAuditLogs
+  useDashAuditLogs,
+  useDashUserAuditLogs
 } from "@better-auth-ui/react/plugins/dash"
 import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
 import { keepPreviousData } from "@tanstack/react-query"
@@ -56,13 +57,19 @@ import { Spinner } from "@/components/ui/spinner"
 import { dashPlugin } from "@/lib/auth/dash-plugin"
 import { cn } from "@/lib/utils"
 
-type ActivityAccess = "organization" | "user"
+type ActivityAccess = "admin-user" | "organization" | "user"
 
 type ActivityFeedProps = {
   access: ActivityAccess
   organizationId?: string
   ready?: boolean
   className?: string
+  userId?: string
+}
+
+export type AdminUserActivityProps = {
+  className?: string
+  userId: string
 }
 
 export type UserActivityProps = { className?: string }
@@ -182,7 +189,8 @@ function ActivityFeed({
   access,
   organizationId,
   ready = true,
-  className
+  className,
+  userId
 }: ActivityFeedProps) {
   const { authClient } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
@@ -199,7 +207,21 @@ function ActivityFeed({
     params,
     placeholderData: keepPreviousData
   })
-  const query = access === "organization" ? organizationQuery : userQuery
+  const adminUserQuery = useDashUserAuditLogs(
+    authClient as DashAuthClient,
+    userId,
+    {
+      enabled: ready && access === "admin-user",
+      params: { limit: pageSize, offset },
+      placeholderData: keepPreviousData
+    }
+  )
+  const query =
+    access === "organization"
+      ? organizationQuery
+      : access === "admin-user"
+        ? adminUserQuery
+        : userQuery
   const { data, error, isFetching, isPending } = query
   const showPending = !ready || isPending
   const pageEnd = offset + (data?.events.length ?? 0)
@@ -213,9 +235,11 @@ function ActivityFeed({
       <CardHeader>
         <CardTitle>{localization.activity}</CardTitle>
         <CardDescription>
-          {organizationId
-            ? localization.organizationActivityDescription
-            : localization.activityDescription}
+          {access === "admin-user"
+            ? localization.adminUserActivityDescription
+            : organizationId
+              ? localization.organizationActivityDescription
+              : localization.activityDescription}
         </CardDescription>
         {organizationId && (
           <CardAction>
@@ -318,6 +342,11 @@ function ActivityFeed({
       )}
     </Card>
   )
+}
+
+/** Authentication and account activity for a user selected by an administrator. */
+export function AdminUserActivity(props: AdminUserActivityProps) {
+  return <ActivityFeed access="admin-user" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/examples/start-shadcn-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-shadcn-example/src/components/auth/dash/activity.tsx
@@ -212,8 +212,7 @@ function ActivityFeed({
     userId,
     {
       enabled: ready && access === "admin-user",
-      params: { limit: pageSize, offset },
-      placeholderData: keepPreviousData
+      params: { limit: pageSize, offset }
     }
   )
   const query =
@@ -346,7 +345,7 @@ function ActivityFeed({
 
 /** Authentication and account activity for a user selected by an administrator. */
 export function AdminUserActivity(props: AdminUserActivityProps) {
-  return <ActivityFeed access="admin-user" {...props} />
+  return <ActivityFeed key={props.userId} access="admin-user" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/examples/start-shadcn-example/src/lib/auth/dash-plugin.ts
+++ b/examples/start-shadcn-example/src/lib/auth/dash-plugin.ts
@@ -7,6 +7,7 @@ import { Activity } from "lucide-react"
 import { createElement } from "react"
 
 import {
+  AdminUserActivity,
   OrganizationActivity,
   UserActivity
 } from "@/components/auth/dash/activity"
@@ -25,6 +26,17 @@ export const dashPlugin = createAuthPlugin(
     const core = coreDashPlugin(options)
     return {
       ...core,
+      ...(core.admin
+        ? {
+            adminUserTabs: [
+              {
+                id: "activity",
+                label: activityLabel(core.localization.activity),
+                component: AdminUserActivity
+              }
+            ]
+          }
+        : {}),
       ...(core.user
         ? {
             settingsTabs: [

--- a/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
@@ -13,6 +13,7 @@ import {
 import { createDebounce } from "@solid-primitives/debounce"
 import { Search } from "lucide-solid"
 import { createMemo, createSignal, For, Show } from "solid-js"
+import { Dynamic } from "solid-js/web"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -329,6 +330,14 @@ function UserDialog(props: {
   const config = () =>
     (auth.plugins.find((plugin) => plugin.id === adminPlugin.id) ??
       adminPlugin()) as ReturnType<typeof adminPlugin>
+  const contributedTabs = createMemo(() =>
+    auth.plugins.flatMap((plugin) =>
+      (plugin.adminUserTabs ?? []).map((tab) => ({
+        ...tab,
+        value: `${plugin.id}:${tab.id}`
+      }))
+    )
+  )
   const user = useAdminUser(authClient, props.userId)
   const sessionsPermission = useAdminPermission(authClient, () => ({
     session: ["list"]
@@ -368,6 +377,13 @@ function UserDialog(props: {
                   <TabsTrigger value="sessions">
                     {config().localization.sessions}
                   </TabsTrigger>
+                  <For each={contributedTabs()}>
+                    {(tab) => (
+                      <TabsTrigger value={tab.value}>
+                        <Dynamic component={tab.label} />
+                      </TabsTrigger>
+                    )}
+                  </For>
                 </TabsList>
                 <TabsContent class="flex flex-col gap-4 pt-4" value="overview">
                   <div class="flex items-center gap-3">
@@ -447,6 +463,13 @@ function UserDialog(props: {
                     </Show>
                   </Show>
                 </TabsContent>
+                <For each={contributedTabs()}>
+                  {(tab) => (
+                    <TabsContent class="pt-4" value={tab.value}>
+                      <Dynamic component={tab.component} userId={detail().id} />
+                    </TabsContent>
+                  )}
+                </For>
               </Tabs>
             )}
           </Show>

--- a/examples/start-solid-zaidan-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/dash/activity.tsx
@@ -221,8 +221,7 @@ function ActivityFeed(props: ActivityFeedProps) {
     () => props.userId,
     () => ({
       enabled: (props.ready ?? true) && props.access === "admin-user",
-      params: { limit: pageSize, offset: offset() },
-      placeholderData: keepPreviousData
+      params: { limit: pageSize, offset: offset() }
     })
   )
   const query = () =>

--- a/examples/start-solid-zaidan-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/dash/activity.tsx
@@ -12,7 +12,8 @@ import {
 import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import {
   useDashAllAuditLogs,
-  useDashAuditLogs
+  useDashAuditLogs,
+  useDashUserAuditLogs
 } from "@better-auth-ui/solid/plugins/dash"
 import { useActiveMemberRole } from "@better-auth-ui/solid/plugins/organization"
 import { keepPreviousData } from "@tanstack/solid-query"
@@ -54,13 +55,19 @@ import { Spinner } from "@/components/ui/spinner"
 import { dashPlugin } from "@/lib/auth/dash-plugin"
 import { cn } from "@/lib/utils"
 
-type ActivityAccess = "organization" | "user"
+type ActivityAccess = "admin-user" | "organization" | "user"
 
 type ActivityFeedProps = {
   access: ActivityAccess
   organizationId?: string
   ready?: boolean
   class?: string
+  userId?: string
+}
+
+export type AdminUserActivityProps = {
+  class?: string
+  userId: string
 }
 
 export type UserActivityProps = { class?: string }
@@ -185,7 +192,7 @@ function ActivityFeed(props: ActivityFeedProps) {
   const [page, setPage] = createSignal(0)
   createEffect(
     on(
-      () => [props.access, props.organizationId] as const,
+      () => [props.access, props.organizationId, props.userId] as const,
       () => setPage(0),
       { defer: true }
     )
@@ -209,8 +216,21 @@ function ActivityFeed(props: ActivityFeedProps) {
       placeholderData: keepPreviousData
     })
   )
+  const adminUserQuery = useDashUserAuditLogs(
+    auth.authClient as DashAuthClient,
+    () => props.userId,
+    () => ({
+      enabled: (props.ready ?? true) && props.access === "admin-user",
+      params: { limit: pageSize, offset: offset() },
+      placeholderData: keepPreviousData
+    })
+  )
   const query = () =>
-    props.access === "organization" ? organizationQuery : userQuery
+    props.access === "organization"
+      ? organizationQuery
+      : props.access === "admin-user"
+        ? adminUserQuery
+        : userQuery
   const showPending = () => !(props.ready ?? true) || query().isPending
   const pageEnd = () => offset() + (query().data?.events.length ?? 0)
   const hasNextPage = () => pageEnd() < (query().data?.total ?? 0)
@@ -223,9 +243,11 @@ function ActivityFeed(props: ActivityFeedProps) {
       <CardHeader>
         <CardTitle>{localization.activity}</CardTitle>
         <CardDescription>
-          {props.organizationId
-            ? localization.organizationActivityDescription
-            : localization.activityDescription}
+          {props.access === "admin-user"
+            ? localization.adminUserActivityDescription
+            : props.organizationId
+              ? localization.organizationActivityDescription
+              : localization.activityDescription}
         </CardDescription>
         <Show when={props.organizationId}>
           <CardAction>
@@ -351,6 +373,11 @@ function ActivityFeed(props: ActivityFeedProps) {
       </Show>
     </Card>
   )
+}
+
+/** Authentication and account activity for a user selected by an administrator. */
+export function AdminUserActivity(props: AdminUserActivityProps) {
+  return <ActivityFeed access="admin-user" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/examples/start-solid-zaidan-example/src/lib/auth/dash-plugin.tsx
+++ b/examples/start-solid-zaidan-example/src/lib/auth/dash-plugin.tsx
@@ -7,6 +7,7 @@ import {
 import { Activity } from "lucide-solid"
 
 import {
+  AdminUserActivity,
   OrganizationActivity,
   UserActivity
 } from "@/components/auth/dash/activity"
@@ -26,6 +27,17 @@ export const dashPlugin = createAuthPlugin(
     return {
       ...core,
       localization: core.localization as DashLocalization,
+      ...(core.admin
+        ? {
+            adminUserTabs: [
+              {
+                id: "activity",
+                label: ActivityLabel,
+                component: AdminUserActivity
+              }
+            ]
+          }
+        : {}),
       ...(core.user
         ? {
             settingsTabs: [

--- a/packages/core/src/plugins/dash/dash-audit-logs-query.ts
+++ b/packages/core/src/plugins/dash/dash-audit-logs-query.ts
@@ -40,6 +40,11 @@ export type DashAllAuditLogsParams = Omit<
   "session" | "userId"
 >
 
+export type DashUserAuditLogsParams = Omit<
+  DashGetAllAuditLogsInput,
+  "organizationId" | "session" | "userId"
+>
+
 const unwrapDashResult = (
   result:
     | { data: DashAuditLogsResponse; error: null }
@@ -78,6 +83,25 @@ export function dashAllAuditLogsOptions(
       ? async () =>
           unwrapDashResult(await authClient.dash.getAllAuditLogs(params))
       : skipToken
+  } satisfies QueryOptions<DashAuditLogsResponse>
+}
+
+/** Query options for one user's audit logs available to owners/admins. */
+export function dashUserAuditLogsOptions(
+  authClient: DashAuthClient,
+  actorUserId?: string,
+  userId?: string,
+  params: DashUserAuditLogsParams = {}
+) {
+  return {
+    queryKey: dashQueryKeys.userAuditLogs(actorUserId, userId, params),
+    queryFn:
+      actorUserId && userId
+        ? async () =>
+            unwrapDashResult(
+              await authClient.dash.getAllAuditLogs({ ...params, userId })
+            )
+        : skipToken
   } satisfies QueryOptions<DashAuditLogsResponse>
 }
 
@@ -127,3 +151,36 @@ export const fetchDashAllAuditLogs = (
   userId: string,
   params?: DashAllAuditLogsParams
 ) => queryClient.fetchQuery(dashAllAuditLogsOptions(authClient, userId, params))
+
+export const ensureDashUserAuditLogs = (
+  queryClient: QueryClient,
+  authClient: DashAuthClient,
+  actorUserId: string,
+  userId: string,
+  params?: DashUserAuditLogsParams
+) =>
+  queryClient.ensureQueryData(
+    dashUserAuditLogsOptions(authClient, actorUserId, userId, params)
+  )
+
+export const prefetchDashUserAuditLogs = (
+  queryClient: QueryClient,
+  authClient: DashAuthClient,
+  actorUserId: string,
+  userId: string,
+  params?: DashUserAuditLogsParams
+) =>
+  queryClient.prefetchQuery(
+    dashUserAuditLogsOptions(authClient, actorUserId, userId, params)
+  )
+
+export const fetchDashUserAuditLogs = (
+  queryClient: QueryClient,
+  authClient: DashAuthClient,
+  actorUserId: string,
+  userId: string,
+  params?: DashUserAuditLogsParams
+) =>
+  queryClient.fetchQuery(
+    dashUserAuditLogsOptions(authClient, actorUserId, userId, params)
+  )

--- a/packages/core/src/plugins/dash/dash-localization.ts
+++ b/packages/core/src/plugins/dash/dash-localization.ts
@@ -43,6 +43,8 @@ export const dashEventLabels = {
 export const dashLocalization = {
   activity: "Activity",
   activityDescription: "Review recent authentication and account activity.",
+  adminUserActivityDescription:
+    "Review recent authentication and account activity for this user.",
   organizationActivityDescription:
     "Review activity you can access for this organization.",
   organizationWide: "Organization-wide",

--- a/packages/core/src/plugins/dash/dash-plugin.ts
+++ b/packages/core/src/plugins/dash/dash-plugin.ts
@@ -13,6 +13,8 @@ declare module "../../lib/view-paths" {
 }
 
 export type DashPluginOptions = {
+  /** Add activity to the admin user inspector. @default true */
+  admin?: boolean
   /** Add activity to personal settings. @default true */
   user?: boolean
   /** Add activity to organization settings. @default true */
@@ -43,6 +45,7 @@ const resolvePageSize = (pageSize?: number) => {
 export const dashPlugin = createAuthPlugin(
   "dash",
   (options: DashPluginOptions = {}) => ({
+    admin: options.admin ?? true,
     user: options.user ?? true,
     organization: options.organization ?? true,
     pageSize: resolvePageSize(options.pageSize),

--- a/packages/core/src/plugins/dash/dash-query-keys.ts
+++ b/packages/core/src/plugins/dash/dash-query-keys.ts
@@ -9,5 +9,17 @@ export const dashQueryKeys = {
     [...dashQueryKeys.all(userId), "audit-logs", params] as const,
 
   allAuditLogs: <TParams>(userId: string | undefined, params: TParams) =>
-    [...dashQueryKeys.all(userId), "all-audit-logs", params] as const
+    [...dashQueryKeys.all(userId), "all-audit-logs", params] as const,
+
+  userAuditLogs: <TParams>(
+    actorUserId: string | undefined,
+    userId: string | undefined,
+    params: TParams
+  ) =>
+    [
+      ...dashQueryKeys.all(actorUserId),
+      "user-audit-logs",
+      userId,
+      params
+    ] as const
 } as const

--- a/packages/core/tests/dash-plugin.test.ts
+++ b/packages/core/tests/dash-plugin.test.ts
@@ -6,6 +6,7 @@ import {
   dashAuditLogsOptions,
   dashPlugin,
   dashQueryKeys,
+  dashUserAuditLogsOptions,
   getDashEventDetail,
   getDashEventLocation
 } from "../src/plugins/dash"
@@ -28,6 +29,7 @@ describe("dashPlugin", () => {
   it("registers static personal and organization activity views", () => {
     expect(dashPlugin()).toMatchObject({
       id: "dash",
+      admin: true,
       user: true,
       organization: true,
       pageSize: 20,
@@ -37,12 +39,14 @@ describe("dashPlugin", () => {
 
     expect(
       dashPlugin({
+        admin: false,
         user: false,
         organization: true,
         pageSize: 250,
         path: "history"
       })
     ).toMatchObject({
+      admin: false,
       user: false,
       organization: true,
       pageSize: 100,
@@ -60,6 +64,9 @@ describe("dashPlugin", () => {
     expect(dashQueryKeys.auditLogs("user-1", params)).not.toEqual(
       dashQueryKeys.allAuditLogs("user-1", params)
     )
+    expect(
+      dashQueryKeys.userAuditLogs("admin-1", "user-1", params)
+    ).not.toEqual(dashQueryKeys.userAuditLogs("admin-1", "user-2", params))
   })
 
   it("waits for a session and forwards explicit organization filters", async () => {
@@ -91,6 +98,29 @@ describe("dashPlugin", () => {
 
     expect(authClient.dash.getAllAuditLogs).toHaveBeenCalledWith({
       organizationId: "org-1"
+    })
+    expect(authClient.dash.getAuditLogs).not.toHaveBeenCalled()
+  })
+
+  it("uses the privileged endpoint for an inspected user", async () => {
+    const authClient = createAuthClient()
+    const params = { limit: 10, offset: 20 }
+
+    expect(
+      dashUserAuditLogsOptions(authClient as never, undefined, "user-2").queryFn
+    ).toBe(skipToken)
+
+    const options = dashUserAuditLogsOptions(
+      authClient as never,
+      "admin-1",
+      "user-2",
+      params
+    )
+    await (options.queryFn as () => Promise<typeof response>)()
+
+    expect(authClient.dash.getAllAuditLogs).toHaveBeenCalledWith({
+      ...params,
+      userId: "user-2"
     })
     expect(authClient.dash.getAuditLogs).not.toHaveBeenCalled()
   })

--- a/packages/heroui/src/components/auth/admin/admin-users.tsx
+++ b/packages/heroui/src/components/auth/admin/admin-users.tsx
@@ -301,8 +301,18 @@ function UserDrawer({
   onOpenChange: (open: boolean) => void
   userId?: string
 }) {
-  const { authClient } = useAuth<AdminAuthClient>()
+  const { authClient, plugins } = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
+  const contributedTabs = useMemo(
+    () =>
+      plugins.flatMap((plugin) =>
+        (plugin.adminUserTabs ?? []).map((tab) => ({
+          ...tab,
+          id: `${plugin.id}:${tab.id}`
+        }))
+      ),
+    [plugins]
+  )
   const user = useAdminUser(authClient, userId)
   const sessionsPermission = useAdminPermission(authClient, {
     session: ["list"]
@@ -338,6 +348,12 @@ function UserDrawer({
                       {config.localization.sessions}
                       <Tabs.Indicator />
                     </Tabs.Tab>
+                    {contributedTabs.map((tab) => (
+                      <Tabs.Tab id={tab.id} key={tab.id}>
+                        {tab.label}
+                        <Tabs.Indicator />
+                      </Tabs.Tab>
+                    ))}
                   </Tabs.List>
                 </Tabs.ListContainer>
                 <Tabs.Panel className="flex flex-col gap-4 pt-4" id="overview">
@@ -389,6 +405,14 @@ function UserDrawer({
                     </p>
                   )}
                 </Tabs.Panel>
+                {contributedTabs.map((tab) => {
+                  const ContributedTab = tab.component
+                  return (
+                    <Tabs.Panel className="pt-4" id={tab.id} key={tab.id}>
+                      <ContributedTab userId={user.data.id} />
+                    </Tabs.Panel>
+                  )
+                })}
               </Tabs>
             ) : (
               <AdminMessage

--- a/packages/heroui/src/components/auth/dash/activity.tsx
+++ b/packages/heroui/src/components/auth/dash/activity.tsx
@@ -214,8 +214,7 @@ function ActivityFeed({
     userId,
     {
       enabled: ready && access === "admin-user",
-      params: { limit: pageSize, offset },
-      placeholderData: keepPreviousData
+      params: { limit: pageSize, offset }
     }
   )
   const query =
@@ -345,7 +344,7 @@ function ActivityFeed({
 
 /** Authentication and account activity for a user selected by an administrator. */
 export function AdminUserActivity(props: AdminUserActivityProps) {
-  return <ActivityFeed access="admin-user" {...props} />
+  return <ActivityFeed key={props.userId} access="admin-user" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/packages/heroui/src/components/auth/dash/activity.tsx
+++ b/packages/heroui/src/components/auth/dash/activity.tsx
@@ -17,7 +17,8 @@ import {
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
   useDashAllAuditLogs,
-  useDashAuditLogs
+  useDashAuditLogs,
+  useDashUserAuditLogs
 } from "@better-auth-ui/react/plugins/dash"
 import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
 import {
@@ -43,13 +44,20 @@ import { keepPreviousData } from "@tanstack/react-query"
 import { useState } from "react"
 import { dashPlugin } from "../../../lib/auth/dash-plugin"
 
-type ActivityAccess = "organization" | "user"
+type ActivityAccess = "admin-user" | "organization" | "user"
 
 type ActivityFeedProps = {
   access: ActivityAccess
   organizationId?: string
   ready?: boolean
   className?: string
+  userId?: string
+  variant?: CardProps["variant"]
+}
+
+export type AdminUserActivityProps = {
+  className?: string
+  userId: string
   variant?: CardProps["variant"]
 }
 
@@ -182,6 +190,7 @@ function ActivityFeed({
   organizationId,
   ready = true,
   className,
+  userId,
   variant
 }: ActivityFeedProps) {
   const { authClient, locale } = useAuth()
@@ -200,7 +209,21 @@ function ActivityFeed({
     params,
     placeholderData: keepPreviousData
   })
-  const query = access === "organization" ? organizationQuery : userQuery
+  const adminUserQuery = useDashUserAuditLogs(
+    authClient as DashAuthClient,
+    userId,
+    {
+      enabled: ready && access === "admin-user",
+      params: { limit: pageSize, offset },
+      placeholderData: keepPreviousData
+    }
+  )
+  const query =
+    access === "organization"
+      ? organizationQuery
+      : access === "admin-user"
+        ? adminUserQuery
+        : userQuery
   const { data, error, isFetching, isPending } = query
   const showPending = !ready || isPending
   const pageEnd = offset + (data?.events.length ?? 0)
@@ -212,9 +235,11 @@ function ActivityFeed({
         <div className="flex min-w-0 flex-col gap-1">
           <h2 className="text-sm font-semibold">{localization.activity}</h2>
           <p className="text-sm text-muted">
-            {organizationId
-              ? localization.organizationActivityDescription
-              : localization.activityDescription}
+            {access === "admin-user"
+              ? localization.adminUserActivityDescription
+              : organizationId
+                ? localization.organizationActivityDescription
+                : localization.activityDescription}
           </p>
         </div>
 
@@ -316,6 +341,11 @@ function ActivityFeed({
       </Card>
     </div>
   )
+}
+
+/** Authentication and account activity for a user selected by an administrator. */
+export function AdminUserActivity(props: AdminUserActivityProps) {
+  return <ActivityFeed access="admin-user" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/packages/heroui/src/lib/auth/dash-plugin.ts
+++ b/packages/heroui/src/lib/auth/dash-plugin.ts
@@ -11,6 +11,7 @@ import {
 import { Pulse } from "@gravity-ui/icons"
 import { createElement } from "react"
 import {
+  AdminUserActivity,
   OrganizationActivity,
   UserActivity
 } from "../../components/auth/dash/activity"
@@ -28,6 +29,17 @@ export const dashPlugin = createAuthPlugin(
   (options: DashPluginOptions = {}) => {
     const core = coreDashPlugin(options)
     const localizedTabs = (localization: DashLocalization) => ({
+      ...(core.admin
+        ? {
+            adminUserTabs: [
+              {
+                id: "activity",
+                label: activityLabel(localization.activity),
+                component: AdminUserActivity
+              }
+            ]
+          }
+        : {}),
       ...(core.user
         ? {
             settingsTabs: [

--- a/packages/locales/src/de-DE-plugins.ts
+++ b/packages/locales/src/de-DE-plugins.ts
@@ -204,6 +204,8 @@ export const deDEPlugins = {
     activity: "Aktivität",
     activityDescription:
       "Prüfe die letzten Authentifizierungs- und Kontoaktivitäten.",
+    adminUserActivityDescription:
+      "Prüfe die letzten Authentifizierungs- und Kontoaktivitäten für diesen Benutzer.",
     organizationActivityDescription:
       "Prüfe die für dich sichtbaren Aktivitäten dieser Organisation.",
     organizationWide: "Gesamte Organisation",

--- a/packages/react/src/lib/auth-plugin.ts
+++ b/packages/react/src/lib/auth-plugin.ts
@@ -104,6 +104,17 @@ export type AdminTab = {
   component: ComponentType
 }
 
+export type AdminUserTabProps = {
+  userId: string
+}
+
+/** A tab contributed to the admin user inspector. */
+export type AdminUserTab = {
+  id: string
+  label: ReactNode
+  component: ComponentType<AdminUserTabProps>
+}
+
 /** Props for plugin-contributed items in the `UserButton` dropdown. */
 export type UserMenuItemProps = {
   className?: string
@@ -188,6 +199,8 @@ export type AuthPlugin<
     settingsTabs?: SettingsTab[]
     /** First-class static views contributed to the administration shell. */
     adminTabs?: AdminTab[]
+    /** Tabs contributed to the administration user inspector. */
+    adminUserTabs?: AdminUserTab[]
     /** First-class organization settings tabs contributed by the plugin. */
     organizationTabs?: OrganizationTab[]
   }

--- a/packages/react/src/plugins/dash/use-dash-audit-logs.ts
+++ b/packages/react/src/plugins/dash/use-dash-audit-logs.ts
@@ -3,8 +3,10 @@ import {
   type DashAuditLogsParams,
   type DashAuditLogsResponse,
   type DashAuthClient,
+  type DashUserAuditLogsParams,
   dashAllAuditLogsOptions,
-  dashAuditLogsOptions
+  dashAuditLogsOptions,
+  dashUserAuditLogsOptions
 } from "@better-auth-ui/core/plugins/dash"
 import {
   type QueryClient,
@@ -21,6 +23,10 @@ export type UseDashAuditLogsOptions = DashQueryOptions & {
 
 export type UseDashAllAuditLogsOptions = DashQueryOptions & {
   params?: DashAllAuditLogsParams
+}
+
+export type UseDashUserAuditLogsOptions = DashQueryOptions & {
+  params?: DashUserAuditLogsParams
 }
 
 /** Load audit logs for the signed-in user. */
@@ -53,6 +59,25 @@ export function useDashAllAuditLogs(
   return useQuery(
     {
       ...dashAllAuditLogsOptions(authClient, session?.user.id, params),
+      ...queryOptions
+    },
+    queryClient
+  )
+}
+
+/** Load one user's audit logs available to organization owners/admins. */
+export function useDashUserAuditLogs(
+  authClient: DashAuthClient,
+  userId: string | undefined,
+  options: UseDashUserAuditLogsOptions = {},
+  queryClient?: QueryClient
+) {
+  const { data: session } = useSession(authClient, undefined, queryClient)
+  const { params, ...queryOptions } = options
+
+  return useQuery(
+    {
+      ...dashUserAuditLogsOptions(authClient, session?.user.id, userId, params),
       ...queryOptions
     },
     queryClient

--- a/packages/solid/src/lib/auth-plugin.ts
+++ b/packages/solid/src/lib/auth-plugin.ts
@@ -21,6 +21,17 @@ export type AdminTab = {
   component: Component
 }
 
+export type AdminUserTabProps = {
+  userId: string
+}
+
+/** A tab contributed to the admin user inspector. */
+export type AdminUserTab = {
+  id: string
+  label: Component
+  component: Component<AdminUserTabProps>
+}
+
 export type CaptchaComponent = Component
 
 export type AuthPromptProps = {
@@ -35,6 +46,8 @@ export type AuthPrompt = {
 export type SolidAuthPlugin = AuthPluginBase & {
   /** First-class static views contributed to the administration shell. */
   adminTabs?: AdminTab[]
+  /** Tabs contributed to the administration user inspector. */
+  adminUserTabs?: AdminUserTab[]
   /** Headless prompts mounted by authentication views. */
   authPrompts?: AuthPrompt[]
   /** Captcha widget rendered above submit buttons in auth forms. */

--- a/packages/solid/src/plugins/dash/index.ts
+++ b/packages/solid/src/plugins/dash/index.ts
@@ -3,8 +3,10 @@ import {
   type DashAuditLogsParams,
   type DashAuditLogsResponse,
   type DashAuthClient,
+  type DashUserAuditLogsParams,
   dashAllAuditLogsOptions,
-  dashAuditLogsOptions
+  dashAuditLogsOptions,
+  dashUserAuditLogsOptions
 } from "@better-auth-ui/core/plugins/dash"
 import {
   type QueryClient,
@@ -22,6 +24,10 @@ export type UseDashAuditLogsOptions = Accessor<
 
 export type UseDashAllAuditLogsOptions = Accessor<
   DashQueryOptions & { params?: DashAllAuditLogsParams }
+>
+
+export type UseDashUserAuditLogsOptions = Accessor<
+  DashQueryOptions & { params?: DashUserAuditLogsParams }
 >
 
 /** Load audit logs for the signed-in user. */
@@ -54,6 +60,30 @@ export function useDashAllAuditLogs(
     const { params, initialData, ...queryOptions } = options?.() ?? {}
     return {
       ...dashAllAuditLogsOptions(authClient, session.data?.user.id, params),
+      ...queryOptions,
+      initialData: initialData as undefined
+    }
+  }, queryClient)
+}
+
+/** Load one user's audit logs available to organization owners/admins. */
+export function useDashUserAuditLogs(
+  authClient: DashAuthClient,
+  userId: Accessor<string | undefined>,
+  options?: UseDashUserAuditLogsOptions,
+  queryClient?: Accessor<QueryClient>
+) {
+  const session = useSession(authClient, undefined, queryClient)
+
+  return useQuery(() => {
+    const { params, initialData, ...queryOptions } = options?.() ?? {}
+    return {
+      ...dashUserAuditLogsOptions(
+        authClient,
+        session.data?.user.id,
+        userId(),
+        params
+      ),
       ...queryOptions,
       initialData: initialData as undefined
     }


### PR DESCRIPTION
Let UI plugins contribute tabs to the Admin user inspector and add a Dash activity view for the selected user. Use the privileged Dash endpoint with actor-scoped cache keys so access remains subject to Dash organization permissions.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Activity tabs to Admin user inspectors for viewing a selected user’s audit history.
  * Added support for plugin-contributed tabs in Admin user inspectors.
  * Added configuration to enable or disable the Admin Activity tab.
  * Restricted Admin Activity access to authorized owners and administrators.
  * Added React and Solid hooks and components for user-specific audit activity.
* **Documentation**
  * Updated React, Solid, HeroUI, shadcn, and Zaidan documentation with setup, access, and usage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->