### PR TITLE
feat(passkey): add authenticator controls

### DIFF
--- a/apps/docs/content/docs/heroui/plugins/passkey.mdx
+++ b/apps/docs/content/docs/heroui/plugins/passkey.mdx
@@ -110,6 +110,42 @@ import { Passkeys } from "@better-auth-ui/heroui/plugins/passkey"
 
 <auto-type-table path="../../../../../../packages/heroui/src/components/auth/passkey/passkeys.tsx" name="PasskeysProps" />
 
+## Passkey registration controls
+
+The add-passkey dialog lets users choose where to create a passkey:
+
+- **Any available option** lets the browser choose.
+- **This device** requests a platform authenticator, such as Touch ID or Windows Hello.
+- **Security key or another device** requests a cross-platform authenticator.
+
+Set the initial choice in the plugin. Use `false` to hide the field and let the browser choose:
+
+```ts
+passkeyPlugin({ authenticatorAttachment: "platform" })
+passkeyPlugin({ authenticatorAttachment: false })
+```
+
+`useAddPasskey` accepts every parameter exposed by `authClient.passkey.addPasskey`. Use it for custom registration UI that needs WebAuthn extensions or the raw response:
+
+```tsx
+const { mutate: addPasskey } = useAddPasskey(
+  authClient as PasskeyAuthClient
+)
+
+addPasskey({
+  name: "Work laptop",
+  authenticatorAttachment: "platform",
+  extensions: { credProps: true },
+  returnWebAuthnResponse: true
+})
+```
+
+<Callout>
+`residentKey` and `userVerification` are server plugin policies. They are not
+parameters of `authClient.passkey.addPasskey`, so the client UI does not expose
+them.
+</Callout>
+
 ## Passkey autofill
 
 With the plugin registered, the sign-in form asks the browser to offer saved
@@ -165,6 +201,8 @@ pass an `AbortSignal` and abort it during cleanup.
 
 ```ts
 passkeyPlugin({
+  // Select the initial authenticator choice, or use false to hide the field.
+  authenticatorAttachment: "any",
   // Override any of the plugin's localization strings.
   localization: {
     passkeys: "Security Keys"

--- a/apps/docs/content/docs/shadcn/plugins/passkey.mdx
+++ b/apps/docs/content/docs/shadcn/plugins/passkey.mdx
@@ -133,6 +133,42 @@ import { Passkeys } from "@/components/auth/passkey/passkeys"
 
 <auto-type-table path="../../../../../../examples/start-shadcn-example/src/components/auth/passkey/passkeys.tsx" name="PasskeysProps" />
 
+## Passkey registration controls
+
+The add-passkey dialog lets users choose where to create a passkey:
+
+- **Any available option** lets the browser choose.
+- **This device** requests a platform authenticator, such as Touch ID or Windows Hello.
+- **Security key or another device** requests a cross-platform authenticator.
+
+Set the initial choice in the plugin. Use `false` to hide the field and let the browser choose:
+
+```ts
+passkeyPlugin({ authenticatorAttachment: "platform" })
+passkeyPlugin({ authenticatorAttachment: false })
+```
+
+`useAddPasskey` accepts every parameter exposed by `authClient.passkey.addPasskey`. Use it for custom registration UI that needs WebAuthn extensions or the raw response:
+
+```tsx
+const { mutate: addPasskey } = useAddPasskey(
+  authClient as PasskeyAuthClient
+)
+
+addPasskey({
+  name: "Work laptop",
+  authenticatorAttachment: "platform",
+  extensions: { credProps: true },
+  returnWebAuthnResponse: true
+})
+```
+
+<Callout>
+`residentKey` and `userVerification` are server plugin policies. They are not
+parameters of `authClient.passkey.addPasskey`, so the client UI does not expose
+them.
+</Callout>
+
 ## Passkey autofill
 
 With the plugin registered, the sign-in form asks the browser to offer saved
@@ -188,6 +224,8 @@ pass an `AbortSignal` and abort it during cleanup.
 
 ```ts
 passkeyPlugin({
+  // Select the initial authenticator choice, or use false to hide the field.
+  authenticatorAttachment: "any",
   // Override any of the plugin's localization strings.
   localization: {
     passkeys: "Security Keys"

--- a/apps/docs/content/docs/zaidan/plugins/passkey.mdx
+++ b/apps/docs/content/docs/zaidan/plugins/passkey.mdx
@@ -166,6 +166,40 @@ The `<PasskeysSettings />` security card is rendered on the security settings pa
 
 <auto-type-table path="../../../../../../examples/start-solid-zaidan-example/src/components/auth/passkey/passkeys.tsx" name="PasskeysSettingsProps" />
 
+## Passkey registration controls
+
+The add-passkey dialog lets users choose where to create a passkey:
+
+- **Any available option** lets the browser choose.
+- **This device** requests a platform authenticator, such as Touch ID or Windows Hello.
+- **Security key or another device** requests a cross-platform authenticator.
+
+Set the initial choice in the plugin. Use `false` to hide the field and let the browser choose:
+
+```ts
+passkeyPlugin({ authenticatorAttachment: "platform" })
+passkeyPlugin({ authenticatorAttachment: false })
+```
+
+`useAddPasskey` accepts every parameter exposed by `authClient.passkey.addPasskey`. Use it for custom registration UI that needs WebAuthn extensions or the raw response:
+
+```tsx
+const addPasskey = useAddPasskey(auth.authClient)
+
+addPasskey.mutate({
+  name: "Work laptop",
+  authenticatorAttachment: "platform",
+  extensions: { credProps: true },
+  returnWebAuthnResponse: true
+})
+```
+
+<Callout>
+`residentKey` and `userVerification` are server plugin policies. They are not
+parameters of `authClient.passkey.addPasskey`, so the client UI does not expose
+them.
+</Callout>
+
 ## Passkey autofill
 
 With the plugin registered, the sign-in form asks the browser to offer saved
@@ -221,6 +255,8 @@ pass an `AbortSignal` and abort it during cleanup.
 
 ```ts
 passkeyPlugin({
+  // Select the initial authenticator choice, or use false to hide the field.
+  authenticatorAttachment: "any",
   // Override any of the plugin's localization strings.
   localization: {
     passkeys: "Security Keys"

--- a/apps/docs/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/apps/docs/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
+import {
+  type PasskeyAuthClient,
+  resolvePasskeyAuthenticatorAttachment
+} from "@better-auth-ui/core/plugins/passkey"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useAddPasskey } from "@better-auth-ui/react/plugins/passkey"
 import { Fingerprint } from "lucide-react"
@@ -17,6 +20,13 @@ import {
 } from "@/components/ui/dialog"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
 
@@ -30,7 +40,8 @@ export function AddPasskeyDialog({
   onOpenChange
 }: AddPasskeyDialogProps) {
   const { authClient, localization } = useAuth<PasskeyAuthClient>()
-  const { localization: passkeyLocalization } = useAuthPlugin(passkeyPlugin)
+  const { authenticatorAttachment, localization: passkeyLocalization } =
+    useAuthPlugin(passkeyPlugin)
 
   const { mutate: addPasskey, isPending: isAdding } = useAddPasskey(authClient)
 
@@ -39,10 +50,17 @@ export function AddPasskeyDialog({
 
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string)?.trim()
+    const attachment = resolvePasskeyAuthenticatorAttachment(
+      formData.get("authenticatorAttachment")
+    )
 
-    addPasskey(name ? { name } : undefined, {
-      onSuccess: () => onOpenChange(false)
-    })
+    addPasskey(
+      {
+        ...(name ? { name } : {}),
+        ...(attachment ? { authenticatorAttachment: attachment } : {})
+      },
+      { onSuccess: () => onOpenChange(false) }
+    )
   }
 
   return (
@@ -75,6 +93,43 @@ export function AddPasskeyDialog({
 
             <FieldError />
           </Field>
+
+          {authenticatorAttachment !== false && (
+            <Field>
+              <FieldLabel htmlFor="passkey-authenticator-attachment">
+                {passkeyLocalization.authenticatorAttachment}
+              </FieldLabel>
+
+              <Select
+                name="authenticatorAttachment"
+                defaultValue={authenticatorAttachment}
+                disabled={isAdding}
+              >
+                <SelectTrigger
+                  id="passkey-authenticator-attachment"
+                  className="w-full"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+
+                <SelectContent>
+                  <SelectItem value="any">
+                    {passkeyLocalization.anyAuthenticator}
+                  </SelectItem>
+                  <SelectItem value="platform">
+                    {passkeyLocalization.platformAuthenticator}
+                  </SelectItem>
+                  <SelectItem value="cross-platform">
+                    {passkeyLocalization.crossPlatformAuthenticator}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+
+              <p className="text-muted-foreground text-sm">
+                {passkeyLocalization.authenticatorAttachmentDescription}
+              </p>
+            </Field>
+          )}
 
           <DialogFooter>
             <DialogClose

--- a/examples/next-shadcn-example/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
+import {
+  type PasskeyAuthClient,
+  resolvePasskeyAuthenticatorAttachment
+} from "@better-auth-ui/core/plugins/passkey"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useAddPasskey } from "@better-auth-ui/react/plugins/passkey"
 import { Fingerprint } from "lucide-react"
@@ -17,6 +20,13 @@ import {
 } from "@/components/ui/dialog"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
 
@@ -30,7 +40,8 @@ export function AddPasskeyDialog({
   onOpenChange
 }: AddPasskeyDialogProps) {
   const { authClient, localization } = useAuth<PasskeyAuthClient>()
-  const { localization: passkeyLocalization } = useAuthPlugin(passkeyPlugin)
+  const { authenticatorAttachment, localization: passkeyLocalization } =
+    useAuthPlugin(passkeyPlugin)
 
   const { mutate: addPasskey, isPending: isAdding } = useAddPasskey(authClient)
 
@@ -39,10 +50,17 @@ export function AddPasskeyDialog({
 
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string)?.trim()
+    const attachment = resolvePasskeyAuthenticatorAttachment(
+      formData.get("authenticatorAttachment")
+    )
 
-    addPasskey(name ? { name } : undefined, {
-      onSuccess: () => onOpenChange(false)
-    })
+    addPasskey(
+      {
+        ...(name ? { name } : {}),
+        ...(attachment ? { authenticatorAttachment: attachment } : {})
+      },
+      { onSuccess: () => onOpenChange(false) }
+    )
   }
 
   return (
@@ -75,6 +93,43 @@ export function AddPasskeyDialog({
 
             <FieldError />
           </Field>
+
+          {authenticatorAttachment !== false && (
+            <Field>
+              <FieldLabel htmlFor="passkey-authenticator-attachment">
+                {passkeyLocalization.authenticatorAttachment}
+              </FieldLabel>
+
+              <Select
+                name="authenticatorAttachment"
+                defaultValue={authenticatorAttachment}
+                disabled={isAdding}
+              >
+                <SelectTrigger
+                  id="passkey-authenticator-attachment"
+                  className="w-full"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+
+                <SelectContent>
+                  <SelectItem value="any">
+                    {passkeyLocalization.anyAuthenticator}
+                  </SelectItem>
+                  <SelectItem value="platform">
+                    {passkeyLocalization.platformAuthenticator}
+                  </SelectItem>
+                  <SelectItem value="cross-platform">
+                    {passkeyLocalization.crossPlatformAuthenticator}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+
+              <p className="text-muted-foreground text-sm">
+                {passkeyLocalization.authenticatorAttachmentDescription}
+              </p>
+            </Field>
+          )}
 
           <DialogFooter>
             <DialogClose

--- a/examples/start-shadcn-baseui-example/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
+import {
+  type PasskeyAuthClient,
+  resolvePasskeyAuthenticatorAttachment
+} from "@better-auth-ui/core/plugins/passkey"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useAddPasskey } from "@better-auth-ui/react/plugins/passkey"
 import { Fingerprint } from "lucide-react"
@@ -17,6 +20,13 @@ import {
 } from "@/components/ui/dialog"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
 
@@ -30,7 +40,8 @@ export function AddPasskeyDialog({
   onOpenChange
 }: AddPasskeyDialogProps) {
   const { authClient, localization } = useAuth<PasskeyAuthClient>()
-  const { localization: passkeyLocalization } = useAuthPlugin(passkeyPlugin)
+  const { authenticatorAttachment, localization: passkeyLocalization } =
+    useAuthPlugin(passkeyPlugin)
 
   const { mutate: addPasskey, isPending: isAdding } = useAddPasskey(authClient)
 
@@ -39,10 +50,17 @@ export function AddPasskeyDialog({
 
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string)?.trim()
+    const attachment = resolvePasskeyAuthenticatorAttachment(
+      formData.get("authenticatorAttachment")
+    )
 
-    addPasskey(name ? { name } : undefined, {
-      onSuccess: () => onOpenChange(false)
-    })
+    addPasskey(
+      {
+        ...(name ? { name } : {}),
+        ...(attachment ? { authenticatorAttachment: attachment } : {})
+      },
+      { onSuccess: () => onOpenChange(false) }
+    )
   }
 
   return (
@@ -75,6 +93,43 @@ export function AddPasskeyDialog({
 
             <FieldError />
           </Field>
+
+          {authenticatorAttachment !== false && (
+            <Field>
+              <FieldLabel htmlFor="passkey-authenticator-attachment">
+                {passkeyLocalization.authenticatorAttachment}
+              </FieldLabel>
+
+              <Select
+                name="authenticatorAttachment"
+                defaultValue={authenticatorAttachment}
+                disabled={isAdding}
+              >
+                <SelectTrigger
+                  id="passkey-authenticator-attachment"
+                  className="w-full"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+
+                <SelectContent>
+                  <SelectItem value="any">
+                    {passkeyLocalization.anyAuthenticator}
+                  </SelectItem>
+                  <SelectItem value="platform">
+                    {passkeyLocalization.platformAuthenticator}
+                  </SelectItem>
+                  <SelectItem value="cross-platform">
+                    {passkeyLocalization.crossPlatformAuthenticator}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+
+              <p className="text-muted-foreground text-sm">
+                {passkeyLocalization.authenticatorAttachmentDescription}
+              </p>
+            </Field>
+          )}
 
           <DialogFooter>
             <DialogClose

--- a/examples/start-shadcn-example/registry.json
+++ b/examples/start-shadcn-example/registry.json
@@ -925,6 +925,7 @@
         "field",
         "input",
         "item",
+        "select",
         "separator",
         "skeleton",
         "spinner"

--- a/examples/start-shadcn-example/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
+import {
+  type PasskeyAuthClient,
+  resolvePasskeyAuthenticatorAttachment
+} from "@better-auth-ui/core/plugins/passkey"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useAddPasskey } from "@better-auth-ui/react/plugins/passkey"
 import { Fingerprint } from "lucide-react"
@@ -17,6 +20,13 @@ import {
 } from "@/components/ui/dialog"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
 
@@ -30,7 +40,8 @@ export function AddPasskeyDialog({
   onOpenChange
 }: AddPasskeyDialogProps) {
   const { authClient, localization } = useAuth<PasskeyAuthClient>()
-  const { localization: passkeyLocalization } = useAuthPlugin(passkeyPlugin)
+  const { authenticatorAttachment, localization: passkeyLocalization } =
+    useAuthPlugin(passkeyPlugin)
 
   const { mutate: addPasskey, isPending: isAdding } = useAddPasskey(authClient)
 
@@ -39,10 +50,17 @@ export function AddPasskeyDialog({
 
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string)?.trim()
+    const attachment = resolvePasskeyAuthenticatorAttachment(
+      formData.get("authenticatorAttachment")
+    )
 
-    addPasskey(name ? { name } : undefined, {
-      onSuccess: () => onOpenChange(false)
-    })
+    addPasskey(
+      {
+        ...(name ? { name } : {}),
+        ...(attachment ? { authenticatorAttachment: attachment } : {})
+      },
+      { onSuccess: () => onOpenChange(false) }
+    )
   }
 
   return (
@@ -75,6 +93,43 @@ export function AddPasskeyDialog({
 
             <FieldError />
           </Field>
+
+          {authenticatorAttachment !== false && (
+            <Field>
+              <FieldLabel htmlFor="passkey-authenticator-attachment">
+                {passkeyLocalization.authenticatorAttachment}
+              </FieldLabel>
+
+              <Select
+                name="authenticatorAttachment"
+                defaultValue={authenticatorAttachment}
+                disabled={isAdding}
+              >
+                <SelectTrigger
+                  id="passkey-authenticator-attachment"
+                  className="w-full"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+
+                <SelectContent>
+                  <SelectItem value="any">
+                    {passkeyLocalization.anyAuthenticator}
+                  </SelectItem>
+                  <SelectItem value="platform">
+                    {passkeyLocalization.platformAuthenticator}
+                  </SelectItem>
+                  <SelectItem value="cross-platform">
+                    {passkeyLocalization.crossPlatformAuthenticator}
+                  </SelectItem>
+                </SelectContent>
+              </Select>
+
+              <p className="text-muted-foreground text-sm">
+                {passkeyLocalization.authenticatorAttachmentDescription}
+              </p>
+            </Field>
+          )}
 
           <DialogFooter>
             <DialogClose

--- a/examples/start-solid-zaidan-example/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -1,5 +1,8 @@
-import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
-import { useAuth } from "@better-auth-ui/solid"
+import {
+  type PasskeyAuthClient,
+  resolvePasskeyAuthenticatorAttachment
+} from "@better-auth-ui/core/plugins/passkey"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import { useAddPasskey } from "@better-auth-ui/solid/plugins/passkey"
 import { Fingerprint } from "lucide-solid"
 import { passkeyLabels } from "@/components/auth/passkey/passkey-localization"
@@ -14,7 +17,9 @@ import {
 } from "@/components/ui/dialog"
 import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
+import { NativeSelect, NativeSelectOption } from "@/components/ui/native-select"
 import { Spinner } from "@/components/ui/spinner"
+import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
 
 export function AddPasskeyDialog(props: {
   onOpenChange: (open: boolean) => void
@@ -22,6 +27,7 @@ export function AddPasskeyDialog(props: {
 }) {
   const auth = useAuth<PasskeyAuthClient>()
   const labels = () => passkeyLabels(auth)
+  const { authenticatorAttachment } = useAuthPlugin(passkeyPlugin)
   const addPasskey = useAddPasskey(auth.authClient, () => ({
     onSuccess: () => {
       props.onOpenChange(false)
@@ -34,10 +40,14 @@ export function AddPasskeyDialog(props: {
 
     const formData = new FormData(event.currentTarget as HTMLFormElement)
     const name = String(formData.get("name") ?? "").trim()
-
-    addPasskey.mutate(
-      (name ? { name } : undefined) as Parameters<typeof addPasskey.mutate>[0]
+    const attachment = resolvePasskeyAuthenticatorAttachment(
+      formData.get("authenticatorAttachment")
     )
+
+    addPasskey.mutate({
+      ...(name ? { name } : {}),
+      ...(attachment ? { authenticatorAttachment: attachment } : {})
+    } as Parameters<typeof addPasskey.mutate>[0])
   }
 
   return (
@@ -61,6 +71,36 @@ export function AddPasskeyDialog(props: {
             placeholder={auth.localization.settings.optional}
           />
         </Field>
+
+        {authenticatorAttachment !== false ? (
+          <Field>
+            <FieldLabel for="passkey-authenticator-attachment">
+              {labels().authenticatorAttachment}
+            </FieldLabel>
+
+            <NativeSelect
+              class="w-full"
+              disabled={addPasskey.isPending}
+              id="passkey-authenticator-attachment"
+              name="authenticatorAttachment"
+              value={authenticatorAttachment}
+            >
+              <NativeSelectOption value="any">
+                {labels().anyAuthenticator}
+              </NativeSelectOption>
+              <NativeSelectOption value="platform">
+                {labels().platformAuthenticator}
+              </NativeSelectOption>
+              <NativeSelectOption value="cross-platform">
+                {labels().crossPlatformAuthenticator}
+              </NativeSelectOption>
+            </NativeSelect>
+
+            <p class="text-muted-foreground text-sm">
+              {labels().authenticatorAttachmentDescription}
+            </p>
+          </Field>
+        ) : null}
 
         <DialogFooter>
           <DialogClose

--- a/examples/start-solid-zaidan-example/tests/auth-route.test.ts
+++ b/examples/start-solid-zaidan-example/tests/auth-route.test.ts
@@ -2898,7 +2898,8 @@ describe("Solid auth route component selection", () => {
     expect(passkeys).toContain("onPasskeyAdded={() => passkeys.refetch()}")
     expect(addPasskeyDialog).toContain("props.onPasskeyAdded()")
     expect(addPasskeyDialog).toContain("addPasskey.mutate(")
-    expect(addPasskeyDialog).toContain("name ? { name } : undefined")
+    expect(addPasskeyDialog).toContain("resolvePasskeyAuthenticatorAttachment")
+    expect(addPasskeyDialog).toContain("authenticatorAttachment: attachment")
     expect(addPasskeyDialog).toContain("props.onOpenChange(false)")
     expect(deletePasskeyDialog).toContain(
       "const auth = useAuth<PasskeyAuthClient>()"

--- a/packages/core/src/plugins/passkey/passkey-localization.ts
+++ b/packages/core/src/plugins/passkey/passkey-localization.ts
@@ -18,6 +18,16 @@ export const passkeyLocalization = {
   noPasskeys: "No passkeys",
   /** @remarks `"Name"` */
   name: "Name",
+  /** @remarks `"Passkey type"` */
+  authenticatorAttachment: "Passkey type",
+  /** @remarks `"Choose where to create this passkey."` */
+  authenticatorAttachmentDescription: "Choose where to create this passkey.",
+  /** @remarks `"Any available option"` */
+  anyAuthenticator: "Any available option",
+  /** @remarks `"This device"` */
+  platformAuthenticator: "This device",
+  /** @remarks `"Security key or another device"` */
+  crossPlatformAuthenticator: "Security key or another device",
   /** @remarks `"Rename passkey"` */
   renamePasskey: "Rename passkey",
   /** @remarks `"Passkey renamed"` */

--- a/packages/core/src/plugins/passkey/passkey-plugin.ts
+++ b/packages/core/src/plugins/passkey/passkey-plugin.ts
@@ -4,6 +4,11 @@ import {
   passkeyLocalization
 } from "./passkey-localization"
 
+export type PasskeyAuthenticatorAttachment =
+  | "any"
+  | "platform"
+  | "cross-platform"
+
 export type PasskeyPluginOptions = {
   /**
    * Offer passkeys through the browser's autofill dropdown (WebAuthn
@@ -16,6 +21,15 @@ export type PasskeyPluginOptions = {
    */
   autoFill?: boolean
   /**
+   * Show an authenticator choice when users add a passkey and select its
+   * initial value. Use `false` to hide the choice and let the browser decide.
+   *
+   * Better Auth forwards `"platform"` and `"cross-platform"` to WebAuthn.
+   * `"any"` leaves `authenticatorAttachment` unset.
+   * @default "any"
+   */
+  authenticatorAttachment?: PasskeyAuthenticatorAttachment | false
+  /**
    * Override the plugin's default localization strings.
    * @remarks `PasskeyLocalization`
    */
@@ -26,6 +40,12 @@ export const passkeyPlugin = createAuthPlugin(
   "passkey",
   (options: PasskeyPluginOptions = {}) => ({
     autoFill: options.autoFill ?? true,
+    authenticatorAttachment: options.authenticatorAttachment ?? "any",
     localization: { ...passkeyLocalization, ...options.localization }
   })
 )
+
+/** Convert the dialog choice to Better Auth's `addPasskey` parameter. */
+export function resolvePasskeyAuthenticatorAttachment(value: unknown) {
+  return value === "platform" || value === "cross-platform" ? value : undefined
+}

--- a/packages/core/tests/passkey-conditional-ui.test.ts
+++ b/packages/core/tests/passkey-conditional-ui.test.ts
@@ -3,6 +3,7 @@ import {
   isConditionalMediationAvailable,
   isPasskeyAutoFillEnabled,
   passkeyPlugin,
+  resolvePasskeyAuthenticatorAttachment,
   withPasskeyAutoFill
 } from "../src/plugins/passkey"
 
@@ -49,6 +50,30 @@ describe("isPasskeyAutoFillEnabled", () => {
 
   it("is off when the passkey plugin isn't registered", () => {
     expect(isPasskeyAutoFillEnabled([])).toBe(false)
+  })
+})
+
+describe("passkey authenticator attachment", () => {
+  it("defaults the registration dialog to any available authenticator", () => {
+    expect(passkeyPlugin().authenticatorAttachment).toBe("any")
+  })
+
+  it("supports a preferred authenticator and hiding the control", () => {
+    expect(
+      passkeyPlugin({ authenticatorAttachment: "platform" })
+        .authenticatorAttachment
+    ).toBe("platform")
+    expect(
+      passkeyPlugin({ authenticatorAttachment: false }).authenticatorAttachment
+    ).toBe(false)
+  })
+
+  it("only forwards WebAuthn attachment values", () => {
+    expect(resolvePasskeyAuthenticatorAttachment("platform")).toBe("platform")
+    expect(resolvePasskeyAuthenticatorAttachment("cross-platform")).toBe(
+      "cross-platform"
+    )
+    expect(resolvePasskeyAuthenticatorAttachment("any")).toBeUndefined()
   })
 })
 

--- a/packages/heroui/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/packages/heroui/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -1,14 +1,20 @@
-import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
+import {
+  type PasskeyAuthClient,
+  resolvePasskeyAuthenticatorAttachment
+} from "@better-auth-ui/core/plugins/passkey"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useAddPasskey } from "@better-auth-ui/react/plugins/passkey"
 import { Fingerprint } from "@gravity-ui/icons"
 import {
   AlertDialog,
   Button,
+  Description,
   FieldError,
   Form,
   Input,
   Label,
+  ListBox,
+  Select,
   Spinner,
   TextField
 } from "@heroui/react"
@@ -26,7 +32,8 @@ export function AddPasskeyDialog({
   onOpenChange
 }: AddPasskeyDialogProps) {
   const { authClient, localization } = useAuth()
-  const { localization: passkeyLocalization } = useAuthPlugin(passkeyPlugin)
+  const { authenticatorAttachment, localization: passkeyLocalization } =
+    useAuthPlugin(passkeyPlugin)
 
   const { mutate: addPasskey, isPending: isAdding } = useAddPasskey(
     authClient as PasskeyAuthClient
@@ -41,10 +48,17 @@ export function AddPasskeyDialog({
 
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string)?.trim()
+    const attachment = resolvePasskeyAuthenticatorAttachment(
+      formData.get("authenticatorAttachment")
+    )
 
-    addPasskey(name ? { name } : undefined, {
-      onSuccess: () => handleOpenChange(false)
-    })
+    addPasskey(
+      {
+        ...(name ? { name } : {}),
+        ...(attachment ? { authenticatorAttachment: attachment } : {})
+      },
+      { onSuccess: () => handleOpenChange(false) }
+    )
   }
 
   return (
@@ -85,6 +99,57 @@ export function AddPasskeyDialog({
 
                 <FieldError />
               </TextField>
+
+              {authenticatorAttachment !== false && (
+                <Select
+                  className="mt-4"
+                  defaultSelectedKey={authenticatorAttachment}
+                  isDisabled={isAdding}
+                  name="authenticatorAttachment"
+                  variant="secondary"
+                >
+                  <Label>{passkeyLocalization.authenticatorAttachment}</Label>
+
+                  <Select.Trigger>
+                    <Select.Value />
+                    <Select.Indicator />
+                  </Select.Trigger>
+
+                  <Select.Popover>
+                    <ListBox>
+                      <ListBox.Item
+                        id="any"
+                        textValue={passkeyLocalization.anyAuthenticator}
+                      >
+                        {passkeyLocalization.anyAuthenticator}
+                        <ListBox.ItemIndicator />
+                      </ListBox.Item>
+
+                      <ListBox.Item
+                        id="platform"
+                        textValue={passkeyLocalization.platformAuthenticator}
+                      >
+                        {passkeyLocalization.platformAuthenticator}
+                        <ListBox.ItemIndicator />
+                      </ListBox.Item>
+
+                      <ListBox.Item
+                        id="cross-platform"
+                        textValue={
+                          passkeyLocalization.crossPlatformAuthenticator
+                        }
+                      >
+                        {passkeyLocalization.crossPlatformAuthenticator}
+                        <ListBox.ItemIndicator />
+                      </ListBox.Item>
+                    </ListBox>
+                  </Select.Popover>
+
+                  <Description>
+                    {passkeyLocalization.authenticatorAttachmentDescription}
+                  </Description>
+                </Select>
+              )}
             </AlertDialog.Body>
 
             <AlertDialog.Footer>

--- a/packages/heroui/tests/passkeys.test.tsx
+++ b/packages/heroui/tests/passkeys.test.tsx
@@ -212,14 +212,17 @@ function createPasskeysAuthClient(
   }
 }
 
-function renderPasskeys(authClient = createPasskeysAuthClient()) {
+function renderPasskeys(
+  authClient = createPasskeysAuthClient(),
+  pluginOptions?: Parameters<typeof passkeyPlugin>[0]
+) {
   return {
     authClient,
     ...render(
       <AuthProvider
         authClient={authClient}
         navigate={() => {}}
-        plugins={[passkeyPlugin()]}
+        plugins={[passkeyPlugin(pluginOptions)]}
         queryClient={createTestQueryClient()}
       >
         <Passkeys />
@@ -331,6 +334,44 @@ describe("<Passkeys />", () => {
         fetchOptions: expect.objectContaining({ throw: true })
       })
     )
+  })
+
+  it("forwards the configured authenticator choice to addPasskey", async () => {
+    const user = userEvent.setup()
+    const authClient = createPasskeysAuthClient()
+    renderPasskeys(authClient, { authenticatorAttachment: "platform" })
+
+    await user.click(
+      await screen.findByRole("button", { name: /add passkey/i })
+    )
+
+    const dialog = await screen.findByRole("alertdialog")
+    await user.click(
+      within(dialog).getByRole("button", { name: /add passkey/i })
+    )
+
+    await waitFor(() => {
+      expect(authClient.passkey.addPasskey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authenticatorAttachment: "platform",
+          fetchOptions: expect.objectContaining({ throw: true })
+        })
+      )
+    })
+  })
+
+  it("can hide the authenticator choice", async () => {
+    const user = userEvent.setup()
+    renderPasskeys(createPasskeysAuthClient(), {
+      authenticatorAttachment: false
+    })
+
+    await user.click(
+      await screen.findByRole("button", { name: /add passkey/i })
+    )
+
+    const dialog = await screen.findByRole("alertdialog")
+    expect(within(dialog).queryByText("Passkey type")).not.toBeInTheDocument()
   })
 
   it("renders registered passkeys", async () => {

--- a/packages/locales/src/de-DE-plugins.ts
+++ b/packages/locales/src/de-DE-plugins.ts
@@ -530,6 +530,12 @@ export const deDEPlugins = {
       "Erstelle einen Passkey für den sicheren Zugriff auf dein Konto.",
     noPasskeys: "Keine Passkeys",
     name: "Name",
+    authenticatorAttachment: "Passkey-Typ",
+    authenticatorAttachmentDescription:
+      "Wähle aus, wo dieser Passkey erstellt werden soll.",
+    anyAuthenticator: "Beliebige verfügbare Option",
+    platformAuthenticator: "Dieses Gerät",
+    crossPlatformAuthenticator: "Sicherheitsschlüssel oder anderes Gerät",
     renamePasskey: "Passkey umbenennen",
     renamePasskeySuccess: "Passkey umbenannt"
   } satisfies Translated<PasskeyLocalization>,


### PR DESCRIPTION
## Summary

- Let users choose any, platform, or cross-platform authenticators during passkey registration.
- Add a plugin default and an option to hide the selector across HeroUI, shadcn, and Solid/Zaidan.
- Keep `useAddPasskey` typed for all remaining `authClient.passkey.addPasskey` parameters and document advanced client usage.
- Explicitly leave server-only resident-key and verification policy out of the client UI.

## Validation

Core, HeroUI, and Solid registry tests, all framework and docs typechecks, both registry builds, Biome, and affected lint pass.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticator selection when registering passkeys, including any, platform, and cross-platform options.
  * Added configuration to set a default authenticator choice or hide the selection control.
  * Passkey registration now submits the selected authenticator preference.
  * Added localized labels and descriptions for authenticator choices.

* **Documentation**
  * Documented authenticator controls, custom registration parameters, WebAuthn extensions, and server-side policy distinctions across supported integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->