### PR TITLE
feat(admin): complete user management actions

### DIFF
--- a/apps/docs/content/docs/heroui/plugins/admin.mdx
+++ b/apps/docs/content/docs/heroui/plugins/admin.mdx
@@ -97,6 +97,16 @@ plugins can add more tabs without adding routes.
 The Dash integration adds an Activity tab when both UI plugins are registered.
 Dash applies its own organization owner or admin access rules to this tab.
 
+## User actions
+
+The users page can create users. The drawer can update a user's name and role,
+set a password, ban or unban the user, impersonate the user, delete the user,
+and revoke one or all of the user's sessions.
+
+The UI checks the matching Admin client permission before it enables each
+action. Dangerous actions require confirmation. The UI also disables actions
+that would ban, delete, impersonate, or revoke sessions for the current user.
+
 ## Permissions and privacy
 
 The users page calls the Better Auth permission API before it requests the
@@ -105,7 +115,8 @@ user list. Do not authorize the page from a role string alone.
 The table searches one field per request. The supported fields are `email`
 and `name`.
 
-Passwords stay in local form state and never enter query keys. Session IP
+Passwords stay in local form state and never enter query keys. The forms clear
+each password after the request or when the user closes the form. Session IP
 addresses are hidden unless `showIpAddress` is `true`.
 
 Configure custom roles with the same names in Better Auth and the UI plugin:

--- a/apps/docs/content/docs/shadcn/plugins/admin.mdx
+++ b/apps/docs/content/docs/shadcn/plugins/admin.mdx
@@ -143,9 +143,10 @@ and Sessions tabs. Registered plugins can add more tabs without adding routes.
 The Dash integration adds an Activity tab when both UI plugins are registered.
 Dash applies its own organization owner or admin access rules to this tab.
 
-The inspector can change roles, set passwords, ban users, impersonate users,
-remove users, and revoke sessions. Dangerous actions require confirmation.
-The UI disables self-destructive actions and still relies on the server.
+The users page can create users. The inspector can update names and roles, set
+passwords, ban or unban users, impersonate users, remove users, and revoke one
+or all sessions. Dangerous actions require confirmation. The UI disables
+self-destructive actions and still relies on the server.
 
 Passwords stay in local form state. The forms clear each password after the
 request or after the user closes the form.

--- a/apps/docs/content/docs/zaidan/plugins/admin.mdx
+++ b/apps/docs/content/docs/zaidan/plugins/admin.mdx
@@ -112,14 +112,25 @@ plugins can add more tabs without adding routes.
 The Dash integration adds an Activity tab when both UI plugins are registered.
 Dash applies its own organization owner or admin access rules to this tab.
 
+## User actions
+
+The users page can create users. The dialog can update a user's name and role,
+set a password, ban or unban the user, impersonate the user, delete the user,
+and revoke one or all of the user's sessions.
+
+The UI checks the matching Admin client permission before it enables each
+action. Dangerous actions require confirmation. The UI also disables actions
+that would ban, delete, impersonate, or revoke sessions for the current user.
+
 ## Permissions and privacy
 
 The users page calls the Better Auth permission API before it requests the
 user list. Do not authorize the page from a role string alone.
 
 The table searches either `email` or `name` in each request. Passwords stay in
-local form state. Session IP addresses are hidden unless `showIpAddress` is
-`true`.
+local form state. The forms clear each password after the request or when the
+user closes the form. Session IP addresses are hidden unless `showIpAddress`
+is `true`.
 
 ```ts
 adminPlugin({

--- a/apps/docs/src/components/auth/admin/admin-users.tsx
+++ b/apps/docs/src/components/auth/admin/admin-users.tsx
@@ -11,7 +11,8 @@ import {
   revokeAdminUserSessionsOptions,
   setAdminUserPasswordOptions,
   setAdminUserRoleOptions,
-  unbanAdminUserOptions
+  unbanAdminUserOptions,
+  updateAdminUserOptions
 } from "@better-auth-ui/core/plugins/admin"
 import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
 import {
@@ -691,6 +692,11 @@ function UserInspector({
     },
     { enabled: Boolean(userId) }
   )
+  const canUpdate = useAdminPermission(
+    auth.authClient,
+    { user: ["update"] },
+    { enabled: Boolean(userId) }
+  )
   const canSetPassword = useAdminPermission(
     auth.authClient,
     {
@@ -723,13 +729,19 @@ function UserInspector({
     { enabled: Boolean(userId) }
   )
   const [role, setRole] = useState(config.defaultRole)
+  const [name, setName] = useState("")
   const [passwordOpen, setPasswordOpen] = useState(false)
   const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
   const user = detail.data
   const isSelf = user?.id === actor?.user.id
   useEffect(() => {
     if (user?.role) setRole(user.role)
-  }, [user?.role])
+    if (user?.name) setName(user.name)
+  }, [user?.name, user?.role])
+
+  const updateUser = useMutation(
+    updateAdminUserOptions(auth.authClient, actor?.user.id)
+  )
 
   const setRoleMutation = useMutation(
     setAdminUserRoleOptions(auth.authClient, actor?.user.id)
@@ -884,6 +896,44 @@ function UserInspector({
                     </Badge>
                   </dd>
                 </dl>
+                <form
+                  className="flex items-end gap-2"
+                  onSubmit={(event) => {
+                    event.preventDefault()
+                    updateUser.mutate({ userId: user.id, data: { name } })
+                  }}
+                >
+                  <Field className="flex-1">
+                    <FieldLabel htmlFor="admin-user-name">
+                      {config.localization.name}
+                    </FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        id="admin-user-name"
+                        value={name}
+                        onChange={(event) => setName(event.target.value)}
+                      />
+                    </InputGroup>
+                    {updateUser.error ? (
+                      <FieldError>
+                        {getAdminErrorMessage(updateUser.error)}
+                      </FieldError>
+                    ) : null}
+                  </Field>
+                  <Button
+                    disabled={
+                      !name.trim() ||
+                      name === user.name ||
+                      updateUser.isPending ||
+                      canUpdate.isPending ||
+                      !canUpdate.data?.success
+                    }
+                    type="submit"
+                    variant="outline"
+                  >
+                    {config.localization.saveUser}
+                  </Button>
+                </form>
                 <div className="flex items-end gap-2">
                   <Field className="flex-1">
                     <FieldLabel>{config.localization.role}</FieldLabel>

--- a/apps/docs/src/components/auth/admin/admin-users.tsx
+++ b/apps/docs/src/components/auth/admin/admin-users.tsx
@@ -734,14 +734,23 @@ function UserInspector({
   const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
   const user = detail.data
   const isSelf = user?.id === actor?.user.id
-  useEffect(() => {
-    if (user?.role) setRole(user.role)
-    if (user?.name) setName(user.name)
-  }, [user?.name, user?.role])
 
   const updateUser = useMutation(
     updateAdminUserOptions(auth.authClient, actor?.user.id)
   )
+
+  useEffect(() => {
+    if (user?.role) setRole(user.role)
+    setName(user?.name ?? "")
+  }, [user?.name, user?.role])
+
+  useEffect(() => {
+    if (user?.id) updateUser.reset()
+  }, [user?.id, updateUser.reset])
+
+  useEffect(() => {
+    if (!open) updateUser.reset()
+  }, [open, updateUser.reset])
 
   const setRoleMutation = useMutation(
     setAdminUserRoleOptions(auth.authClient, actor?.user.id)

--- a/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -11,7 +11,8 @@ import {
   revokeAdminUserSessionsOptions,
   setAdminUserPasswordOptions,
   setAdminUserRoleOptions,
-  unbanAdminUserOptions
+  unbanAdminUserOptions,
+  updateAdminUserOptions
 } from "@better-auth-ui/core/plugins/admin"
 import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
 import {
@@ -691,6 +692,11 @@ function UserInspector({
     },
     { enabled: Boolean(userId) }
   )
+  const canUpdate = useAdminPermission(
+    auth.authClient,
+    { user: ["update"] },
+    { enabled: Boolean(userId) }
+  )
   const canSetPassword = useAdminPermission(
     auth.authClient,
     {
@@ -723,13 +729,19 @@ function UserInspector({
     { enabled: Boolean(userId) }
   )
   const [role, setRole] = useState(config.defaultRole)
+  const [name, setName] = useState("")
   const [passwordOpen, setPasswordOpen] = useState(false)
   const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
   const user = detail.data
   const isSelf = user?.id === actor?.user.id
   useEffect(() => {
     if (user?.role) setRole(user.role)
-  }, [user?.role])
+    if (user?.name) setName(user.name)
+  }, [user?.name, user?.role])
+
+  const updateUser = useMutation(
+    updateAdminUserOptions(auth.authClient, actor?.user.id)
+  )
 
   const setRoleMutation = useMutation(
     setAdminUserRoleOptions(auth.authClient, actor?.user.id)
@@ -884,6 +896,44 @@ function UserInspector({
                     </Badge>
                   </dd>
                 </dl>
+                <form
+                  className="flex items-end gap-2"
+                  onSubmit={(event) => {
+                    event.preventDefault()
+                    updateUser.mutate({ userId: user.id, data: { name } })
+                  }}
+                >
+                  <Field className="flex-1">
+                    <FieldLabel htmlFor="admin-user-name">
+                      {config.localization.name}
+                    </FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        id="admin-user-name"
+                        value={name}
+                        onChange={(event) => setName(event.target.value)}
+                      />
+                    </InputGroup>
+                    {updateUser.error ? (
+                      <FieldError>
+                        {getAdminErrorMessage(updateUser.error)}
+                      </FieldError>
+                    ) : null}
+                  </Field>
+                  <Button
+                    disabled={
+                      !name.trim() ||
+                      name === user.name ||
+                      updateUser.isPending ||
+                      canUpdate.isPending ||
+                      !canUpdate.data?.success
+                    }
+                    type="submit"
+                    variant="outline"
+                  >
+                    {config.localization.saveUser}
+                  </Button>
+                </form>
                 <div className="flex items-end gap-2">
                   <Field className="flex-1">
                     <FieldLabel>{config.localization.role}</FieldLabel>

--- a/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -734,14 +734,23 @@ function UserInspector({
   const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
   const user = detail.data
   const isSelf = user?.id === actor?.user.id
-  useEffect(() => {
-    if (user?.role) setRole(user.role)
-    if (user?.name) setName(user.name)
-  }, [user?.name, user?.role])
 
   const updateUser = useMutation(
     updateAdminUserOptions(auth.authClient, actor?.user.id)
   )
+
+  useEffect(() => {
+    if (user?.role) setRole(user.role)
+    setName(user?.name ?? "")
+  }, [user?.name, user?.role])
+
+  useEffect(() => {
+    if (user?.id) updateUser.reset()
+  }, [user?.id, updateUser.reset])
+
+  useEffect(() => {
+    if (!open) updateUser.reset()
+  }, [open, updateUser.reset])
 
   const setRoleMutation = useMutation(
     setAdminUserRoleOptions(auth.authClient, actor?.user.id)

--- a/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
@@ -11,7 +11,8 @@ import {
   revokeAdminUserSessionsOptions,
   setAdminUserPasswordOptions,
   setAdminUserRoleOptions,
-  unbanAdminUserOptions
+  unbanAdminUserOptions,
+  updateAdminUserOptions
 } from "@better-auth-ui/core/plugins/admin"
 import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
 import {
@@ -691,6 +692,11 @@ function UserInspector({
     },
     { enabled: Boolean(userId) }
   )
+  const canUpdate = useAdminPermission(
+    auth.authClient,
+    { user: ["update"] },
+    { enabled: Boolean(userId) }
+  )
   const canSetPassword = useAdminPermission(
     auth.authClient,
     {
@@ -723,13 +729,19 @@ function UserInspector({
     { enabled: Boolean(userId) }
   )
   const [role, setRole] = useState(config.defaultRole)
+  const [name, setName] = useState("")
   const [passwordOpen, setPasswordOpen] = useState(false)
   const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
   const user = detail.data
   const isSelf = user?.id === actor?.user.id
   useEffect(() => {
     if (user?.role) setRole(user.role)
-  }, [user?.role])
+    if (user?.name) setName(user.name)
+  }, [user?.name, user?.role])
+
+  const updateUser = useMutation(
+    updateAdminUserOptions(auth.authClient, actor?.user.id)
+  )
 
   const setRoleMutation = useMutation(
     setAdminUserRoleOptions(auth.authClient, actor?.user.id)
@@ -884,6 +896,44 @@ function UserInspector({
                     </Badge>
                   </dd>
                 </dl>
+                <form
+                  className="flex items-end gap-2"
+                  onSubmit={(event) => {
+                    event.preventDefault()
+                    updateUser.mutate({ userId: user.id, data: { name } })
+                  }}
+                >
+                  <Field className="flex-1">
+                    <FieldLabel htmlFor="admin-user-name">
+                      {config.localization.name}
+                    </FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        id="admin-user-name"
+                        value={name}
+                        onChange={(event) => setName(event.target.value)}
+                      />
+                    </InputGroup>
+                    {updateUser.error ? (
+                      <FieldError>
+                        {getAdminErrorMessage(updateUser.error)}
+                      </FieldError>
+                    ) : null}
+                  </Field>
+                  <Button
+                    disabled={
+                      !name.trim() ||
+                      name === user.name ||
+                      updateUser.isPending ||
+                      canUpdate.isPending ||
+                      !canUpdate.data?.success
+                    }
+                    type="submit"
+                    variant="outline"
+                  >
+                    {config.localization.saveUser}
+                  </Button>
+                </form>
                 <div className="flex items-end gap-2">
                   <Field className="flex-1">
                     <FieldLabel>{config.localization.role}</FieldLabel>

--- a/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
@@ -734,14 +734,23 @@ function UserInspector({
   const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
   const user = detail.data
   const isSelf = user?.id === actor?.user.id
-  useEffect(() => {
-    if (user?.role) setRole(user.role)
-    if (user?.name) setName(user.name)
-  }, [user?.name, user?.role])
 
   const updateUser = useMutation(
     updateAdminUserOptions(auth.authClient, actor?.user.id)
   )
+
+  useEffect(() => {
+    if (user?.role) setRole(user.role)
+    setName(user?.name ?? "")
+  }, [user?.name, user?.role])
+
+  useEffect(() => {
+    if (user?.id) updateUser.reset()
+  }, [user?.id, updateUser.reset])
+
+  useEffect(() => {
+    if (!open) updateUser.reset()
+  }, [open, updateUser.reset])
 
   const setRoleMutation = useMutation(
     setAdminUserRoleOptions(auth.authClient, actor?.user.id)

--- a/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -11,7 +11,8 @@ import {
   revokeAdminUserSessionsOptions,
   setAdminUserPasswordOptions,
   setAdminUserRoleOptions,
-  unbanAdminUserOptions
+  unbanAdminUserOptions,
+  updateAdminUserOptions
 } from "@better-auth-ui/core/plugins/admin"
 import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
 import {
@@ -691,6 +692,11 @@ function UserInspector({
     },
     { enabled: Boolean(userId) }
   )
+  const canUpdate = useAdminPermission(
+    auth.authClient,
+    { user: ["update"] },
+    { enabled: Boolean(userId) }
+  )
   const canSetPassword = useAdminPermission(
     auth.authClient,
     {
@@ -723,13 +729,19 @@ function UserInspector({
     { enabled: Boolean(userId) }
   )
   const [role, setRole] = useState(config.defaultRole)
+  const [name, setName] = useState("")
   const [passwordOpen, setPasswordOpen] = useState(false)
   const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
   const user = detail.data
   const isSelf = user?.id === actor?.user.id
   useEffect(() => {
     if (user?.role) setRole(user.role)
-  }, [user?.role])
+    if (user?.name) setName(user.name)
+  }, [user?.name, user?.role])
+
+  const updateUser = useMutation(
+    updateAdminUserOptions(auth.authClient, actor?.user.id)
+  )
 
   const setRoleMutation = useMutation(
     setAdminUserRoleOptions(auth.authClient, actor?.user.id)
@@ -884,6 +896,44 @@ function UserInspector({
                     </Badge>
                   </dd>
                 </dl>
+                <form
+                  className="flex items-end gap-2"
+                  onSubmit={(event) => {
+                    event.preventDefault()
+                    updateUser.mutate({ userId: user.id, data: { name } })
+                  }}
+                >
+                  <Field className="flex-1">
+                    <FieldLabel htmlFor="admin-user-name">
+                      {config.localization.name}
+                    </FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        id="admin-user-name"
+                        value={name}
+                        onChange={(event) => setName(event.target.value)}
+                      />
+                    </InputGroup>
+                    {updateUser.error ? (
+                      <FieldError>
+                        {getAdminErrorMessage(updateUser.error)}
+                      </FieldError>
+                    ) : null}
+                  </Field>
+                  <Button
+                    disabled={
+                      !name.trim() ||
+                      name === user.name ||
+                      updateUser.isPending ||
+                      canUpdate.isPending ||
+                      !canUpdate.data?.success
+                    }
+                    type="submit"
+                    variant="outline"
+                  >
+                    {config.localization.saveUser}
+                  </Button>
+                </form>
                 <div className="flex items-end gap-2">
                   <Field className="flex-1">
                     <FieldLabel>{config.localization.role}</FieldLabel>

--- a/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -734,14 +734,23 @@ function UserInspector({
   const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
   const user = detail.data
   const isSelf = user?.id === actor?.user.id
-  useEffect(() => {
-    if (user?.role) setRole(user.role)
-    if (user?.name) setName(user.name)
-  }, [user?.name, user?.role])
 
   const updateUser = useMutation(
     updateAdminUserOptions(auth.authClient, actor?.user.id)
   )
+
+  useEffect(() => {
+    if (user?.role) setRole(user.role)
+    setName(user?.name ?? "")
+  }, [user?.name, user?.role])
+
+  useEffect(() => {
+    if (user?.id) updateUser.reset()
+  }, [user?.id, updateUser.reset])
+
+  useEffect(() => {
+    if (!open) updateUser.reset()
+  }, [open, updateUser.reset])
 
   const setRoleMutation = useMutation(
     setAdminUserRoleOptions(auth.authClient, actor?.user.id)

--- a/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
@@ -3,18 +3,38 @@ import {
   type AdminListUsersParams,
   adminPlugin
 } from "@better-auth-ui/core/plugins/admin"
-import { useAuth } from "@better-auth-ui/solid"
+import { useAuth, useSession } from "@better-auth-ui/solid"
 import {
   useAdminPermission,
   useAdminUser,
   useAdminUserSessions,
-  useAdminUsers
+  useAdminUsers,
+  useBanAdminUser,
+  useCreateAdminUser,
+  useImpersonateAdminUser,
+  useRemoveAdminUser,
+  useRevokeAdminUserSession,
+  useRevokeAdminUserSessions,
+  useSetAdminUserPassword,
+  useSetAdminUserRole,
+  useUnbanAdminUser,
+  useUpdateAdminUser
 } from "@better-auth-ui/solid/plugins/admin"
 import { createDebounce } from "@solid-primitives/debounce"
-import { Search } from "lucide-solid"
-import { createMemo, createSignal, For, Show } from "solid-js"
+import { Ban, KeyRound, LogIn, Search, Trash2, UserPlus } from "lucide-solid"
+import { createEffect, createMemo, createSignal, For, Show } from "solid-js"
 import { Dynamic } from "solid-js/web"
 
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import {
@@ -31,6 +51,8 @@ import {
   EmptyHeader,
   EmptyTitle
 } from "@/components/ui/empty"
+import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
 import {
   InputGroup,
   InputGroupAddon,
@@ -56,6 +78,8 @@ export type AdminUsersProps = {
   selectedUserId?: string
 }
 
+type DangerousAction = "ban" | "delete" | "impersonate" | "revokeAll"
+
 const skeletonIds = ["solid-admin-1", "solid-admin-2", "solid-admin-3"]
 
 const formatDate = (value: Date | string | undefined | null) =>
@@ -64,6 +88,10 @@ const formatDate = (value: Date | string | undefined | null) =>
         new Date(value)
       )
     : "–"
+
+const asAdminRole = (role: string) => role as "user" | "admin"
+
+const getAdminErrorMessage = (error: Error | null) => error?.message
 
 /** Zaidan presentation for the static Admin users view. */
 export function AdminUsers(props: AdminUsersProps) {
@@ -82,6 +110,10 @@ export function AdminUsers(props: AdminUsersProps) {
   const selectedUserId = () =>
     props.onSelectedUserIdChange ? props.selectedUserId : localSelectedUserId()
   const permission = useAdminPermission(authClient, () => ({ user: ["list"] }))
+  const createPermission = useAdminPermission(authClient, () => ({
+    user: ["create"]
+  }))
+  const [createOpen, setCreateOpen] = createSignal(false)
   const params = createMemo<AdminListUsersParams>(() => ({
     limit: config().pageSize,
     offset: page() * config().pageSize,
@@ -104,11 +136,19 @@ export function AdminUsers(props: AdminUsersProps) {
 
   return (
     <section class={cn("flex flex-col gap-4", props.class)}>
-      <header class="flex flex-col gap-1">
-        <h1 class="text-xl font-semibold">{config().localization.users}</h1>
-        <p class="text-sm text-muted-foreground">
-          {config().localization.usersDescription}
-        </p>
+      <header class="flex items-end justify-between gap-3">
+        <div class="flex flex-col gap-1">
+          <h1 class="text-xl font-semibold">{config().localization.users}</h1>
+          <p class="text-sm text-muted-foreground">
+            {config().localization.usersDescription}
+          </p>
+        </div>
+        <Show when={createPermission.data?.success}>
+          <Button onClick={() => setCreateOpen(true)}>
+            <UserPlus />
+            {config().localization.createUser}
+          </Button>
+        </Show>
       </header>
 
       <div class="flex flex-col gap-2 sm:flex-row">
@@ -299,6 +339,7 @@ export function AdminUsers(props: AdminUsersProps) {
         onOpenChange={(open) => !open && selectUser(undefined)}
         userId={selectedUserId}
       />
+      <CreateUserDialog open={createOpen()} onOpenChange={setCreateOpen} />
     </section>
   )
 }
@@ -317,6 +358,111 @@ function SessionRowsSkeleton() {
     <For each={skeletonIds}>
       {(id) => <Skeleton class="h-20 w-full" data-id={`session-${id}`} />}
     </For>
+  )
+}
+
+function CreateUserDialog(props: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const auth = useAuth()
+  const authClient = auth.authClient as AdminAuthClient
+  const config = () =>
+    (auth.plugins.find((plugin) => plugin.id === adminPlugin.id) ??
+      adminPlugin()) as ReturnType<typeof adminPlugin>
+  const createUser = useCreateAdminUser(authClient)
+
+  const close = () => {
+    createUser.reset()
+    props.onOpenChange(false)
+  }
+  const submit = (event: SubmitEvent) => {
+    event.preventDefault()
+    const data = new FormData(event.currentTarget as HTMLFormElement)
+    createUser.mutate(
+      {
+        email: String(data.get("email")),
+        name: String(data.get("name")),
+        password: String(data.get("password")),
+        role: asAdminRole(String(data.get("role") || config().defaultRole))
+      },
+      { onSuccess: close }
+    )
+  }
+
+  return (
+    <Dialog
+      open={props.open}
+      onOpenChange={(open) => (open ? props.onOpenChange(true) : close())}
+    >
+      <DialogContent>
+        <form class="flex flex-col gap-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{config().localization.createUser}</DialogTitle>
+            <DialogDescription>
+              {config().localization.usersDescription}
+            </DialogDescription>
+          </DialogHeader>
+          <Field>
+            <FieldLabel for="solid-admin-create-name">
+              {config().localization.name}
+            </FieldLabel>
+            <Input id="solid-admin-create-name" name="name" required />
+          </Field>
+          <Field>
+            <FieldLabel for="solid-admin-create-email">
+              {config().localization.email}
+            </FieldLabel>
+            <Input
+              autocomplete="off"
+              id="solid-admin-create-email"
+              name="email"
+              required
+              type="email"
+            />
+          </Field>
+          <Field>
+            <FieldLabel for="solid-admin-create-password">
+              {config().localization.password}
+            </FieldLabel>
+            <Input
+              autocomplete="new-password"
+              id="solid-admin-create-password"
+              name="password"
+              required
+              type="password"
+            />
+          </Field>
+          <Field>
+            <FieldLabel for="solid-admin-create-role">
+              {config().localization.role}
+            </FieldLabel>
+            <select
+              class="h-8 rounded-lg border bg-transparent px-2 text-sm"
+              id="solid-admin-create-role"
+              name="role"
+            >
+              <For each={config().roles}>
+                {(role) => (
+                  <option selected={role === config().defaultRole} value={role}>
+                    {role}
+                  </option>
+                )}
+              </For>
+            </select>
+          </Field>
+          <FieldError>{getAdminErrorMessage(createUser.error)}</FieldError>
+          <DialogFooter>
+            <Button onClick={close} type="button" variant="outline">
+              {config().localization.cancel}
+            </Button>
+            <Button disabled={createUser.isPending} type="submit">
+              {config().localization.createUser}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   )
 }
 
@@ -339,93 +485,357 @@ function UserDialog(props: {
     )
   )
   const user = useAdminUser(authClient, props.userId)
-  const sessionsPermission = useAdminPermission(authClient, () => ({
-    session: ["list"]
-  }))
+  const actor = useSession(authClient)
+  const enabled = () => ({ enabled: Boolean(props.userId()) })
+  const sessionsPermission = useAdminPermission(
+    authClient,
+    () => ({ session: ["list"] }),
+    enabled
+  )
   const sessions = useAdminUserSessions(authClient, props.userId, () => ({
     enabled: sessionsPermission.data?.success === true
   }))
+  const canUpdate = useAdminPermission(
+    authClient,
+    () => ({ user: ["update"] }),
+    enabled
+  )
+  const canSetRole = useAdminPermission(
+    authClient,
+    () => ({ user: ["set-role"] }),
+    enabled
+  )
+  const canSetPassword = useAdminPermission(
+    authClient,
+    () => ({ user: ["set-password"] }),
+    enabled
+  )
+  const canBan = useAdminPermission(
+    authClient,
+    () => ({ user: ["ban"] }),
+    enabled
+  )
+  const canImpersonate = useAdminPermission(
+    authClient,
+    () => ({ user: ["impersonate"] }),
+    enabled
+  )
+  const canDelete = useAdminPermission(
+    authClient,
+    () => ({ user: ["delete"] }),
+    enabled
+  )
+  const canRevoke = useAdminPermission(
+    authClient,
+    () => ({ session: ["revoke"] }),
+    enabled
+  )
+  const [name, setName] = createSignal("")
+  const [role, setRole] = createSignal(config().defaultRole)
+  const [passwordOpen, setPasswordOpen] = createSignal(false)
+  const [dangerousAction, setDangerousAction] = createSignal<DangerousAction>()
+  const detail = () => user.data
+  const isSelf = () => detail()?.id === actor.data?.user.id
+  const updateUser = useUpdateAdminUser(authClient)
+  const setRoleMutation = useSetAdminUserRole(authClient)
+  const ban = useBanAdminUser(authClient)
+  const unban = useUnbanAdminUser(authClient)
+  const impersonate = useImpersonateAdminUser(authClient)
+  const remove = useRemoveAdminUser(authClient)
+  const revokeSession = useRevokeAdminUserSession(authClient, props.userId)
+  const revokeSessions = useRevokeAdminUserSessions(authClient, props.userId)
+
+  createEffect(() => {
+    setName(detail()?.name ?? "")
+    setRole(detail()?.role ?? config().defaultRole)
+  })
+
+  const confirmDangerousAction = () => {
+    const selectedUser = detail()
+    if (!selectedUser) return
+    if (dangerousAction() === "ban")
+      ban.mutate(
+        { userId: selectedUser.id },
+        { onSuccess: () => setDangerousAction(undefined) }
+      )
+    if (dangerousAction() === "delete")
+      remove.mutate(
+        { userId: selectedUser.id },
+        {
+          onSuccess: () => {
+            setDangerousAction(undefined)
+            props.onOpenChange(false)
+          }
+        }
+      )
+    if (dangerousAction() === "revokeAll")
+      revokeSessions.mutate(
+        { userId: selectedUser.id },
+        { onSuccess: () => setDangerousAction(undefined) }
+      )
+    if (dangerousAction() === "impersonate")
+      impersonate.mutate(
+        { userId: selectedUser.id },
+        {
+          onSuccess: () => {
+            setDangerousAction(undefined)
+            const redirectTo = config().impersonationRedirectTo
+            if (redirectTo) auth.navigate({ to: redirectTo })
+          }
+        }
+      )
+  }
+  const closeDangerousAction = () => {
+    ban.reset()
+    remove.reset()
+    revokeSessions.reset()
+    impersonate.reset()
+    setDangerousAction(undefined)
+  }
+  const dangerousMutation = () =>
+    dangerousAction() === "ban"
+      ? ban
+      : dangerousAction() === "delete"
+        ? remove
+        : dangerousAction() === "revokeAll"
+          ? revokeSessions
+          : impersonate
+  const dangerousLabel = () =>
+    dangerousAction() === "ban"
+      ? config().localization.banUser
+      : dangerousAction() === "delete"
+        ? config().localization.deleteUser
+        : dangerousAction() === "revokeAll"
+          ? config().localization.revokeAllSessions
+          : config().localization.impersonateUser
 
   return (
-    <Dialog open={props.open} onOpenChange={props.onOpenChange}>
-      <DialogContent class="max-h-[90vh] max-w-lg overflow-y-auto rounded-xl border bg-popover p-4">
-        <DialogHeader>
-          <DialogTitle>{config().localization.userDetails}</DialogTitle>
-          <DialogDescription>
-            {user.data?.email ?? config().localization.usersDescription}
-          </DialogDescription>
-        </DialogHeader>
-        <Show
-          fallback={
-            <AdminMessage
-              title={config().localization.loadUsersError}
-              description={config().localization.loadUsersErrorDescription}
-            />
-          }
-          when={!user.isError}
-        >
+    <>
+      <Dialog open={props.open} onOpenChange={props.onOpenChange}>
+        <DialogContent class="max-h-[90vh] max-w-lg overflow-y-auto rounded-xl border bg-popover p-4">
+          <DialogHeader>
+            <DialogTitle>{config().localization.userDetails}</DialogTitle>
+            <DialogDescription>
+              {detail()?.email ?? config().localization.usersDescription}
+            </DialogDescription>
+          </DialogHeader>
           <Show
-            fallback={<Skeleton class="mt-4 h-40 w-full" />}
-            when={user.data}
+            fallback={
+              <AdminMessage
+                title={config().localization.loadUsersError}
+                description={config().localization.loadUsersErrorDescription}
+              />
+            }
+            when={!user.isError}
           >
-            {(detail) => (
-              <Tabs class="mt-4" defaultValue="overview">
-                <TabsList>
-                  <TabsTrigger value="overview">
-                    {config().localization.overview}
-                  </TabsTrigger>
-                  <TabsTrigger value="sessions">
-                    {config().localization.sessions}
-                  </TabsTrigger>
-                  <For each={contributedTabs()}>
-                    {(tab) => (
-                      <TabsTrigger value={tab.value}>
-                        <Dynamic component={tab.label} />
-                      </TabsTrigger>
-                    )}
-                  </For>
-                </TabsList>
-                <TabsContent class="flex flex-col gap-4 pt-4" value="overview">
-                  <div class="flex items-center gap-3">
-                    <UserAvatar class="size-12" user={detail()} />
-                    <div>
-                      <div class="font-medium">{detail().name}</div>
-                      <div class="text-sm text-muted-foreground">
-                        {detail().email}
+            <Show
+              fallback={<Skeleton class="mt-4 h-40 w-full" />}
+              when={detail()}
+            >
+              {(selectedUser) => (
+                <Tabs class="mt-4" defaultValue="overview">
+                  <TabsList>
+                    <TabsTrigger value="overview">
+                      {config().localization.overview}
+                    </TabsTrigger>
+                    <TabsTrigger value="sessions">
+                      {config().localization.sessions}
+                    </TabsTrigger>
+                    <For each={contributedTabs()}>
+                      {(tab) => (
+                        <TabsTrigger value={tab.value}>
+                          <Dynamic component={tab.label} />
+                        </TabsTrigger>
+                      )}
+                    </For>
+                  </TabsList>
+                  <TabsContent
+                    class="flex flex-col gap-6 pt-4"
+                    value="overview"
+                  >
+                    <div class="flex items-center gap-3">
+                      <UserAvatar class="size-12" user={selectedUser()} />
+                      <div>
+                        <div class="font-medium">{selectedUser().name}</div>
+                        <div class="text-sm text-muted-foreground">
+                          {selectedUser().email}
+                        </div>
                       </div>
                     </div>
-                  </div>
-                  <dl class="grid grid-cols-[auto_1fr] gap-3 text-sm">
-                    <dt class="text-muted-foreground">
-                      {config().localization.userId}
-                    </dt>
-                    <dd class="font-mono text-xs">{detail().id}</dd>
-                    <dt class="text-muted-foreground">
-                      {config().localization.role}
-                    </dt>
-                    <dd>{detail().role ?? config().defaultRole}</dd>
-                    <dt class="text-muted-foreground">
-                      {config().localization.created}
-                    </dt>
-                    <dd>{formatDate(detail().createdAt)}</dd>
-                  </dl>
-                </TabsContent>
-                <TabsContent class="flex flex-col gap-2 pt-4" value="sessions">
-                  <Show
-                    fallback={<SessionRowsSkeleton />}
-                    when={!sessionsPermission.isPending}
+                    <dl class="grid grid-cols-[auto_1fr] gap-3 text-sm">
+                      <dt class="text-muted-foreground">
+                        {config().localization.userId}
+                      </dt>
+                      <dd class="font-mono text-xs">{selectedUser().id}</dd>
+                      <dt class="text-muted-foreground">
+                        {config().localization.created}
+                      </dt>
+                      <dd>{formatDate(selectedUser().createdAt)}</dd>
+                      <dt class="text-muted-foreground">
+                        {config().localization.status}
+                      </dt>
+                      <dd>
+                        <Badge
+                          variant={
+                            selectedUser().banned ? "destructive" : "secondary"
+                          }
+                        >
+                          {selectedUser().banned
+                            ? config().localization.banned
+                            : config().localization.active}
+                        </Badge>
+                      </dd>
+                    </dl>
+                    <form
+                      class="flex items-end gap-2"
+                      onSubmit={(event) => {
+                        event.preventDefault()
+                        updateUser.mutate({
+                          userId: selectedUser().id,
+                          data: { name: name().trim() }
+                        })
+                      }}
+                    >
+                      <Field class="flex-1">
+                        <FieldLabel for="solid-admin-user-name">
+                          {config().localization.name}
+                        </FieldLabel>
+                        <Input
+                          id="solid-admin-user-name"
+                          value={name()}
+                          onInput={(event) =>
+                            setName(event.currentTarget.value)
+                          }
+                        />
+                        <FieldError>
+                          {getAdminErrorMessage(updateUser.error)}
+                        </FieldError>
+                      </Field>
+                      <Button
+                        disabled={
+                          !name().trim() ||
+                          name() === selectedUser().name ||
+                          updateUser.isPending ||
+                          canUpdate.isPending ||
+                          !canUpdate.data?.success
+                        }
+                        type="submit"
+                        variant="outline"
+                      >
+                        {config().localization.saveUser}
+                      </Button>
+                    </form>
+                    <div class="flex items-end gap-2">
+                      <Field class="flex-1">
+                        <FieldLabel for="solid-admin-user-role">
+                          {config().localization.role}
+                        </FieldLabel>
+                        <select
+                          class="h-8 rounded-lg border bg-transparent px-2 text-sm"
+                          id="solid-admin-user-role"
+                          value={role()}
+                          onChange={(event) =>
+                            setRole(event.currentTarget.value)
+                          }
+                        >
+                          <For each={config().roles}>
+                            {(item) => <option value={item}>{item}</option>}
+                          </For>
+                        </select>
+                      </Field>
+                      <Button
+                        disabled={
+                          setRoleMutation.isPending ||
+                          canSetRole.isPending ||
+                          !canSetRole.data?.success ||
+                          isSelf()
+                        }
+                        variant="outline"
+                        onClick={() =>
+                          setRoleMutation.mutate({
+                            userId: selectedUser().id,
+                            role: asAdminRole(role())
+                          })
+                        }
+                      >
+                        {config().localization.saveRole}
+                      </Button>
+                    </div>
+                    <FieldError>
+                      {getAdminErrorMessage(setRoleMutation.error)}
+                    </FieldError>
+                    <div class="flex flex-wrap gap-2">
+                      <Button
+                        disabled={
+                          canSetPassword.isPending ||
+                          !canSetPassword.data?.success
+                        }
+                        variant="outline"
+                        onClick={() => setPasswordOpen(true)}
+                      >
+                        <KeyRound />
+                        {config().localization.setPassword}
+                      </Button>
+                      <Button
+                        disabled={
+                          canBan.isPending || !canBan.data?.success || isSelf()
+                        }
+                        variant="outline"
+                        onClick={() =>
+                          selectedUser().banned
+                            ? unban.mutate({ userId: selectedUser().id })
+                            : setDangerousAction("ban")
+                        }
+                      >
+                        <Ban />
+                        {selectedUser().banned
+                          ? config().localization.unbanUser
+                          : config().localization.banUser}
+                      </Button>
+                      <Button
+                        disabled={
+                          canImpersonate.isPending ||
+                          !canImpersonate.data?.success ||
+                          isSelf()
+                        }
+                        variant="outline"
+                        onClick={() => setDangerousAction("impersonate")}
+                      >
+                        <LogIn />
+                        {config().localization.impersonateUser}
+                      </Button>
+                      <Button
+                        disabled={
+                          canDelete.isPending ||
+                          !canDelete.data?.success ||
+                          isSelf()
+                        }
+                        variant="destructive"
+                        onClick={() => setDangerousAction("delete")}
+                      >
+                        <Trash2 />
+                        {config().localization.deleteUser}
+                      </Button>
+                    </div>
+                    <FieldError>{getAdminErrorMessage(unban.error)}</FieldError>
+                  </TabsContent>
+                  <TabsContent
+                    class="flex flex-col gap-3 pt-4"
+                    value="sessions"
                   >
                     <Show
-                      fallback={
-                        <p class="py-8 text-center text-sm text-muted-foreground">
-                          {config().localization.accessDeniedDescription}
-                        </p>
+                      fallback={<SessionRowsSkeleton />}
+                      when={
+                        !sessionsPermission.isPending && !sessions.isPending
                       }
-                      when={sessionsPermission.data?.success}
                     >
                       <Show
-                        fallback={<SessionRowsSkeleton />}
-                        when={!sessions.isPending}
+                        fallback={
+                          <p class="py-8 text-center text-sm text-muted-foreground">
+                            {config().localization.accessDeniedDescription}
+                          </p>
+                        }
+                        when={sessionsPermission.data?.success}
                       >
                         <Show
                           fallback={
@@ -435,46 +845,200 @@ function UserDialog(props: {
                           }
                           when={sessions.data?.sessions.length}
                         >
+                          <Button
+                            class="self-end"
+                            disabled={
+                              canRevoke.isPending ||
+                              !canRevoke.data?.success ||
+                              isSelf()
+                            }
+                            variant="outline"
+                            onClick={() => setDangerousAction("revokeAll")}
+                          >
+                            {config().localization.revokeAllSessions}
+                          </Button>
                           <For each={sessions.data?.sessions}>
                             {(session) => (
-                              <div class="rounded-lg border p-3">
-                                <div class="truncate text-sm font-medium">
-                                  {session.userAgent ||
-                                    config().localization.sessions}
+                              <div class="flex items-start justify-between gap-3 rounded-lg border p-3">
+                                <div class="min-w-0">
+                                  <div class="truncate text-sm font-medium">
+                                    {session.userAgent ||
+                                      config().localization.sessions}
+                                  </div>
+                                  <div class="text-xs text-muted-foreground">
+                                    {formatDate(session.createdAt)} ·{" "}
+                                    {formatDate(session.expiresAt)}
+                                  </div>
+                                  <Show
+                                    when={
+                                      config().showIpAddress &&
+                                      session.ipAddress
+                                    }
+                                  >
+                                    <div class="mt-1 font-mono text-xs text-muted-foreground">
+                                      {session.ipAddress}
+                                    </div>
+                                  </Show>
                                 </div>
-                                <div class="text-xs text-muted-foreground">
-                                  {formatDate(session.createdAt)} ·{" "}
-                                  {formatDate(session.expiresAt)}
-                                </div>
-                                <Show
-                                  when={
-                                    config().showIpAddress && session.ipAddress
+                                <Button
+                                  aria-label={config().localization.revoke}
+                                  disabled={
+                                    revokeSession.isPending ||
+                                    canRevoke.isPending ||
+                                    !canRevoke.data?.success ||
+                                    isSelf()
+                                  }
+                                  size="icon-sm"
+                                  variant="ghost"
+                                  onClick={() =>
+                                    revokeSession.mutate({
+                                      sessionToken: session.token
+                                    })
                                   }
                                 >
-                                  <div class="mt-1 font-mono text-xs text-muted-foreground">
-                                    {session.ipAddress}
-                                  </div>
-                                </Show>
+                                  <Trash2 />
+                                </Button>
                               </div>
                             )}
                           </For>
                         </Show>
                       </Show>
                     </Show>
-                  </Show>
-                </TabsContent>
-                <For each={contributedTabs()}>
-                  {(tab) => (
-                    <TabsContent class="pt-4" value={tab.value}>
-                      <Dynamic component={tab.component} userId={detail().id} />
-                    </TabsContent>
-                  )}
-                </For>
-              </Tabs>
-            )}
+                  </TabsContent>
+                  <For each={contributedTabs()}>
+                    {(tab) => (
+                      <TabsContent class="pt-4" value={tab.value}>
+                        <Dynamic
+                          component={tab.component}
+                          userId={selectedUser().id}
+                        />
+                      </TabsContent>
+                    )}
+                  </For>
+                </Tabs>
+              )}
+            </Show>
           </Show>
-        </Show>
-        <DialogFooter showCloseButton />
+          <DialogFooter showCloseButton />
+        </DialogContent>
+      </Dialog>
+      <PasswordDialog
+        open={passwordOpen()}
+        onOpenChange={setPasswordOpen}
+        userId={detail()?.id}
+      />
+      <AlertDialog
+        open={Boolean(dangerousAction())}
+        onOpenChange={(open) => !open && closeDangerousAction()}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{dangerousLabel()}</AlertDialogTitle>
+            <AlertDialogDescription class="flex flex-col gap-2">
+              <span>{detail()?.email}</span>
+              <Show when={dangerousMutation().error}>
+                <span class="text-destructive" role="alert">
+                  {getAdminErrorMessage(dangerousMutation().error)}
+                </span>
+              </Show>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>
+              {config().localization.cancel}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              disabled={isSelf() || dangerousMutation().isPending}
+              variant={
+                dangerousAction() === "delete" ? "destructive" : "default"
+              }
+              onClick={(event: MouseEvent) => {
+                event.preventDefault()
+                confirmDangerousAction()
+              }}
+            >
+              {dangerousLabel()}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  )
+}
+
+function PasswordDialog(props: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  userId?: string
+}) {
+  const auth = useAuth()
+  const authClient = auth.authClient as AdminAuthClient
+  const config = () =>
+    (auth.plugins.find((plugin) => plugin.id === adminPlugin.id) ??
+      adminPlugin()) as ReturnType<typeof adminPlugin>
+  const [password, setPassword] = createSignal("")
+  const [errorMessage, setErrorMessage] = createSignal<string>()
+  const setPasswordMutation = useSetAdminUserPassword(authClient)
+
+  const close = () => {
+    setPassword("")
+    setErrorMessage(undefined)
+    setPasswordMutation.reset()
+    props.onOpenChange(false)
+  }
+  const submit = (event: SubmitEvent) => {
+    event.preventDefault()
+    setErrorMessage(undefined)
+    if (props.userId)
+      setPasswordMutation.mutate(
+        { userId: props.userId, newPassword: password() },
+        {
+          onError: (error) => setErrorMessage(getAdminErrorMessage(error)),
+          onSuccess: close
+        }
+      )
+  }
+
+  return (
+    <Dialog
+      open={props.open}
+      onOpenChange={(open) => (open ? props.onOpenChange(true) : close())}
+    >
+      <DialogContent>
+        <form class="flex flex-col gap-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{config().localization.setPassword}</DialogTitle>
+            <DialogDescription>
+              {config().localization.userDetails}
+            </DialogDescription>
+          </DialogHeader>
+          <Field data-invalid={Boolean(errorMessage())}>
+            <FieldLabel for="solid-admin-new-password">
+              {config().localization.password}
+            </FieldLabel>
+            <Input
+              aria-invalid={Boolean(errorMessage())}
+              autocomplete="new-password"
+              id="solid-admin-new-password"
+              required
+              type="password"
+              value={password()}
+              onInput={(event) => setPassword(event.currentTarget.value)}
+            />
+            <FieldError>{errorMessage()}</FieldError>
+          </Field>
+          <DialogFooter>
+            <Button onClick={close} type="button" variant="outline">
+              {config().localization.cancel}
+            </Button>
+            <Button
+              disabled={!password() || setPasswordMutation.isPending}
+              type="submit"
+            >
+              {config().localization.setPassword}
+            </Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
@@ -22,7 +22,7 @@ import {
 } from "@better-auth-ui/solid/plugins/admin"
 import { createDebounce } from "@solid-primitives/debounce"
 import { Ban, KeyRound, LogIn, Search, Trash2, UserPlus } from "lucide-solid"
-import { createEffect, createMemo, createSignal, For, Show } from "solid-js"
+import { createEffect, createMemo, createSignal, For, on, Show } from "solid-js"
 import { Dynamic } from "solid-js/web"
 
 import {
@@ -545,10 +545,15 @@ function UserDialog(props: {
   const revokeSession = useRevokeAdminUserSession(authClient, props.userId)
   const revokeSessions = useRevokeAdminUserSessions(authClient, props.userId)
 
-  createEffect(() => {
-    setName(detail()?.name ?? "")
-    setRole(detail()?.role ?? config().defaultRole)
-  })
+  createEffect(
+    on(
+      () => [detail()?.name, detail()?.role] as const,
+      ([userName, userRole]) => {
+        setName(userName ?? "")
+        setRole(userRole ?? config().defaultRole)
+      }
+    )
+  )
 
   const confirmDangerousAction = () => {
     const selectedUser = detail()
@@ -826,7 +831,9 @@ function UserDialog(props: {
                     <Show
                       fallback={<SessionRowsSkeleton />}
                       when={
-                        !sessionsPermission.isPending && !sessions.isPending
+                        !sessionsPermission.isPending &&
+                        (!sessionsPermission.data?.success ||
+                          !sessions.isPending)
                       }
                     >
                       <Show

--- a/packages/core/src/plugins/admin/admin-localization.ts
+++ b/packages/core/src/plugins/admin/admin-localization.ts
@@ -66,6 +66,8 @@ export const adminLocalization = {
   revokeAllSessions: "Revoke all sessions",
   /** @remarks `"Save role"` */
   saveRole: "Save role",
+  /** @remarks `"Save user"` */
+  saveUser: "Save user",
   /** @remarks `"Set password"` */
   setPassword: "Set password",
   /** @remarks `"Status"` */

--- a/packages/heroui/src/components/auth/admin/admin-users.tsx
+++ b/packages/heroui/src/components/auth/admin/admin-users.tsx
@@ -4,33 +4,63 @@ import type {
   AdminAuthClient,
   AdminListUsersParams
 } from "@better-auth-ui/core/plugins/admin"
-import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
+import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
 import {
   useAdminPermission,
   useAdminUser,
   useAdminUserSessions,
-  useAdminUsers
+  useAdminUsers,
+  useBanAdminUser,
+  useCreateAdminUser,
+  useImpersonateAdminUser,
+  useRemoveAdminUser,
+  useRevokeAdminUserSession,
+  useRevokeAdminUserSessions,
+  useSetAdminUserPassword,
+  useSetAdminUserRole,
+  useUnbanAdminUser,
+  useUpdateAdminUser
 } from "@better-auth-ui/react/plugins/admin"
 import {
+  ArrowRightToSquare,
+  Ban,
+  Key,
+  PersonPlus,
+  TrashBin
+} from "@gravity-ui/icons"
+import {
+  AlertDialog,
   Button,
   Chip,
   cn,
   Drawer,
+  FieldError,
+  Form,
+  Input,
   Label,
   ListBox,
   SearchField,
   Select,
   Skeleton,
   Table,
-  Tabs
+  Tabs,
+  TextField
 } from "@heroui/react"
 import { keepPreviousData } from "@tanstack/react-query"
-import { useDeferredValue, useMemo, useState } from "react"
+import type { BetterFetchError } from "better-auth/client"
+import {
+  type FormEvent,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useState
+} from "react"
 
 import { adminPlugin } from "../../../lib/auth/admin-plugin"
 import { UserAvatar } from "../user/user-avatar"
 
 type SearchFieldName = "email" | "name"
+type DangerousAction = "ban" | "delete" | "impersonate" | "revokeAll"
 
 export type AdminUsersProps = {
   className?: string
@@ -47,6 +77,13 @@ const formatDate = (value: Date | string | undefined | null) =>
       )
     : "–"
 
+const getAdminErrorMessage = (error: Error | null) => {
+  const authError = error as BetterFetchError | null
+  return authError?.error?.message ?? authError?.message
+}
+
+const asAdminRole = (role: string) => role as "user" | "admin"
+
 /** HeroUI presentation for the static Admin users view. */
 export function AdminUsers({
   className,
@@ -59,12 +96,14 @@ export function AdminUsers({
   const [page, setPage] = useState(0)
   const [search, setSearch] = useState("")
   const [searchField, setSearchField] = useState<SearchFieldName>("email")
+  const [createOpen, setCreateOpen] = useState(false)
   const deferredSearch = useDeferredValue(search.trim())
   const isSelectionControlled = onSelectedUserIdChange !== undefined
   const selectedUserId = isSelectionControlled
     ? controlledSelectedUserId
     : localSelectedUserId
   const permission = useAdminPermission(authClient, { user: ["list"] })
+  const createPermission = useAdminPermission(authClient, { user: ["create"] })
   const params = useMemo<AdminListUsersParams>(
     () => ({
       limit: config.pageSize,
@@ -91,11 +130,19 @@ export function AdminUsers({
 
   return (
     <section className={cn("flex flex-col gap-4", className)}>
-      <header className="flex flex-col gap-1">
-        <h1 className="text-xl font-semibold">{config.localization.users}</h1>
-        <p className="text-sm text-muted">
-          {config.localization.usersDescription}
-        </p>
+      <header className="flex items-end justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-xl font-semibold">{config.localization.users}</h1>
+          <p className="text-sm text-muted">
+            {config.localization.usersDescription}
+          </p>
+        </div>
+        {createPermission.data?.success ? (
+          <Button size="sm" onPress={() => setCreateOpen(true)}>
+            <PersonPlus />
+            {config.localization.createUser}
+          </Button>
+        ) : null}
       </header>
 
       <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
@@ -263,6 +310,7 @@ export function AdminUsers({
         onOpenChange={(open) => !open && selectUser(undefined)}
         userId={selectedUserId}
       />
+      <CreateUserDialog isOpen={createOpen} onOpenChange={setCreateOpen} />
     </section>
   )
 }
@@ -292,6 +340,120 @@ function AdminTableSkeleton() {
   )
 }
 
+function CreateUserDialog({
+  isOpen,
+  onOpenChange
+}: {
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+}) {
+  const { authClient } = useAuth<AdminAuthClient>()
+  const config = useAuthPlugin(adminPlugin)
+  const createUser = useCreateAdminUser(authClient)
+
+  const close = () => {
+    createUser.reset()
+    onOpenChange(false)
+  }
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    const data = new FormData(event.currentTarget)
+    createUser.mutate(
+      {
+        email: String(data.get("email")),
+        name: String(data.get("name")),
+        password: String(data.get("password")),
+        role: asAdminRole(String(data.get("role") || config.defaultRole))
+      },
+      { onSuccess: close }
+    )
+  }
+
+  return (
+    <AlertDialog.Backdrop
+      isOpen={isOpen}
+      onOpenChange={(open) => (open ? onOpenChange(true) : close())}
+    >
+      <AlertDialog.Container>
+        <AlertDialog.Dialog>
+          <Form onSubmit={submit}>
+            <AlertDialog.CloseTrigger />
+            <AlertDialog.Header>
+              <AlertDialog.Icon status="default">
+                <PersonPlus />
+              </AlertDialog.Icon>
+              <AlertDialog.Heading>
+                {config.localization.createUser}
+              </AlertDialog.Heading>
+            </AlertDialog.Header>
+            <AlertDialog.Body className="overflow-visible">
+              <p className="text-sm text-muted">
+                {config.localization.usersDescription}
+              </p>
+              <div className="mt-4 flex flex-col gap-4">
+                <TextField isRequired name="name">
+                  <Label>{config.localization.name}</Label>
+                  <Input autoFocus variant="secondary" />
+                  <FieldError />
+                </TextField>
+                <TextField isRequired name="email" type="email">
+                  <Label>{config.localization.email}</Label>
+                  <Input autoComplete="off" variant="secondary" />
+                  <FieldError />
+                </TextField>
+                <TextField isRequired name="password" type="password">
+                  <Label>{config.localization.password}</Label>
+                  <Input autoComplete="new-password" variant="secondary" />
+                  <FieldError />
+                </TextField>
+                <Select
+                  defaultValue={config.defaultRole}
+                  fullWidth
+                  name="role"
+                  variant="secondary"
+                >
+                  <Label>{config.localization.role}</Label>
+                  <Select.Trigger>
+                    <Select.Value />
+                    <Select.Indicator />
+                  </Select.Trigger>
+                  <Select.Popover>
+                    <ListBox>
+                      {config.roles.map((role) => (
+                        <ListBox.Item id={role} key={role} textValue={role}>
+                          {role}
+                          <ListBox.ItemIndicator />
+                        </ListBox.Item>
+                      ))}
+                    </ListBox>
+                  </Select.Popover>
+                </Select>
+                {createUser.error ? (
+                  <FieldError>
+                    {getAdminErrorMessage(createUser.error)}
+                  </FieldError>
+                ) : null}
+              </div>
+            </AlertDialog.Body>
+            <AlertDialog.Footer>
+              <Button
+                isDisabled={createUser.isPending}
+                slot="close"
+                variant="tertiary"
+              >
+                {config.localization.cancel}
+              </Button>
+              <Button isPending={createUser.isPending} type="submit">
+                {config.localization.createUser}
+              </Button>
+            </AlertDialog.Footer>
+          </Form>
+        </AlertDialog.Dialog>
+      </AlertDialog.Container>
+    </AlertDialog.Backdrop>
+  )
+}
+
 function UserDrawer({
   isOpen,
   onOpenChange,
@@ -301,7 +463,7 @@ function UserDrawer({
   onOpenChange: (open: boolean) => void
   userId?: string
 }) {
-  const { authClient, plugins } = useAuth<AdminAuthClient>()
+  const { authClient, navigate, plugins } = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
   const contributedTabs = useMemo(
     () =>
@@ -314,120 +476,574 @@ function UserDrawer({
     [plugins]
   )
   const user = useAdminUser(authClient, userId)
-  const sessionsPermission = useAdminPermission(authClient, {
-    session: ["list"]
-  })
+  const { data: actor } = useSession(authClient)
+  const sessionsPermission = useAdminPermission(
+    authClient,
+    {
+      session: ["list"]
+    },
+    { enabled: Boolean(userId) }
+  )
   const sessions = useAdminUserSessions(authClient, userId, {
     enabled: sessionsPermission.data?.success === true
   })
+  const canUpdate = useAdminPermission(
+    authClient,
+    { user: ["update"] },
+    { enabled: Boolean(userId) }
+  )
+  const canSetRole = useAdminPermission(
+    authClient,
+    { user: ["set-role"] },
+    { enabled: Boolean(userId) }
+  )
+  const canSetPassword = useAdminPermission(
+    authClient,
+    { user: ["set-password"] },
+    { enabled: Boolean(userId) }
+  )
+  const canBan = useAdminPermission(
+    authClient,
+    { user: ["ban"] },
+    { enabled: Boolean(userId) }
+  )
+  const canImpersonate = useAdminPermission(
+    authClient,
+    { user: ["impersonate"] },
+    { enabled: Boolean(userId) }
+  )
+  const canDelete = useAdminPermission(
+    authClient,
+    { user: ["delete"] },
+    { enabled: Boolean(userId) }
+  )
+  const canRevoke = useAdminPermission(
+    authClient,
+    { session: ["revoke"] },
+    { enabled: Boolean(userId) }
+  )
+  const [name, setName] = useState("")
+  const [role, setRole] = useState(config.defaultRole)
+  const [passwordOpen, setPasswordOpen] = useState(false)
+  const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
+  const detail = user.data
+  const isSelf = detail?.id === actor?.user.id
+  const updateUser = useUpdateAdminUser(authClient)
+  const setRoleMutation = useSetAdminUserRole(authClient)
+  const setPassword = useSetAdminUserPassword(authClient)
+  const ban = useBanAdminUser(authClient)
+  const unban = useUnbanAdminUser(authClient)
+  const impersonate = useImpersonateAdminUser(authClient)
+  const remove = useRemoveAdminUser(authClient)
+  const revokeSession = useRevokeAdminUserSession(authClient, userId)
+  const revokeSessions = useRevokeAdminUserSessions(authClient, userId)
+
+  useEffect(() => {
+    setName(detail?.name ?? "")
+    setRole(detail?.role ?? config.defaultRole)
+  }, [config.defaultRole, detail?.name, detail?.role])
+
+  const confirmDangerousAction = () => {
+    if (!detail) return
+    if (dangerousAction === "ban")
+      ban.mutate(
+        { userId: detail.id },
+        { onSuccess: () => setDangerousAction(undefined) }
+      )
+    if (dangerousAction === "delete")
+      remove.mutate(
+        { userId: detail.id },
+        {
+          onSuccess: () => {
+            setDangerousAction(undefined)
+            onOpenChange(false)
+          }
+        }
+      )
+    if (dangerousAction === "revokeAll")
+      revokeSessions.mutate(
+        { userId: detail.id },
+        { onSuccess: () => setDangerousAction(undefined) }
+      )
+    if (dangerousAction === "impersonate")
+      impersonate.mutate(
+        { userId: detail.id },
+        {
+          onSuccess: () => {
+            setDangerousAction(undefined)
+            if (config.impersonationRedirectTo)
+              navigate({ to: config.impersonationRedirectTo })
+          }
+        }
+      )
+  }
+  const closeDangerousAction = () => {
+    ban.reset()
+    remove.reset()
+    revokeSessions.reset()
+    impersonate.reset()
+    setDangerousAction(undefined)
+  }
+  const dangerousMutation =
+    dangerousAction === "ban"
+      ? ban
+      : dangerousAction === "delete"
+        ? remove
+        : dangerousAction === "revokeAll"
+          ? revokeSessions
+          : impersonate
+  const dangerousLabel =
+    dangerousAction === "ban"
+      ? config.localization.banUser
+      : dangerousAction === "delete"
+        ? config.localization.deleteUser
+        : dangerousAction === "revokeAll"
+          ? config.localization.revokeAllSessions
+          : config.localization.impersonateUser
 
   return (
-    <Drawer.Backdrop isOpen={isOpen} onOpenChange={onOpenChange}>
-      <Drawer.Content placement="right">
-        <Drawer.Dialog>
-          <Drawer.CloseTrigger />
-          <Drawer.Header>
-            <Drawer.Heading>{config.localization.userDetails}</Drawer.Heading>
-          </Drawer.Header>
-          <Drawer.Body>
-            {user.isPending ? (
-              <div className="flex flex-col gap-3">
-                <Skeleton className="size-12 rounded-full" />
-                <Skeleton className="h-5 w-40" />
-                <Skeleton className="h-4 w-64" />
-              </div>
-            ) : user.data ? (
-              <Tabs>
-                <Tabs.ListContainer>
-                  <Tabs.List aria-label={config.localization.userDetails}>
-                    <Tabs.Tab id="overview">
-                      {config.localization.overview}
-                      <Tabs.Indicator />
-                    </Tabs.Tab>
-                    <Tabs.Tab id="sessions">
-                      {config.localization.sessions}
-                      <Tabs.Indicator />
-                    </Tabs.Tab>
-                    {contributedTabs.map((tab) => (
-                      <Tabs.Tab id={tab.id} key={tab.id}>
-                        {tab.label}
+    <>
+      <Drawer.Backdrop isOpen={isOpen} onOpenChange={onOpenChange}>
+        <Drawer.Content placement="right">
+          <Drawer.Dialog>
+            <Drawer.CloseTrigger />
+            <Drawer.Header>
+              <Drawer.Heading>{config.localization.userDetails}</Drawer.Heading>
+            </Drawer.Header>
+            <Drawer.Body>
+              {user.isPending ? (
+                <div className="flex flex-col gap-3">
+                  <Skeleton className="size-12 rounded-full" />
+                  <Skeleton className="h-5 w-40" />
+                  <Skeleton className="h-4 w-64" />
+                </div>
+              ) : detail ? (
+                <Tabs>
+                  <Tabs.ListContainer>
+                    <Tabs.List aria-label={config.localization.userDetails}>
+                      <Tabs.Tab id="overview">
+                        {config.localization.overview}
                         <Tabs.Indicator />
                       </Tabs.Tab>
-                    ))}
-                  </Tabs.List>
-                </Tabs.ListContainer>
-                <Tabs.Panel className="flex flex-col gap-4 pt-4" id="overview">
-                  <div className="flex items-center gap-3">
-                    <UserAvatar size="lg" user={user.data} />
-                    <div>
-                      <div className="font-medium">{user.data.name}</div>
-                      <div className="text-sm text-muted">
-                        {user.data.email}
+                      <Tabs.Tab id="sessions">
+                        {config.localization.sessions}
+                        <Tabs.Indicator />
+                      </Tabs.Tab>
+                      {contributedTabs.map((tab) => (
+                        <Tabs.Tab id={tab.id} key={tab.id}>
+                          {tab.label}
+                          <Tabs.Indicator />
+                        </Tabs.Tab>
+                      ))}
+                    </Tabs.List>
+                  </Tabs.ListContainer>
+                  <Tabs.Panel
+                    className="flex flex-col gap-4 pt-4"
+                    id="overview"
+                  >
+                    <div className="flex items-center gap-3">
+                      <UserAvatar size="lg" user={detail} />
+                      <div>
+                        <div className="font-medium">{detail.name}</div>
+                        <div className="text-sm text-muted">{detail.email}</div>
                       </div>
                     </div>
-                  </div>
-                  <dl className="grid grid-cols-[auto_1fr] gap-3 text-sm">
-                    <dt className="text-muted">{config.localization.userId}</dt>
-                    <dd className="font-mono text-xs">{user.data.id}</dd>
-                    <dt className="text-muted">{config.localization.role}</dt>
-                    <dd>{user.data.role ?? config.defaultRole}</dd>
-                    <dt className="text-muted">
-                      {config.localization.created}
-                    </dt>
-                    <dd>{formatDate(user.data.createdAt)}</dd>
-                  </dl>
-                </Tabs.Panel>
-                <Tabs.Panel className="flex flex-col gap-2 pt-4" id="sessions">
-                  {sessions.isPending ? (
-                    rowSkeletonIds.map((id) => (
-                      <Skeleton className="h-16 w-full" key={`drawer-${id}`} />
-                    ))
-                  ) : sessions.data?.sessions.length ? (
-                    sessions.data.sessions.map((session) => (
-                      <div className="rounded-xl border p-3" key={session.id}>
-                        <div className="truncate text-sm font-medium">
-                          {session.userAgent || config.localization.sessions}
-                        </div>
-                        <div className="text-xs text-muted">
-                          {formatDate(session.createdAt)} ·{" "}
-                          {formatDate(session.expiresAt)}
-                        </div>
-                        {config.showIpAddress && session.ipAddress ? (
-                          <div className="mt-1 font-mono text-xs text-muted">
-                            {session.ipAddress}
-                          </div>
+                    <dl className="grid grid-cols-[auto_1fr] gap-3 text-sm">
+                      <dt className="text-muted">
+                        {config.localization.userId}
+                      </dt>
+                      <dd className="font-mono text-xs">{detail.id}</dd>
+                      <dt className="text-muted">
+                        {config.localization.created}
+                      </dt>
+                      <dd>{formatDate(detail.createdAt)}</dd>
+                      <dt className="text-muted">
+                        {config.localization.status}
+                      </dt>
+                      <dd>
+                        <Chip
+                          color={detail.banned ? "danger" : "default"}
+                          size="sm"
+                        >
+                          {detail.banned
+                            ? config.localization.banned
+                            : config.localization.active}
+                        </Chip>
+                      </dd>
+                    </dl>
+                    <Form
+                      className="flex items-end gap-2"
+                      onSubmit={(event) => {
+                        event.preventDefault()
+                        updateUser.mutate({
+                          userId: detail.id,
+                          data: { name: name.trim() }
+                        })
+                      }}
+                    >
+                      <TextField
+                        className="flex-1"
+                        value={name}
+                        onChange={setName}
+                      >
+                        <Label>{config.localization.name}</Label>
+                        <Input variant="secondary" />
+                        {updateUser.error ? (
+                          <FieldError>
+                            {getAdminErrorMessage(updateUser.error)}
+                          </FieldError>
                         ) : null}
-                      </div>
-                    ))
-                  ) : (
-                    <p className="py-8 text-center text-sm text-muted">
-                      {config.localization.noSessions}
-                    </p>
-                  )}
-                </Tabs.Panel>
-                {contributedTabs.map((tab) => {
-                  const ContributedTab = tab.component
-                  return (
-                    <Tabs.Panel className="pt-4" id={tab.id} key={tab.id}>
-                      <ContributedTab userId={user.data.id} />
-                    </Tabs.Panel>
-                  )
-                })}
-              </Tabs>
-            ) : (
-              <AdminMessage
-                title={config.localization.loadUsersError}
-                description={config.localization.loadUsersErrorDescription}
-              />
-            )}
-          </Drawer.Body>
-          <Drawer.Footer>
-            <Button slot="close" variant="secondary">
-              {config.localization.close}
-            </Button>
-          </Drawer.Footer>
-        </Drawer.Dialog>
-      </Drawer.Content>
-    </Drawer.Backdrop>
+                      </TextField>
+                      <Button
+                        isDisabled={
+                          !name.trim() ||
+                          name === detail.name ||
+                          updateUser.isPending ||
+                          canUpdate.isPending ||
+                          !canUpdate.data?.success
+                        }
+                        type="submit"
+                        variant="outline"
+                      >
+                        {config.localization.saveUser}
+                      </Button>
+                    </Form>
+                    <div className="flex items-end gap-2">
+                      <Select
+                        className="flex-1"
+                        fullWidth
+                        value={role}
+                        variant="secondary"
+                        onChange={(value) => setRole(String(value))}
+                      >
+                        <Label>{config.localization.role}</Label>
+                        <Select.Trigger>
+                          <Select.Value />
+                          <Select.Indicator />
+                        </Select.Trigger>
+                        <Select.Popover>
+                          <ListBox>
+                            {config.roles.map((item) => (
+                              <ListBox.Item
+                                id={item}
+                                key={item}
+                                textValue={item}
+                              >
+                                {item}
+                                <ListBox.ItemIndicator />
+                              </ListBox.Item>
+                            ))}
+                          </ListBox>
+                        </Select.Popover>
+                      </Select>
+                      <Button
+                        isDisabled={
+                          setRoleMutation.isPending ||
+                          canSetRole.isPending ||
+                          !canSetRole.data?.success ||
+                          isSelf
+                        }
+                        variant="outline"
+                        onPress={() =>
+                          setRoleMutation.mutate({
+                            userId: detail.id,
+                            role: asAdminRole(role)
+                          })
+                        }
+                      >
+                        {config.localization.saveRole}
+                      </Button>
+                    </div>
+                    {setRoleMutation.error ? (
+                      <FieldError>
+                        {getAdminErrorMessage(setRoleMutation.error)}
+                      </FieldError>
+                    ) : null}
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        isDisabled={
+                          canSetPassword.isPending ||
+                          !canSetPassword.data?.success
+                        }
+                        variant="outline"
+                        onPress={() => setPasswordOpen(true)}
+                      >
+                        <Key />
+                        {config.localization.setPassword}
+                      </Button>
+                      <Button
+                        isDisabled={
+                          canBan.isPending || !canBan.data?.success || isSelf
+                        }
+                        variant="outline"
+                        onPress={() =>
+                          detail.banned
+                            ? unban.mutate({ userId: detail.id })
+                            : setDangerousAction("ban")
+                        }
+                      >
+                        <Ban />
+                        {detail.banned
+                          ? config.localization.unbanUser
+                          : config.localization.banUser}
+                      </Button>
+                      <Button
+                        isDisabled={
+                          canImpersonate.isPending ||
+                          !canImpersonate.data?.success ||
+                          isSelf
+                        }
+                        variant="outline"
+                        onPress={() => setDangerousAction("impersonate")}
+                      >
+                        <ArrowRightToSquare />
+                        {config.localization.impersonateUser}
+                      </Button>
+                      <Button
+                        isDisabled={
+                          canDelete.isPending ||
+                          !canDelete.data?.success ||
+                          isSelf
+                        }
+                        variant="danger"
+                        onPress={() => setDangerousAction("delete")}
+                      >
+                        <TrashBin />
+                        {config.localization.deleteUser}
+                      </Button>
+                    </div>
+                    {unban.error ? (
+                      <FieldError>
+                        {getAdminErrorMessage(unban.error)}
+                      </FieldError>
+                    ) : null}
+                  </Tabs.Panel>
+                  <Tabs.Panel
+                    className="flex flex-col gap-3 pt-4"
+                    id="sessions"
+                  >
+                    {sessions.isPending ? (
+                      rowSkeletonIds.map((id) => (
+                        <Skeleton
+                          className="h-16 w-full"
+                          key={`drawer-${id}`}
+                        />
+                      ))
+                    ) : sessions.data?.sessions.length ? (
+                      <>
+                        <Button
+                          className="self-end"
+                          isDisabled={
+                            canRevoke.isPending ||
+                            !canRevoke.data?.success ||
+                            isSelf
+                          }
+                          variant="outline"
+                          onPress={() => setDangerousAction("revokeAll")}
+                        >
+                          {config.localization.revokeAllSessions}
+                        </Button>
+                        {sessions.data.sessions.map((session) => (
+                          <div
+                            className="flex items-start justify-between gap-3 rounded-xl border p-3"
+                            key={session.id}
+                          >
+                            <div className="min-w-0">
+                              <div className="truncate text-sm font-medium">
+                                {session.userAgent ||
+                                  config.localization.sessions}
+                              </div>
+                              <div className="text-xs text-muted">
+                                {formatDate(session.createdAt)} ·{" "}
+                                {formatDate(session.expiresAt)}
+                              </div>
+                              {config.showIpAddress && session.ipAddress ? (
+                                <div className="mt-1 font-mono text-xs text-muted">
+                                  {session.ipAddress}
+                                </div>
+                              ) : null}
+                            </div>
+                            <Button
+                              aria-label={config.localization.revoke}
+                              isDisabled={
+                                revokeSession.isPending ||
+                                canRevoke.isPending ||
+                                !canRevoke.data?.success ||
+                                isSelf
+                              }
+                              isIconOnly
+                              size="sm"
+                              variant="tertiary"
+                              onPress={() =>
+                                revokeSession.mutate({
+                                  sessionToken: session.token
+                                })
+                              }
+                            >
+                              <TrashBin />
+                            </Button>
+                          </div>
+                        ))}
+                      </>
+                    ) : (
+                      <p className="py-8 text-center text-sm text-muted">
+                        {config.localization.noSessions}
+                      </p>
+                    )}
+                  </Tabs.Panel>
+                  {contributedTabs.map((tab) => {
+                    const ContributedTab = tab.component
+                    return (
+                      <Tabs.Panel className="pt-4" id={tab.id} key={tab.id}>
+                        <ContributedTab userId={detail.id} />
+                      </Tabs.Panel>
+                    )
+                  })}
+                </Tabs>
+              ) : (
+                <AdminMessage
+                  title={config.localization.loadUsersError}
+                  description={config.localization.loadUsersErrorDescription}
+                />
+              )}
+            </Drawer.Body>
+            <Drawer.Footer>
+              <Button slot="close" variant="secondary">
+                {config.localization.close}
+              </Button>
+            </Drawer.Footer>
+          </Drawer.Dialog>
+        </Drawer.Content>
+      </Drawer.Backdrop>
+      <PasswordDialog
+        isOpen={passwordOpen}
+        mutation={setPassword}
+        userId={detail?.id}
+        onOpenChange={setPasswordOpen}
+      />
+      <AlertDialog.Backdrop
+        isOpen={Boolean(dangerousAction)}
+        onOpenChange={(open) => !open && closeDangerousAction()}
+      >
+        <AlertDialog.Container>
+          <AlertDialog.Dialog>
+            <AlertDialog.CloseTrigger />
+            <AlertDialog.Header>
+              <AlertDialog.Icon status="danger">
+                <Ban />
+              </AlertDialog.Icon>
+              <AlertDialog.Heading>{dangerousLabel}</AlertDialog.Heading>
+            </AlertDialog.Header>
+            <AlertDialog.Body className="flex flex-col gap-2">
+              <p className="text-sm text-muted">{detail?.email}</p>
+              {dangerousMutation.error ? (
+                <FieldError>
+                  {getAdminErrorMessage(dangerousMutation.error)}
+                </FieldError>
+              ) : null}
+            </AlertDialog.Body>
+            <AlertDialog.Footer>
+              <Button slot="close" variant="tertiary">
+                {config.localization.cancel}
+              </Button>
+              <Button
+                isDisabled={isSelf}
+                isPending={dangerousMutation.isPending}
+                variant={dangerousAction === "delete" ? "danger" : "primary"}
+                onPress={confirmDangerousAction}
+              >
+                {dangerousLabel}
+              </Button>
+            </AlertDialog.Footer>
+          </AlertDialog.Dialog>
+        </AlertDialog.Container>
+      </AlertDialog.Backdrop>
+    </>
+  )
+}
+
+function PasswordDialog({
+  isOpen,
+  mutation,
+  onOpenChange,
+  userId
+}: {
+  isOpen: boolean
+  mutation: ReturnType<typeof useSetAdminUserPassword>
+  onOpenChange: (open: boolean) => void
+  userId?: string
+}) {
+  const config = useAuthPlugin(adminPlugin)
+  const [password, setPassword] = useState("")
+  const [errorMessage, setErrorMessage] = useState<string>()
+  const close = () => {
+    setPassword("")
+    setErrorMessage(undefined)
+    mutation.reset()
+    onOpenChange(false)
+  }
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setErrorMessage(undefined)
+    if (userId)
+      mutation.mutate(
+        { userId, newPassword: password },
+        {
+          onError: (error) => setErrorMessage(getAdminErrorMessage(error)),
+          onSuccess: close
+        }
+      )
+  }
+
+  return (
+    <AlertDialog.Backdrop
+      isOpen={isOpen}
+      onOpenChange={(open) => (open ? onOpenChange(true) : close())}
+    >
+      <AlertDialog.Container>
+        <AlertDialog.Dialog>
+          <Form onSubmit={submit}>
+            <AlertDialog.CloseTrigger />
+            <AlertDialog.Header>
+              <AlertDialog.Icon status="default">
+                <Key />
+              </AlertDialog.Icon>
+              <AlertDialog.Heading>
+                {config.localization.setPassword}
+              </AlertDialog.Heading>
+            </AlertDialog.Header>
+            <AlertDialog.Body className="overflow-visible">
+              <TextField
+                isInvalid={Boolean(errorMessage)}
+                isRequired
+                type="password"
+                value={password}
+                onChange={setPassword}
+              >
+                <Label>{config.localization.password}</Label>
+                <Input autoComplete="new-password" variant="secondary" />
+                <FieldError>{errorMessage}</FieldError>
+              </TextField>
+            </AlertDialog.Body>
+            <AlertDialog.Footer>
+              <Button
+                isDisabled={mutation.isPending}
+                slot="close"
+                variant="tertiary"
+              >
+                {config.localization.cancel}
+              </Button>
+              <Button
+                isDisabled={!password}
+                isPending={mutation.isPending}
+                type="submit"
+              >
+                {config.localization.setPassword}
+              </Button>
+            </AlertDialog.Footer>
+          </Form>
+        </AlertDialog.Dialog>
+      </AlertDialog.Container>
+    </AlertDialog.Backdrop>
   )
 }

--- a/packages/heroui/tests/admin.test.tsx
+++ b/packages/heroui/tests/admin.test.tsx
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import { AuthProvider } from "../src/components/auth/auth-provider"
 import { adminPlugin, StopImpersonating } from "../src/plugins"
+import { AdminUsers } from "../src/plugins/admin"
 
 function renderStopImpersonating(
   session: { session: { impersonatedBy?: string } },
@@ -37,6 +38,46 @@ function renderStopImpersonating(
         <Dropdown.Menu aria-label="User menu">
           <StopImpersonating />
         </Dropdown.Menu>
+      </AuthProvider>
+    )
+  }
+}
+
+function renderAdminUsers() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity },
+      mutations: { retry: false }
+    }
+  })
+  const session = {
+    session: { id: "session-1" },
+    user: { id: "admin-1", email: "admin@example.com", name: "Admin" }
+  }
+  queryClient.setQueryData(authQueryKeys.session, session)
+  const hasPermission = vi.fn(async () => ({
+    data: { success: true },
+    error: null
+  }))
+  const listUsers = vi.fn(async () => ({
+    data: { users: [], total: 0 },
+    error: null
+  }))
+  const authClient = {
+    admin: { hasPermission, listUsers },
+    getSession: vi.fn(async () => session)
+  } as unknown as Parameters<typeof AuthProvider>[0]["authClient"]
+
+  return {
+    hasPermission,
+    ...render(
+      <AuthProvider
+        authClient={authClient}
+        navigate={() => {}}
+        plugins={[adminPlugin()]}
+        queryClient={queryClient}
+      >
+        <AdminUsers />
       </AuthProvider>
     )
   }
@@ -100,5 +141,18 @@ describe("adminPlugin", () => {
     await waitFor(() => {
       expect(action).not.toHaveAttribute("data-disabled")
     })
+  })
+
+  it("opens user creation after the client grants permission", async () => {
+    const user = userEvent.setup()
+    const { hasPermission } = renderAdminUsers()
+
+    await user.click(await screen.findByRole("button", { name: "Create user" }))
+
+    expect(await screen.findByRole("alertdialog")).toBeVisible()
+    expect(screen.getByRole("textbox", { name: "Email" })).toBeVisible()
+    expect(hasPermission).toHaveBeenCalledWith(
+      expect.objectContaining({ permissions: { user: ["create"] } })
+    )
   })
 })

--- a/packages/locales/src/de-DE-plugins.ts
+++ b/packages/locales/src/de-DE-plugins.ts
@@ -63,6 +63,7 @@ export const deDEPlugins = {
     revoke: "Widerrufen",
     revokeAllSessions: "Alle Sitzungen widerrufen",
     saveRole: "Rolle speichern",
+    saveUser: "Benutzer speichern",
     setPassword: "Passwort festlegen",
     status: "Status",
     stopImpersonating: "Identitätswechsel beenden",


### PR DESCRIPTION
## Summary

- Expose all supported browser-side Admin user actions across HeroUI, shadcn, and Solid/Zaidan.
- Add create, profile and role updates, password reset, ban and unban, impersonation, deletion, and session revocation flows.
- Gate actions by client permission checks and protect the acting user from destructive self-actions.

## Scope

This layer is limited to methods exposed by `authClient.admin`.

## Validation

Core and HeroUI tests, framework typechecks, registry builds, Biome, and affected lint pass.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin workflows for creating and editing users.
  * Added role and password management, banning/unbanning, impersonation, deletion, and individual or bulk session revocation.
  * Added permission-aware controls, confirmations, loading states, error messages, and safeguards against actions targeting the current user.
  * Added editable user details and account status indicators.
  * Added localized “Save user” labels.

* **Documentation**
  * Expanded guidance for supported actions, permissions, confirmations, and privacy safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->