### PR TITLE
fix(passkey): remove authenticator selector

### DIFF
--- a/apps/docs/content/docs/heroui/plugins/passkey.mdx
+++ b/apps/docs/content/docs/heroui/plugins/passkey.mdx
@@ -110,6 +110,41 @@ import { Passkeys } from "@better-auth-ui/heroui/plugins/passkey"
 
 <auto-type-table path="../../../../../../packages/heroui/src/components/auth/passkey/passkeys.tsx" name="PasskeysProps" />
 
+## Passkey registration policy
+
+By default, the add-passkey dialog does not set `authenticatorAttachment`.
+The browser and operating system show the available passkey options.
+
+Set a preference in the plugin when all registrations must use one authenticator type:
+
+```ts
+passkeyPlugin({ authenticatorAttachment: "platform" })
+passkeyPlugin({ authenticatorAttachment: "cross-platform" })
+```
+
+`"platform"` prefers the current device. `"cross-platform"` prefers a security key or another device. The dialog does not show an attachment selector.
+
+`useAddPasskey` accepts every parameter exposed by `authClient.passkey.addPasskey`. Use this hook for custom registration flows:
+
+```tsx
+const { mutate: addPasskey } = useAddPasskey(
+  authClient as PasskeyAuthClient
+)
+
+addPasskey({
+  name: "Work laptop",
+  authenticatorAttachment: "platform",
+  extensions: { credProps: true },
+  returnWebAuthnResponse: true
+})
+```
+
+<Callout>
+`residentKey` and `userVerification` are server plugin policies. They are not
+parameters of `authClient.passkey.addPasskey`, so the client UI does not expose
+them.
+</Callout>
+
 ## Passkey autofill
 
 With the plugin registered, the sign-in form asks the browser to offer saved
@@ -165,6 +200,8 @@ pass an `AbortSignal` and abort it during cleanup.
 
 ```ts
 passkeyPlugin({
+  // Omit this option to let the browser show all available choices.
+  authenticatorAttachment: "platform",
   // Override any of the plugin's localization strings.
   localization: {
     passkeys: "Security Keys"

--- a/apps/docs/content/docs/heroui/plugins/passkey.mdx
+++ b/apps/docs/content/docs/heroui/plugins/passkey.mdx
@@ -110,42 +110,6 @@ import { Passkeys } from "@better-auth-ui/heroui/plugins/passkey"
 
 <auto-type-table path="../../../../../../packages/heroui/src/components/auth/passkey/passkeys.tsx" name="PasskeysProps" />
 
-## Passkey registration controls
-
-The add-passkey dialog lets users choose where to create a passkey:
-
-- **Any available option** lets the browser choose.
-- **This device** requests a platform authenticator, such as Touch ID or Windows Hello.
-- **Security key or another device** requests a cross-platform authenticator.
-
-Set the initial choice in the plugin. Use `false` to hide the field and let the browser choose:
-
-```ts
-passkeyPlugin({ authenticatorAttachment: "platform" })
-passkeyPlugin({ authenticatorAttachment: false })
-```
-
-`useAddPasskey` accepts every parameter exposed by `authClient.passkey.addPasskey`. Use it for custom registration UI that needs WebAuthn extensions or the raw response:
-
-```tsx
-const { mutate: addPasskey } = useAddPasskey(
-  authClient as PasskeyAuthClient
-)
-
-addPasskey({
-  name: "Work laptop",
-  authenticatorAttachment: "platform",
-  extensions: { credProps: true },
-  returnWebAuthnResponse: true
-})
-```
-
-<Callout>
-`residentKey` and `userVerification` are server plugin policies. They are not
-parameters of `authClient.passkey.addPasskey`, so the client UI does not expose
-them.
-</Callout>
-
 ## Passkey autofill
 
 With the plugin registered, the sign-in form asks the browser to offer saved
@@ -201,8 +165,6 @@ pass an `AbortSignal` and abort it during cleanup.
 
 ```ts
 passkeyPlugin({
-  // Select the initial authenticator choice, or use false to hide the field.
-  authenticatorAttachment: "any",
   // Override any of the plugin's localization strings.
   localization: {
     passkeys: "Security Keys"

--- a/apps/docs/content/docs/shadcn/plugins/passkey.mdx
+++ b/apps/docs/content/docs/shadcn/plugins/passkey.mdx
@@ -133,6 +133,41 @@ import { Passkeys } from "@/components/auth/passkey/passkeys"
 
 <auto-type-table path="../../../../../../examples/start-shadcn-example/src/components/auth/passkey/passkeys.tsx" name="PasskeysProps" />
 
+## Passkey registration policy
+
+By default, the add-passkey dialog does not set `authenticatorAttachment`.
+The browser and operating system show the available passkey options.
+
+Set a preference in the plugin when all registrations must use one authenticator type:
+
+```ts
+passkeyPlugin({ authenticatorAttachment: "platform" })
+passkeyPlugin({ authenticatorAttachment: "cross-platform" })
+```
+
+`"platform"` prefers the current device. `"cross-platform"` prefers a security key or another device. The dialog does not show an attachment selector.
+
+`useAddPasskey` accepts every parameter exposed by `authClient.passkey.addPasskey`. Use this hook for custom registration flows:
+
+```tsx
+const { mutate: addPasskey } = useAddPasskey(
+  authClient as PasskeyAuthClient
+)
+
+addPasskey({
+  name: "Work laptop",
+  authenticatorAttachment: "platform",
+  extensions: { credProps: true },
+  returnWebAuthnResponse: true
+})
+```
+
+<Callout>
+`residentKey` and `userVerification` are server plugin policies. They are not
+parameters of `authClient.passkey.addPasskey`, so the client UI does not expose
+them.
+</Callout>
+
 ## Passkey autofill
 
 With the plugin registered, the sign-in form asks the browser to offer saved
@@ -188,6 +223,8 @@ pass an `AbortSignal` and abort it during cleanup.
 
 ```ts
 passkeyPlugin({
+  // Omit this option to let the browser show all available choices.
+  authenticatorAttachment: "platform",
   // Override any of the plugin's localization strings.
   localization: {
     passkeys: "Security Keys"

--- a/apps/docs/content/docs/shadcn/plugins/passkey.mdx
+++ b/apps/docs/content/docs/shadcn/plugins/passkey.mdx
@@ -133,42 +133,6 @@ import { Passkeys } from "@/components/auth/passkey/passkeys"
 
 <auto-type-table path="../../../../../../examples/start-shadcn-example/src/components/auth/passkey/passkeys.tsx" name="PasskeysProps" />
 
-## Passkey registration controls
-
-The add-passkey dialog lets users choose where to create a passkey:
-
-- **Any available option** lets the browser choose.
-- **This device** requests a platform authenticator, such as Touch ID or Windows Hello.
-- **Security key or another device** requests a cross-platform authenticator.
-
-Set the initial choice in the plugin. Use `false` to hide the field and let the browser choose:
-
-```ts
-passkeyPlugin({ authenticatorAttachment: "platform" })
-passkeyPlugin({ authenticatorAttachment: false })
-```
-
-`useAddPasskey` accepts every parameter exposed by `authClient.passkey.addPasskey`. Use it for custom registration UI that needs WebAuthn extensions or the raw response:
-
-```tsx
-const { mutate: addPasskey } = useAddPasskey(
-  authClient as PasskeyAuthClient
-)
-
-addPasskey({
-  name: "Work laptop",
-  authenticatorAttachment: "platform",
-  extensions: { credProps: true },
-  returnWebAuthnResponse: true
-})
-```
-
-<Callout>
-`residentKey` and `userVerification` are server plugin policies. They are not
-parameters of `authClient.passkey.addPasskey`, so the client UI does not expose
-them.
-</Callout>
-
 ## Passkey autofill
 
 With the plugin registered, the sign-in form asks the browser to offer saved
@@ -224,8 +188,6 @@ pass an `AbortSignal` and abort it during cleanup.
 
 ```ts
 passkeyPlugin({
-  // Select the initial authenticator choice, or use false to hide the field.
-  authenticatorAttachment: "any",
   // Override any of the plugin's localization strings.
   localization: {
     passkeys: "Security Keys"

--- a/apps/docs/content/docs/zaidan/plugins/passkey.mdx
+++ b/apps/docs/content/docs/zaidan/plugins/passkey.mdx
@@ -166,6 +166,39 @@ The `<PasskeysSettings />` security card is rendered on the security settings pa
 
 <auto-type-table path="../../../../../../examples/start-solid-zaidan-example/src/components/auth/passkey/passkeys.tsx" name="PasskeysSettingsProps" />
 
+## Passkey registration policy
+
+By default, the add-passkey dialog does not set `authenticatorAttachment`.
+The browser and operating system show the available passkey options.
+
+Set a preference in the plugin when all registrations must use one authenticator type:
+
+```ts
+passkeyPlugin({ authenticatorAttachment: "platform" })
+passkeyPlugin({ authenticatorAttachment: "cross-platform" })
+```
+
+`"platform"` prefers the current device. `"cross-platform"` prefers a security key or another device. The dialog does not show an attachment selector.
+
+`useAddPasskey` accepts every parameter exposed by `authClient.passkey.addPasskey`. Use this hook for custom registration flows:
+
+```tsx
+const addPasskey = useAddPasskey(auth.authClient)
+
+addPasskey.mutate({
+  name: "Work laptop",
+  authenticatorAttachment: "platform",
+  extensions: { credProps: true },
+  returnWebAuthnResponse: true
+})
+```
+
+<Callout>
+`residentKey` and `userVerification` are server plugin policies. They are not
+parameters of `authClient.passkey.addPasskey`, so the client UI does not expose
+them.
+</Callout>
+
 ## Passkey autofill
 
 With the plugin registered, the sign-in form asks the browser to offer saved
@@ -221,6 +254,8 @@ pass an `AbortSignal` and abort it during cleanup.
 
 ```ts
 passkeyPlugin({
+  // Omit this option to let the browser show all available choices.
+  authenticatorAttachment: "platform",
   // Override any of the plugin's localization strings.
   localization: {
     passkeys: "Security Keys"

--- a/apps/docs/content/docs/zaidan/plugins/passkey.mdx
+++ b/apps/docs/content/docs/zaidan/plugins/passkey.mdx
@@ -166,40 +166,6 @@ The `<PasskeysSettings />` security card is rendered on the security settings pa
 
 <auto-type-table path="../../../../../../examples/start-solid-zaidan-example/src/components/auth/passkey/passkeys.tsx" name="PasskeysSettingsProps" />
 
-## Passkey registration controls
-
-The add-passkey dialog lets users choose where to create a passkey:
-
-- **Any available option** lets the browser choose.
-- **This device** requests a platform authenticator, such as Touch ID or Windows Hello.
-- **Security key or another device** requests a cross-platform authenticator.
-
-Set the initial choice in the plugin. Use `false` to hide the field and let the browser choose:
-
-```ts
-passkeyPlugin({ authenticatorAttachment: "platform" })
-passkeyPlugin({ authenticatorAttachment: false })
-```
-
-`useAddPasskey` accepts every parameter exposed by `authClient.passkey.addPasskey`. Use it for custom registration UI that needs WebAuthn extensions or the raw response:
-
-```tsx
-const addPasskey = useAddPasskey(auth.authClient)
-
-addPasskey.mutate({
-  name: "Work laptop",
-  authenticatorAttachment: "platform",
-  extensions: { credProps: true },
-  returnWebAuthnResponse: true
-})
-```
-
-<Callout>
-`residentKey` and `userVerification` are server plugin policies. They are not
-parameters of `authClient.passkey.addPasskey`, so the client UI does not expose
-them.
-</Callout>
-
 ## Passkey autofill
 
 With the plugin registered, the sign-in form asks the browser to offer saved
@@ -255,8 +221,6 @@ pass an `AbortSignal` and abort it during cleanup.
 
 ```ts
 passkeyPlugin({
-  // Select the initial authenticator choice, or use false to hide the field.
-  authenticatorAttachment: "any",
   // Override any of the plugin's localization strings.
   localization: {
     passkeys: "Security Keys"

--- a/apps/docs/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/apps/docs/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -1,9 +1,6 @@
 "use client"
 
-import {
-  type PasskeyAuthClient,
-  resolvePasskeyAuthenticatorAttachment
-} from "@better-auth-ui/core/plugins/passkey"
+import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useAddPasskey } from "@better-auth-ui/react/plugins/passkey"
 import { Fingerprint } from "lucide-react"
@@ -20,13 +17,6 @@ import {
 } from "@/components/ui/dialog"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
 
@@ -40,8 +30,7 @@ export function AddPasskeyDialog({
   onOpenChange
 }: AddPasskeyDialogProps) {
   const { authClient, localization } = useAuth<PasskeyAuthClient>()
-  const { authenticatorAttachment, localization: passkeyLocalization } =
-    useAuthPlugin(passkeyPlugin)
+  const { localization: passkeyLocalization } = useAuthPlugin(passkeyPlugin)
 
   const { mutate: addPasskey, isPending: isAdding } = useAddPasskey(authClient)
 
@@ -50,17 +39,10 @@ export function AddPasskeyDialog({
 
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string)?.trim()
-    const attachment = resolvePasskeyAuthenticatorAttachment(
-      formData.get("authenticatorAttachment")
-    )
 
-    addPasskey(
-      {
-        ...(name ? { name } : {}),
-        ...(attachment ? { authenticatorAttachment: attachment } : {})
-      },
-      { onSuccess: () => onOpenChange(false) }
-    )
+    addPasskey(name ? { name } : undefined, {
+      onSuccess: () => onOpenChange(false)
+    })
   }
 
   return (
@@ -93,43 +75,6 @@ export function AddPasskeyDialog({
 
             <FieldError />
           </Field>
-
-          {authenticatorAttachment !== false && (
-            <Field>
-              <FieldLabel htmlFor="passkey-authenticator-attachment">
-                {passkeyLocalization.authenticatorAttachment}
-              </FieldLabel>
-
-              <Select
-                name="authenticatorAttachment"
-                defaultValue={authenticatorAttachment}
-                disabled={isAdding}
-              >
-                <SelectTrigger
-                  id="passkey-authenticator-attachment"
-                  className="w-full"
-                >
-                  <SelectValue />
-                </SelectTrigger>
-
-                <SelectContent>
-                  <SelectItem value="any">
-                    {passkeyLocalization.anyAuthenticator}
-                  </SelectItem>
-                  <SelectItem value="platform">
-                    {passkeyLocalization.platformAuthenticator}
-                  </SelectItem>
-                  <SelectItem value="cross-platform">
-                    {passkeyLocalization.crossPlatformAuthenticator}
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-
-              <p className="text-muted-foreground text-sm">
-                {passkeyLocalization.authenticatorAttachmentDescription}
-              </p>
-            </Field>
-          )}
 
           <DialogFooter>
             <DialogClose

--- a/apps/docs/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/apps/docs/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -30,7 +30,8 @@ export function AddPasskeyDialog({
   onOpenChange
 }: AddPasskeyDialogProps) {
   const { authClient, localization } = useAuth<PasskeyAuthClient>()
-  const { localization: passkeyLocalization } = useAuthPlugin(passkeyPlugin)
+  const { authenticatorAttachment, localization: passkeyLocalization } =
+    useAuthPlugin(passkeyPlugin)
 
   const { mutate: addPasskey, isPending: isAdding } = useAddPasskey(authClient)
 
@@ -40,9 +41,13 @@ export function AddPasskeyDialog({
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string)?.trim()
 
-    addPasskey(name ? { name } : undefined, {
-      onSuccess: () => onOpenChange(false)
-    })
+    addPasskey(
+      {
+        ...(name ? { name } : {}),
+        ...(authenticatorAttachment ? { authenticatorAttachment } : {})
+      },
+      { onSuccess: () => onOpenChange(false) }
+    )
   }
 
   return (

--- a/examples/next-shadcn-example/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -1,9 +1,6 @@
 "use client"
 
-import {
-  type PasskeyAuthClient,
-  resolvePasskeyAuthenticatorAttachment
-} from "@better-auth-ui/core/plugins/passkey"
+import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useAddPasskey } from "@better-auth-ui/react/plugins/passkey"
 import { Fingerprint } from "lucide-react"
@@ -20,13 +17,6 @@ import {
 } from "@/components/ui/dialog"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
 
@@ -40,8 +30,7 @@ export function AddPasskeyDialog({
   onOpenChange
 }: AddPasskeyDialogProps) {
   const { authClient, localization } = useAuth<PasskeyAuthClient>()
-  const { authenticatorAttachment, localization: passkeyLocalization } =
-    useAuthPlugin(passkeyPlugin)
+  const { localization: passkeyLocalization } = useAuthPlugin(passkeyPlugin)
 
   const { mutate: addPasskey, isPending: isAdding } = useAddPasskey(authClient)
 
@@ -50,17 +39,10 @@ export function AddPasskeyDialog({
 
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string)?.trim()
-    const attachment = resolvePasskeyAuthenticatorAttachment(
-      formData.get("authenticatorAttachment")
-    )
 
-    addPasskey(
-      {
-        ...(name ? { name } : {}),
-        ...(attachment ? { authenticatorAttachment: attachment } : {})
-      },
-      { onSuccess: () => onOpenChange(false) }
-    )
+    addPasskey(name ? { name } : undefined, {
+      onSuccess: () => onOpenChange(false)
+    })
   }
 
   return (
@@ -93,43 +75,6 @@ export function AddPasskeyDialog({
 
             <FieldError />
           </Field>
-
-          {authenticatorAttachment !== false && (
-            <Field>
-              <FieldLabel htmlFor="passkey-authenticator-attachment">
-                {passkeyLocalization.authenticatorAttachment}
-              </FieldLabel>
-
-              <Select
-                name="authenticatorAttachment"
-                defaultValue={authenticatorAttachment}
-                disabled={isAdding}
-              >
-                <SelectTrigger
-                  id="passkey-authenticator-attachment"
-                  className="w-full"
-                >
-                  <SelectValue />
-                </SelectTrigger>
-
-                <SelectContent>
-                  <SelectItem value="any">
-                    {passkeyLocalization.anyAuthenticator}
-                  </SelectItem>
-                  <SelectItem value="platform">
-                    {passkeyLocalization.platformAuthenticator}
-                  </SelectItem>
-                  <SelectItem value="cross-platform">
-                    {passkeyLocalization.crossPlatformAuthenticator}
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-
-              <p className="text-muted-foreground text-sm">
-                {passkeyLocalization.authenticatorAttachmentDescription}
-              </p>
-            </Field>
-          )}
 
           <DialogFooter>
             <DialogClose

--- a/examples/next-shadcn-example/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -30,7 +30,8 @@ export function AddPasskeyDialog({
   onOpenChange
 }: AddPasskeyDialogProps) {
   const { authClient, localization } = useAuth<PasskeyAuthClient>()
-  const { localization: passkeyLocalization } = useAuthPlugin(passkeyPlugin)
+  const { authenticatorAttachment, localization: passkeyLocalization } =
+    useAuthPlugin(passkeyPlugin)
 
   const { mutate: addPasskey, isPending: isAdding } = useAddPasskey(authClient)
 
@@ -40,9 +41,13 @@ export function AddPasskeyDialog({
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string)?.trim()
 
-    addPasskey(name ? { name } : undefined, {
-      onSuccess: () => onOpenChange(false)
-    })
+    addPasskey(
+      {
+        ...(name ? { name } : {}),
+        ...(authenticatorAttachment ? { authenticatorAttachment } : {})
+      },
+      { onSuccess: () => onOpenChange(false) }
+    )
   }
 
   return (

--- a/examples/start-shadcn-baseui-example/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -1,9 +1,6 @@
 "use client"
 
-import {
-  type PasskeyAuthClient,
-  resolvePasskeyAuthenticatorAttachment
-} from "@better-auth-ui/core/plugins/passkey"
+import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useAddPasskey } from "@better-auth-ui/react/plugins/passkey"
 import { Fingerprint } from "lucide-react"
@@ -20,13 +17,6 @@ import {
 } from "@/components/ui/dialog"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
 
@@ -40,8 +30,7 @@ export function AddPasskeyDialog({
   onOpenChange
 }: AddPasskeyDialogProps) {
   const { authClient, localization } = useAuth<PasskeyAuthClient>()
-  const { authenticatorAttachment, localization: passkeyLocalization } =
-    useAuthPlugin(passkeyPlugin)
+  const { localization: passkeyLocalization } = useAuthPlugin(passkeyPlugin)
 
   const { mutate: addPasskey, isPending: isAdding } = useAddPasskey(authClient)
 
@@ -50,17 +39,10 @@ export function AddPasskeyDialog({
 
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string)?.trim()
-    const attachment = resolvePasskeyAuthenticatorAttachment(
-      formData.get("authenticatorAttachment")
-    )
 
-    addPasskey(
-      {
-        ...(name ? { name } : {}),
-        ...(attachment ? { authenticatorAttachment: attachment } : {})
-      },
-      { onSuccess: () => onOpenChange(false) }
-    )
+    addPasskey(name ? { name } : undefined, {
+      onSuccess: () => onOpenChange(false)
+    })
   }
 
   return (
@@ -93,43 +75,6 @@ export function AddPasskeyDialog({
 
             <FieldError />
           </Field>
-
-          {authenticatorAttachment !== false && (
-            <Field>
-              <FieldLabel htmlFor="passkey-authenticator-attachment">
-                {passkeyLocalization.authenticatorAttachment}
-              </FieldLabel>
-
-              <Select
-                name="authenticatorAttachment"
-                defaultValue={authenticatorAttachment}
-                disabled={isAdding}
-              >
-                <SelectTrigger
-                  id="passkey-authenticator-attachment"
-                  className="w-full"
-                >
-                  <SelectValue />
-                </SelectTrigger>
-
-                <SelectContent>
-                  <SelectItem value="any">
-                    {passkeyLocalization.anyAuthenticator}
-                  </SelectItem>
-                  <SelectItem value="platform">
-                    {passkeyLocalization.platformAuthenticator}
-                  </SelectItem>
-                  <SelectItem value="cross-platform">
-                    {passkeyLocalization.crossPlatformAuthenticator}
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-
-              <p className="text-muted-foreground text-sm">
-                {passkeyLocalization.authenticatorAttachmentDescription}
-              </p>
-            </Field>
-          )}
 
           <DialogFooter>
             <DialogClose

--- a/examples/start-shadcn-baseui-example/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -30,7 +30,8 @@ export function AddPasskeyDialog({
   onOpenChange
 }: AddPasskeyDialogProps) {
   const { authClient, localization } = useAuth<PasskeyAuthClient>()
-  const { localization: passkeyLocalization } = useAuthPlugin(passkeyPlugin)
+  const { authenticatorAttachment, localization: passkeyLocalization } =
+    useAuthPlugin(passkeyPlugin)
 
   const { mutate: addPasskey, isPending: isAdding } = useAddPasskey(authClient)
 
@@ -40,9 +41,13 @@ export function AddPasskeyDialog({
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string)?.trim()
 
-    addPasskey(name ? { name } : undefined, {
-      onSuccess: () => onOpenChange(false)
-    })
+    addPasskey(
+      {
+        ...(name ? { name } : {}),
+        ...(authenticatorAttachment ? { authenticatorAttachment } : {})
+      },
+      { onSuccess: () => onOpenChange(false) }
+    )
   }
 
   return (

--- a/examples/start-shadcn-example/registry.json
+++ b/examples/start-shadcn-example/registry.json
@@ -925,7 +925,6 @@
         "field",
         "input",
         "item",
-        "select",
         "separator",
         "skeleton",
         "spinner"

--- a/examples/start-shadcn-example/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -1,9 +1,6 @@
 "use client"
 
-import {
-  type PasskeyAuthClient,
-  resolvePasskeyAuthenticatorAttachment
-} from "@better-auth-ui/core/plugins/passkey"
+import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useAddPasskey } from "@better-auth-ui/react/plugins/passkey"
 import { Fingerprint } from "lucide-react"
@@ -20,13 +17,6 @@ import {
 } from "@/components/ui/dialog"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
 
@@ -40,8 +30,7 @@ export function AddPasskeyDialog({
   onOpenChange
 }: AddPasskeyDialogProps) {
   const { authClient, localization } = useAuth<PasskeyAuthClient>()
-  const { authenticatorAttachment, localization: passkeyLocalization } =
-    useAuthPlugin(passkeyPlugin)
+  const { localization: passkeyLocalization } = useAuthPlugin(passkeyPlugin)
 
   const { mutate: addPasskey, isPending: isAdding } = useAddPasskey(authClient)
 
@@ -50,17 +39,10 @@ export function AddPasskeyDialog({
 
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string)?.trim()
-    const attachment = resolvePasskeyAuthenticatorAttachment(
-      formData.get("authenticatorAttachment")
-    )
 
-    addPasskey(
-      {
-        ...(name ? { name } : {}),
-        ...(attachment ? { authenticatorAttachment: attachment } : {})
-      },
-      { onSuccess: () => onOpenChange(false) }
-    )
+    addPasskey(name ? { name } : undefined, {
+      onSuccess: () => onOpenChange(false)
+    })
   }
 
   return (
@@ -93,43 +75,6 @@ export function AddPasskeyDialog({
 
             <FieldError />
           </Field>
-
-          {authenticatorAttachment !== false && (
-            <Field>
-              <FieldLabel htmlFor="passkey-authenticator-attachment">
-                {passkeyLocalization.authenticatorAttachment}
-              </FieldLabel>
-
-              <Select
-                name="authenticatorAttachment"
-                defaultValue={authenticatorAttachment}
-                disabled={isAdding}
-              >
-                <SelectTrigger
-                  id="passkey-authenticator-attachment"
-                  className="w-full"
-                >
-                  <SelectValue />
-                </SelectTrigger>
-
-                <SelectContent>
-                  <SelectItem value="any">
-                    {passkeyLocalization.anyAuthenticator}
-                  </SelectItem>
-                  <SelectItem value="platform">
-                    {passkeyLocalization.platformAuthenticator}
-                  </SelectItem>
-                  <SelectItem value="cross-platform">
-                    {passkeyLocalization.crossPlatformAuthenticator}
-                  </SelectItem>
-                </SelectContent>
-              </Select>
-
-              <p className="text-muted-foreground text-sm">
-                {passkeyLocalization.authenticatorAttachmentDescription}
-              </p>
-            </Field>
-          )}
 
           <DialogFooter>
             <DialogClose

--- a/examples/start-shadcn-example/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -30,7 +30,8 @@ export function AddPasskeyDialog({
   onOpenChange
 }: AddPasskeyDialogProps) {
   const { authClient, localization } = useAuth<PasskeyAuthClient>()
-  const { localization: passkeyLocalization } = useAuthPlugin(passkeyPlugin)
+  const { authenticatorAttachment, localization: passkeyLocalization } =
+    useAuthPlugin(passkeyPlugin)
 
   const { mutate: addPasskey, isPending: isAdding } = useAddPasskey(authClient)
 
@@ -40,9 +41,13 @@ export function AddPasskeyDialog({
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string)?.trim()
 
-    addPasskey(name ? { name } : undefined, {
-      onSuccess: () => onOpenChange(false)
-    })
+    addPasskey(
+      {
+        ...(name ? { name } : {}),
+        ...(authenticatorAttachment ? { authenticatorAttachment } : {})
+      },
+      { onSuccess: () => onOpenChange(false) }
+    )
   }
 
   return (

--- a/examples/start-solid-zaidan-example/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -1,8 +1,5 @@
-import {
-  type PasskeyAuthClient,
-  resolvePasskeyAuthenticatorAttachment
-} from "@better-auth-ui/core/plugins/passkey"
-import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
+import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
+import { useAuth } from "@better-auth-ui/solid"
 import { useAddPasskey } from "@better-auth-ui/solid/plugins/passkey"
 import { Fingerprint } from "lucide-solid"
 import { passkeyLabels } from "@/components/auth/passkey/passkey-localization"
@@ -17,9 +14,7 @@ import {
 } from "@/components/ui/dialog"
 import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import { NativeSelect, NativeSelectOption } from "@/components/ui/native-select"
 import { Spinner } from "@/components/ui/spinner"
-import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
 
 export function AddPasskeyDialog(props: {
   onOpenChange: (open: boolean) => void
@@ -27,7 +22,6 @@ export function AddPasskeyDialog(props: {
 }) {
   const auth = useAuth<PasskeyAuthClient>()
   const labels = () => passkeyLabels(auth)
-  const { authenticatorAttachment } = useAuthPlugin(passkeyPlugin)
   const addPasskey = useAddPasskey(auth.authClient, () => ({
     onSuccess: () => {
       props.onOpenChange(false)
@@ -40,14 +34,10 @@ export function AddPasskeyDialog(props: {
 
     const formData = new FormData(event.currentTarget as HTMLFormElement)
     const name = String(formData.get("name") ?? "").trim()
-    const attachment = resolvePasskeyAuthenticatorAttachment(
-      formData.get("authenticatorAttachment")
-    )
 
-    addPasskey.mutate({
-      ...(name ? { name } : {}),
-      ...(attachment ? { authenticatorAttachment: attachment } : {})
-    } as Parameters<typeof addPasskey.mutate>[0])
+    addPasskey.mutate(
+      (name ? { name } : undefined) as Parameters<typeof addPasskey.mutate>[0]
+    )
   }
 
   return (
@@ -71,36 +61,6 @@ export function AddPasskeyDialog(props: {
             placeholder={auth.localization.settings.optional}
           />
         </Field>
-
-        {authenticatorAttachment !== false ? (
-          <Field>
-            <FieldLabel for="passkey-authenticator-attachment">
-              {labels().authenticatorAttachment}
-            </FieldLabel>
-
-            <NativeSelect
-              class="w-full"
-              disabled={addPasskey.isPending}
-              id="passkey-authenticator-attachment"
-              name="authenticatorAttachment"
-              value={authenticatorAttachment}
-            >
-              <NativeSelectOption value="any">
-                {labels().anyAuthenticator}
-              </NativeSelectOption>
-              <NativeSelectOption value="platform">
-                {labels().platformAuthenticator}
-              </NativeSelectOption>
-              <NativeSelectOption value="cross-platform">
-                {labels().crossPlatformAuthenticator}
-              </NativeSelectOption>
-            </NativeSelect>
-
-            <p class="text-muted-foreground text-sm">
-              {labels().authenticatorAttachmentDescription}
-            </p>
-          </Field>
-        ) : null}
 
         <DialogFooter>
           <DialogClose

--- a/examples/start-solid-zaidan-example/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -1,5 +1,5 @@
 import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
-import { useAuth } from "@better-auth-ui/solid"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import { useAddPasskey } from "@better-auth-ui/solid/plugins/passkey"
 import { Fingerprint } from "lucide-solid"
 import { passkeyLabels } from "@/components/auth/passkey/passkey-localization"
@@ -15,6 +15,7 @@ import {
 import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
+import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
 
 export function AddPasskeyDialog(props: {
   onOpenChange: (open: boolean) => void
@@ -22,6 +23,7 @@ export function AddPasskeyDialog(props: {
 }) {
   const auth = useAuth<PasskeyAuthClient>()
   const labels = () => passkeyLabels(auth)
+  const { authenticatorAttachment } = useAuthPlugin(passkeyPlugin)
   const addPasskey = useAddPasskey(auth.authClient, () => ({
     onSuccess: () => {
       props.onOpenChange(false)
@@ -35,9 +37,10 @@ export function AddPasskeyDialog(props: {
     const formData = new FormData(event.currentTarget as HTMLFormElement)
     const name = String(formData.get("name") ?? "").trim()
 
-    addPasskey.mutate(
-      (name ? { name } : undefined) as Parameters<typeof addPasskey.mutate>[0]
-    )
+    addPasskey.mutate({
+      ...(name ? { name } : {}),
+      ...(authenticatorAttachment ? { authenticatorAttachment } : {})
+    } as Parameters<typeof addPasskey.mutate>[0])
   }
 
   return (

--- a/examples/start-solid-zaidan-example/tests/auth-route.test.ts
+++ b/examples/start-solid-zaidan-example/tests/auth-route.test.ts
@@ -2898,7 +2898,8 @@ describe("Solid auth route component selection", () => {
     expect(passkeys).toContain("onPasskeyAdded={() => passkeys.refetch()}")
     expect(addPasskeyDialog).toContain("props.onPasskeyAdded()")
     expect(addPasskeyDialog).toContain("addPasskey.mutate(")
-    expect(addPasskeyDialog).toContain("name ? { name } : undefined")
+    expect(addPasskeyDialog).toContain("useAuthPlugin(passkeyPlugin)")
+    expect(addPasskeyDialog).toContain("authenticatorAttachment")
     expect(addPasskeyDialog).toContain("props.onOpenChange(false)")
     expect(deletePasskeyDialog).toContain(
       "const auth = useAuth<PasskeyAuthClient>()"

--- a/examples/start-solid-zaidan-example/tests/auth-route.test.ts
+++ b/examples/start-solid-zaidan-example/tests/auth-route.test.ts
@@ -2898,8 +2898,7 @@ describe("Solid auth route component selection", () => {
     expect(passkeys).toContain("onPasskeyAdded={() => passkeys.refetch()}")
     expect(addPasskeyDialog).toContain("props.onPasskeyAdded()")
     expect(addPasskeyDialog).toContain("addPasskey.mutate(")
-    expect(addPasskeyDialog).toContain("resolvePasskeyAuthenticatorAttachment")
-    expect(addPasskeyDialog).toContain("authenticatorAttachment: attachment")
+    expect(addPasskeyDialog).toContain("name ? { name } : undefined")
     expect(addPasskeyDialog).toContain("props.onOpenChange(false)")
     expect(deletePasskeyDialog).toContain(
       "const auth = useAuth<PasskeyAuthClient>()"

--- a/packages/core/src/plugins/passkey/passkey-localization.ts
+++ b/packages/core/src/plugins/passkey/passkey-localization.ts
@@ -18,16 +18,6 @@ export const passkeyLocalization = {
   noPasskeys: "No passkeys",
   /** @remarks `"Name"` */
   name: "Name",
-  /** @remarks `"Passkey type"` */
-  authenticatorAttachment: "Passkey type",
-  /** @remarks `"Choose where to create this passkey."` */
-  authenticatorAttachmentDescription: "Choose where to create this passkey.",
-  /** @remarks `"Any available option"` */
-  anyAuthenticator: "Any available option",
-  /** @remarks `"This device"` */
-  platformAuthenticator: "This device",
-  /** @remarks `"Security key or another device"` */
-  crossPlatformAuthenticator: "Security key or another device",
   /** @remarks `"Rename passkey"` */
   renamePasskey: "Rename passkey",
   /** @remarks `"Passkey renamed"` */

--- a/packages/core/src/plugins/passkey/passkey-plugin.ts
+++ b/packages/core/src/plugins/passkey/passkey-plugin.ts
@@ -4,11 +4,6 @@ import {
   passkeyLocalization
 } from "./passkey-localization"
 
-export type PasskeyAuthenticatorAttachment =
-  | "any"
-  | "platform"
-  | "cross-platform"
-
 export type PasskeyPluginOptions = {
   /**
    * Offer passkeys through the browser's autofill dropdown (WebAuthn
@@ -21,15 +16,6 @@ export type PasskeyPluginOptions = {
    */
   autoFill?: boolean
   /**
-   * Show an authenticator choice when users add a passkey and select its
-   * initial value. Use `false` to hide the choice and let the browser decide.
-   *
-   * Better Auth forwards `"platform"` and `"cross-platform"` to WebAuthn.
-   * `"any"` leaves `authenticatorAttachment` unset.
-   * @default "any"
-   */
-  authenticatorAttachment?: PasskeyAuthenticatorAttachment | false
-  /**
    * Override the plugin's default localization strings.
    * @remarks `PasskeyLocalization`
    */
@@ -40,12 +26,6 @@ export const passkeyPlugin = createAuthPlugin(
   "passkey",
   (options: PasskeyPluginOptions = {}) => ({
     autoFill: options.autoFill ?? true,
-    authenticatorAttachment: options.authenticatorAttachment ?? "any",
     localization: { ...passkeyLocalization, ...options.localization }
   })
 )
-
-/** Convert the dialog choice to Better Auth's `addPasskey` parameter. */
-export function resolvePasskeyAuthenticatorAttachment(value: unknown) {
-  return value === "platform" || value === "cross-platform" ? value : undefined
-}

--- a/packages/core/src/plugins/passkey/passkey-plugin.ts
+++ b/packages/core/src/plugins/passkey/passkey-plugin.ts
@@ -4,6 +4,8 @@ import {
   passkeyLocalization
 } from "./passkey-localization"
 
+export type PasskeyAuthenticatorAttachment = "platform" | "cross-platform"
+
 export type PasskeyPluginOptions = {
   /**
    * Offer passkeys through the browser's autofill dropdown (WebAuthn
@@ -16,6 +18,14 @@ export type PasskeyPluginOptions = {
    */
   autoFill?: boolean
   /**
+   * Request one authenticator type for passkey registration. Omit this option
+   * to let the browser and operating system show all available choices.
+   *
+   * `"platform"` prefers this device. `"cross-platform"` prefers a security
+   * key or another device.
+   */
+  authenticatorAttachment?: PasskeyAuthenticatorAttachment
+  /**
    * Override the plugin's default localization strings.
    * @remarks `PasskeyLocalization`
    */
@@ -26,6 +36,7 @@ export const passkeyPlugin = createAuthPlugin(
   "passkey",
   (options: PasskeyPluginOptions = {}) => ({
     autoFill: options.autoFill ?? true,
+    authenticatorAttachment: options.authenticatorAttachment,
     localization: { ...passkeyLocalization, ...options.localization }
   })
 )

--- a/packages/core/tests/passkey-conditional-ui.test.ts
+++ b/packages/core/tests/passkey-conditional-ui.test.ts
@@ -52,6 +52,23 @@ describe("isPasskeyAutoFillEnabled", () => {
   })
 })
 
+describe("passkey authenticator attachment", () => {
+  it("lets the browser choose by default", () => {
+    expect(passkeyPlugin().authenticatorAttachment).toBeUndefined()
+  })
+
+  it("supports a plugin-level registration preference", () => {
+    expect(
+      passkeyPlugin({ authenticatorAttachment: "platform" })
+        .authenticatorAttachment
+    ).toBe("platform")
+    expect(
+      passkeyPlugin({ authenticatorAttachment: "cross-platform" })
+        .authenticatorAttachment
+    ).toBe("cross-platform")
+  })
+})
+
 describe("isConditionalMediationAvailable", () => {
   it("resolves false when the browser lacks the feature probe", async () => {
     stubPublicKeyCredential(null)

--- a/packages/core/tests/passkey-conditional-ui.test.ts
+++ b/packages/core/tests/passkey-conditional-ui.test.ts
@@ -3,7 +3,6 @@ import {
   isConditionalMediationAvailable,
   isPasskeyAutoFillEnabled,
   passkeyPlugin,
-  resolvePasskeyAuthenticatorAttachment,
   withPasskeyAutoFill
 } from "../src/plugins/passkey"
 
@@ -50,30 +49,6 @@ describe("isPasskeyAutoFillEnabled", () => {
 
   it("is off when the passkey plugin isn't registered", () => {
     expect(isPasskeyAutoFillEnabled([])).toBe(false)
-  })
-})
-
-describe("passkey authenticator attachment", () => {
-  it("defaults the registration dialog to any available authenticator", () => {
-    expect(passkeyPlugin().authenticatorAttachment).toBe("any")
-  })
-
-  it("supports a preferred authenticator and hiding the control", () => {
-    expect(
-      passkeyPlugin({ authenticatorAttachment: "platform" })
-        .authenticatorAttachment
-    ).toBe("platform")
-    expect(
-      passkeyPlugin({ authenticatorAttachment: false }).authenticatorAttachment
-    ).toBe(false)
-  })
-
-  it("only forwards WebAuthn attachment values", () => {
-    expect(resolvePasskeyAuthenticatorAttachment("platform")).toBe("platform")
-    expect(resolvePasskeyAuthenticatorAttachment("cross-platform")).toBe(
-      "cross-platform"
-    )
-    expect(resolvePasskeyAuthenticatorAttachment("any")).toBeUndefined()
   })
 })
 

--- a/packages/heroui/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/packages/heroui/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -1,20 +1,14 @@
-import {
-  type PasskeyAuthClient,
-  resolvePasskeyAuthenticatorAttachment
-} from "@better-auth-ui/core/plugins/passkey"
+import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useAddPasskey } from "@better-auth-ui/react/plugins/passkey"
 import { Fingerprint } from "@gravity-ui/icons"
 import {
   AlertDialog,
   Button,
-  Description,
   FieldError,
   Form,
   Input,
   Label,
-  ListBox,
-  Select,
   Spinner,
   TextField
 } from "@heroui/react"
@@ -32,8 +26,7 @@ export function AddPasskeyDialog({
   onOpenChange
 }: AddPasskeyDialogProps) {
   const { authClient, localization } = useAuth()
-  const { authenticatorAttachment, localization: passkeyLocalization } =
-    useAuthPlugin(passkeyPlugin)
+  const { localization: passkeyLocalization } = useAuthPlugin(passkeyPlugin)
 
   const { mutate: addPasskey, isPending: isAdding } = useAddPasskey(
     authClient as PasskeyAuthClient
@@ -48,17 +41,10 @@ export function AddPasskeyDialog({
 
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string)?.trim()
-    const attachment = resolvePasskeyAuthenticatorAttachment(
-      formData.get("authenticatorAttachment")
-    )
 
-    addPasskey(
-      {
-        ...(name ? { name } : {}),
-        ...(attachment ? { authenticatorAttachment: attachment } : {})
-      },
-      { onSuccess: () => handleOpenChange(false) }
-    )
+    addPasskey(name ? { name } : undefined, {
+      onSuccess: () => handleOpenChange(false)
+    })
   }
 
   return (
@@ -99,57 +85,6 @@ export function AddPasskeyDialog({
 
                 <FieldError />
               </TextField>
-
-              {authenticatorAttachment !== false && (
-                <Select
-                  className="mt-4"
-                  defaultSelectedKey={authenticatorAttachment}
-                  isDisabled={isAdding}
-                  name="authenticatorAttachment"
-                  variant="secondary"
-                >
-                  <Label>{passkeyLocalization.authenticatorAttachment}</Label>
-
-                  <Select.Trigger>
-                    <Select.Value />
-                    <Select.Indicator />
-                  </Select.Trigger>
-
-                  <Select.Popover>
-                    <ListBox>
-                      <ListBox.Item
-                        id="any"
-                        textValue={passkeyLocalization.anyAuthenticator}
-                      >
-                        {passkeyLocalization.anyAuthenticator}
-                        <ListBox.ItemIndicator />
-                      </ListBox.Item>
-
-                      <ListBox.Item
-                        id="platform"
-                        textValue={passkeyLocalization.platformAuthenticator}
-                      >
-                        {passkeyLocalization.platformAuthenticator}
-                        <ListBox.ItemIndicator />
-                      </ListBox.Item>
-
-                      <ListBox.Item
-                        id="cross-platform"
-                        textValue={
-                          passkeyLocalization.crossPlatformAuthenticator
-                        }
-                      >
-                        {passkeyLocalization.crossPlatformAuthenticator}
-                        <ListBox.ItemIndicator />
-                      </ListBox.Item>
-                    </ListBox>
-                  </Select.Popover>
-
-                  <Description>
-                    {passkeyLocalization.authenticatorAttachmentDescription}
-                  </Description>
-                </Select>
-              )}
             </AlertDialog.Body>
 
             <AlertDialog.Footer>

--- a/packages/heroui/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/packages/heroui/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -26,7 +26,8 @@ export function AddPasskeyDialog({
   onOpenChange
 }: AddPasskeyDialogProps) {
   const { authClient, localization } = useAuth()
-  const { localization: passkeyLocalization } = useAuthPlugin(passkeyPlugin)
+  const { authenticatorAttachment, localization: passkeyLocalization } =
+    useAuthPlugin(passkeyPlugin)
 
   const { mutate: addPasskey, isPending: isAdding } = useAddPasskey(
     authClient as PasskeyAuthClient
@@ -42,9 +43,13 @@ export function AddPasskeyDialog({
     const formData = new FormData(e.target as HTMLFormElement)
     const name = (formData.get("name") as string)?.trim()
 
-    addPasskey(name ? { name } : undefined, {
-      onSuccess: () => handleOpenChange(false)
-    })
+    addPasskey(
+      {
+        ...(name ? { name } : {}),
+        ...(authenticatorAttachment ? { authenticatorAttachment } : {})
+      },
+      { onSuccess: () => handleOpenChange(false) }
+    )
   }
 
   return (

--- a/packages/heroui/tests/passkeys.test.tsx
+++ b/packages/heroui/tests/passkeys.test.tsx
@@ -212,14 +212,17 @@ function createPasskeysAuthClient(
   }
 }
 
-function renderPasskeys(authClient = createPasskeysAuthClient()) {
+function renderPasskeys(
+  authClient = createPasskeysAuthClient(),
+  pluginOptions?: Parameters<typeof passkeyPlugin>[0]
+) {
   return {
     authClient,
     ...render(
       <AuthProvider
         authClient={authClient}
         navigate={() => {}}
-        plugins={[passkeyPlugin()]}
+        plugins={[passkeyPlugin(pluginOptions)]}
         queryClient={createTestQueryClient()}
       >
         <Passkeys />
@@ -296,6 +299,9 @@ describe("<Passkeys />", () => {
     expect(authClient.passkey.addPasskey.mock.calls[0][0]).not.toHaveProperty(
       "name"
     )
+    expect(authClient.passkey.addPasskey.mock.calls[0][0]).not.toHaveProperty(
+      "authenticatorAttachment"
+    )
   })
 
   it("forwards the typed name to addPasskey", async () => {
@@ -331,6 +337,32 @@ describe("<Passkeys />", () => {
         fetchOptions: expect.objectContaining({ throw: true })
       })
     )
+  })
+
+  it("forwards the configured authenticator preference without a selector", async () => {
+    const user = userEvent.setup()
+    const authClient = createPasskeysAuthClient()
+    renderPasskeys(authClient, { authenticatorAttachment: "platform" })
+
+    await user.click(
+      await screen.findByRole("button", { name: /add passkey/i })
+    )
+
+    const dialog = await screen.findByRole("alertdialog")
+    expect(within(dialog).queryByRole("combobox")).not.toBeInTheDocument()
+
+    await user.click(
+      within(dialog).getByRole("button", { name: /add passkey/i })
+    )
+
+    await waitFor(() => {
+      expect(authClient.passkey.addPasskey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          authenticatorAttachment: "platform",
+          fetchOptions: expect.objectContaining({ throw: true })
+        })
+      )
+    })
   })
 
   it("renders registered passkeys", async () => {

--- a/packages/heroui/tests/passkeys.test.tsx
+++ b/packages/heroui/tests/passkeys.test.tsx
@@ -212,17 +212,14 @@ function createPasskeysAuthClient(
   }
 }
 
-function renderPasskeys(
-  authClient = createPasskeysAuthClient(),
-  pluginOptions?: Parameters<typeof passkeyPlugin>[0]
-) {
+function renderPasskeys(authClient = createPasskeysAuthClient()) {
   return {
     authClient,
     ...render(
       <AuthProvider
         authClient={authClient}
         navigate={() => {}}
-        plugins={[passkeyPlugin(pluginOptions)]}
+        plugins={[passkeyPlugin()]}
         queryClient={createTestQueryClient()}
       >
         <Passkeys />
@@ -334,44 +331,6 @@ describe("<Passkeys />", () => {
         fetchOptions: expect.objectContaining({ throw: true })
       })
     )
-  })
-
-  it("forwards the configured authenticator choice to addPasskey", async () => {
-    const user = userEvent.setup()
-    const authClient = createPasskeysAuthClient()
-    renderPasskeys(authClient, { authenticatorAttachment: "platform" })
-
-    await user.click(
-      await screen.findByRole("button", { name: /add passkey/i })
-    )
-
-    const dialog = await screen.findByRole("alertdialog")
-    await user.click(
-      within(dialog).getByRole("button", { name: /add passkey/i })
-    )
-
-    await waitFor(() => {
-      expect(authClient.passkey.addPasskey).toHaveBeenCalledWith(
-        expect.objectContaining({
-          authenticatorAttachment: "platform",
-          fetchOptions: expect.objectContaining({ throw: true })
-        })
-      )
-    })
-  })
-
-  it("can hide the authenticator choice", async () => {
-    const user = userEvent.setup()
-    renderPasskeys(createPasskeysAuthClient(), {
-      authenticatorAttachment: false
-    })
-
-    await user.click(
-      await screen.findByRole("button", { name: /add passkey/i })
-    )
-
-    const dialog = await screen.findByRole("alertdialog")
-    expect(within(dialog).queryByText("Passkey type")).not.toBeInTheDocument()
   })
 
   it("renders registered passkeys", async () => {

--- a/packages/locales/src/de-DE-plugins.ts
+++ b/packages/locales/src/de-DE-plugins.ts
@@ -530,12 +530,6 @@ export const deDEPlugins = {
       "Erstelle einen Passkey für den sicheren Zugriff auf dein Konto.",
     noPasskeys: "Keine Passkeys",
     name: "Name",
-    authenticatorAttachment: "Passkey-Typ",
-    authenticatorAttachmentDescription:
-      "Wähle aus, wo dieser Passkey erstellt werden soll.",
-    anyAuthenticator: "Beliebige verfügbare Option",
-    platformAuthenticator: "Dieses Gerät",
-    crossPlatformAuthenticator: "Sicherheitsschlüssel oder anderes Gerät",
     renamePasskey: "Passkey umbenennen",
     renamePasskeySuccess: "Passkey umbenannt"
   } satisfies Translated<PasskeyLocalization>,


### PR DESCRIPTION
## Summary

- revert the selector-based passkey registration controls introduced in #521
- keep `authenticatorAttachment` as an optional passkey plugin policy with `platform` and `cross-platform` values
- leave the option unset by default so the browser and operating system present the available passkey choices
- remove the selector UI, localization strings, and shadcn registry dependency across React, HeroUI, Base UI, and Solid consumers
- document and test both the browser-default behavior and plugin-level override

## Validation

- `bun nx test @better-auth-ui/core -- --run tests/passkey-conditional-ui.test.ts`
- `bun nx test @better-auth-ui/heroui -- --run tests/passkeys.test.tsx`
- `bun nx test start-solid-zaidan-example -- --run tests/auth-route.test.ts`
- `bun nx typecheck start-shadcn-example --skip-nx-cache`
- `bun nx typecheck start-solid-zaidan-example`
- `bun nx run-many -t typecheck -p start-shadcn-baseui-example @better-auth-ui/heroui @better-auth-ui/locales docs`
- `bun nx run-many -t lint -p next-shadcn-example docs`
- Biome check on all modified source files
- shadcn and Solid registry builds
