### PR TITLE
feat(two-factor): add OTP enrollment

### DIFF
--- a/apps/docs/content/docs/heroui/plugins/two-factor.mdx
+++ b/apps/docs/content/docs/heroui/plugins/two-factor.mdx
@@ -217,7 +217,7 @@ import { TwoFactorChallenge } from "@better-auth-ui/heroui/plugins"
 
 ### `<TwoFactorSettings />`
 
-Added to `<SecuritySettings />` automatically. Enrollment asks for the password, shows the QR code and setup key, requires one verified code, then displays the backup codes once. Enrolled users can regenerate backup codes or turn two-factor off.
+Added to `<SecuritySettings />` automatically. Users can enroll with an authenticator app or a delivered code. Enrolled users can regenerate backup codes or turn two-factor off.
 
 ```tsx
 import { TwoFactorSettings } from "@better-auth-ui/heroui/plugins"
@@ -228,6 +228,24 @@ import { TwoFactorSettings } from "@better-auth-ui/heroui/plugins"
 <auto-type-table path="../../../../../../packages/heroui/src/components/auth/two-factor/two-factor-settings.tsx" name="TwoFactorSettingsProps" />
 
 Backup codes live in component state and are never written to storage or the query cache: once the dialog closes they are gone.
+
+## Delivered-code enrollment
+
+The enrollment dialog offers authenticator apps by default. Configure OTP delivery on the server before you add the delivered-code option:
+
+```ts
+// Server
+twoFactor({
+  otpOptions: { sendOTP }
+})
+```
+
+```tsx
+// UI
+twoFactorPlugin({ enrollmentMethods: ["totp", "otp"] })
+```
+
+Better Auth activates OTP enrollment immediately. The dialog closes after `authClient.twoFactor.enable({ method: "otp" })` succeeds.
 
 ## Passwordless accounts
 
@@ -256,7 +274,9 @@ twoFactorPlugin({
   // Turn off when the server sets `backupCodeOptions: { enabled: false }`
   backupCodes: true,
   // Hide the "Trust this device" checkbox
-  trustDevice: false
+  trustDevice: false,
+  // Offer delivered-code enrollment after the server configures sendOTP
+  enrollmentMethods: ["totp", "otp"]
 })
 ```
 

--- a/apps/docs/content/docs/shadcn/plugins/two-factor.mdx
+++ b/apps/docs/content/docs/shadcn/plugins/two-factor.mdx
@@ -192,11 +192,29 @@ Offers the methods the sign-in response reported, plus backup-code recovery and 
 
 ### `<TwoFactorSettings />`
 
-Added to `<SecuritySettings />` automatically. Enrollment asks for the password, shows the QR code and setup key, requires one verified code, then displays the backup codes once. Enrolled users can regenerate backup codes or turn two-factor off.
+Added to `<SecuritySettings />` automatically. Users can enroll with an authenticator app or a delivered code. Enrolled users can regenerate backup codes or turn two-factor off.
 
 <auto-type-table path="../../../../../../examples/start-shadcn-example/src/components/auth/two-factor/two-factor-settings.tsx" name="TwoFactorSettingsProps" />
 
 Backup codes live in component state and are never written to storage or the query cache: once the dialog closes they are gone.
+
+## Delivered-code enrollment
+
+The enrollment dialog offers authenticator apps by default. Configure OTP delivery on the server before you add the delivered-code option:
+
+```ts
+// Server
+twoFactor({
+  otpOptions: { sendOTP }
+})
+```
+
+```tsx
+// UI
+twoFactorPlugin({ enrollmentMethods: ["totp", "otp"] })
+```
+
+Better Auth activates OTP enrollment immediately. The dialog closes after `authClient.twoFactor.enable({ method: "otp" })` succeeds.
 
 ## Passwordless accounts
 

--- a/apps/docs/content/docs/zaidan/plugins/two-factor.mdx
+++ b/apps/docs/content/docs/zaidan/plugins/two-factor.mdx
@@ -186,11 +186,29 @@ Offers the methods the sign-in response reported, plus backup-code recovery and 
 
 ### `<TwoFactorSettings />`
 
-Added to `<SecuritySettings />` automatically. Enrollment asks for the password, shows the QR code and setup key, requires one verified code, then displays the backup codes once. Enrolled users can regenerate backup codes or turn two-factor off.
+Added to `<SecuritySettings />` automatically. Users can enroll with an authenticator app or a delivered code. Enrolled users can regenerate backup codes or turn two-factor off.
 
 <auto-type-table path="../../../../../../examples/start-solid-zaidan-example/src/components/auth/two-factor/two-factor-settings.tsx" name="TwoFactorSettingsProps" />
 
 Backup codes live in component state and are never written to storage or the query cache: once the dialog closes they are gone.
+
+## Delivered-code enrollment
+
+The enrollment dialog offers authenticator apps by default. Configure OTP delivery on the server before you add the delivered-code option:
+
+```ts
+// Server
+twoFactor({
+  otpOptions: { sendOTP }
+})
+```
+
+```tsx
+// UI
+twoFactorPlugin({ enrollmentMethods: ["totp", "otp"] })
+```
+
+Better Auth activates OTP enrollment immediately. The dialog closes after `authClient.twoFactor.enable({ method: "otp" })` succeeds.
 
 ## Passwordless accounts
 

--- a/apps/docs/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/apps/docs/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -119,7 +119,7 @@ export function EnableTwoFactorDialog({
     onSuccess: (data) => {
       if (data.method === "otp") {
         toast.success(twoFactorLocalization.twoFactorEnabled)
-        onOpenChange(false)
+        handleOpenChange(false)
         return
       }
 

--- a/apps/docs/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/apps/docs/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -1,7 +1,10 @@
 "use client"
 
 import { createQrCodeSvgData } from "@better-auth-ui/core"
-import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-factor"
+import type {
+  TwoFactorAuthClient,
+  TwoFactorMethod
+} from "@better-auth-ui/core/plugins/two-factor"
 import {
   useAuth,
   useAuthPlugin,
@@ -33,6 +36,7 @@ import {
   InputGroupInput
 } from "@/components/ui/input-group"
 import { Spinner } from "@/components/ui/spinner"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
 import { OtpField } from "../otp-field"
@@ -46,11 +50,10 @@ export type EnableTwoFactorDialogProps = {
 }
 
 /**
- * Three-step two-factor enrollment: confirm the password, scan the QR code
- * and verify a first code, then save the backup codes.
+ * Two-factor enrollment with authenticator-app and delivered-code methods.
  *
- * Better Auth only marks two-factor as active once a TOTP code verifies, so
- * the dialog never closes on the enable call alone.
+ * TOTP continues through QR verification and backup-code capture. OTP becomes
+ * active as soon as Better Auth accepts the enrollment request.
  *
  * @param open - Whether the dialog is open.
  * @param onOpenChange - Called when the dialog requests an open state change.
@@ -60,14 +63,20 @@ export function EnableTwoFactorDialog({
   onOpenChange
 }: EnableTwoFactorDialogProps) {
   const { authClient, localization } = useAuth()
-  const { codeLength, localization: twoFactorLocalization } =
-    useAuthPlugin(twoFactorPlugin)
+  const {
+    codeLength,
+    enrollmentMethods,
+    localization: twoFactorLocalization
+  } = useAuthPlugin(twoFactorPlugin)
   const { isPending: isResolvingPasswordRequirement, requiresPassword } =
     useTwoFactorPasswordRequirement()
 
   const twoFactorClient = authClient as TwoFactorAuthClient
 
   const [step, setStep] = useState<EnrollmentStep>("password")
+  const [method, setMethod] = useState<TwoFactorMethod>(
+    enrollmentMethods[0] ?? "totp"
+  )
   const [totpUri, setTotpUri] = useState("")
   const [backupCodes, setBackupCodes] = useState<string[]>([])
   const [code, setCode] = useState("")
@@ -108,7 +117,11 @@ export function EnableTwoFactorDialog({
     reset: resetEnrollment
   } = useEnableTwoFactor(twoFactorClient, {
     onSuccess: (data) => {
-      if (data.method !== "totp") return
+      if (data.method === "otp") {
+        toast.success(twoFactorLocalization.twoFactorEnabled)
+        onOpenChange(false)
+        return
+      }
 
       setTotpUri(data.totpURI)
       setBackupCodes(data.backupCodes)
@@ -142,6 +155,7 @@ export function EnableTwoFactorDialog({
 
     if (!nextOpen) {
       setStep("password")
+      setMethod(enrollmentMethods[0] ?? "totp")
       setTotpUri("")
       setBackupCodes([])
       setCode("")
@@ -167,9 +181,7 @@ export function EnableTwoFactorDialog({
     const formData = new FormData(e.currentTarget)
     const password = formData.get("password") as string
 
-    enableTwoFactor(
-      requiresPassword ? { method: "totp", password } : { method: "totp" }
-    )
+    enableTwoFactor(requiresPassword ? { method, password } : { method })
   }
 
   const submitLabel =
@@ -198,25 +210,58 @@ export function EnableTwoFactorDialog({
             </DialogDescription>
           </DialogHeader>
 
-          {step === "password" && requiresPassword && (
-            <Field>
-              <FieldLabel htmlFor="two-factor-password">
-                {localization.auth.password}
-              </FieldLabel>
+          {step === "password" && (
+            <div className="flex flex-col gap-4">
+              {enrollmentMethods.length > 1 && (
+                <Tabs
+                  value={method}
+                  onValueChange={(value) => setMethod(value as TwoFactorMethod)}
+                >
+                  <TabsList
+                    aria-label={twoFactorLocalization.chooseEnrollmentMethod}
+                    className="w-full"
+                  >
+                    {enrollmentMethods.includes("totp") && (
+                      <TabsTrigger value="totp">
+                        {twoFactorLocalization.authenticatorApp}
+                      </TabsTrigger>
+                    )}
+                    {enrollmentMethods.includes("otp") && (
+                      <TabsTrigger value="otp">
+                        {twoFactorLocalization.deliveredCode}
+                      </TabsTrigger>
+                    )}
+                  </TabsList>
+                </Tabs>
+              )}
 
-              <Input
-                id="two-factor-password"
-                name="password"
-                type="password"
-                autoComplete="current-password"
-                autoFocus
-                required
-                placeholder={localization.auth.passwordPlaceholder}
-                disabled={isPending}
-              />
+              <p className="text-muted-foreground text-sm">
+                {method === "totp"
+                  ? twoFactorLocalization.authenticatorAppDescription
+                  : twoFactorLocalization.deliveredCodeDescription}
+              </p>
 
-              <FieldError />
-            </Field>
+              {requiresPassword && (
+                <Field>
+                  <FieldLabel htmlFor="two-factor-password">
+                    {localization.auth.password}
+                  </FieldLabel>
+
+                  <Input
+                    id="two-factor-password"
+                    name="password"
+                    type="password"
+                    autoComplete="current-password"
+                    autoFocus
+                    required
+                    placeholder={localization.auth.passwordPlaceholder}
+                    disabled={isPending}
+                  />
+
+                  <FieldError />
+                </Field>
+              )}
+            </div>
           )}
 
           {step === "verify" && (

--- a/examples/next-shadcn-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -119,7 +119,7 @@ export function EnableTwoFactorDialog({
     onSuccess: (data) => {
       if (data.method === "otp") {
         toast.success(twoFactorLocalization.twoFactorEnabled)
-        onOpenChange(false)
+        handleOpenChange(false)
         return
       }
 

--- a/examples/next-shadcn-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -1,7 +1,10 @@
 "use client"
 
 import { createQrCodeSvgData } from "@better-auth-ui/core"
-import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-factor"
+import type {
+  TwoFactorAuthClient,
+  TwoFactorMethod
+} from "@better-auth-ui/core/plugins/two-factor"
 import {
   useAuth,
   useAuthPlugin,
@@ -33,6 +36,7 @@ import {
   InputGroupInput
 } from "@/components/ui/input-group"
 import { Spinner } from "@/components/ui/spinner"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
 import { OtpField } from "../otp-field"
@@ -46,11 +50,10 @@ export type EnableTwoFactorDialogProps = {
 }
 
 /**
- * Three-step two-factor enrollment: confirm the password, scan the QR code
- * and verify a first code, then save the backup codes.
+ * Two-factor enrollment with authenticator-app and delivered-code methods.
  *
- * Better Auth only marks two-factor as active once a TOTP code verifies, so
- * the dialog never closes on the enable call alone.
+ * TOTP continues through QR verification and backup-code capture. OTP becomes
+ * active as soon as Better Auth accepts the enrollment request.
  *
  * @param open - Whether the dialog is open.
  * @param onOpenChange - Called when the dialog requests an open state change.
@@ -60,14 +63,20 @@ export function EnableTwoFactorDialog({
   onOpenChange
 }: EnableTwoFactorDialogProps) {
   const { authClient, localization } = useAuth()
-  const { codeLength, localization: twoFactorLocalization } =
-    useAuthPlugin(twoFactorPlugin)
+  const {
+    codeLength,
+    enrollmentMethods,
+    localization: twoFactorLocalization
+  } = useAuthPlugin(twoFactorPlugin)
   const { isPending: isResolvingPasswordRequirement, requiresPassword } =
     useTwoFactorPasswordRequirement()
 
   const twoFactorClient = authClient as TwoFactorAuthClient
 
   const [step, setStep] = useState<EnrollmentStep>("password")
+  const [method, setMethod] = useState<TwoFactorMethod>(
+    enrollmentMethods[0] ?? "totp"
+  )
   const [totpUri, setTotpUri] = useState("")
   const [backupCodes, setBackupCodes] = useState<string[]>([])
   const [code, setCode] = useState("")
@@ -108,7 +117,11 @@ export function EnableTwoFactorDialog({
     reset: resetEnrollment
   } = useEnableTwoFactor(twoFactorClient, {
     onSuccess: (data) => {
-      if (data.method !== "totp") return
+      if (data.method === "otp") {
+        toast.success(twoFactorLocalization.twoFactorEnabled)
+        onOpenChange(false)
+        return
+      }
 
       setTotpUri(data.totpURI)
       setBackupCodes(data.backupCodes)
@@ -142,6 +155,7 @@ export function EnableTwoFactorDialog({
 
     if (!nextOpen) {
       setStep("password")
+      setMethod(enrollmentMethods[0] ?? "totp")
       setTotpUri("")
       setBackupCodes([])
       setCode("")
@@ -167,9 +181,7 @@ export function EnableTwoFactorDialog({
     const formData = new FormData(e.currentTarget)
     const password = formData.get("password") as string
 
-    enableTwoFactor(
-      requiresPassword ? { method: "totp", password } : { method: "totp" }
-    )
+    enableTwoFactor(requiresPassword ? { method, password } : { method })
   }
 
   const submitLabel =
@@ -198,25 +210,58 @@ export function EnableTwoFactorDialog({
             </DialogDescription>
           </DialogHeader>
 
-          {step === "password" && requiresPassword && (
-            <Field>
-              <FieldLabel htmlFor="two-factor-password">
-                {localization.auth.password}
-              </FieldLabel>
+          {step === "password" && (
+            <div className="flex flex-col gap-4">
+              {enrollmentMethods.length > 1 && (
+                <Tabs
+                  value={method}
+                  onValueChange={(value) => setMethod(value as TwoFactorMethod)}
+                >
+                  <TabsList
+                    aria-label={twoFactorLocalization.chooseEnrollmentMethod}
+                    className="w-full"
+                  >
+                    {enrollmentMethods.includes("totp") && (
+                      <TabsTrigger value="totp">
+                        {twoFactorLocalization.authenticatorApp}
+                      </TabsTrigger>
+                    )}
+                    {enrollmentMethods.includes("otp") && (
+                      <TabsTrigger value="otp">
+                        {twoFactorLocalization.deliveredCode}
+                      </TabsTrigger>
+                    )}
+                  </TabsList>
+                </Tabs>
+              )}
 
-              <Input
-                id="two-factor-password"
-                name="password"
-                type="password"
-                autoComplete="current-password"
-                autoFocus
-                required
-                placeholder={localization.auth.passwordPlaceholder}
-                disabled={isPending}
-              />
+              <p className="text-muted-foreground text-sm">
+                {method === "totp"
+                  ? twoFactorLocalization.authenticatorAppDescription
+                  : twoFactorLocalization.deliveredCodeDescription}
+              </p>
 
-              <FieldError />
-            </Field>
+              {requiresPassword && (
+                <Field>
+                  <FieldLabel htmlFor="two-factor-password">
+                    {localization.auth.password}
+                  </FieldLabel>
+
+                  <Input
+                    id="two-factor-password"
+                    name="password"
+                    type="password"
+                    autoComplete="current-password"
+                    autoFocus
+                    required
+                    placeholder={localization.auth.passwordPlaceholder}
+                    disabled={isPending}
+                  />
+
+                  <FieldError />
+                </Field>
+              )}
+            </div>
           )}
 
           {step === "verify" && (

--- a/examples/start-shadcn-baseui-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -119,7 +119,7 @@ export function EnableTwoFactorDialog({
     onSuccess: (data) => {
       if (data.method === "otp") {
         toast.success(twoFactorLocalization.twoFactorEnabled)
-        onOpenChange(false)
+        handleOpenChange(false)
         return
       }
 

--- a/examples/start-shadcn-baseui-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -1,7 +1,10 @@
 "use client"
 
 import { createQrCodeSvgData } from "@better-auth-ui/core"
-import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-factor"
+import type {
+  TwoFactorAuthClient,
+  TwoFactorMethod
+} from "@better-auth-ui/core/plugins/two-factor"
 import {
   useAuth,
   useAuthPlugin,
@@ -33,6 +36,7 @@ import {
   InputGroupInput
 } from "@/components/ui/input-group"
 import { Spinner } from "@/components/ui/spinner"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
 import { OtpField } from "../otp-field"
@@ -46,11 +50,10 @@ export type EnableTwoFactorDialogProps = {
 }
 
 /**
- * Three-step two-factor enrollment: confirm the password, scan the QR code
- * and verify a first code, then save the backup codes.
+ * Two-factor enrollment with authenticator-app and delivered-code methods.
  *
- * Better Auth only marks two-factor as active once a TOTP code verifies, so
- * the dialog never closes on the enable call alone.
+ * TOTP continues through QR verification and backup-code capture. OTP becomes
+ * active as soon as Better Auth accepts the enrollment request.
  *
  * @param open - Whether the dialog is open.
  * @param onOpenChange - Called when the dialog requests an open state change.
@@ -60,14 +63,20 @@ export function EnableTwoFactorDialog({
   onOpenChange
 }: EnableTwoFactorDialogProps) {
   const { authClient, localization } = useAuth()
-  const { codeLength, localization: twoFactorLocalization } =
-    useAuthPlugin(twoFactorPlugin)
+  const {
+    codeLength,
+    enrollmentMethods,
+    localization: twoFactorLocalization
+  } = useAuthPlugin(twoFactorPlugin)
   const { isPending: isResolvingPasswordRequirement, requiresPassword } =
     useTwoFactorPasswordRequirement()
 
   const twoFactorClient = authClient as TwoFactorAuthClient
 
   const [step, setStep] = useState<EnrollmentStep>("password")
+  const [method, setMethod] = useState<TwoFactorMethod>(
+    enrollmentMethods[0] ?? "totp"
+  )
   const [totpUri, setTotpUri] = useState("")
   const [backupCodes, setBackupCodes] = useState<string[]>([])
   const [code, setCode] = useState("")
@@ -108,7 +117,11 @@ export function EnableTwoFactorDialog({
     reset: resetEnrollment
   } = useEnableTwoFactor(twoFactorClient, {
     onSuccess: (data) => {
-      if (data.method !== "totp") return
+      if (data.method === "otp") {
+        toast.success(twoFactorLocalization.twoFactorEnabled)
+        onOpenChange(false)
+        return
+      }
 
       setTotpUri(data.totpURI)
       setBackupCodes(data.backupCodes)
@@ -142,6 +155,7 @@ export function EnableTwoFactorDialog({
 
     if (!nextOpen) {
       setStep("password")
+      setMethod(enrollmentMethods[0] ?? "totp")
       setTotpUri("")
       setBackupCodes([])
       setCode("")
@@ -167,9 +181,7 @@ export function EnableTwoFactorDialog({
     const formData = new FormData(e.currentTarget)
     const password = formData.get("password") as string
 
-    enableTwoFactor(
-      requiresPassword ? { method: "totp", password } : { method: "totp" }
-    )
+    enableTwoFactor(requiresPassword ? { method, password } : { method })
   }
 
   const submitLabel =
@@ -198,25 +210,58 @@ export function EnableTwoFactorDialog({
             </DialogDescription>
           </DialogHeader>
 
-          {step === "password" && requiresPassword && (
-            <Field>
-              <FieldLabel htmlFor="two-factor-password">
-                {localization.auth.password}
-              </FieldLabel>
+          {step === "password" && (
+            <div className="flex flex-col gap-4">
+              {enrollmentMethods.length > 1 && (
+                <Tabs
+                  value={method}
+                  onValueChange={(value) => setMethod(value as TwoFactorMethod)}
+                >
+                  <TabsList
+                    aria-label={twoFactorLocalization.chooseEnrollmentMethod}
+                    className="w-full"
+                  >
+                    {enrollmentMethods.includes("totp") && (
+                      <TabsTrigger value="totp">
+                        {twoFactorLocalization.authenticatorApp}
+                      </TabsTrigger>
+                    )}
+                    {enrollmentMethods.includes("otp") && (
+                      <TabsTrigger value="otp">
+                        {twoFactorLocalization.deliveredCode}
+                      </TabsTrigger>
+                    )}
+                  </TabsList>
+                </Tabs>
+              )}
 
-              <Input
-                id="two-factor-password"
-                name="password"
-                type="password"
-                autoComplete="current-password"
-                autoFocus
-                required
-                placeholder={localization.auth.passwordPlaceholder}
-                disabled={isPending}
-              />
+              <p className="text-muted-foreground text-sm">
+                {method === "totp"
+                  ? twoFactorLocalization.authenticatorAppDescription
+                  : twoFactorLocalization.deliveredCodeDescription}
+              </p>
 
-              <FieldError />
-            </Field>
+              {requiresPassword && (
+                <Field>
+                  <FieldLabel htmlFor="two-factor-password">
+                    {localization.auth.password}
+                  </FieldLabel>
+
+                  <Input
+                    id="two-factor-password"
+                    name="password"
+                    type="password"
+                    autoComplete="current-password"
+                    autoFocus
+                    required
+                    placeholder={localization.auth.passwordPlaceholder}
+                    disabled={isPending}
+                  />
+
+                  <FieldError />
+                </Field>
+              )}
+            </div>
           )}
 
           {step === "verify" && (

--- a/examples/start-shadcn-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -119,7 +119,7 @@ export function EnableTwoFactorDialog({
     onSuccess: (data) => {
       if (data.method === "otp") {
         toast.success(twoFactorLocalization.twoFactorEnabled)
-        onOpenChange(false)
+        handleOpenChange(false)
         return
       }
 

--- a/examples/start-shadcn-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -1,7 +1,10 @@
 "use client"
 
 import { createQrCodeSvgData } from "@better-auth-ui/core"
-import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-factor"
+import type {
+  TwoFactorAuthClient,
+  TwoFactorMethod
+} from "@better-auth-ui/core/plugins/two-factor"
 import {
   useAuth,
   useAuthPlugin,
@@ -33,6 +36,7 @@ import {
   InputGroupInput
 } from "@/components/ui/input-group"
 import { Spinner } from "@/components/ui/spinner"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
 import { OtpField } from "../otp-field"
@@ -46,11 +50,10 @@ export type EnableTwoFactorDialogProps = {
 }
 
 /**
- * Three-step two-factor enrollment: confirm the password, scan the QR code
- * and verify a first code, then save the backup codes.
+ * Two-factor enrollment with authenticator-app and delivered-code methods.
  *
- * Better Auth only marks two-factor as active once a TOTP code verifies, so
- * the dialog never closes on the enable call alone.
+ * TOTP continues through QR verification and backup-code capture. OTP becomes
+ * active as soon as Better Auth accepts the enrollment request.
  *
  * @param open - Whether the dialog is open.
  * @param onOpenChange - Called when the dialog requests an open state change.
@@ -60,14 +63,20 @@ export function EnableTwoFactorDialog({
   onOpenChange
 }: EnableTwoFactorDialogProps) {
   const { authClient, localization } = useAuth()
-  const { codeLength, localization: twoFactorLocalization } =
-    useAuthPlugin(twoFactorPlugin)
+  const {
+    codeLength,
+    enrollmentMethods,
+    localization: twoFactorLocalization
+  } = useAuthPlugin(twoFactorPlugin)
   const { isPending: isResolvingPasswordRequirement, requiresPassword } =
     useTwoFactorPasswordRequirement()
 
   const twoFactorClient = authClient as TwoFactorAuthClient
 
   const [step, setStep] = useState<EnrollmentStep>("password")
+  const [method, setMethod] = useState<TwoFactorMethod>(
+    enrollmentMethods[0] ?? "totp"
+  )
   const [totpUri, setTotpUri] = useState("")
   const [backupCodes, setBackupCodes] = useState<string[]>([])
   const [code, setCode] = useState("")
@@ -108,7 +117,11 @@ export function EnableTwoFactorDialog({
     reset: resetEnrollment
   } = useEnableTwoFactor(twoFactorClient, {
     onSuccess: (data) => {
-      if (data.method !== "totp") return
+      if (data.method === "otp") {
+        toast.success(twoFactorLocalization.twoFactorEnabled)
+        onOpenChange(false)
+        return
+      }
 
       setTotpUri(data.totpURI)
       setBackupCodes(data.backupCodes)
@@ -142,6 +155,7 @@ export function EnableTwoFactorDialog({
 
     if (!nextOpen) {
       setStep("password")
+      setMethod(enrollmentMethods[0] ?? "totp")
       setTotpUri("")
       setBackupCodes([])
       setCode("")
@@ -167,9 +181,7 @@ export function EnableTwoFactorDialog({
     const formData = new FormData(e.currentTarget)
     const password = formData.get("password") as string
 
-    enableTwoFactor(
-      requiresPassword ? { method: "totp", password } : { method: "totp" }
-    )
+    enableTwoFactor(requiresPassword ? { method, password } : { method })
   }
 
   const submitLabel =
@@ -198,25 +210,58 @@ export function EnableTwoFactorDialog({
             </DialogDescription>
           </DialogHeader>
 
-          {step === "password" && requiresPassword && (
-            <Field>
-              <FieldLabel htmlFor="two-factor-password">
-                {localization.auth.password}
-              </FieldLabel>
+          {step === "password" && (
+            <div className="flex flex-col gap-4">
+              {enrollmentMethods.length > 1 && (
+                <Tabs
+                  value={method}
+                  onValueChange={(value) => setMethod(value as TwoFactorMethod)}
+                >
+                  <TabsList
+                    aria-label={twoFactorLocalization.chooseEnrollmentMethod}
+                    className="w-full"
+                  >
+                    {enrollmentMethods.includes("totp") && (
+                      <TabsTrigger value="totp">
+                        {twoFactorLocalization.authenticatorApp}
+                      </TabsTrigger>
+                    )}
+                    {enrollmentMethods.includes("otp") && (
+                      <TabsTrigger value="otp">
+                        {twoFactorLocalization.deliveredCode}
+                      </TabsTrigger>
+                    )}
+                  </TabsList>
+                </Tabs>
+              )}
 
-              <Input
-                id="two-factor-password"
-                name="password"
-                type="password"
-                autoComplete="current-password"
-                autoFocus
-                required
-                placeholder={localization.auth.passwordPlaceholder}
-                disabled={isPending}
-              />
+              <p className="text-muted-foreground text-sm">
+                {method === "totp"
+                  ? twoFactorLocalization.authenticatorAppDescription
+                  : twoFactorLocalization.deliveredCodeDescription}
+              </p>
 
-              <FieldError />
-            </Field>
+              {requiresPassword && (
+                <Field>
+                  <FieldLabel htmlFor="two-factor-password">
+                    {localization.auth.password}
+                  </FieldLabel>
+
+                  <Input
+                    id="two-factor-password"
+                    name="password"
+                    type="password"
+                    autoComplete="current-password"
+                    autoFocus
+                    required
+                    placeholder={localization.auth.passwordPlaceholder}
+                    disabled={isPending}
+                  />
+
+                  <FieldError />
+                </Field>
+              )}
+            </div>
           )}
 
           {step === "verify" && (

--- a/examples/start-solid-zaidan-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -2,6 +2,7 @@ import { createQrCodeSvgData } from "@better-auth-ui/core"
 import {
   enableTwoFactorOptions,
   type TwoFactorAuthClient,
+  type TwoFactorMethod,
   verifyTotpOptions
 } from "@better-auth-ui/core/plugins/two-factor"
 import {
@@ -33,28 +34,34 @@ import {
   InputGroupInput
 } from "@/components/ui/input-group"
 import { Spinner } from "@/components/ui/spinner"
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
 
 type EnrollmentStep = "password" | "verify" | "backupCodes"
 
 /**
- * Three-step two-factor enrollment: confirm the password, scan the QR code
- * and verify a first code, then save the backup codes.
+ * Two-factor enrollment with authenticator-app and delivered-code methods.
  *
- * Better Auth only marks two-factor as active once a TOTP code verifies, so
- * the dialog never closes on the enable call alone.
+ * TOTP continues through QR verification and backup-code capture. OTP becomes
+ * active as soon as Better Auth accepts the enrollment request.
  */
 export function EnableTwoFactorDialog(props: {
   onOpenChange: (open: boolean) => void
 }) {
   const auth = useAuth()
-  const { codeLength, localization: twoFactorLocalization } =
-    useAuthPlugin(twoFactorPlugin)
+  const {
+    codeLength,
+    enrollmentMethods,
+    localization: twoFactorLocalization
+  } = useAuthPlugin(twoFactorPlugin)
   const { isPending: isResolvingPasswordRequirement, requiresPassword } =
     useTwoFactorPasswordRequirement()
 
   const [step, setStep] = createSignal<EnrollmentStep>("password")
+  const [method, setMethod] = createSignal<TwoFactorMethod>(
+    enrollmentMethods[0] ?? "totp"
+  )
   const [totpUri, setTotpUri] = createSignal("")
   const [backupCodes, setBackupCodes] = createSignal<string[]>([])
   const [code, setCode] = createSignal("")
@@ -81,7 +88,11 @@ export function EnableTwoFactorDialog(props: {
   const enableTwoFactor = createMutation(() => ({
     ...enableTwoFactorOptions(twoFactorClient()),
     onSuccess: (data) => {
-      if (data.method !== "totp") return
+      if (data.method === "otp") {
+        toast.success(twoFactorLocalization.twoFactorEnabled)
+        props.onOpenChange(false)
+        return
+      }
 
       setTotpUri(data.totpURI)
       setBackupCodes(data.backupCodes)
@@ -135,8 +146,8 @@ export function EnableTwoFactorDialog(props: {
 
     enableTwoFactor.mutate(
       (requiresPassword()
-        ? { method: "totp", password }
-        : { method: "totp" }) as Parameters<typeof enableTwoFactor.mutate>[0]
+        ? { method: method(), password }
+        : { method: method() }) as Parameters<typeof enableTwoFactor.mutate>[0]
     )
   }
 
@@ -167,23 +178,53 @@ export function EnableTwoFactorDialog(props: {
           <DialogDescription>{description()}</DialogDescription>
         </DialogHeader>
 
-        <Show when={step() === "password" && requiresPassword()}>
-          <Field>
-            <FieldLabel for="enable-two-factor-password">
-              {auth.localization.auth.password}
-            </FieldLabel>
+        <Show when={step() === "password"}>
+          <div class="flex flex-col gap-4">
+            <Show when={enrollmentMethods.length > 1}>
+              <Tabs value={method()} onChange={setMethod}>
+                <TabsList
+                  aria-label={twoFactorLocalization.chooseEnrollmentMethod}
+                  class="w-full"
+                >
+                  <Show when={enrollmentMethods.includes("totp")}>
+                    <TabsTrigger value="totp">
+                      {twoFactorLocalization.authenticatorApp}
+                    </TabsTrigger>
+                  </Show>
+                  <Show when={enrollmentMethods.includes("otp")}>
+                    <TabsTrigger value="otp">
+                      {twoFactorLocalization.deliveredCode}
+                    </TabsTrigger>
+                  </Show>
+                </TabsList>
+              </Tabs>
+            </Show>
 
-            <Input
-              autocomplete="current-password"
-              autofocus
-              disabled={isPending()}
-              id="enable-two-factor-password"
-              name="password"
-              placeholder={auth.localization.auth.passwordPlaceholder}
-              required
-              type="password"
-            />
-          </Field>
+            <p class="text-muted-foreground text-sm">
+              {method() === "totp"
+                ? twoFactorLocalization.authenticatorAppDescription
+                : twoFactorLocalization.deliveredCodeDescription}
+            </p>
+
+            <Show when={requiresPassword()}>
+              <Field>
+                <FieldLabel for="enable-two-factor-password">
+                  {auth.localization.auth.password}
+                </FieldLabel>
+
+                <Input
+                  autocomplete="current-password"
+                  autofocus
+                  disabled={isPending()}
+                  id="enable-two-factor-password"
+                  name="password"
+                  placeholder={auth.localization.auth.passwordPlaceholder}
+                  required
+                  type="password"
+                />
+              </Field>
+            </Show>
+          </div>
         </Show>
 
         <Show when={step() === "verify"}>

--- a/packages/core/src/plugins/two-factor/two-factor-localization.ts
+++ b/packages/core/src/plugins/two-factor/two-factor-localization.ts
@@ -14,6 +14,16 @@ export const twoFactorLocalization = {
   twoFactorDisabled: "Two-factor authentication is off",
   /** @remarks `"Enter your password to continue"` */
   passwordConfirmation: "Enter your password to continue",
+  /** @remarks `"Choose how you want to verify future sign-ins"` */
+  chooseEnrollmentMethod: "Choose how you want to verify future sign-ins",
+  /** @remarks `"Authenticator app"` */
+  authenticatorApp: "Authenticator app",
+  /** @remarks `"Use a rotating code from an authenticator app"` */
+  authenticatorAppDescription: "Use a rotating code from an authenticator app",
+  /** @remarks `"Email or SMS code"` */
+  deliveredCode: "Email or SMS code",
+  /** @remarks `"Receive a new code each time you sign in"` */
+  deliveredCodeDescription: "Receive a new code each time you sign in",
   /** @remarks `"Scan this with your authenticator app"` */
   scanQrCode: "Scan this with your authenticator app",
   /** @remarks `"Can't scan? Enter this setup key instead"` */

--- a/packages/core/src/plugins/two-factor/two-factor-plugin.ts
+++ b/packages/core/src/plugins/two-factor/two-factor-plugin.ts
@@ -3,6 +3,10 @@ import { createAuthPlugin } from "../../lib/create-auth-plugin"
 // same module instance that external consumers reach via `@better-auth-ui/core`.
 import type {} from "../../lib/view-paths"
 import {
+  parseTwoFactorMethods,
+  type TwoFactorMethod
+} from "./two-factor-challenge"
+import {
   type TwoFactorLocalization,
   twoFactorLocalization
 } from "./two-factor-localization"
@@ -65,6 +69,15 @@ export type TwoFactorPluginOptions = {
    * @default false
    */
   allowPasswordless?: boolean
+  /**
+   * Methods users can choose while enrolling in two-factor authentication.
+   *
+   * Add `"otp"` only when the server configures `otpOptions.sendOTP`.
+   *
+   * @remarks `TwoFactorMethod[]`
+   * @default ["totp"]
+   */
+  enrollmentMethods?: TwoFactorMethod[]
 }
 
 const DEFAULT_CODE_LENGTH = 6
@@ -77,6 +90,11 @@ function resolveCodeLength(value?: number) {
   return Math.max(1, Math.floor(value))
 }
 
+function resolveEnrollmentMethods(methods?: TwoFactorMethod[]) {
+  const resolved = parseTwoFactorMethods(methods)
+  return resolved.length ? resolved : (["totp"] satisfies TwoFactorMethod[])
+}
+
 export const twoFactorPlugin = createAuthPlugin(
   "twoFactor",
   (options: TwoFactorPluginOptions = {}) => ({
@@ -85,6 +103,7 @@ export const twoFactorPlugin = createAuthPlugin(
     backupCodes: options.backupCodes ?? true,
     trustDevice: options.trustDevice ?? true,
     allowPasswordless: options.allowPasswordless ?? false,
+    enrollmentMethods: resolveEnrollmentMethods(options.enrollmentMethods),
     viewPaths: {
       auth: {
         twoFactor: options.path ?? "two-factor"

--- a/packages/core/tests/two-factor-plugin.test.ts
+++ b/packages/core/tests/two-factor-plugin.test.ts
@@ -39,6 +39,7 @@ describe("twoFactorPlugin", () => {
       backupCodes: true,
       trustDevice: true,
       allowPasswordless: false,
+      enrollmentMethods: ["totp"],
       viewPaths: { auth: { twoFactor: "two-factor" } }
     })
   })
@@ -47,6 +48,16 @@ describe("twoFactorPlugin", () => {
     expect(twoFactorPlugin({ codeLength: 8.7 }).codeLength).toBe(8)
     expect(twoFactorPlugin({ codeLength: Number.NaN }).codeLength).toBe(6)
     expect(twoFactorPlugin({ codeLength: 0 }).codeLength).toBe(1)
+  })
+
+  it("normalizes enrollment methods", () => {
+    expect(
+      twoFactorPlugin({ enrollmentMethods: ["otp", "totp", "otp"] })
+        .enrollmentMethods
+    ).toEqual(["totp", "otp"])
+    expect(
+      twoFactorPlugin({ enrollmentMethods: [] }).enrollmentMethods
+    ).toEqual(["totp"])
   })
 })
 

--- a/packages/heroui/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/packages/heroui/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -109,7 +109,7 @@ export function EnableTwoFactorDialog({
     onSuccess: (data) => {
       if (data.method === "otp") {
         toast.success(twoFactorLocalization.twoFactorEnabled)
-        onOpenChange(false)
+        handleOpenChange(false)
         return
       }
 

--- a/packages/heroui/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/packages/heroui/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -1,5 +1,8 @@
 import { createQrCodeSvgData } from "@better-auth-ui/core"
-import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-factor"
+import type {
+  TwoFactorAuthClient,
+  TwoFactorMethod
+} from "@better-auth-ui/core/plugins/two-factor"
 import {
   useAuth,
   useAuthPlugin,
@@ -19,6 +22,7 @@ import {
   InputGroup,
   Label,
   Spinner,
+  Tabs,
   TextField,
   toast
 } from "@heroui/react"
@@ -37,11 +41,10 @@ export type EnableTwoFactorDialogProps = {
 }
 
 /**
- * Three-step two-factor enrollment: confirm the password, scan the QR code
- * and verify a first code, then save the backup codes.
+ * Two-factor enrollment with authenticator-app and delivered-code methods.
  *
- * Better Auth only marks two-factor as active once a TOTP code verifies, so
- * the dialog never closes on the enable call alone.
+ * TOTP continues through QR verification and backup-code capture. OTP becomes
+ * active as soon as Better Auth accepts the enrollment request.
  *
  * @param isOpen - Whether the dialog is open.
  * @param onOpenChange - Called when the dialog requests an open state change.
@@ -51,14 +54,20 @@ export function EnableTwoFactorDialog({
   onOpenChange
 }: EnableTwoFactorDialogProps) {
   const { authClient, localization } = useAuth()
-  const { codeLength, localization: twoFactorLocalization } =
-    useAuthPlugin(twoFactorPlugin)
+  const {
+    codeLength,
+    enrollmentMethods,
+    localization: twoFactorLocalization
+  } = useAuthPlugin(twoFactorPlugin)
   const { isPending: isResolvingPasswordRequirement, requiresPassword } =
     useTwoFactorPasswordRequirement()
 
   const twoFactorClient = authClient as TwoFactorAuthClient
 
   const [step, setStep] = useState<EnrollmentStep>("password")
+  const [method, setMethod] = useState<TwoFactorMethod>(
+    enrollmentMethods[0] ?? "totp"
+  )
   const [totpUri, setTotpUri] = useState("")
   const [backupCodes, setBackupCodes] = useState<string[]>([])
   const [code, setCode] = useState("")
@@ -98,7 +107,11 @@ export function EnableTwoFactorDialog({
     reset: resetEnrollment
   } = useEnableTwoFactor(twoFactorClient, {
     onSuccess: (data) => {
-      if (data.method !== "totp") return
+      if (data.method === "otp") {
+        toast.success(twoFactorLocalization.twoFactorEnabled)
+        onOpenChange(false)
+        return
+      }
 
       setTotpUri(data.totpURI)
       setBackupCodes(data.backupCodes)
@@ -132,6 +145,7 @@ export function EnableTwoFactorDialog({
 
     if (!open) {
       setStep("password")
+      setMethod(enrollmentMethods[0] ?? "totp")
       setTotpUri("")
       setBackupCodes([])
       setCode("")
@@ -157,9 +171,7 @@ export function EnableTwoFactorDialog({
     const formData = new FormData(e.currentTarget)
     const password = formData.get("password") as string
 
-    enableTwoFactor(
-      requiresPassword ? { method: "totp", password } : { method: "totp" }
-    )
+    enableTwoFactor(requiresPassword ? { method, password } : { method })
   }
 
   const submitLabel =
@@ -193,6 +205,44 @@ export function EnableTwoFactorDialog({
                     {requiresPassword
                       ? twoFactorLocalization.passwordConfirmation
                       : twoFactorLocalization.twoFactorDescription}
+                  </p>
+
+                  {enrollmentMethods.length > 1 && (
+                    <Tabs
+                      className="mt-4"
+                      selectedKey={method}
+                      onSelectionChange={(key) =>
+                        setMethod(String(key) as TwoFactorMethod)
+                      }
+                      variant="secondary"
+                    >
+                      <Tabs.ListContainer>
+                        <Tabs.List
+                          aria-label={
+                            twoFactorLocalization.chooseEnrollmentMethod
+                          }
+                        >
+                          {enrollmentMethods.includes("totp") && (
+                            <Tabs.Tab id="totp">
+                              {twoFactorLocalization.authenticatorApp}
+                              <Tabs.Indicator />
+                            </Tabs.Tab>
+                          )}
+                          {enrollmentMethods.includes("otp") && (
+                            <Tabs.Tab id="otp">
+                              {twoFactorLocalization.deliveredCode}
+                              <Tabs.Indicator />
+                            </Tabs.Tab>
+                          )}
+                        </Tabs.List>
+                      </Tabs.ListContainer>
+                    </Tabs>
+                  )}
+
+                  <p className="text-muted mt-4 text-sm">
+                    {method === "totp"
+                      ? twoFactorLocalization.authenticatorAppDescription
+                      : twoFactorLocalization.deliveredCodeDescription}
                   </p>
 
                   {requiresPassword && (

--- a/packages/heroui/tests/two-factor.test.tsx
+++ b/packages/heroui/tests/two-factor.test.tsx
@@ -17,11 +17,16 @@ function createMockAuthClient(signInResult: SignInResult = {}) {
   const verifyTotp = vi.fn(async () => ({ token: "session-token" }))
   const verifyOtp = vi.fn(async () => ({ token: "session-token" }))
   const verifyBackupCode = vi.fn(async () => ({ token: "session-token" }))
-  const enable = vi.fn(async () => ({
-    method: "totp" as const,
-    totpURI: "otpauth://totp/App:user@example.com?secret=SECRET123&issuer=App",
-    backupCodes: ["code-1", "code-2"]
-  }))
+  const enable = vi.fn(async ({ method }: { method?: "otp" | "totp" }) =>
+    method === "otp"
+      ? { method: "otp" as const }
+      : {
+          method: "totp" as const,
+          totpURI:
+            "otpauth://totp/App:user@example.com?secret=SECRET123&issuer=App",
+          backupCodes: ["code-1", "code-2"]
+        }
+  )
 
   return {
     signIn: { email: signInEmail },
@@ -58,7 +63,8 @@ function createMockAuthClient(signInResult: SignInResult = {}) {
 
 function renderWithProvider(
   children: React.ReactNode,
-  authClient = createMockAuthClient()
+  authClient = createMockAuthClient(),
+  plugin = twoFactorPlugin()
 ) {
   const navigate = vi.fn()
 
@@ -70,7 +76,7 @@ function renderWithProvider(
         authClient={authClient}
         navigate={navigate}
         redirectTo="/dashboard"
-        plugins={[twoFactorPlugin()]}
+        plugins={[plugin]}
       >
         {children}
       </AuthProvider>
@@ -205,6 +211,33 @@ describe("<TwoFactorChallenge />", () => {
 })
 
 describe("<TwoFactorSettings />", () => {
+  it("enables delivered-code two-factor without a TOTP verification step", async () => {
+    const user = userEvent.setup()
+    const { authClient } = renderWithProvider(
+      <TwoFactorSettings />,
+      createMockAuthClient(),
+      twoFactorPlugin({ enrollmentMethods: ["totp", "otp"] })
+    )
+
+    await user.click(screen.getByRole("button", { name: /enable two-factor/i }))
+
+    const dialog = await screen.findByRole("alertdialog")
+    await user.click(
+      within(dialog).getByRole("tab", { name: /email or sms code/i })
+    )
+    await user.type(within(dialog).getByLabelText(/password/i), "password123")
+    await user.click(
+      within(dialog).getByRole("button", { name: /enable two-factor/i })
+    )
+
+    await waitFor(() => {
+      expect(authClient.twoFactor.enable).toHaveBeenCalledWith(
+        expect.objectContaining({ method: "otp", password: "password123" })
+      )
+    })
+    expect(authClient.twoFactor.verifyTotp).not.toHaveBeenCalled()
+  })
+
   it("auto-verifies enrollment codes before showing backup codes", async () => {
     const user = userEvent.setup()
     const writeText = vi

--- a/packages/locales/src/de-DE-plugins.ts
+++ b/packages/locales/src/de-DE-plugins.ts
@@ -630,6 +630,13 @@ export const deDEPlugins = {
     twoFactorEnabled: "Zwei-Faktor-Authentifizierung ist aktiviert",
     twoFactorDisabled: "Zwei-Faktor-Authentifizierung ist deaktiviert",
     passwordConfirmation: "Gib dein Passwort ein, um fortzufahren",
+    chooseEnrollmentMethod:
+      "Wähle aus, wie du zukünftige Anmeldungen bestätigen möchtest",
+    authenticatorApp: "Authenticator-App",
+    authenticatorAppDescription:
+      "Verwende einen wechselnden Code aus einer Authenticator-App",
+    deliveredCode: "Code per E-Mail oder SMS",
+    deliveredCodeDescription: "Erhalte bei jeder Anmeldung einen neuen Code",
     scanQrCode: "Scanne dies mit deiner Authenticator-App",
     setupKey: "Scannen nicht möglich? Gib stattdessen diesen Schlüssel ein",
     setupKeyCopied: "Einrichtungsschlüssel kopiert",


### PR DESCRIPTION
## Summary

- Support Better Auth two-factor enrollment with `method: "otp"`.
- Add configurable `enrollmentMethods` with TOTP and delivered-code choices.
- Add the enrollment choice to HeroUI, shadcn, and Solid/Zaidan, with matching docs and tests.

## Scope

This layer maps directly to `authClient.twoFactor.enable` and keeps the existing TOTP setup flow intact.

## Validation

Core and HeroUI tests, framework typechecks, registry builds, Biome, and affected lint pass.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for choosing between authenticator-app and delivered-code enrollment for two-factor authentication.
  * Delivered-code enrollment now completes immediately after successful activation.
  * Added configurable enrollment methods, with authenticator-app enrollment enabled by default.
  * Added localized labels and descriptions for each enrollment method.

* **Documentation**
  * Updated two-factor setup guidance to cover delivered-code configuration and enrollment options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->