### PR TITLE
feat(sso): manage organization providers

### DIFF
--- a/apps/docs/src/components/auth/sso/organization-sso-providers.tsx
+++ b/apps/docs/src/components/auth/sso/organization-sso-providers.tsx
@@ -1,0 +1,504 @@
+"use client"
+
+import {
+  hasMemberRole,
+  type OrganizationAuthClient
+} from "@better-auth-ui/core/plugins/organization"
+import type {
+  SsoAuthClient,
+  SsoProvider,
+  UpdateSsoProviderParams
+} from "@better-auth-ui/core/plugins/sso"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
+import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
+import {
+  useDeleteSsoProvider,
+  useSsoProviders,
+  useUpdateSsoProvider
+} from "@better-auth-ui/react/plugins/sso"
+import type { BetterFetchError } from "better-auth/client"
+import { PencilIcon, Trash2Icon } from "lucide-react"
+import { type FormEvent, useMemo, useState } from "react"
+import { toast } from "sonner"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle
+} from "@/components/ui/empty"
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel
+} from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Spinner } from "@/components/ui/spinner"
+import { Textarea } from "@/components/ui/textarea"
+import { ssoPlugin } from "@/lib/auth/sso-plugin"
+import { cn } from "@/lib/utils"
+
+import { SsoDomainVerification } from "./sso-domain-verification"
+import { SsoProviderSetup } from "./sso-provider-setup"
+
+export type OrganizationSsoProvidersProps = {
+  className?: string
+  organizationId: string
+  organizationSlug: string
+}
+
+const providerSkeletonIds = ["sso-provider-1", "sso-provider-2"]
+
+const readString = (formData: FormData, name: string) =>
+  String(formData.get(name) ?? "").trim()
+
+const getErrorMessage = (error: Error | null) => {
+  const authError = error as BetterFetchError | null
+  return authError?.error?.message ?? authError?.message
+}
+
+/** Manage the SSO providers that belong to one explicit organization. */
+export function OrganizationSsoProviders({
+  className,
+  organizationId,
+  organizationSlug: _organizationSlug
+}: OrganizationSsoProvidersProps) {
+  const { authClient } = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const memberRole = useActiveMemberRole(authClient as OrganizationAuthClient, {
+    query: { organizationId }
+  })
+  const canManage =
+    hasMemberRole(memberRole.data?.role, "owner") ||
+    hasMemberRole(memberRole.data?.role, "admin")
+  const providersQuery = useSsoProviders(authClient as SsoAuthClient, {
+    enabled: !memberRole.isPending && canManage
+  })
+  const [creating, setCreating] = useState(false)
+  const [editing, setEditing] = useState<SsoProvider>()
+  const [verifying, setVerifying] = useState<SsoProvider>()
+  const [deleting, setDeleting] = useState<SsoProvider>()
+  const providers = useMemo(
+    () =>
+      providersQuery.data?.providers.filter(
+        (provider) => provider.organizationId === organizationId
+      ) ?? [],
+    [organizationId, providersQuery.data?.providers]
+  )
+
+  return (
+    <Card className={cn(className)}>
+      <CardHeader>
+        <CardTitle>{localization.providerList}</CardTitle>
+        <CardDescription>
+          {localization.providerListDescription}
+        </CardDescription>
+        <CardAction>
+          <Button
+            disabled={memberRole.isPending || !canManage}
+            onClick={() => setCreating((open) => !open)}
+            size="sm"
+          >
+            {localization.addProvider}
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {creating ? (
+          <SsoProviderSetup
+            className="max-w-none"
+            organizationId={organizationId}
+            onRegistered={() => setCreating(false)}
+          />
+        ) : null}
+
+        {memberRole.isPending || (canManage && providersQuery.isPending) ? (
+          <div className="flex flex-col gap-2">
+            {providerSkeletonIds.map((id) => (
+              <Skeleton className="h-24 w-full" key={id} />
+            ))}
+          </div>
+        ) : !canManage ? (
+          <div
+            className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-sm"
+            role="alert"
+          >
+            {localization.providerAccessDenied}
+          </div>
+        ) : providersQuery.error ? (
+          <div
+            className="flex items-center justify-between gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm"
+            role="alert"
+          >
+            <span>{localization.providerLoadError}</span>
+            <Button
+              onClick={() => providersQuery.refetch()}
+              size="sm"
+              variant="outline"
+            >
+              {localization.retry}
+            </Button>
+          </div>
+        ) : providers.length ? (
+          <div className="flex flex-col gap-2">
+            {providers.map((provider) => (
+              <div
+                className="flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+                key={provider.providerId}
+              >
+                <div className="flex min-w-0 flex-col gap-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium">{provider.providerId}</span>
+                    <Badge variant="outline">
+                      {provider.type.toUpperCase()}
+                    </Badge>
+                    <Badge
+                      variant={
+                        provider.domainVerified ? "secondary" : "outline"
+                      }
+                    >
+                      {provider.domainVerified
+                        ? localization.domainVerified
+                        : localization.verifyDomain}
+                    </Badge>
+                  </div>
+                  <span className="truncate text-sm text-muted-foreground">
+                    {provider.domain} · {provider.issuer}
+                  </span>
+                </div>
+                <div className="flex shrink-0 flex-wrap gap-2">
+                  {!provider.domainVerified ? (
+                    <Button
+                      onClick={() => setVerifying(provider)}
+                      size="sm"
+                      variant="outline"
+                    >
+                      {localization.verifyDomain}
+                    </Button>
+                  ) : null}
+                  <Button
+                    aria-label={localization.editProvider}
+                    onClick={() => setEditing(provider)}
+                    size="icon-sm"
+                    variant="ghost"
+                  >
+                    <PencilIcon />
+                  </Button>
+                  <Button
+                    aria-label={localization.deleteProvider}
+                    onClick={() => setDeleting(provider)}
+                    size="icon-sm"
+                    variant="destructive"
+                  >
+                    <Trash2Icon />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <Empty className="min-h-32 border">
+            <EmptyHeader>
+              <EmptyTitle>{localization.noProviders}</EmptyTitle>
+              <EmptyDescription>
+                {localization.noProvidersDescription}
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        )}
+      </CardContent>
+
+      <EditSsoProviderDialog onOpenChange={setEditing} provider={editing} />
+      <DeleteSsoProviderDialog onOpenChange={setDeleting} provider={deleting} />
+      <Dialog
+        open={Boolean(verifying)}
+        onOpenChange={(open) => !open && setVerifying(undefined)}
+      >
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>{localization.domainVerification}</DialogTitle>
+          </DialogHeader>
+          {verifying ? (
+            <SsoDomainVerification
+              className="max-w-none shadow-none ring-0"
+              defaultProviderId={verifying.providerId}
+            />
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </Card>
+  )
+}
+
+function EditSsoProviderDialog({
+  onOpenChange,
+  provider
+}: {
+  onOpenChange: (provider: SsoProvider | undefined) => void
+  provider?: SsoProvider
+}) {
+  const { authClient } = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const update = useUpdateSsoProvider(authClient as SsoAuthClient)
+
+  const close = () => {
+    update.reset()
+    onOpenChange(undefined)
+  }
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!provider) return
+    const data = new FormData(event.currentTarget)
+    const clientId = readString(data, "clientId")
+    const clientSecret = readString(data, "clientSecret")
+    const identityProviderMetadata = readString(
+      data,
+      "identityProviderMetadata"
+    )
+    const params = {
+      providerId: provider.providerId,
+      issuer: readString(data, "issuer"),
+      domain: readString(data, "domain"),
+      ...(provider.oidcConfig
+        ? {
+            oidcConfig: {
+              ...(clientId ? { clientId } : {}),
+              ...(clientSecret ? { clientSecret } : {}),
+              discoveryEndpoint:
+                readString(data, "discoveryEndpoint") || undefined
+            }
+          }
+        : {}),
+      ...(provider.samlConfig
+        ? {
+            samlConfig: {
+              entryPoint: readString(data, "entryPoint"),
+              ...(identityProviderMetadata
+                ? { idpMetadata: { metadata: identityProviderMetadata } }
+                : {})
+            }
+          }
+        : {})
+    } as UpdateSsoProviderParams
+
+    update.mutate(params, {
+      onSuccess: () => {
+        toast.success(localization.providerUpdated)
+        close()
+      }
+    })
+  }
+
+  return (
+    <Dialog
+      open={Boolean(provider)}
+      onOpenChange={(open) => {
+        if (!open && !update.isPending) close()
+      }}
+    >
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
+        <form className="flex flex-col gap-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{localization.editProvider}</DialogTitle>
+            <DialogDescription>{provider?.providerId}</DialogDescription>
+          </DialogHeader>
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor="sso-edit-domain">
+                {localization.domain}
+              </FieldLabel>
+              <Input
+                defaultValue={provider?.domain}
+                id="sso-edit-domain"
+                name="domain"
+                required
+              />
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="sso-edit-issuer">
+                {localization.issuer}
+              </FieldLabel>
+              <Input
+                defaultValue={provider?.issuer}
+                id="sso-edit-issuer"
+                name="issuer"
+                required
+                type="url"
+              />
+            </Field>
+            {provider?.oidcConfig ? (
+              <>
+                <Field>
+                  <FieldLabel htmlFor="sso-edit-discovery">
+                    {localization.discoveryEndpoint}
+                  </FieldLabel>
+                  <Input
+                    defaultValue={provider.oidcConfig.discoveryEndpoint}
+                    id="sso-edit-discovery"
+                    name="discoveryEndpoint"
+                    type="url"
+                  />
+                </Field>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <Field>
+                    <FieldLabel htmlFor="sso-edit-client-id">
+                      {localization.clientId}
+                    </FieldLabel>
+                    <Input
+                      id="sso-edit-client-id"
+                      name="clientId"
+                      placeholder={`••••${provider.oidcConfig.clientIdLastFour}`}
+                    />
+                  </Field>
+                  <Field>
+                    <FieldLabel htmlFor="sso-edit-client-secret">
+                      {localization.clientSecret}
+                    </FieldLabel>
+                    <Input
+                      autoComplete="new-password"
+                      id="sso-edit-client-secret"
+                      name="clientSecret"
+                      type="password"
+                    />
+                  </Field>
+                </div>
+              </>
+            ) : null}
+            {provider?.samlConfig ? (
+              <>
+                <Field>
+                  <FieldLabel htmlFor="sso-edit-entry-point">
+                    {localization.entryPoint}
+                  </FieldLabel>
+                  <Input
+                    defaultValue={provider.samlConfig.entryPoint}
+                    id="sso-edit-entry-point"
+                    name="entryPoint"
+                    required
+                    type="url"
+                  />
+                </Field>
+                <Field>
+                  <FieldLabel htmlFor="sso-edit-metadata">
+                    {localization.identityProviderMetadata}
+                  </FieldLabel>
+                  <Textarea
+                    className="font-mono text-xs"
+                    id="sso-edit-metadata"
+                    name="identityProviderMetadata"
+                    rows={6}
+                  />
+                </Field>
+              </>
+            ) : null}
+          </FieldGroup>
+          <FieldError>{getErrorMessage(update.error)}</FieldError>
+          <DialogFooter>
+            <Button
+              disabled={update.isPending}
+              onClick={close}
+              type="button"
+              variant="outline"
+            >
+              {localization.cancel}
+            </Button>
+            <Button disabled={update.isPending} type="submit">
+              {update.isPending ? <Spinner data-icon="inline-start" /> : null}
+              {localization.saveProvider}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function DeleteSsoProviderDialog({
+  onOpenChange,
+  provider
+}: {
+  onOpenChange: (provider: SsoProvider | undefined) => void
+  provider?: SsoProvider
+}) {
+  const { authClient } = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const remove = useDeleteSsoProvider(authClient as SsoAuthClient)
+  const close = () => {
+    remove.reset()
+    onOpenChange(undefined)
+  }
+
+  return (
+    <AlertDialog
+      open={Boolean(provider)}
+      onOpenChange={(open) => {
+        if (!open && !remove.isPending) close()
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{localization.deleteProvider}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {localization.deleteProviderDescription}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <p className="font-mono text-xs">{provider?.providerId}</p>
+        <FieldError>{getErrorMessage(remove.error)}</FieldError>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={remove.isPending}>
+            {localization.cancel}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            disabled={remove.isPending}
+            onClick={(event) => {
+              event.preventDefault()
+              if (!provider) return
+              remove.mutate(
+                { providerId: provider.providerId },
+                {
+                  onSuccess: () => {
+                    toast.success(localization.providerDeleted)
+                    close()
+                  }
+                }
+              )
+            }}
+            variant="destructive"
+          >
+            {localization.deleteProvider}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/apps/docs/src/components/auth/sso/sso-domain-verification.tsx
+++ b/apps/docs/src/components/auth/sso/sso-domain-verification.tsx
@@ -90,6 +90,7 @@ export function SsoDomainVerification({
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    setCopyError("")
     setVerified(false)
     verify.mutate({ providerId })
   }
@@ -115,6 +116,7 @@ export function SsoDomainVerification({
                 value={providerId}
                 onChange={(event) => {
                   setProviderId(event.target.value.trim())
+                  setToken("")
                   setVerified(false)
                 }}
                 required
@@ -190,6 +192,7 @@ export function SsoDomainVerification({
                 variant="outline"
                 disabled={!providerId || verify.isPending}
                 onClick={() => {
+                  setCopyError("")
                   setVerified(false)
                   requestToken.mutate({ providerId })
                 }}

--- a/apps/docs/src/lib/auth/sso-plugin.ts
+++ b/apps/docs/src/lib/auth/sso-plugin.ts
@@ -1,20 +1,47 @@
-import { createAuthPlugin } from "@better-auth-ui/core"
+import {
+  type AuthPluginBase,
+  type AuthPluginLocalizationContext,
+  createAuthPlugin
+} from "@better-auth-ui/core"
 import {
   ssoPlugin as coreSsoPlugin,
+  type SsoLocalization,
   type SsoPluginOptions
 } from "@better-auth-ui/core/plugins/sso"
 
 import { EmailFirstSignIn } from "@/components/auth/sso/email-first-sign-in"
+import { OrganizationSsoProviders } from "@/components/auth/sso/organization-sso-providers"
 
 export const ssoPlugin = createAuthPlugin(
   coreSsoPlugin.id,
   (options: SsoPluginOptions = {}) => {
     const plugin = coreSsoPlugin(options)
+    const localizedOrganizationTab = (localization: SsoLocalization) =>
+      plugin.organization
+        ? {
+            organizationTabs: [
+              {
+                id: "sso",
+                path: plugin.path,
+                label: localization.providerList,
+                component: OrganizationSsoProviders
+              }
+            ]
+          }
+        : {}
 
     return {
       ...plugin,
+      ...localizedOrganizationTab(plugin.localization),
       ...(plugin.emailFirst && {
         views: { auth: { signIn: EmailFirstSignIn } }
+      }),
+      _localizationResolver: (
+        resolvedPlugin: AuthPluginBase,
+        context: AuthPluginLocalizationContext
+      ) => ({
+        ...resolvedPlugin,
+        ...localizedOrganizationTab(context.localization as SsoLocalization)
       })
     }
   }

--- a/examples/next-shadcn-example/src/components/auth/sso/organization-sso-providers.tsx
+++ b/examples/next-shadcn-example/src/components/auth/sso/organization-sso-providers.tsx
@@ -1,0 +1,504 @@
+"use client"
+
+import {
+  hasMemberRole,
+  type OrganizationAuthClient
+} from "@better-auth-ui/core/plugins/organization"
+import type {
+  SsoAuthClient,
+  SsoProvider,
+  UpdateSsoProviderParams
+} from "@better-auth-ui/core/plugins/sso"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
+import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
+import {
+  useDeleteSsoProvider,
+  useSsoProviders,
+  useUpdateSsoProvider
+} from "@better-auth-ui/react/plugins/sso"
+import type { BetterFetchError } from "better-auth/client"
+import { PencilIcon, Trash2Icon } from "lucide-react"
+import { type FormEvent, useMemo, useState } from "react"
+import { toast } from "sonner"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle
+} from "@/components/ui/empty"
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel
+} from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Spinner } from "@/components/ui/spinner"
+import { Textarea } from "@/components/ui/textarea"
+import { ssoPlugin } from "@/lib/auth/sso-plugin"
+import { cn } from "@/lib/utils"
+
+import { SsoDomainVerification } from "./sso-domain-verification"
+import { SsoProviderSetup } from "./sso-provider-setup"
+
+export type OrganizationSsoProvidersProps = {
+  className?: string
+  organizationId: string
+  organizationSlug: string
+}
+
+const providerSkeletonIds = ["sso-provider-1", "sso-provider-2"]
+
+const readString = (formData: FormData, name: string) =>
+  String(formData.get(name) ?? "").trim()
+
+const getErrorMessage = (error: Error | null) => {
+  const authError = error as BetterFetchError | null
+  return authError?.error?.message ?? authError?.message
+}
+
+/** Manage the SSO providers that belong to one explicit organization. */
+export function OrganizationSsoProviders({
+  className,
+  organizationId,
+  organizationSlug: _organizationSlug
+}: OrganizationSsoProvidersProps) {
+  const { authClient } = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const memberRole = useActiveMemberRole(authClient as OrganizationAuthClient, {
+    query: { organizationId }
+  })
+  const canManage =
+    hasMemberRole(memberRole.data?.role, "owner") ||
+    hasMemberRole(memberRole.data?.role, "admin")
+  const providersQuery = useSsoProviders(authClient as SsoAuthClient, {
+    enabled: !memberRole.isPending && canManage
+  })
+  const [creating, setCreating] = useState(false)
+  const [editing, setEditing] = useState<SsoProvider>()
+  const [verifying, setVerifying] = useState<SsoProvider>()
+  const [deleting, setDeleting] = useState<SsoProvider>()
+  const providers = useMemo(
+    () =>
+      providersQuery.data?.providers.filter(
+        (provider) => provider.organizationId === organizationId
+      ) ?? [],
+    [organizationId, providersQuery.data?.providers]
+  )
+
+  return (
+    <Card className={cn(className)}>
+      <CardHeader>
+        <CardTitle>{localization.providerList}</CardTitle>
+        <CardDescription>
+          {localization.providerListDescription}
+        </CardDescription>
+        <CardAction>
+          <Button
+            disabled={memberRole.isPending || !canManage}
+            onClick={() => setCreating((open) => !open)}
+            size="sm"
+          >
+            {localization.addProvider}
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {creating ? (
+          <SsoProviderSetup
+            className="max-w-none"
+            organizationId={organizationId}
+            onRegistered={() => setCreating(false)}
+          />
+        ) : null}
+
+        {memberRole.isPending || (canManage && providersQuery.isPending) ? (
+          <div className="flex flex-col gap-2">
+            {providerSkeletonIds.map((id) => (
+              <Skeleton className="h-24 w-full" key={id} />
+            ))}
+          </div>
+        ) : !canManage ? (
+          <div
+            className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-sm"
+            role="alert"
+          >
+            {localization.providerAccessDenied}
+          </div>
+        ) : providersQuery.error ? (
+          <div
+            className="flex items-center justify-between gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm"
+            role="alert"
+          >
+            <span>{localization.providerLoadError}</span>
+            <Button
+              onClick={() => providersQuery.refetch()}
+              size="sm"
+              variant="outline"
+            >
+              {localization.retry}
+            </Button>
+          </div>
+        ) : providers.length ? (
+          <div className="flex flex-col gap-2">
+            {providers.map((provider) => (
+              <div
+                className="flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+                key={provider.providerId}
+              >
+                <div className="flex min-w-0 flex-col gap-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium">{provider.providerId}</span>
+                    <Badge variant="outline">
+                      {provider.type.toUpperCase()}
+                    </Badge>
+                    <Badge
+                      variant={
+                        provider.domainVerified ? "secondary" : "outline"
+                      }
+                    >
+                      {provider.domainVerified
+                        ? localization.domainVerified
+                        : localization.verifyDomain}
+                    </Badge>
+                  </div>
+                  <span className="truncate text-sm text-muted-foreground">
+                    {provider.domain} · {provider.issuer}
+                  </span>
+                </div>
+                <div className="flex shrink-0 flex-wrap gap-2">
+                  {!provider.domainVerified ? (
+                    <Button
+                      onClick={() => setVerifying(provider)}
+                      size="sm"
+                      variant="outline"
+                    >
+                      {localization.verifyDomain}
+                    </Button>
+                  ) : null}
+                  <Button
+                    aria-label={localization.editProvider}
+                    onClick={() => setEditing(provider)}
+                    size="icon-sm"
+                    variant="ghost"
+                  >
+                    <PencilIcon />
+                  </Button>
+                  <Button
+                    aria-label={localization.deleteProvider}
+                    onClick={() => setDeleting(provider)}
+                    size="icon-sm"
+                    variant="destructive"
+                  >
+                    <Trash2Icon />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <Empty className="min-h-32 border">
+            <EmptyHeader>
+              <EmptyTitle>{localization.noProviders}</EmptyTitle>
+              <EmptyDescription>
+                {localization.noProvidersDescription}
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        )}
+      </CardContent>
+
+      <EditSsoProviderDialog onOpenChange={setEditing} provider={editing} />
+      <DeleteSsoProviderDialog onOpenChange={setDeleting} provider={deleting} />
+      <Dialog
+        open={Boolean(verifying)}
+        onOpenChange={(open) => !open && setVerifying(undefined)}
+      >
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>{localization.domainVerification}</DialogTitle>
+          </DialogHeader>
+          {verifying ? (
+            <SsoDomainVerification
+              className="max-w-none shadow-none ring-0"
+              defaultProviderId={verifying.providerId}
+            />
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </Card>
+  )
+}
+
+function EditSsoProviderDialog({
+  onOpenChange,
+  provider
+}: {
+  onOpenChange: (provider: SsoProvider | undefined) => void
+  provider?: SsoProvider
+}) {
+  const { authClient } = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const update = useUpdateSsoProvider(authClient as SsoAuthClient)
+
+  const close = () => {
+    update.reset()
+    onOpenChange(undefined)
+  }
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!provider) return
+    const data = new FormData(event.currentTarget)
+    const clientId = readString(data, "clientId")
+    const clientSecret = readString(data, "clientSecret")
+    const identityProviderMetadata = readString(
+      data,
+      "identityProviderMetadata"
+    )
+    const params = {
+      providerId: provider.providerId,
+      issuer: readString(data, "issuer"),
+      domain: readString(data, "domain"),
+      ...(provider.oidcConfig
+        ? {
+            oidcConfig: {
+              ...(clientId ? { clientId } : {}),
+              ...(clientSecret ? { clientSecret } : {}),
+              discoveryEndpoint:
+                readString(data, "discoveryEndpoint") || undefined
+            }
+          }
+        : {}),
+      ...(provider.samlConfig
+        ? {
+            samlConfig: {
+              entryPoint: readString(data, "entryPoint"),
+              ...(identityProviderMetadata
+                ? { idpMetadata: { metadata: identityProviderMetadata } }
+                : {})
+            }
+          }
+        : {})
+    } as UpdateSsoProviderParams
+
+    update.mutate(params, {
+      onSuccess: () => {
+        toast.success(localization.providerUpdated)
+        close()
+      }
+    })
+  }
+
+  return (
+    <Dialog
+      open={Boolean(provider)}
+      onOpenChange={(open) => {
+        if (!open && !update.isPending) close()
+      }}
+    >
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
+        <form className="flex flex-col gap-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{localization.editProvider}</DialogTitle>
+            <DialogDescription>{provider?.providerId}</DialogDescription>
+          </DialogHeader>
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor="sso-edit-domain">
+                {localization.domain}
+              </FieldLabel>
+              <Input
+                defaultValue={provider?.domain}
+                id="sso-edit-domain"
+                name="domain"
+                required
+              />
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="sso-edit-issuer">
+                {localization.issuer}
+              </FieldLabel>
+              <Input
+                defaultValue={provider?.issuer}
+                id="sso-edit-issuer"
+                name="issuer"
+                required
+                type="url"
+              />
+            </Field>
+            {provider?.oidcConfig ? (
+              <>
+                <Field>
+                  <FieldLabel htmlFor="sso-edit-discovery">
+                    {localization.discoveryEndpoint}
+                  </FieldLabel>
+                  <Input
+                    defaultValue={provider.oidcConfig.discoveryEndpoint}
+                    id="sso-edit-discovery"
+                    name="discoveryEndpoint"
+                    type="url"
+                  />
+                </Field>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <Field>
+                    <FieldLabel htmlFor="sso-edit-client-id">
+                      {localization.clientId}
+                    </FieldLabel>
+                    <Input
+                      id="sso-edit-client-id"
+                      name="clientId"
+                      placeholder={`••••${provider.oidcConfig.clientIdLastFour}`}
+                    />
+                  </Field>
+                  <Field>
+                    <FieldLabel htmlFor="sso-edit-client-secret">
+                      {localization.clientSecret}
+                    </FieldLabel>
+                    <Input
+                      autoComplete="new-password"
+                      id="sso-edit-client-secret"
+                      name="clientSecret"
+                      type="password"
+                    />
+                  </Field>
+                </div>
+              </>
+            ) : null}
+            {provider?.samlConfig ? (
+              <>
+                <Field>
+                  <FieldLabel htmlFor="sso-edit-entry-point">
+                    {localization.entryPoint}
+                  </FieldLabel>
+                  <Input
+                    defaultValue={provider.samlConfig.entryPoint}
+                    id="sso-edit-entry-point"
+                    name="entryPoint"
+                    required
+                    type="url"
+                  />
+                </Field>
+                <Field>
+                  <FieldLabel htmlFor="sso-edit-metadata">
+                    {localization.identityProviderMetadata}
+                  </FieldLabel>
+                  <Textarea
+                    className="font-mono text-xs"
+                    id="sso-edit-metadata"
+                    name="identityProviderMetadata"
+                    rows={6}
+                  />
+                </Field>
+              </>
+            ) : null}
+          </FieldGroup>
+          <FieldError>{getErrorMessage(update.error)}</FieldError>
+          <DialogFooter>
+            <Button
+              disabled={update.isPending}
+              onClick={close}
+              type="button"
+              variant="outline"
+            >
+              {localization.cancel}
+            </Button>
+            <Button disabled={update.isPending} type="submit">
+              {update.isPending ? <Spinner data-icon="inline-start" /> : null}
+              {localization.saveProvider}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function DeleteSsoProviderDialog({
+  onOpenChange,
+  provider
+}: {
+  onOpenChange: (provider: SsoProvider | undefined) => void
+  provider?: SsoProvider
+}) {
+  const { authClient } = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const remove = useDeleteSsoProvider(authClient as SsoAuthClient)
+  const close = () => {
+    remove.reset()
+    onOpenChange(undefined)
+  }
+
+  return (
+    <AlertDialog
+      open={Boolean(provider)}
+      onOpenChange={(open) => {
+        if (!open && !remove.isPending) close()
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{localization.deleteProvider}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {localization.deleteProviderDescription}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <p className="font-mono text-xs">{provider?.providerId}</p>
+        <FieldError>{getErrorMessage(remove.error)}</FieldError>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={remove.isPending}>
+            {localization.cancel}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            disabled={remove.isPending}
+            onClick={(event) => {
+              event.preventDefault()
+              if (!provider) return
+              remove.mutate(
+                { providerId: provider.providerId },
+                {
+                  onSuccess: () => {
+                    toast.success(localization.providerDeleted)
+                    close()
+                  }
+                }
+              )
+            }}
+            variant="destructive"
+          >
+            {localization.deleteProvider}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/examples/next-shadcn-example/src/components/auth/sso/sso-domain-verification.tsx
+++ b/examples/next-shadcn-example/src/components/auth/sso/sso-domain-verification.tsx
@@ -90,6 +90,7 @@ export function SsoDomainVerification({
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    setCopyError("")
     setVerified(false)
     verify.mutate({ providerId })
   }
@@ -115,6 +116,7 @@ export function SsoDomainVerification({
                 value={providerId}
                 onChange={(event) => {
                   setProviderId(event.target.value.trim())
+                  setToken("")
                   setVerified(false)
                 }}
                 required
@@ -190,6 +192,7 @@ export function SsoDomainVerification({
                 variant="outline"
                 disabled={!providerId || verify.isPending}
                 onClick={() => {
+                  setCopyError("")
                   setVerified(false)
                   requestToken.mutate({ providerId })
                 }}

--- a/examples/next-shadcn-example/src/components/auth/sso/sso-provider-setup.tsx
+++ b/examples/next-shadcn-example/src/components/auth/sso/sso-provider-setup.tsx
@@ -38,6 +38,7 @@ type SsoProtocol = "oidc" | "saml"
 export type SsoProviderSetupProps = {
   className?: string
   defaultOrganizationId?: string
+  organizationId?: string
   onRegistered?: (provider: RegisterSsoProviderData) => void
 }
 
@@ -53,6 +54,7 @@ const getErrorMessage = (error: Error | null) => {
 export function SsoProviderSetup({
   className,
   defaultOrganizationId,
+  organizationId: fixedOrganizationId,
   onRegistered
 }: SsoProviderSetupProps) {
   const { authClient } = useAuth()
@@ -70,7 +72,10 @@ export function SsoProviderSetup({
       providerId: readString(formData, "providerId"),
       issuer: readString(formData, "issuer"),
       domain: readString(formData, "domain"),
-      organizationId: readString(formData, "organizationId") || undefined
+      organizationId:
+        fixedOrganizationId ||
+        readString(formData, "organizationId") ||
+        undefined
     }
     const params =
       protocol === "oidc"
@@ -143,16 +148,18 @@ export function SsoProviderSetup({
               />
             </Field>
 
-            <Field>
-              <FieldLabel htmlFor="sso-organization-id">
-                {localization.organizationId}
-              </FieldLabel>
-              <Input
-                defaultValue={defaultOrganizationId}
-                id="sso-organization-id"
-                name="organizationId"
-              />
-            </Field>
+            {!fixedOrganizationId ? (
+              <Field>
+                <FieldLabel htmlFor="sso-organization-id">
+                  {localization.organizationId}
+                </FieldLabel>
+                <Input
+                  defaultValue={defaultOrganizationId}
+                  id="sso-organization-id"
+                  name="organizationId"
+                />
+              </Field>
+            ) : null}
 
             <Tabs
               value={protocol}

--- a/examples/next-shadcn-example/src/lib/auth/sso-plugin.ts
+++ b/examples/next-shadcn-example/src/lib/auth/sso-plugin.ts
@@ -1,20 +1,47 @@
-import { createAuthPlugin } from "@better-auth-ui/core"
+import {
+  type AuthPluginBase,
+  type AuthPluginLocalizationContext,
+  createAuthPlugin
+} from "@better-auth-ui/core"
 import {
   ssoPlugin as coreSsoPlugin,
+  type SsoLocalization,
   type SsoPluginOptions
 } from "@better-auth-ui/core/plugins/sso"
 
 import { EmailFirstSignIn } from "@/components/auth/sso/email-first-sign-in"
+import { OrganizationSsoProviders } from "@/components/auth/sso/organization-sso-providers"
 
 export const ssoPlugin = createAuthPlugin(
   coreSsoPlugin.id,
   (options: SsoPluginOptions = {}) => {
     const plugin = coreSsoPlugin(options)
+    const localizedOrganizationTab = (localization: SsoLocalization) =>
+      plugin.organization
+        ? {
+            organizationTabs: [
+              {
+                id: "sso",
+                path: plugin.path,
+                label: localization.providerList,
+                component: OrganizationSsoProviders
+              }
+            ]
+          }
+        : {}
 
     return {
       ...plugin,
+      ...localizedOrganizationTab(plugin.localization),
       ...(plugin.emailFirst && {
         views: { auth: { signIn: EmailFirstSignIn } }
+      }),
+      _localizationResolver: (
+        resolvedPlugin: AuthPluginBase,
+        context: AuthPluginLocalizationContext
+      ) => ({
+        ...resolvedPlugin,
+        ...localizedOrganizationTab(context.localization as SsoLocalization)
       })
     }
   }

--- a/examples/start-shadcn-baseui-example/src/components/auth/sso/organization-sso-providers.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/sso/organization-sso-providers.tsx
@@ -1,0 +1,504 @@
+"use client"
+
+import {
+  hasMemberRole,
+  type OrganizationAuthClient
+} from "@better-auth-ui/core/plugins/organization"
+import type {
+  SsoAuthClient,
+  SsoProvider,
+  UpdateSsoProviderParams
+} from "@better-auth-ui/core/plugins/sso"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
+import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
+import {
+  useDeleteSsoProvider,
+  useSsoProviders,
+  useUpdateSsoProvider
+} from "@better-auth-ui/react/plugins/sso"
+import type { BetterFetchError } from "better-auth/client"
+import { PencilIcon, Trash2Icon } from "lucide-react"
+import { type FormEvent, useMemo, useState } from "react"
+import { toast } from "sonner"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle
+} from "@/components/ui/empty"
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel
+} from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Spinner } from "@/components/ui/spinner"
+import { Textarea } from "@/components/ui/textarea"
+import { ssoPlugin } from "@/lib/auth/sso-plugin"
+import { cn } from "@/lib/utils"
+
+import { SsoDomainVerification } from "./sso-domain-verification"
+import { SsoProviderSetup } from "./sso-provider-setup"
+
+export type OrganizationSsoProvidersProps = {
+  className?: string
+  organizationId: string
+  organizationSlug: string
+}
+
+const providerSkeletonIds = ["sso-provider-1", "sso-provider-2"]
+
+const readString = (formData: FormData, name: string) =>
+  String(formData.get(name) ?? "").trim()
+
+const getErrorMessage = (error: Error | null) => {
+  const authError = error as BetterFetchError | null
+  return authError?.error?.message ?? authError?.message
+}
+
+/** Manage the SSO providers that belong to one explicit organization. */
+export function OrganizationSsoProviders({
+  className,
+  organizationId,
+  organizationSlug: _organizationSlug
+}: OrganizationSsoProvidersProps) {
+  const { authClient } = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const memberRole = useActiveMemberRole(authClient as OrganizationAuthClient, {
+    query: { organizationId }
+  })
+  const canManage =
+    hasMemberRole(memberRole.data?.role, "owner") ||
+    hasMemberRole(memberRole.data?.role, "admin")
+  const providersQuery = useSsoProviders(authClient as SsoAuthClient, {
+    enabled: !memberRole.isPending && canManage
+  })
+  const [creating, setCreating] = useState(false)
+  const [editing, setEditing] = useState<SsoProvider>()
+  const [verifying, setVerifying] = useState<SsoProvider>()
+  const [deleting, setDeleting] = useState<SsoProvider>()
+  const providers = useMemo(
+    () =>
+      providersQuery.data?.providers.filter(
+        (provider) => provider.organizationId === organizationId
+      ) ?? [],
+    [organizationId, providersQuery.data?.providers]
+  )
+
+  return (
+    <Card className={cn(className)}>
+      <CardHeader>
+        <CardTitle>{localization.providerList}</CardTitle>
+        <CardDescription>
+          {localization.providerListDescription}
+        </CardDescription>
+        <CardAction>
+          <Button
+            disabled={memberRole.isPending || !canManage}
+            onClick={() => setCreating((open) => !open)}
+            size="sm"
+          >
+            {localization.addProvider}
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {creating ? (
+          <SsoProviderSetup
+            className="max-w-none"
+            organizationId={organizationId}
+            onRegistered={() => setCreating(false)}
+          />
+        ) : null}
+
+        {memberRole.isPending || (canManage && providersQuery.isPending) ? (
+          <div className="flex flex-col gap-2">
+            {providerSkeletonIds.map((id) => (
+              <Skeleton className="h-24 w-full" key={id} />
+            ))}
+          </div>
+        ) : !canManage ? (
+          <div
+            className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-sm"
+            role="alert"
+          >
+            {localization.providerAccessDenied}
+          </div>
+        ) : providersQuery.error ? (
+          <div
+            className="flex items-center justify-between gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm"
+            role="alert"
+          >
+            <span>{localization.providerLoadError}</span>
+            <Button
+              onClick={() => providersQuery.refetch()}
+              size="sm"
+              variant="outline"
+            >
+              {localization.retry}
+            </Button>
+          </div>
+        ) : providers.length ? (
+          <div className="flex flex-col gap-2">
+            {providers.map((provider) => (
+              <div
+                className="flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+                key={provider.providerId}
+              >
+                <div className="flex min-w-0 flex-col gap-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium">{provider.providerId}</span>
+                    <Badge variant="outline">
+                      {provider.type.toUpperCase()}
+                    </Badge>
+                    <Badge
+                      variant={
+                        provider.domainVerified ? "secondary" : "outline"
+                      }
+                    >
+                      {provider.domainVerified
+                        ? localization.domainVerified
+                        : localization.verifyDomain}
+                    </Badge>
+                  </div>
+                  <span className="truncate text-sm text-muted-foreground">
+                    {provider.domain} · {provider.issuer}
+                  </span>
+                </div>
+                <div className="flex shrink-0 flex-wrap gap-2">
+                  {!provider.domainVerified ? (
+                    <Button
+                      onClick={() => setVerifying(provider)}
+                      size="sm"
+                      variant="outline"
+                    >
+                      {localization.verifyDomain}
+                    </Button>
+                  ) : null}
+                  <Button
+                    aria-label={localization.editProvider}
+                    onClick={() => setEditing(provider)}
+                    size="icon-sm"
+                    variant="ghost"
+                  >
+                    <PencilIcon />
+                  </Button>
+                  <Button
+                    aria-label={localization.deleteProvider}
+                    onClick={() => setDeleting(provider)}
+                    size="icon-sm"
+                    variant="destructive"
+                  >
+                    <Trash2Icon />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <Empty className="min-h-32 border">
+            <EmptyHeader>
+              <EmptyTitle>{localization.noProviders}</EmptyTitle>
+              <EmptyDescription>
+                {localization.noProvidersDescription}
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        )}
+      </CardContent>
+
+      <EditSsoProviderDialog onOpenChange={setEditing} provider={editing} />
+      <DeleteSsoProviderDialog onOpenChange={setDeleting} provider={deleting} />
+      <Dialog
+        open={Boolean(verifying)}
+        onOpenChange={(open) => !open && setVerifying(undefined)}
+      >
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>{localization.domainVerification}</DialogTitle>
+          </DialogHeader>
+          {verifying ? (
+            <SsoDomainVerification
+              className="max-w-none shadow-none ring-0"
+              defaultProviderId={verifying.providerId}
+            />
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </Card>
+  )
+}
+
+function EditSsoProviderDialog({
+  onOpenChange,
+  provider
+}: {
+  onOpenChange: (provider: SsoProvider | undefined) => void
+  provider?: SsoProvider
+}) {
+  const { authClient } = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const update = useUpdateSsoProvider(authClient as SsoAuthClient)
+
+  const close = () => {
+    update.reset()
+    onOpenChange(undefined)
+  }
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!provider) return
+    const data = new FormData(event.currentTarget)
+    const clientId = readString(data, "clientId")
+    const clientSecret = readString(data, "clientSecret")
+    const identityProviderMetadata = readString(
+      data,
+      "identityProviderMetadata"
+    )
+    const params = {
+      providerId: provider.providerId,
+      issuer: readString(data, "issuer"),
+      domain: readString(data, "domain"),
+      ...(provider.oidcConfig
+        ? {
+            oidcConfig: {
+              ...(clientId ? { clientId } : {}),
+              ...(clientSecret ? { clientSecret } : {}),
+              discoveryEndpoint:
+                readString(data, "discoveryEndpoint") || undefined
+            }
+          }
+        : {}),
+      ...(provider.samlConfig
+        ? {
+            samlConfig: {
+              entryPoint: readString(data, "entryPoint"),
+              ...(identityProviderMetadata
+                ? { idpMetadata: { metadata: identityProviderMetadata } }
+                : {})
+            }
+          }
+        : {})
+    } as UpdateSsoProviderParams
+
+    update.mutate(params, {
+      onSuccess: () => {
+        toast.success(localization.providerUpdated)
+        close()
+      }
+    })
+  }
+
+  return (
+    <Dialog
+      open={Boolean(provider)}
+      onOpenChange={(open) => {
+        if (!open && !update.isPending) close()
+      }}
+    >
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
+        <form className="flex flex-col gap-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{localization.editProvider}</DialogTitle>
+            <DialogDescription>{provider?.providerId}</DialogDescription>
+          </DialogHeader>
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor="sso-edit-domain">
+                {localization.domain}
+              </FieldLabel>
+              <Input
+                defaultValue={provider?.domain}
+                id="sso-edit-domain"
+                name="domain"
+                required
+              />
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="sso-edit-issuer">
+                {localization.issuer}
+              </FieldLabel>
+              <Input
+                defaultValue={provider?.issuer}
+                id="sso-edit-issuer"
+                name="issuer"
+                required
+                type="url"
+              />
+            </Field>
+            {provider?.oidcConfig ? (
+              <>
+                <Field>
+                  <FieldLabel htmlFor="sso-edit-discovery">
+                    {localization.discoveryEndpoint}
+                  </FieldLabel>
+                  <Input
+                    defaultValue={provider.oidcConfig.discoveryEndpoint}
+                    id="sso-edit-discovery"
+                    name="discoveryEndpoint"
+                    type="url"
+                  />
+                </Field>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <Field>
+                    <FieldLabel htmlFor="sso-edit-client-id">
+                      {localization.clientId}
+                    </FieldLabel>
+                    <Input
+                      id="sso-edit-client-id"
+                      name="clientId"
+                      placeholder={`••••${provider.oidcConfig.clientIdLastFour}`}
+                    />
+                  </Field>
+                  <Field>
+                    <FieldLabel htmlFor="sso-edit-client-secret">
+                      {localization.clientSecret}
+                    </FieldLabel>
+                    <Input
+                      autoComplete="new-password"
+                      id="sso-edit-client-secret"
+                      name="clientSecret"
+                      type="password"
+                    />
+                  </Field>
+                </div>
+              </>
+            ) : null}
+            {provider?.samlConfig ? (
+              <>
+                <Field>
+                  <FieldLabel htmlFor="sso-edit-entry-point">
+                    {localization.entryPoint}
+                  </FieldLabel>
+                  <Input
+                    defaultValue={provider.samlConfig.entryPoint}
+                    id="sso-edit-entry-point"
+                    name="entryPoint"
+                    required
+                    type="url"
+                  />
+                </Field>
+                <Field>
+                  <FieldLabel htmlFor="sso-edit-metadata">
+                    {localization.identityProviderMetadata}
+                  </FieldLabel>
+                  <Textarea
+                    className="font-mono text-xs"
+                    id="sso-edit-metadata"
+                    name="identityProviderMetadata"
+                    rows={6}
+                  />
+                </Field>
+              </>
+            ) : null}
+          </FieldGroup>
+          <FieldError>{getErrorMessage(update.error)}</FieldError>
+          <DialogFooter>
+            <Button
+              disabled={update.isPending}
+              onClick={close}
+              type="button"
+              variant="outline"
+            >
+              {localization.cancel}
+            </Button>
+            <Button disabled={update.isPending} type="submit">
+              {update.isPending ? <Spinner data-icon="inline-start" /> : null}
+              {localization.saveProvider}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function DeleteSsoProviderDialog({
+  onOpenChange,
+  provider
+}: {
+  onOpenChange: (provider: SsoProvider | undefined) => void
+  provider?: SsoProvider
+}) {
+  const { authClient } = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const remove = useDeleteSsoProvider(authClient as SsoAuthClient)
+  const close = () => {
+    remove.reset()
+    onOpenChange(undefined)
+  }
+
+  return (
+    <AlertDialog
+      open={Boolean(provider)}
+      onOpenChange={(open) => {
+        if (!open && !remove.isPending) close()
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{localization.deleteProvider}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {localization.deleteProviderDescription}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <p className="font-mono text-xs">{provider?.providerId}</p>
+        <FieldError>{getErrorMessage(remove.error)}</FieldError>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={remove.isPending}>
+            {localization.cancel}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            disabled={remove.isPending}
+            onClick={(event) => {
+              event.preventDefault()
+              if (!provider) return
+              remove.mutate(
+                { providerId: provider.providerId },
+                {
+                  onSuccess: () => {
+                    toast.success(localization.providerDeleted)
+                    close()
+                  }
+                }
+              )
+            }}
+            variant="destructive"
+          >
+            {localization.deleteProvider}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/examples/start-shadcn-baseui-example/src/components/auth/sso/sso-domain-verification.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/sso/sso-domain-verification.tsx
@@ -90,6 +90,7 @@ export function SsoDomainVerification({
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    setCopyError("")
     setVerified(false)
     verify.mutate({ providerId })
   }
@@ -115,6 +116,7 @@ export function SsoDomainVerification({
                 value={providerId}
                 onChange={(event) => {
                   setProviderId(event.target.value.trim())
+                  setToken("")
                   setVerified(false)
                 }}
                 required
@@ -190,6 +192,7 @@ export function SsoDomainVerification({
                 variant="outline"
                 disabled={!providerId || verify.isPending}
                 onClick={() => {
+                  setCopyError("")
                   setVerified(false)
                   requestToken.mutate({ providerId })
                 }}

--- a/examples/start-shadcn-baseui-example/src/components/auth/sso/sso-provider-setup.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/sso/sso-provider-setup.tsx
@@ -38,6 +38,7 @@ type SsoProtocol = "oidc" | "saml"
 export type SsoProviderSetupProps = {
   className?: string
   defaultOrganizationId?: string
+  organizationId?: string
   onRegistered?: (provider: RegisterSsoProviderData) => void
 }
 
@@ -53,6 +54,7 @@ const getErrorMessage = (error: Error | null) => {
 export function SsoProviderSetup({
   className,
   defaultOrganizationId,
+  organizationId: fixedOrganizationId,
   onRegistered
 }: SsoProviderSetupProps) {
   const { authClient } = useAuth()
@@ -70,7 +72,10 @@ export function SsoProviderSetup({
       providerId: readString(formData, "providerId"),
       issuer: readString(formData, "issuer"),
       domain: readString(formData, "domain"),
-      organizationId: readString(formData, "organizationId") || undefined
+      organizationId:
+        fixedOrganizationId ||
+        readString(formData, "organizationId") ||
+        undefined
     }
     const params =
       protocol === "oidc"
@@ -143,16 +148,18 @@ export function SsoProviderSetup({
               />
             </Field>
 
-            <Field>
-              <FieldLabel htmlFor="sso-organization-id">
-                {localization.organizationId}
-              </FieldLabel>
-              <Input
-                defaultValue={defaultOrganizationId}
-                id="sso-organization-id"
-                name="organizationId"
-              />
-            </Field>
+            {!fixedOrganizationId ? (
+              <Field>
+                <FieldLabel htmlFor="sso-organization-id">
+                  {localization.organizationId}
+                </FieldLabel>
+                <Input
+                  defaultValue={defaultOrganizationId}
+                  id="sso-organization-id"
+                  name="organizationId"
+                />
+              </Field>
+            ) : null}
 
             <Tabs
               value={protocol}

--- a/examples/start-shadcn-baseui-example/src/lib/auth/sso-plugin.ts
+++ b/examples/start-shadcn-baseui-example/src/lib/auth/sso-plugin.ts
@@ -1,20 +1,47 @@
-import { createAuthPlugin } from "@better-auth-ui/core"
+import {
+  type AuthPluginBase,
+  type AuthPluginLocalizationContext,
+  createAuthPlugin
+} from "@better-auth-ui/core"
 import {
   ssoPlugin as coreSsoPlugin,
+  type SsoLocalization,
   type SsoPluginOptions
 } from "@better-auth-ui/core/plugins/sso"
 
 import { EmailFirstSignIn } from "@/components/auth/sso/email-first-sign-in"
+import { OrganizationSsoProviders } from "@/components/auth/sso/organization-sso-providers"
 
 export const ssoPlugin = createAuthPlugin(
   coreSsoPlugin.id,
   (options: SsoPluginOptions = {}) => {
     const plugin = coreSsoPlugin(options)
+    const localizedOrganizationTab = (localization: SsoLocalization) =>
+      plugin.organization
+        ? {
+            organizationTabs: [
+              {
+                id: "sso",
+                path: plugin.path,
+                label: localization.providerList,
+                component: OrganizationSsoProviders
+              }
+            ]
+          }
+        : {}
 
     return {
       ...plugin,
+      ...localizedOrganizationTab(plugin.localization),
       ...(plugin.emailFirst && {
         views: { auth: { signIn: EmailFirstSignIn } }
+      }),
+      _localizationResolver: (
+        resolvedPlugin: AuthPluginBase,
+        context: AuthPluginLocalizationContext
+      ) => ({
+        ...resolvedPlugin,
+        ...localizedOrganizationTab(context.localization as SsoLocalization)
       })
     }
   }

--- a/examples/start-shadcn-example/registry.json
+++ b/examples/start-shadcn-example/registry.json
@@ -196,21 +196,27 @@
       "name": "sso",
       "type": "registry:component",
       "title": "SSO and Email-First Sign In",
-      "description": "Discovers organization SSO from an email address, then falls back to configured password, email OTP, magic-link, or plugin sign-in methods.",
+      "description": "Discovers organization SSO from an email address and manages organization identity providers and domain verification.",
       "dependencies": [
         "@better-auth-ui/react@latest",
         "@better-auth-ui/core@latest",
         "@better-auth/sso",
         "better-auth",
-        "lucide-react"
+        "lucide-react",
+        "sonner"
       ],
       "registryDependencies": [
+        "alert-dialog",
+        "badge",
         "button",
         "card",
         "checkbox",
+        "dialog",
+        "empty",
         "field",
         "input",
         "input-group",
+        "skeleton",
         "spinner",
         "tabs",
         "textarea",
@@ -231,6 +237,11 @@
           "path": "src/components/auth/sso/email-first-sign-in.tsx",
           "type": "registry:component",
           "target": "@components/auth/sso/email-first-sign-in.tsx"
+        },
+        {
+          "path": "src/components/auth/sso/organization-sso-providers.tsx",
+          "type": "registry:component",
+          "target": "@components/auth/sso/organization-sso-providers.tsx"
         },
         {
           "path": "src/components/auth/sso/sso-domain-verification.tsx",

--- a/examples/start-shadcn-example/src/components/auth/sso/organization-sso-providers.tsx
+++ b/examples/start-shadcn-example/src/components/auth/sso/organization-sso-providers.tsx
@@ -1,0 +1,504 @@
+"use client"
+
+import {
+  hasMemberRole,
+  type OrganizationAuthClient
+} from "@better-auth-ui/core/plugins/organization"
+import type {
+  SsoAuthClient,
+  SsoProvider,
+  UpdateSsoProviderParams
+} from "@better-auth-ui/core/plugins/sso"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
+import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
+import {
+  useDeleteSsoProvider,
+  useSsoProviders,
+  useUpdateSsoProvider
+} from "@better-auth-ui/react/plugins/sso"
+import type { BetterFetchError } from "better-auth/client"
+import { PencilIcon, Trash2Icon } from "lucide-react"
+import { type FormEvent, useMemo, useState } from "react"
+import { toast } from "sonner"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle
+} from "@/components/ui/empty"
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel
+} from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Spinner } from "@/components/ui/spinner"
+import { Textarea } from "@/components/ui/textarea"
+import { ssoPlugin } from "@/lib/auth/sso-plugin"
+import { cn } from "@/lib/utils"
+
+import { SsoDomainVerification } from "./sso-domain-verification"
+import { SsoProviderSetup } from "./sso-provider-setup"
+
+export type OrganizationSsoProvidersProps = {
+  className?: string
+  organizationId: string
+  organizationSlug: string
+}
+
+const providerSkeletonIds = ["sso-provider-1", "sso-provider-2"]
+
+const readString = (formData: FormData, name: string) =>
+  String(formData.get(name) ?? "").trim()
+
+const getErrorMessage = (error: Error | null) => {
+  const authError = error as BetterFetchError | null
+  return authError?.error?.message ?? authError?.message
+}
+
+/** Manage the SSO providers that belong to one explicit organization. */
+export function OrganizationSsoProviders({
+  className,
+  organizationId,
+  organizationSlug: _organizationSlug
+}: OrganizationSsoProvidersProps) {
+  const { authClient } = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const memberRole = useActiveMemberRole(authClient as OrganizationAuthClient, {
+    query: { organizationId }
+  })
+  const canManage =
+    hasMemberRole(memberRole.data?.role, "owner") ||
+    hasMemberRole(memberRole.data?.role, "admin")
+  const providersQuery = useSsoProviders(authClient as SsoAuthClient, {
+    enabled: !memberRole.isPending && canManage
+  })
+  const [creating, setCreating] = useState(false)
+  const [editing, setEditing] = useState<SsoProvider>()
+  const [verifying, setVerifying] = useState<SsoProvider>()
+  const [deleting, setDeleting] = useState<SsoProvider>()
+  const providers = useMemo(
+    () =>
+      providersQuery.data?.providers.filter(
+        (provider) => provider.organizationId === organizationId
+      ) ?? [],
+    [organizationId, providersQuery.data?.providers]
+  )
+
+  return (
+    <Card className={cn(className)}>
+      <CardHeader>
+        <CardTitle>{localization.providerList}</CardTitle>
+        <CardDescription>
+          {localization.providerListDescription}
+        </CardDescription>
+        <CardAction>
+          <Button
+            disabled={memberRole.isPending || !canManage}
+            onClick={() => setCreating((open) => !open)}
+            size="sm"
+          >
+            {localization.addProvider}
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-4">
+        {creating ? (
+          <SsoProviderSetup
+            className="max-w-none"
+            organizationId={organizationId}
+            onRegistered={() => setCreating(false)}
+          />
+        ) : null}
+
+        {memberRole.isPending || (canManage && providersQuery.isPending) ? (
+          <div className="flex flex-col gap-2">
+            {providerSkeletonIds.map((id) => (
+              <Skeleton className="h-24 w-full" key={id} />
+            ))}
+          </div>
+        ) : !canManage ? (
+          <div
+            className="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-sm"
+            role="alert"
+          >
+            {localization.providerAccessDenied}
+          </div>
+        ) : providersQuery.error ? (
+          <div
+            className="flex items-center justify-between gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm"
+            role="alert"
+          >
+            <span>{localization.providerLoadError}</span>
+            <Button
+              onClick={() => providersQuery.refetch()}
+              size="sm"
+              variant="outline"
+            >
+              {localization.retry}
+            </Button>
+          </div>
+        ) : providers.length ? (
+          <div className="flex flex-col gap-2">
+            {providers.map((provider) => (
+              <div
+                className="flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+                key={provider.providerId}
+              >
+                <div className="flex min-w-0 flex-col gap-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium">{provider.providerId}</span>
+                    <Badge variant="outline">
+                      {provider.type.toUpperCase()}
+                    </Badge>
+                    <Badge
+                      variant={
+                        provider.domainVerified ? "secondary" : "outline"
+                      }
+                    >
+                      {provider.domainVerified
+                        ? localization.domainVerified
+                        : localization.verifyDomain}
+                    </Badge>
+                  </div>
+                  <span className="truncate text-sm text-muted-foreground">
+                    {provider.domain} · {provider.issuer}
+                  </span>
+                </div>
+                <div className="flex shrink-0 flex-wrap gap-2">
+                  {!provider.domainVerified ? (
+                    <Button
+                      onClick={() => setVerifying(provider)}
+                      size="sm"
+                      variant="outline"
+                    >
+                      {localization.verifyDomain}
+                    </Button>
+                  ) : null}
+                  <Button
+                    aria-label={localization.editProvider}
+                    onClick={() => setEditing(provider)}
+                    size="icon-sm"
+                    variant="ghost"
+                  >
+                    <PencilIcon />
+                  </Button>
+                  <Button
+                    aria-label={localization.deleteProvider}
+                    onClick={() => setDeleting(provider)}
+                    size="icon-sm"
+                    variant="destructive"
+                  >
+                    <Trash2Icon />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <Empty className="min-h-32 border">
+            <EmptyHeader>
+              <EmptyTitle>{localization.noProviders}</EmptyTitle>
+              <EmptyDescription>
+                {localization.noProvidersDescription}
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        )}
+      </CardContent>
+
+      <EditSsoProviderDialog onOpenChange={setEditing} provider={editing} />
+      <DeleteSsoProviderDialog onOpenChange={setDeleting} provider={deleting} />
+      <Dialog
+        open={Boolean(verifying)}
+        onOpenChange={(open) => !open && setVerifying(undefined)}
+      >
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
+          <DialogHeader>
+            <DialogTitle>{localization.domainVerification}</DialogTitle>
+          </DialogHeader>
+          {verifying ? (
+            <SsoDomainVerification
+              className="max-w-none shadow-none ring-0"
+              defaultProviderId={verifying.providerId}
+            />
+          ) : null}
+        </DialogContent>
+      </Dialog>
+    </Card>
+  )
+}
+
+function EditSsoProviderDialog({
+  onOpenChange,
+  provider
+}: {
+  onOpenChange: (provider: SsoProvider | undefined) => void
+  provider?: SsoProvider
+}) {
+  const { authClient } = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const update = useUpdateSsoProvider(authClient as SsoAuthClient)
+
+  const close = () => {
+    update.reset()
+    onOpenChange(undefined)
+  }
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!provider) return
+    const data = new FormData(event.currentTarget)
+    const clientId = readString(data, "clientId")
+    const clientSecret = readString(data, "clientSecret")
+    const identityProviderMetadata = readString(
+      data,
+      "identityProviderMetadata"
+    )
+    const params = {
+      providerId: provider.providerId,
+      issuer: readString(data, "issuer"),
+      domain: readString(data, "domain"),
+      ...(provider.oidcConfig
+        ? {
+            oidcConfig: {
+              ...(clientId ? { clientId } : {}),
+              ...(clientSecret ? { clientSecret } : {}),
+              discoveryEndpoint:
+                readString(data, "discoveryEndpoint") || undefined
+            }
+          }
+        : {}),
+      ...(provider.samlConfig
+        ? {
+            samlConfig: {
+              entryPoint: readString(data, "entryPoint"),
+              ...(identityProviderMetadata
+                ? { idpMetadata: { metadata: identityProviderMetadata } }
+                : {})
+            }
+          }
+        : {})
+    } as UpdateSsoProviderParams
+
+    update.mutate(params, {
+      onSuccess: () => {
+        toast.success(localization.providerUpdated)
+        close()
+      }
+    })
+  }
+
+  return (
+    <Dialog
+      open={Boolean(provider)}
+      onOpenChange={(open) => {
+        if (!open && !update.isPending) close()
+      }}
+    >
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
+        <form className="flex flex-col gap-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{localization.editProvider}</DialogTitle>
+            <DialogDescription>{provider?.providerId}</DialogDescription>
+          </DialogHeader>
+          <FieldGroup>
+            <Field>
+              <FieldLabel htmlFor="sso-edit-domain">
+                {localization.domain}
+              </FieldLabel>
+              <Input
+                defaultValue={provider?.domain}
+                id="sso-edit-domain"
+                name="domain"
+                required
+              />
+            </Field>
+            <Field>
+              <FieldLabel htmlFor="sso-edit-issuer">
+                {localization.issuer}
+              </FieldLabel>
+              <Input
+                defaultValue={provider?.issuer}
+                id="sso-edit-issuer"
+                name="issuer"
+                required
+                type="url"
+              />
+            </Field>
+            {provider?.oidcConfig ? (
+              <>
+                <Field>
+                  <FieldLabel htmlFor="sso-edit-discovery">
+                    {localization.discoveryEndpoint}
+                  </FieldLabel>
+                  <Input
+                    defaultValue={provider.oidcConfig.discoveryEndpoint}
+                    id="sso-edit-discovery"
+                    name="discoveryEndpoint"
+                    type="url"
+                  />
+                </Field>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <Field>
+                    <FieldLabel htmlFor="sso-edit-client-id">
+                      {localization.clientId}
+                    </FieldLabel>
+                    <Input
+                      id="sso-edit-client-id"
+                      name="clientId"
+                      placeholder={`••••${provider.oidcConfig.clientIdLastFour}`}
+                    />
+                  </Field>
+                  <Field>
+                    <FieldLabel htmlFor="sso-edit-client-secret">
+                      {localization.clientSecret}
+                    </FieldLabel>
+                    <Input
+                      autoComplete="new-password"
+                      id="sso-edit-client-secret"
+                      name="clientSecret"
+                      type="password"
+                    />
+                  </Field>
+                </div>
+              </>
+            ) : null}
+            {provider?.samlConfig ? (
+              <>
+                <Field>
+                  <FieldLabel htmlFor="sso-edit-entry-point">
+                    {localization.entryPoint}
+                  </FieldLabel>
+                  <Input
+                    defaultValue={provider.samlConfig.entryPoint}
+                    id="sso-edit-entry-point"
+                    name="entryPoint"
+                    required
+                    type="url"
+                  />
+                </Field>
+                <Field>
+                  <FieldLabel htmlFor="sso-edit-metadata">
+                    {localization.identityProviderMetadata}
+                  </FieldLabel>
+                  <Textarea
+                    className="font-mono text-xs"
+                    id="sso-edit-metadata"
+                    name="identityProviderMetadata"
+                    rows={6}
+                  />
+                </Field>
+              </>
+            ) : null}
+          </FieldGroup>
+          <FieldError>{getErrorMessage(update.error)}</FieldError>
+          <DialogFooter>
+            <Button
+              disabled={update.isPending}
+              onClick={close}
+              type="button"
+              variant="outline"
+            >
+              {localization.cancel}
+            </Button>
+            <Button disabled={update.isPending} type="submit">
+              {update.isPending ? <Spinner data-icon="inline-start" /> : null}
+              {localization.saveProvider}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function DeleteSsoProviderDialog({
+  onOpenChange,
+  provider
+}: {
+  onOpenChange: (provider: SsoProvider | undefined) => void
+  provider?: SsoProvider
+}) {
+  const { authClient } = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const remove = useDeleteSsoProvider(authClient as SsoAuthClient)
+  const close = () => {
+    remove.reset()
+    onOpenChange(undefined)
+  }
+
+  return (
+    <AlertDialog
+      open={Boolean(provider)}
+      onOpenChange={(open) => {
+        if (!open && !remove.isPending) close()
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{localization.deleteProvider}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {localization.deleteProviderDescription}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <p className="font-mono text-xs">{provider?.providerId}</p>
+        <FieldError>{getErrorMessage(remove.error)}</FieldError>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={remove.isPending}>
+            {localization.cancel}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            disabled={remove.isPending}
+            onClick={(event) => {
+              event.preventDefault()
+              if (!provider) return
+              remove.mutate(
+                { providerId: provider.providerId },
+                {
+                  onSuccess: () => {
+                    toast.success(localization.providerDeleted)
+                    close()
+                  }
+                }
+              )
+            }}
+            variant="destructive"
+          >
+            {localization.deleteProvider}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/examples/start-shadcn-example/src/components/auth/sso/sso-domain-verification.tsx
+++ b/examples/start-shadcn-example/src/components/auth/sso/sso-domain-verification.tsx
@@ -90,6 +90,7 @@ export function SsoDomainVerification({
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    setCopyError("")
     setVerified(false)
     verify.mutate({ providerId })
   }
@@ -115,6 +116,7 @@ export function SsoDomainVerification({
                 value={providerId}
                 onChange={(event) => {
                   setProviderId(event.target.value.trim())
+                  setToken("")
                   setVerified(false)
                 }}
                 required
@@ -190,6 +192,7 @@ export function SsoDomainVerification({
                 variant="outline"
                 disabled={!providerId || verify.isPending}
                 onClick={() => {
+                  setCopyError("")
                   setVerified(false)
                   requestToken.mutate({ providerId })
                 }}

--- a/examples/start-shadcn-example/src/components/auth/sso/sso-provider-setup.tsx
+++ b/examples/start-shadcn-example/src/components/auth/sso/sso-provider-setup.tsx
@@ -38,6 +38,7 @@ type SsoProtocol = "oidc" | "saml"
 export type SsoProviderSetupProps = {
   className?: string
   defaultOrganizationId?: string
+  organizationId?: string
   onRegistered?: (provider: RegisterSsoProviderData) => void
 }
 
@@ -53,6 +54,7 @@ const getErrorMessage = (error: Error | null) => {
 export function SsoProviderSetup({
   className,
   defaultOrganizationId,
+  organizationId: fixedOrganizationId,
   onRegistered
 }: SsoProviderSetupProps) {
   const { authClient } = useAuth()
@@ -70,7 +72,10 @@ export function SsoProviderSetup({
       providerId: readString(formData, "providerId"),
       issuer: readString(formData, "issuer"),
       domain: readString(formData, "domain"),
-      organizationId: readString(formData, "organizationId") || undefined
+      organizationId:
+        fixedOrganizationId ||
+        readString(formData, "organizationId") ||
+        undefined
     }
     const params =
       protocol === "oidc"
@@ -143,16 +148,18 @@ export function SsoProviderSetup({
               />
             </Field>
 
-            <Field>
-              <FieldLabel htmlFor="sso-organization-id">
-                {localization.organizationId}
-              </FieldLabel>
-              <Input
-                defaultValue={defaultOrganizationId}
-                id="sso-organization-id"
-                name="organizationId"
-              />
-            </Field>
+            {!fixedOrganizationId ? (
+              <Field>
+                <FieldLabel htmlFor="sso-organization-id">
+                  {localization.organizationId}
+                </FieldLabel>
+                <Input
+                  defaultValue={defaultOrganizationId}
+                  id="sso-organization-id"
+                  name="organizationId"
+                />
+              </Field>
+            ) : null}
 
             <Tabs
               value={protocol}

--- a/examples/start-shadcn-example/src/lib/auth/sso-plugin.ts
+++ b/examples/start-shadcn-example/src/lib/auth/sso-plugin.ts
@@ -1,20 +1,47 @@
-import { createAuthPlugin } from "@better-auth-ui/core"
+import {
+  type AuthPluginBase,
+  type AuthPluginLocalizationContext,
+  createAuthPlugin
+} from "@better-auth-ui/core"
 import {
   ssoPlugin as coreSsoPlugin,
+  type SsoLocalization,
   type SsoPluginOptions
 } from "@better-auth-ui/core/plugins/sso"
 
 import { EmailFirstSignIn } from "@/components/auth/sso/email-first-sign-in"
+import { OrganizationSsoProviders } from "@/components/auth/sso/organization-sso-providers"
 
 export const ssoPlugin = createAuthPlugin(
   coreSsoPlugin.id,
   (options: SsoPluginOptions = {}) => {
     const plugin = coreSsoPlugin(options)
+    const localizedOrganizationTab = (localization: SsoLocalization) =>
+      plugin.organization
+        ? {
+            organizationTabs: [
+              {
+                id: "sso",
+                path: plugin.path,
+                label: localization.providerList,
+                component: OrganizationSsoProviders
+              }
+            ]
+          }
+        : {}
 
     return {
       ...plugin,
+      ...localizedOrganizationTab(plugin.localization),
       ...(plugin.emailFirst && {
         views: { auth: { signIn: EmailFirstSignIn } }
+      }),
+      _localizationResolver: (
+        resolvedPlugin: AuthPluginBase,
+        context: AuthPluginLocalizationContext
+      ) => ({
+        ...resolvedPlugin,
+        ...localizedOrganizationTab(context.localization as SsoLocalization)
       })
     }
   }

--- a/examples/start-solid-zaidan-example/registry.manifest.ts
+++ b/examples/start-solid-zaidan-example/registry.manifest.ts
@@ -426,7 +426,7 @@ export const solidRegistryManifest = {
       type: "registry:component",
       title: "Solid SSO",
       description:
-        "Solid email-first sign-in that discovers an organization's SSO provider before offering fallback methods.",
+        "Solid email-first sign-in and organization provider management for Better Auth SSO.",
       registryDependencies: [
         betterAuthSolidRegistryDependency("auth-provider"),
         betterAuthSolidRegistryDependency("sign-in")
@@ -436,6 +436,9 @@ export const solidRegistryManifest = {
         libFile("src/lib/auth/use-sign-in-continuation.ts"),
         libFile("src/lib/auth/two-factor-methods.ts"),
         componentFile("src/components/auth/sso/email-first-sign-in.tsx"),
+        componentFile("src/components/auth/sso/organization-sso-providers.tsx"),
+        componentFile("src/components/auth/sso/sso-domain-verification.tsx"),
+        componentFile("src/components/auth/sso/sso-provider-setup.tsx"),
         componentFile("src/components/auth/provider-button.tsx"),
         componentFile("src/components/auth/provider-buttons.tsx"),
         ...zaidanFormSupportFiles

--- a/examples/start-solid-zaidan-example/src/components/auth/sso/organization-sso-providers.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/sso/organization-sso-providers.tsx
@@ -1,0 +1,523 @@
+import {
+  hasMemberRole,
+  type OrganizationAuthClient
+} from "@better-auth-ui/core/plugins/organization"
+import type {
+  SsoAuthClient,
+  SsoProvider,
+  UpdateSsoProviderParams
+} from "@better-auth-ui/core/plugins/sso"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
+import { useActiveMemberRole } from "@better-auth-ui/solid/plugins/organization"
+import {
+  useDeleteSsoProvider,
+  useSsoProviders,
+  useUpdateSsoProvider
+} from "@better-auth-ui/solid/plugins/sso"
+import type { BetterFetchError } from "better-auth/client"
+import { Pencil, Trash2 } from "lucide-solid"
+import { createMemo, createSignal, For, Show } from "solid-js"
+import { toast } from "solid-sonner"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog"
+import { Badge } from "@/components/ui/badge"
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardAction,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog"
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle
+} from "@/components/ui/empty"
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel
+} from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Spinner } from "@/components/ui/spinner"
+import { Textarea } from "@/components/ui/textarea"
+import { ssoPlugin } from "@/lib/auth/sso-plugin"
+import { cn } from "@/lib/utils"
+
+import { SsoDomainVerification } from "./sso-domain-verification"
+import { SsoProviderSetup } from "./sso-provider-setup"
+
+export type OrganizationSsoProvidersProps = {
+  class?: string
+  organizationId: string
+  organizationSlug: string
+}
+
+const providerSkeletonIds = ["solid-sso-provider-1", "solid-sso-provider-2"]
+
+const readString = (formData: FormData, name: string) =>
+  String(formData.get(name) ?? "").trim()
+
+const getErrorMessage = (error: Error | null) => {
+  const authError = error as BetterFetchError | null
+  return authError?.error?.message ?? authError?.message
+}
+
+export function OrganizationSsoProviders(props: OrganizationSsoProvidersProps) {
+  const auth = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const memberRole = useActiveMemberRole(
+    auth.authClient as OrganizationAuthClient,
+    () => ({ query: { organizationId: props.organizationId } })
+  )
+  const canManage = () =>
+    hasMemberRole(memberRole.data?.role, "owner") ||
+    hasMemberRole(memberRole.data?.role, "admin")
+  const providersQuery = useSsoProviders(
+    auth.authClient as SsoAuthClient,
+    () => ({ enabled: !memberRole.isPending && canManage() })
+  )
+  const [creating, setCreating] = createSignal(false)
+  const [editing, setEditing] = createSignal<SsoProvider>()
+  const [verifying, setVerifying] = createSignal<SsoProvider>()
+  const [deleting, setDeleting] = createSignal<SsoProvider>()
+  const providers = createMemo(
+    () =>
+      providersQuery.data?.providers.filter(
+        (provider) => provider.organizationId === props.organizationId
+      ) ?? []
+  )
+
+  return (
+    <Card class={cn(props.class)}>
+      <CardHeader>
+        <CardTitle>{localization.providerList}</CardTitle>
+        <CardDescription>
+          {localization.providerListDescription}
+        </CardDescription>
+        <CardAction>
+          <Button
+            disabled={memberRole.isPending || !canManage()}
+            onClick={() => setCreating((open) => !open)}
+            size="sm"
+          >
+            {localization.addProvider}
+          </Button>
+        </CardAction>
+      </CardHeader>
+      <CardContent class="flex flex-col gap-4">
+        <Show when={creating()}>
+          <SsoProviderSetup
+            class="max-w-none"
+            organizationId={props.organizationId}
+            onRegistered={() => setCreating(false)}
+          />
+        </Show>
+        <Show
+          fallback={
+            <div class="flex flex-col gap-2">
+              <For each={providerSkeletonIds}>
+                {(id) => <Skeleton class="h-24 w-full" data-id={id} />}
+              </For>
+            </div>
+          }
+          when={
+            !memberRole.isPending && (!canManage() || !providersQuery.isPending)
+          }
+        >
+          <Show
+            fallback={
+              <div
+                class="rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-sm"
+                role="alert"
+              >
+                {localization.providerAccessDenied}
+              </div>
+            }
+            when={canManage()}
+          >
+            <Show
+              fallback={
+                <div
+                  class="flex items-center justify-between gap-3 rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-sm"
+                  role="alert"
+                >
+                  <span>{localization.providerLoadError}</span>
+                  <Button
+                    onClick={() => providersQuery.refetch()}
+                    size="sm"
+                    variant="outline"
+                  >
+                    {localization.retry}
+                  </Button>
+                </div>
+              }
+              when={!providersQuery.error}
+            >
+              <Show
+                fallback={
+                  <Empty class="min-h-32 border">
+                    <EmptyHeader>
+                      <EmptyTitle>{localization.noProviders}</EmptyTitle>
+                      <EmptyDescription>
+                        {localization.noProvidersDescription}
+                      </EmptyDescription>
+                    </EmptyHeader>
+                  </Empty>
+                }
+                when={providers().length}
+              >
+                <div class="flex flex-col gap-2">
+                  <For each={providers()}>
+                    {(provider) => (
+                      <div class="flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div class="flex min-w-0 flex-col gap-1">
+                          <div class="flex flex-wrap items-center gap-2">
+                            <span class="font-medium">
+                              {provider.providerId}
+                            </span>
+                            <Badge variant="outline">
+                              {provider.type.toUpperCase()}
+                            </Badge>
+                            <Badge
+                              variant={
+                                provider.domainVerified
+                                  ? "secondary"
+                                  : "outline"
+                              }
+                            >
+                              {provider.domainVerified
+                                ? localization.domainVerified
+                                : localization.verifyDomain}
+                            </Badge>
+                          </div>
+                          <span class="truncate text-sm text-muted-foreground">
+                            {provider.domain} · {provider.issuer}
+                          </span>
+                        </div>
+                        <div class="flex shrink-0 flex-wrap gap-2">
+                          <Show when={!provider.domainVerified}>
+                            <Button
+                              onClick={() => setVerifying(provider)}
+                              size="sm"
+                              variant="outline"
+                            >
+                              {localization.verifyDomain}
+                            </Button>
+                          </Show>
+                          <Button
+                            aria-label={localization.editProvider}
+                            onClick={() => setEditing(provider)}
+                            size="icon-sm"
+                            variant="ghost"
+                          >
+                            <Pencil />
+                          </Button>
+                          <Button
+                            aria-label={localization.deleteProvider}
+                            onClick={() => setDeleting(provider)}
+                            size="icon-sm"
+                            variant="destructive"
+                          >
+                            <Trash2 />
+                          </Button>
+                        </div>
+                      </div>
+                    )}
+                  </For>
+                </div>
+              </Show>
+            </Show>
+          </Show>
+        </Show>
+      </CardContent>
+
+      <EditSsoProviderDialog onOpenChange={setEditing} provider={editing()} />
+      <DeleteSsoProviderDialog
+        onOpenChange={setDeleting}
+        provider={deleting()}
+      />
+      <Dialog
+        open={Boolean(verifying())}
+        onOpenChange={(open) => !open && setVerifying(undefined)}
+      >
+        <DialogContent class="max-h-[90vh] max-w-xl overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>{localization.domainVerification}</DialogTitle>
+          </DialogHeader>
+          <Show when={verifying()}>
+            {(provider) => (
+              <SsoDomainVerification
+                class="max-w-none shadow-none ring-0"
+                defaultProviderId={provider().providerId}
+              />
+            )}
+          </Show>
+        </DialogContent>
+      </Dialog>
+    </Card>
+  )
+}
+
+function EditSsoProviderDialog(props: {
+  onOpenChange: (provider: SsoProvider | undefined) => void
+  provider?: SsoProvider
+}) {
+  const auth = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const update = useUpdateSsoProvider(auth.authClient as SsoAuthClient)
+  const close = () => {
+    update.reset()
+    props.onOpenChange(undefined)
+  }
+  const submit = (event: SubmitEvent) => {
+    event.preventDefault()
+    if (!props.provider) return
+    const data = new FormData(event.currentTarget as HTMLFormElement)
+    const clientId = readString(data, "clientId")
+    const clientSecret = readString(data, "clientSecret")
+    const identityProviderMetadata = readString(
+      data,
+      "identityProviderMetadata"
+    )
+    const params = {
+      providerId: props.provider.providerId,
+      issuer: readString(data, "issuer"),
+      domain: readString(data, "domain"),
+      ...(props.provider.oidcConfig
+        ? {
+            oidcConfig: {
+              ...(clientId ? { clientId } : {}),
+              ...(clientSecret ? { clientSecret } : {}),
+              discoveryEndpoint:
+                readString(data, "discoveryEndpoint") || undefined
+            }
+          }
+        : {}),
+      ...(props.provider.samlConfig
+        ? {
+            samlConfig: {
+              entryPoint: readString(data, "entryPoint"),
+              ...(identityProviderMetadata
+                ? { idpMetadata: { metadata: identityProviderMetadata } }
+                : {})
+            }
+          }
+        : {})
+    } as UpdateSsoProviderParams
+    update.mutate(params, {
+      onSuccess: () => {
+        toast.success(localization.providerUpdated)
+        close()
+      }
+    })
+  }
+
+  return (
+    <Dialog
+      open={Boolean(props.provider)}
+      onOpenChange={(open) => {
+        if (!open && !update.isPending) close()
+      }}
+    >
+      <DialogContent class="max-h-[90vh] max-w-xl overflow-y-auto">
+        <form class="flex flex-col gap-4" onSubmit={submit}>
+          <DialogHeader>
+            <DialogTitle>{localization.editProvider}</DialogTitle>
+            <DialogDescription>{props.provider?.providerId}</DialogDescription>
+          </DialogHeader>
+          <FieldGroup>
+            <Field>
+              <FieldLabel for="solid-sso-edit-domain">
+                {localization.domain}
+              </FieldLabel>
+              <Input
+                id="solid-sso-edit-domain"
+                name="domain"
+                required
+                value={props.provider?.domain ?? ""}
+              />
+            </Field>
+            <Field>
+              <FieldLabel for="solid-sso-edit-issuer">
+                {localization.issuer}
+              </FieldLabel>
+              <Input
+                id="solid-sso-edit-issuer"
+                name="issuer"
+                required
+                type="url"
+                value={props.provider?.issuer ?? ""}
+              />
+            </Field>
+            <Show when={props.provider?.oidcConfig}>
+              {(oidc) => (
+                <>
+                  <Field>
+                    <FieldLabel for="solid-sso-edit-discovery">
+                      {localization.discoveryEndpoint}
+                    </FieldLabel>
+                    <Input
+                      id="solid-sso-edit-discovery"
+                      name="discoveryEndpoint"
+                      type="url"
+                      value={oidc().discoveryEndpoint ?? ""}
+                    />
+                  </Field>
+                  <div class="grid gap-4 sm:grid-cols-2">
+                    <Field>
+                      <FieldLabel for="solid-sso-edit-client-id">
+                        {localization.clientId}
+                      </FieldLabel>
+                      <Input
+                        id="solid-sso-edit-client-id"
+                        name="clientId"
+                        placeholder={`••••${oidc().clientIdLastFour}`}
+                      />
+                    </Field>
+                    <Field>
+                      <FieldLabel for="solid-sso-edit-client-secret">
+                        {localization.clientSecret}
+                      </FieldLabel>
+                      <Input
+                        autocomplete="new-password"
+                        id="solid-sso-edit-client-secret"
+                        name="clientSecret"
+                        type="password"
+                      />
+                    </Field>
+                  </div>
+                </>
+              )}
+            </Show>
+            <Show when={props.provider?.samlConfig}>
+              {(saml) => (
+                <>
+                  <Field>
+                    <FieldLabel for="solid-sso-edit-entry-point">
+                      {localization.entryPoint}
+                    </FieldLabel>
+                    <Input
+                      id="solid-sso-edit-entry-point"
+                      name="entryPoint"
+                      required
+                      type="url"
+                      value={saml().entryPoint}
+                    />
+                  </Field>
+                  <Field>
+                    <FieldLabel for="solid-sso-edit-metadata">
+                      {localization.identityProviderMetadata}
+                    </FieldLabel>
+                    <Textarea
+                      class="font-mono text-xs"
+                      id="solid-sso-edit-metadata"
+                      name="identityProviderMetadata"
+                      rows={6}
+                    />
+                  </Field>
+                </>
+              )}
+            </Show>
+          </FieldGroup>
+          <FieldError>{getErrorMessage(update.error)}</FieldError>
+          <DialogFooter>
+            <Button
+              disabled={update.isPending}
+              onClick={close}
+              type="button"
+              variant="outline"
+            >
+              {localization.cancel}
+            </Button>
+            <Button disabled={update.isPending} type="submit">
+              <Show when={update.isPending}>
+                <Spinner />
+              </Show>
+              {localization.saveProvider}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function DeleteSsoProviderDialog(props: {
+  onOpenChange: (provider: SsoProvider | undefined) => void
+  provider?: SsoProvider
+}) {
+  const auth = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const remove = useDeleteSsoProvider(auth.authClient as SsoAuthClient)
+  const close = () => {
+    remove.reset()
+    props.onOpenChange(undefined)
+  }
+
+  return (
+    <AlertDialog
+      open={Boolean(props.provider)}
+      onOpenChange={(open) => {
+        if (!open && !remove.isPending) close()
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{localization.deleteProvider}</AlertDialogTitle>
+          <AlertDialogDescription>
+            {localization.deleteProviderDescription}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <p class="font-mono text-xs">{props.provider?.providerId}</p>
+        <FieldError>{getErrorMessage(remove.error)}</FieldError>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={remove.isPending}>
+            {localization.cancel}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            disabled={remove.isPending}
+            onClick={(event: MouseEvent) => {
+              event.preventDefault()
+              if (!props.provider) return
+              remove.mutate(
+                { providerId: props.provider.providerId },
+                {
+                  onSuccess: () => {
+                    toast.success(localization.providerDeleted)
+                    close()
+                  }
+                }
+              )
+            }}
+            variant="destructive"
+          >
+            {localization.deleteProvider}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/examples/start-solid-zaidan-example/src/components/auth/sso/sso-domain-verification.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/sso/sso-domain-verification.tsx
@@ -1,0 +1,215 @@
+import type { SsoAuthClient } from "@better-auth-ui/core/plugins/sso"
+import {
+  createCopyToClipboard,
+  useAuth,
+  useAuthPlugin
+} from "@better-auth-ui/solid"
+import {
+  useRequestSsoDomainVerification,
+  useVerifySsoDomain
+} from "@better-auth-ui/solid/plugins/sso"
+import type { BetterFetchError } from "better-auth/client"
+import { Check, Copy } from "lucide-solid"
+import { createSignal, Show } from "solid-js"
+
+import { Button } from "@/components/ui/button"
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle
+} from "@/components/ui/card"
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel
+} from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
+import {
+  InputGroup,
+  InputGroupButton,
+  InputGroupInput
+} from "@/components/ui/input-group"
+import { Spinner } from "@/components/ui/spinner"
+import { ssoPlugin } from "@/lib/auth/sso-plugin"
+import { cn } from "@/lib/utils"
+
+export type SsoDomainVerificationProps = {
+  class?: string
+  defaultProviderId?: string
+  defaultToken?: string
+  tokenPrefix?: string
+}
+
+const getErrorMessage = (error: Error | null | undefined) => {
+  const authError = error as BetterFetchError | null | undefined
+  return authError?.error?.message ?? authError?.message
+}
+
+export function SsoDomainVerification(props: SsoDomainVerificationProps) {
+  const auth = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const [providerId, setProviderId] = createSignal(
+    props.defaultProviderId ?? ""
+  )
+  const [token, setToken] = createSignal(props.defaultToken ?? "")
+  const [verified, setVerified] = createSignal(false)
+  const [copyError, setCopyError] = createSignal("")
+  const requestToken = useRequestSsoDomainVerification(
+    auth.authClient as SsoAuthClient,
+    () => ({
+      onSuccess: (data) => setToken(data.domainVerificationToken)
+    })
+  )
+  const verify = useVerifySsoDomain(auth.authClient as SsoAuthClient, () => ({
+    onSuccess: () => setVerified(true)
+  }))
+  const host = () =>
+    providerId()
+      ? `_${props.tokenPrefix ?? "better-auth-token"}-${providerId()}`
+      : ""
+  const hostCopy = createCopyToClipboard({
+    onError: (error) =>
+      setCopyError(error instanceof Error ? error.message : String(error))
+  })
+  const tokenCopy = createCopyToClipboard({
+    onError: (error) =>
+      setCopyError(error instanceof Error ? error.message : String(error))
+  })
+  const error = () =>
+    requestToken.submittedAt > verify.submittedAt
+      ? requestToken.error
+      : verify.error
+
+  const submit = (event: SubmitEvent) => {
+    event.preventDefault()
+    setCopyError("")
+    setVerified(false)
+    verify.mutate({ providerId: providerId() })
+  }
+
+  return (
+    <Card class={cn("w-full max-w-xl", props.class)}>
+      <CardHeader>
+        <CardTitle>{localization.domainVerification}</CardTitle>
+        <CardDescription>
+          {localization.domainVerificationDescription}
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={submit}>
+          <FieldGroup>
+            <Field>
+              <FieldLabel for="solid-sso-verification-provider-id">
+                {localization.providerId}
+              </FieldLabel>
+              <Input
+                id="solid-sso-verification-provider-id"
+                name="providerId"
+                onInput={(event) => {
+                  setProviderId(event.currentTarget.value.trim())
+                  setToken("")
+                  setVerified(false)
+                }}
+                required
+                value={providerId()}
+              />
+            </Field>
+            <Show when={token()}>
+              <div class="grid gap-3 rounded-lg border p-3">
+                <Field>
+                  <FieldLabel for="solid-sso-dns-host">
+                    {localization.txtRecordHost}
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupInput
+                      id="solid-sso-dns-host"
+                      readonly
+                      value={host()}
+                    />
+                    <InputGroupButton
+                      aria-label={localization.copyDnsHost}
+                      onClick={() => {
+                        setCopyError("")
+                        void hostCopy.copy(host())
+                      }}
+                      type="button"
+                    >
+                      <Show fallback={<Copy />} when={hostCopy.copied()}>
+                        <Check />
+                      </Show>
+                    </InputGroupButton>
+                  </InputGroup>
+                </Field>
+                <Field>
+                  <FieldLabel for="solid-sso-dns-value">
+                    {localization.txtRecordValue}
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupInput
+                      id="solid-sso-dns-value"
+                      readonly
+                      value={token()}
+                    />
+                    <InputGroupButton
+                      aria-label={localization.copyDnsValue}
+                      onClick={() => {
+                        setCopyError("")
+                        void tokenCopy.copy(token())
+                      }}
+                      type="button"
+                    >
+                      <Show fallback={<Copy />} when={tokenCopy.copied()}>
+                        <Check />
+                      </Show>
+                    </InputGroupButton>
+                  </InputGroup>
+                </Field>
+              </div>
+            </Show>
+            <div class="flex flex-wrap gap-2">
+              <Button
+                disabled={!providerId() || requestToken.isPending}
+                onClick={() => {
+                  setCopyError("")
+                  setVerified(false)
+                  requestToken.mutate({ providerId: providerId() })
+                }}
+                type="button"
+                variant="outline"
+              >
+                <Show when={requestToken.isPending}>
+                  <Spinner />
+                </Show>
+                {localization.requestNewToken}
+              </Button>
+              <Button
+                disabled={!providerId() || verify.isPending}
+                type="submit"
+              >
+                <Show when={verify.isPending}>
+                  <Spinner />
+                </Show>
+                {localization.verifyDomain}
+              </Button>
+            </div>
+            <Show when={verified()}>
+              <FieldDescription role="status">
+                {localization.domainVerified}
+              </FieldDescription>
+            </Show>
+            <FieldError>{copyError() || getErrorMessage(error())}</FieldError>
+            <span aria-live="polite" class="sr-only">
+              {token() && !verified()
+                ? localization.domainVerificationRequested
+                : ""}
+            </span>
+          </FieldGroup>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/examples/start-solid-zaidan-example/src/components/auth/sso/sso-provider-setup.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/sso/sso-provider-setup.tsx
@@ -1,14 +1,12 @@
-"use client"
-
 import type {
   RegisterSsoProviderData,
   RegisterSsoProviderParams,
   SsoAuthClient
 } from "@better-auth-ui/core/plugins/sso"
-import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
-import { useRegisterSsoProvider } from "@better-auth-ui/react/plugins/sso"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
+import { useRegisterSsoProvider } from "@better-auth-ui/solid/plugins/sso"
 import type { BetterFetchError } from "better-auth/client"
-import { type FormEvent, useState } from "react"
+import { createSignal, Show } from "solid-js"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -36,7 +34,7 @@ import { cn } from "@/lib/utils"
 type SsoProtocol = "oidc" | "saml"
 
 export type SsoProviderSetupProps = {
-  className?: string
+  class?: string
   defaultOrganizationId?: string
   organizationId?: string
   onRegistered?: (provider: RegisterSsoProviderData) => void
@@ -45,40 +43,33 @@ export type SsoProviderSetupProps = {
 const readString = (formData: FormData, name: string) =>
   String(formData.get(name) ?? "").trim()
 
-const getErrorMessage = (error: Error | null) => {
-  const authError = error as BetterFetchError | null
+const getErrorMessage = (error: Error | null | undefined) => {
+  const authError = error as BetterFetchError | null | undefined
   return authError?.error?.message ?? authError?.message
 }
 
-/** Self-service form for registering an OIDC or SAML SSO provider. */
-export function SsoProviderSetup({
-  className,
-  defaultOrganizationId,
-  organizationId: fixedOrganizationId,
-  onRegistered
-}: SsoProviderSetupProps) {
-  const { authClient } = useAuth()
+export function SsoProviderSetup(props: SsoProviderSetupProps) {
+  const auth = useAuth()
   const { localization } = useAuthPlugin(ssoPlugin)
-  const [protocol, setProtocol] = useState<SsoProtocol>("oidc")
-  const [created, setCreated] = useState(false)
-  const register = useRegisterSsoProvider(authClient as SsoAuthClient)
+  const [protocol, setProtocol] = createSignal<SsoProtocol>("oidc")
+  const [created, setCreated] = createSignal(false)
+  const register = useRegisterSsoProvider(auth.authClient as SsoAuthClient)
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+  const submit = (event: SubmitEvent) => {
     event.preventDefault()
     setCreated(false)
-
-    const formData = new FormData(event.currentTarget)
+    const formData = new FormData(event.currentTarget as HTMLFormElement)
     const common = {
       providerId: readString(formData, "providerId"),
       issuer: readString(formData, "issuer"),
       domain: readString(formData, "domain"),
       organizationId:
-        fixedOrganizationId ||
+        props.organizationId ||
         readString(formData, "organizationId") ||
         undefined
     }
     const params =
-      protocol === "oidc"
+      protocol() === "oidc"
         ? {
             ...common,
             oidcConfig: {
@@ -99,13 +90,13 @@ export function SsoProviderSetup({
     register.mutate(params as RegisterSsoProviderParams<SsoAuthClient>, {
       onSuccess: (provider) => {
         setCreated(true)
-        onRegistered?.(provider)
+        props.onRegistered?.(provider)
       }
     })
   }
 
   return (
-    <form className={cn("w-full max-w-xl", className)} onSubmit={handleSubmit}>
+    <form class={cn("w-full max-w-xl", props.class)} onSubmit={submit}>
       <Card>
         <CardHeader>
           <CardTitle>{localization.providerSetup}</CardTitle>
@@ -115,124 +106,120 @@ export function SsoProviderSetup({
         </CardHeader>
         <CardContent>
           <FieldGroup>
-            <div className="grid gap-4 sm:grid-cols-2">
+            <div class="grid gap-4 sm:grid-cols-2">
               <Field>
-                <FieldLabel htmlFor="sso-provider-id">
+                <FieldLabel for="solid-sso-provider-id">
                   {localization.providerId}
                 </FieldLabel>
-                <Input id="sso-provider-id" name="providerId" required />
+                <Input id="solid-sso-provider-id" name="providerId" required />
               </Field>
               <Field>
-                <FieldLabel htmlFor="sso-domain">
+                <FieldLabel for="solid-sso-domain">
                   {localization.domain}
                 </FieldLabel>
                 <Input
-                  id="sso-domain"
+                  id="solid-sso-domain"
                   name="domain"
                   placeholder="example.com"
                   required
                 />
               </Field>
             </div>
-
             <Field>
-              <FieldLabel htmlFor="sso-issuer">
+              <FieldLabel for="solid-sso-issuer">
                 {localization.issuer}
               </FieldLabel>
               <Input
-                id="sso-issuer"
+                id="solid-sso-issuer"
                 name="issuer"
                 placeholder="https://idp.example.com"
-                type="url"
                 required
+                type="url"
               />
             </Field>
-
-            {!fixedOrganizationId ? (
+            <Show when={!props.organizationId}>
               <Field>
-                <FieldLabel htmlFor="sso-organization-id">
+                <FieldLabel for="solid-sso-organization-id">
                   {localization.organizationId}
                 </FieldLabel>
                 <Input
-                  defaultValue={defaultOrganizationId}
-                  id="sso-organization-id"
+                  id="solid-sso-organization-id"
                   name="organizationId"
+                  value={props.defaultOrganizationId ?? ""}
                 />
               </Field>
-            ) : null}
-
+            </Show>
             <Tabs
-              value={protocol}
-              onValueChange={(value) => setProtocol(value as SsoProtocol)}
+              value={protocol()}
+              onChange={(value) => setProtocol(value as SsoProtocol)}
             >
               <TabsList aria-label={localization.providerSetup}>
                 <TabsTrigger value="oidc">{localization.oidc}</TabsTrigger>
                 <TabsTrigger value="saml">{localization.saml}</TabsTrigger>
               </TabsList>
-              <TabsContent className="grid gap-4 sm:grid-cols-2" value="oidc">
+              <TabsContent class="grid gap-4 sm:grid-cols-2" value="oidc">
                 <Field>
-                  <FieldLabel htmlFor="sso-client-id">
+                  <FieldLabel for="solid-sso-client-id">
                     {localization.clientId}
                   </FieldLabel>
                   <Input
-                    autoComplete="off"
-                    id="sso-client-id"
+                    autocomplete="off"
+                    id="solid-sso-client-id"
                     name="clientId"
                     required
                   />
                 </Field>
                 <Field>
-                  <FieldLabel htmlFor="sso-client-secret">
+                  <FieldLabel for="solid-sso-client-secret">
                     {localization.clientSecret}
                   </FieldLabel>
                   <Input
-                    autoComplete="new-password"
-                    id="sso-client-secret"
+                    autocomplete="new-password"
+                    id="solid-sso-client-secret"
                     name="clientSecret"
-                    type="password"
                     required
+                    type="password"
                   />
                 </Field>
               </TabsContent>
-              <TabsContent className="flex flex-col gap-4" value="saml">
+              <TabsContent class="flex flex-col gap-4" value="saml">
                 <Field>
-                  <FieldLabel htmlFor="sso-entry-point">
+                  <FieldLabel for="solid-sso-entry-point">
                     {localization.entryPoint}
                   </FieldLabel>
                   <Input
-                    id="sso-entry-point"
+                    id="solid-sso-entry-point"
                     name="entryPoint"
-                    type="url"
                     required
+                    type="url"
                   />
                 </Field>
                 <Field>
-                  <FieldLabel htmlFor="sso-idp-metadata">
+                  <FieldLabel for="solid-sso-idp-metadata">
                     {localization.identityProviderMetadata}
                   </FieldLabel>
                   <Textarea
-                    className="min-h-40 font-mono text-xs"
-                    id="sso-idp-metadata"
+                    class="min-h-40 font-mono text-xs"
+                    id="solid-sso-idp-metadata"
                     name="identityProviderMetadata"
                     required
                   />
                 </Field>
               </TabsContent>
             </Tabs>
-
-            {register.error ? (
-              <FieldError>{getErrorMessage(register.error)}</FieldError>
-            ) : null}
-            {created ? (
-              <FieldDescription role="status" className="text-foreground">
+            <FieldError>{getErrorMessage(register.error)}</FieldError>
+            <Show when={created()}>
+              <FieldDescription role="status">
                 {localization.providerCreated}
               </FieldDescription>
-            ) : null}
+            </Show>
           </FieldGroup>
         </CardContent>
-        <CardFooter className="justify-end">
-          <Button type="submit" disabled={register.isPending}>
-            {register.isPending ? <Spinner data-icon="inline-start" /> : null}
+        <CardFooter class="justify-end">
+          <Button disabled={register.isPending} type="submit">
+            <Show when={register.isPending}>
+              <Spinner />
+            </Show>
             {localization.addProvider}
           </Button>
         </CardFooter>

--- a/examples/start-solid-zaidan-example/src/lib/auth/sso-plugin.ts
+++ b/examples/start-solid-zaidan-example/src/lib/auth/sso-plugin.ts
@@ -1,20 +1,49 @@
-import { createAuthPlugin } from "@better-auth-ui/core"
+import {
+  type AuthPluginBase,
+  type AuthPluginLocalizationContext,
+  createAuthPlugin
+} from "@better-auth-ui/core"
 import {
   ssoPlugin as coreSsoPlugin,
+  type SsoLocalization,
   type SsoPluginOptions
 } from "@better-auth-ui/core/plugins/sso"
 
 import { EmailFirstSignIn } from "@/components/auth/sso/email-first-sign-in"
+import { OrganizationSsoProviders } from "@/components/auth/sso/organization-sso-providers"
 
 export const ssoPlugin = createAuthPlugin(
   coreSsoPlugin.id,
   (options: SsoPluginOptions = {}) => {
     const plugin = coreSsoPlugin(options)
+    const localizedOrganizationTab = (localization: SsoLocalization) => {
+      const ProviderLabel = () => localization.providerList
+      return plugin.organization
+        ? {
+            organizationTabs: [
+              {
+                id: "sso",
+                path: plugin.path,
+                label: ProviderLabel,
+                component: OrganizationSsoProviders
+              }
+            ]
+          }
+        : {}
+    }
 
     return {
       ...plugin,
+      ...localizedOrganizationTab(plugin.localization),
       ...(plugin.emailFirst && {
         views: { auth: { signIn: EmailFirstSignIn } }
+      }),
+      _localizationResolver: (
+        resolvedPlugin: AuthPluginBase,
+        context: AuthPluginLocalizationContext
+      ) => ({
+        ...resolvedPlugin,
+        ...localizedOrganizationTab(context.localization as SsoLocalization)
       })
     }
   }

--- a/packages/core/src/plugins/sso/sso-localization.ts
+++ b/packages/core/src/plugins/sso/sso-localization.ts
@@ -1,5 +1,6 @@
 export const ssoLocalization = {
   addProvider: "Add SSO provider",
+  cancel: "Cancel",
   clientId: "Client ID",
   clientSecret: "Client secret",
   continueWithEmail: "Continue with email",
@@ -12,18 +13,36 @@ export const ssoLocalization = {
     "Publish the TXT record for every configured domain, then verify it.",
   domainVerificationRequested: "A new verification token was created.",
   domainVerified: "The provider domain is verified.",
+  deleteProvider: "Delete provider",
+  deleteProviderDescription:
+    "Users will no longer be able to sign in through this provider.",
+  discoveryEndpoint: "Discovery endpoint",
+  editProvider: "Edit provider",
   emailFirstDescription: "Enter your work email to continue.",
   entryPoint: "SSO URL",
   identityProviderMetadata: "Identity provider metadata XML",
   issuer: "Issuer URL",
   oidc: "OIDC",
   organizationId: "Organization ID",
+  noProviders: "No SSO providers",
+  noProvidersDescription:
+    "Add an identity provider to enable organization sign-in.",
+  providerDeleted: "The SSO provider was deleted.",
+  providerList: "Organization SSO",
+  providerListDescription:
+    "Manage identity providers and verified domains for this organization.",
+  providerAccessDenied:
+    "Only organization owners and administrators can manage SSO providers.",
+  providerLoadError: "SSO providers could not be loaded.",
+  providerUpdated: "The SSO provider was updated.",
   providerCreated: "The SSO provider was added.",
   providerId: "Provider ID",
   providerSetup: "SSO provider setup",
   providerSetupDescription:
     "Connect an OpenID Connect or SAML identity provider.",
   requestNewToken: "Create new token",
+  retry: "Retry",
+  saveProvider: "Save provider",
   saml: "SAML",
   txtRecordHost: "TXT record host",
   txtRecordValue: "TXT record value",

--- a/packages/heroui/src/components/auth/sso/organization-sso-providers.tsx
+++ b/packages/heroui/src/components/auth/sso/organization-sso-providers.tsx
@@ -1,0 +1,475 @@
+"use client"
+
+import {
+  hasMemberRole,
+  type OrganizationAuthClient
+} from "@better-auth-ui/core/plugins/organization"
+import type {
+  SsoAuthClient,
+  SsoProvider,
+  UpdateSsoProviderParams
+} from "@better-auth-ui/core/plugins/sso"
+import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
+import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
+import {
+  useDeleteSsoProvider,
+  useSsoProviders,
+  useUpdateSsoProvider
+} from "@better-auth-ui/react/plugins/sso"
+import { Pencil, TrashBin } from "@gravity-ui/icons"
+import {
+  Alert,
+  AlertDialog,
+  Button,
+  Card,
+  type CardProps,
+  Chip,
+  cn,
+  FieldError,
+  Form,
+  Input,
+  Label,
+  Skeleton,
+  TextArea,
+  TextField,
+  toast
+} from "@heroui/react"
+import type { BetterFetchError } from "better-auth/client"
+import { type FormEvent, useMemo, useState } from "react"
+
+import { ssoPlugin } from "../../../lib/auth/sso-plugin"
+import { SsoDomainVerification } from "./sso-domain-verification"
+import { SsoProviderSetup } from "./sso-provider-setup"
+
+export type OrganizationSsoProvidersProps = {
+  organizationId: string
+  organizationSlug: string
+} & Omit<CardProps, "children">
+
+const providerSkeletonIds = ["sso-provider-1", "sso-provider-2"]
+
+const readString = (formData: FormData, name: string) =>
+  String(formData.get(name) ?? "").trim()
+
+const getErrorMessage = (error: Error | null) => {
+  const authError = error as BetterFetchError | null
+  return authError?.error?.message ?? authError?.message
+}
+
+export function OrganizationSsoProviders({
+  className,
+  organizationId,
+  organizationSlug: _organizationSlug,
+  variant,
+  ...props
+}: OrganizationSsoProvidersProps) {
+  const { authClient } = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const memberRole = useActiveMemberRole(authClient as OrganizationAuthClient, {
+    query: { organizationId }
+  })
+  const canManage =
+    hasMemberRole(memberRole.data?.role, "owner") ||
+    hasMemberRole(memberRole.data?.role, "admin")
+  const providersQuery = useSsoProviders(authClient as SsoAuthClient, {
+    enabled: !memberRole.isPending && canManage
+  })
+  const [creating, setCreating] = useState(false)
+  const [editing, setEditing] = useState<SsoProvider>()
+  const [verifying, setVerifying] = useState<SsoProvider>()
+  const [deleting, setDeleting] = useState<SsoProvider>()
+  const providers = useMemo(
+    () =>
+      providersQuery.data?.providers.filter(
+        (provider) => provider.organizationId === organizationId
+      ) ?? [],
+    [organizationId, providersQuery.data?.providers]
+  )
+
+  return (
+    <Card className={cn(className)} variant={variant} {...props}>
+      <Card.Header className="flex-row items-start justify-between gap-3">
+        <div className="flex flex-col gap-1">
+          <Card.Title>{localization.providerList}</Card.Title>
+          <Card.Description>
+            {localization.providerListDescription}
+          </Card.Description>
+        </div>
+        <Button
+          isDisabled={memberRole.isPending || !canManage}
+          size="sm"
+          onPress={() => setCreating((open) => !open)}
+        >
+          {localization.addProvider}
+        </Button>
+      </Card.Header>
+      <Card.Content className="flex flex-col gap-4">
+        {creating ? (
+          <SsoProviderSetup
+            organizationId={organizationId}
+            variant="transparent"
+            onRegistered={() => setCreating(false)}
+          />
+        ) : null}
+
+        {memberRole.isPending || (canManage && providersQuery.isPending) ? (
+          <div className="flex flex-col gap-2">
+            {providerSkeletonIds.map((id) => (
+              <Skeleton className="h-24 w-full" key={id} />
+            ))}
+          </div>
+        ) : !canManage ? (
+          <Alert data-access-denied status="warning">
+            <Alert.Indicator />
+            <Alert.Content>
+              <Alert.Description>
+                {localization.providerAccessDenied}
+              </Alert.Description>
+            </Alert.Content>
+          </Alert>
+        ) : providersQuery.error ? (
+          <Alert status="danger">
+            <Alert.Indicator />
+            <Alert.Content>
+              <Alert.Description>
+                {localization.providerLoadError}
+              </Alert.Description>
+            </Alert.Content>
+            <Button
+              size="sm"
+              variant="outline"
+              onPress={() => providersQuery.refetch()}
+            >
+              {localization.retry}
+            </Button>
+          </Alert>
+        ) : providers.length ? (
+          <div className="flex flex-col gap-2">
+            {providers.map((provider) => (
+              <div
+                className="flex flex-col gap-3 rounded-lg border p-3 sm:flex-row sm:items-center sm:justify-between"
+                key={provider.providerId}
+              >
+                <div className="flex min-w-0 flex-col gap-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-medium">{provider.providerId}</span>
+                    <Chip size="sm" variant="secondary">
+                      {provider.type.toUpperCase()}
+                    </Chip>
+                    <Chip
+                      color={provider.domainVerified ? "success" : "warning"}
+                      size="sm"
+                    >
+                      {provider.domainVerified
+                        ? localization.domainVerified
+                        : localization.verifyDomain}
+                    </Chip>
+                  </div>
+                  <span className="truncate text-sm text-muted">
+                    {provider.domain} · {provider.issuer}
+                  </span>
+                </div>
+                <div className="flex shrink-0 flex-wrap gap-2">
+                  {!provider.domainVerified ? (
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onPress={() => setVerifying(provider)}
+                    >
+                      {localization.verifyDomain}
+                    </Button>
+                  ) : null}
+                  <Button
+                    isIconOnly
+                    aria-label={localization.editProvider}
+                    size="sm"
+                    variant="tertiary"
+                    onPress={() => setEditing(provider)}
+                  >
+                    <Pencil />
+                  </Button>
+                  <Button
+                    isIconOnly
+                    aria-label={localization.deleteProvider}
+                    size="sm"
+                    variant="danger-soft"
+                    onPress={() => setDeleting(provider)}
+                  >
+                    <TrashBin />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="flex min-h-32 flex-col items-center justify-center gap-1 rounded-lg border border-dashed p-6 text-center">
+            <p className="text-sm font-medium">{localization.noProviders}</p>
+            <p className="text-xs text-muted">
+              {localization.noProvidersDescription}
+            </p>
+          </div>
+        )}
+      </Card.Content>
+
+      <EditSsoProviderDialog provider={editing} onOpenChange={setEditing} />
+      <DeleteSsoProviderDialog provider={deleting} onOpenChange={setDeleting} />
+      <AlertDialog.Backdrop
+        isOpen={Boolean(verifying)}
+        onOpenChange={(open) => !open && setVerifying(undefined)}
+      >
+        <AlertDialog.Container>
+          <AlertDialog.Dialog className="max-w-xl">
+            <AlertDialog.CloseTrigger />
+            <AlertDialog.Header>
+              <AlertDialog.Heading>
+                {localization.domainVerification}
+              </AlertDialog.Heading>
+            </AlertDialog.Header>
+            <AlertDialog.Body>
+              {verifying ? (
+                <SsoDomainVerification
+                  defaultProviderId={verifying.providerId}
+                  variant="transparent"
+                />
+              ) : null}
+            </AlertDialog.Body>
+          </AlertDialog.Dialog>
+        </AlertDialog.Container>
+      </AlertDialog.Backdrop>
+    </Card>
+  )
+}
+
+function EditSsoProviderDialog({
+  onOpenChange,
+  provider
+}: {
+  onOpenChange: (provider: SsoProvider | undefined) => void
+  provider?: SsoProvider
+}) {
+  const { authClient } = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const update = useUpdateSsoProvider(authClient as SsoAuthClient)
+
+  const close = () => {
+    update.reset()
+    onOpenChange(undefined)
+  }
+  const submit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!provider) return
+    const data = new FormData(event.currentTarget)
+    const clientId = readString(data, "clientId")
+    const clientSecret = readString(data, "clientSecret")
+    const identityProviderMetadata = readString(
+      data,
+      "identityProviderMetadata"
+    )
+    const params = {
+      providerId: provider.providerId,
+      issuer: readString(data, "issuer"),
+      domain: readString(data, "domain"),
+      ...(provider.oidcConfig
+        ? {
+            oidcConfig: {
+              ...(clientId ? { clientId } : {}),
+              ...(clientSecret ? { clientSecret } : {}),
+              discoveryEndpoint:
+                readString(data, "discoveryEndpoint") || undefined
+            }
+          }
+        : {}),
+      ...(provider.samlConfig
+        ? {
+            samlConfig: {
+              entryPoint: readString(data, "entryPoint"),
+              ...(identityProviderMetadata
+                ? { idpMetadata: { metadata: identityProviderMetadata } }
+                : {})
+            }
+          }
+        : {})
+    } as UpdateSsoProviderParams
+
+    update.mutate(params, {
+      onSuccess: () => {
+        toast.success(localization.providerUpdated)
+        close()
+      }
+    })
+  }
+
+  return (
+    <AlertDialog.Backdrop
+      isOpen={Boolean(provider)}
+      onOpenChange={(open) => {
+        if (!open && !update.isPending) close()
+      }}
+    >
+      <AlertDialog.Container>
+        <AlertDialog.Dialog className="max-w-xl">
+          <Form onSubmit={submit}>
+            <AlertDialog.CloseTrigger />
+            <AlertDialog.Header>
+              <AlertDialog.Heading>
+                {localization.editProvider}
+              </AlertDialog.Heading>
+            </AlertDialog.Header>
+            <AlertDialog.Body className="flex flex-col gap-4 overflow-visible">
+              <TextField
+                defaultValue={provider?.domain}
+                isRequired
+                name="domain"
+              >
+                <Label>{localization.domain}</Label>
+                <Input variant="secondary" />
+                <FieldError />
+              </TextField>
+              <TextField
+                defaultValue={provider?.issuer}
+                isRequired
+                name="issuer"
+              >
+                <Label>{localization.issuer}</Label>
+                <Input type="url" variant="secondary" />
+                <FieldError />
+              </TextField>
+              {provider?.oidcConfig ? (
+                <>
+                  <TextField name="discoveryEndpoint">
+                    <Label>{localization.discoveryEndpoint}</Label>
+                    <Input
+                      defaultValue={provider.oidcConfig.discoveryEndpoint}
+                      type="url"
+                      variant="secondary"
+                    />
+                  </TextField>
+                  <div className="grid gap-4 sm:grid-cols-2">
+                    <TextField name="clientId">
+                      <Label>{localization.clientId}</Label>
+                      <Input
+                        placeholder={`••••${provider.oidcConfig.clientIdLastFour}`}
+                        variant="secondary"
+                      />
+                    </TextField>
+                    <TextField name="clientSecret" type="password">
+                      <Label>{localization.clientSecret}</Label>
+                      <Input autoComplete="new-password" variant="secondary" />
+                    </TextField>
+                  </div>
+                </>
+              ) : null}
+              {provider?.samlConfig ? (
+                <>
+                  <TextField isRequired name="entryPoint">
+                    <Label>{localization.entryPoint}</Label>
+                    <Input
+                      defaultValue={provider.samlConfig.entryPoint}
+                      type="url"
+                      variant="secondary"
+                    />
+                    <FieldError />
+                  </TextField>
+                  <TextField name="identityProviderMetadata">
+                    <Label>{localization.identityProviderMetadata}</Label>
+                    <TextArea className="font-mono text-xs" rows={6} />
+                  </TextField>
+                </>
+              ) : null}
+              {update.error ? (
+                <FieldError>{getErrorMessage(update.error)}</FieldError>
+              ) : null}
+            </AlertDialog.Body>
+            <AlertDialog.Footer>
+              <Button
+                isDisabled={update.isPending}
+                slot="close"
+                variant="tertiary"
+              >
+                {localization.cancel}
+              </Button>
+              <Button isPending={update.isPending} type="submit">
+                {localization.saveProvider}
+              </Button>
+            </AlertDialog.Footer>
+          </Form>
+        </AlertDialog.Dialog>
+      </AlertDialog.Container>
+    </AlertDialog.Backdrop>
+  )
+}
+
+function DeleteSsoProviderDialog({
+  onOpenChange,
+  provider
+}: {
+  onOpenChange: (provider: SsoProvider | undefined) => void
+  provider?: SsoProvider
+}) {
+  const { authClient } = useAuth()
+  const { localization } = useAuthPlugin(ssoPlugin)
+  const remove = useDeleteSsoProvider(authClient as SsoAuthClient)
+  const close = () => {
+    remove.reset()
+    onOpenChange(undefined)
+  }
+
+  return (
+    <AlertDialog.Backdrop
+      isOpen={Boolean(provider)}
+      onOpenChange={(open) => {
+        if (!open && !remove.isPending) close()
+      }}
+    >
+      <AlertDialog.Container>
+        <AlertDialog.Dialog>
+          <AlertDialog.CloseTrigger />
+          <AlertDialog.Header>
+            <AlertDialog.Icon status="danger">
+              <TrashBin />
+            </AlertDialog.Icon>
+            <AlertDialog.Heading>
+              {localization.deleteProvider}
+            </AlertDialog.Heading>
+          </AlertDialog.Header>
+          <AlertDialog.Body className="flex flex-col gap-2">
+            <p className="text-sm text-muted">
+              {localization.deleteProviderDescription}
+            </p>
+            <p className="font-mono text-xs">{provider?.providerId}</p>
+            {remove.error ? (
+              <FieldError>{getErrorMessage(remove.error)}</FieldError>
+            ) : null}
+          </AlertDialog.Body>
+          <AlertDialog.Footer>
+            <Button
+              isDisabled={remove.isPending}
+              slot="close"
+              variant="tertiary"
+            >
+              {localization.cancel}
+            </Button>
+            <Button
+              isPending={remove.isPending}
+              variant="danger"
+              onPress={() =>
+                provider &&
+                remove.mutate(
+                  { providerId: provider.providerId },
+                  {
+                    onSuccess: () => {
+                      toast.success(localization.providerDeleted)
+                      close()
+                    }
+                  }
+                )
+              }
+            >
+              {localization.deleteProvider}
+            </Button>
+          </AlertDialog.Footer>
+        </AlertDialog.Dialog>
+      </AlertDialog.Container>
+    </AlertDialog.Backdrop>
+  )
+}

--- a/packages/heroui/src/components/auth/sso/sso-domain-verification.tsx
+++ b/packages/heroui/src/components/auth/sso/sso-domain-verification.tsx
@@ -100,6 +100,7 @@ export function SsoDomainVerification({
             name="providerId"
             onChange={(value) => {
               setProviderId(value.trim())
+              setToken("")
               setVerified(false)
             }}
             value={providerId}

--- a/packages/heroui/src/components/auth/sso/sso-provider-setup.tsx
+++ b/packages/heroui/src/components/auth/sso/sso-provider-setup.tsx
@@ -31,6 +31,7 @@ type SsoProtocol = "oidc" | "saml"
 
 export type SsoProviderSetupProps = {
   defaultOrganizationId?: string
+  organizationId?: string
   onRegistered?: (provider: RegisterSsoProviderData) => void
 } & Omit<CardProps, "children">
 
@@ -46,6 +47,7 @@ const getErrorMessage = (error: Error | null) => {
 export function SsoProviderSetup({
   className,
   defaultOrganizationId,
+  organizationId: fixedOrganizationId,
   onRegistered,
   variant,
   ...props
@@ -64,7 +66,8 @@ export function SsoProviderSetup({
     const providerId = readString(formData, "providerId")
     const issuer = readString(formData, "issuer")
     const domain = readString(formData, "domain")
-    const organizationId = readString(formData, "organizationId") || undefined
+    const organizationId =
+      fixedOrganizationId || readString(formData, "organizationId") || undefined
     const common = { providerId, issuer, domain, organizationId }
     const params =
       protocol === "oidc"
@@ -126,11 +129,16 @@ export function SsoProviderSetup({
             <FieldError />
           </TextField>
 
-          <TextField defaultValue={defaultOrganizationId} name="organizationId">
-            <Label>{localization.organizationId}</Label>
-            <Input variant="secondary" />
-            <FieldError />
-          </TextField>
+          {!fixedOrganizationId ? (
+            <TextField
+              defaultValue={defaultOrganizationId}
+              name="organizationId"
+            >
+              <Label>{localization.organizationId}</Label>
+              <Input variant="secondary" />
+              <FieldError />
+            </TextField>
+          ) : null}
 
           <Tabs
             selectedKey={protocol}

--- a/packages/heroui/src/lib/auth/sso-plugin.ts
+++ b/packages/heroui/src/lib/auth/sso-plugin.ts
@@ -1,20 +1,47 @@
-import { createAuthPlugin } from "@better-auth-ui/core"
+import {
+  type AuthPluginBase,
+  type AuthPluginLocalizationContext,
+  createAuthPlugin
+} from "@better-auth-ui/core"
 import {
   ssoPlugin as coreSsoPlugin,
+  type SsoLocalization,
   type SsoPluginOptions
 } from "@better-auth-ui/core/plugins/sso"
 
 import { EmailFirstSignIn } from "../../components/auth/sso/email-first-sign-in"
+import { OrganizationSsoProviders } from "../../components/auth/sso/organization-sso-providers"
 
 export const ssoPlugin = createAuthPlugin(
   coreSsoPlugin.id,
   (options: SsoPluginOptions = {}) => {
     const plugin = coreSsoPlugin(options)
+    const localizedOrganizationTab = (localization: SsoLocalization) =>
+      plugin.organization
+        ? {
+            organizationTabs: [
+              {
+                id: "sso",
+                path: plugin.path,
+                label: localization.providerList,
+                component: OrganizationSsoProviders
+              }
+            ]
+          }
+        : {}
 
     return {
       ...plugin,
+      ...localizedOrganizationTab(plugin.localization),
       ...(plugin.emailFirst && {
         views: { auth: { signIn: EmailFirstSignIn } }
+      }),
+      _localizationResolver: (
+        resolvedPlugin: AuthPluginBase,
+        context: AuthPluginLocalizationContext
+      ) => ({
+        ...resolvedPlugin,
+        ...localizedOrganizationTab(context.localization as SsoLocalization)
       })
     }
   }

--- a/packages/heroui/src/plugins/sso/index.ts
+++ b/packages/heroui/src/plugins/sso/index.ts
@@ -1,6 +1,7 @@
 "use client"
 
 export * from "../../components/auth/sso/email-first-sign-in"
+export * from "../../components/auth/sso/organization-sso-providers"
 export * from "../../components/auth/sso/sso-domain-verification"
 export * from "../../components/auth/sso/sso-provider-setup"
 export * from "../../lib/auth/auth-plugin"

--- a/packages/heroui/tests/sso.test.tsx
+++ b/packages/heroui/tests/sso.test.tsx
@@ -1,15 +1,25 @@
+import { authQueryKeys } from "@better-auth-ui/core"
+import { QueryClient } from "@tanstack/react-query"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { Auth } from "../src/components/auth/auth"
 import { AuthProvider } from "../src/components/auth/auth-provider"
+import { OrganizationSsoProviders } from "../src/components/auth/sso/organization-sso-providers"
 import { SsoDomainVerification } from "../src/components/auth/sso/sso-domain-verification"
 import { SsoProviderSetup } from "../src/components/auth/sso/sso-provider-setup"
+import { organizationPlugin } from "../src/lib/auth/organization-plugin"
 import { passkeyPlugin } from "../src/lib/auth/passkey-plugin"
 import { ssoPlugin } from "../src/lib/auth/sso-plugin"
 
-function createMockAuthClient({ hasProvider = false } = {}) {
+function createMockAuthClient({
+  hasProvider = false,
+  memberRole
+}: {
+  hasProvider?: boolean
+  memberRole?: string
+} = {}) {
   const sso = vi.fn(async () => {
     if (!hasProvider) {
       throw Object.assign(new Error("No provider found"), { status: 404 })
@@ -30,11 +40,19 @@ function createMockAuthClient({ hasProvider = false } = {}) {
     domainVerificationToken: "renewed-token"
   }))
   const verifyDomain = vi.fn(async () => undefined)
+  const getActiveMemberRole = vi.fn(async () => ({ role: memberRole }))
+  const session = memberRole
+    ? {
+        session: { id: "session-1" },
+        user: { id: "user-1", email: "person@example.com", name: "Person" }
+      }
+    : null
 
   return {
     signIn: { email, passkey, sso },
     sso: { register, requestDomainVerification, verifyDomain },
-    useSession: () => ({ data: null, isPending: false, error: null })
+    organization: { getActiveMemberRole },
+    useSession: () => ({ data: session, isPending: false, error: null })
   } as unknown as Parameters<typeof AuthProvider>[0]["authClient"] & {
     signIn: { email: typeof email; passkey: typeof passkey; sso: typeof sso }
     sso: {
@@ -166,6 +184,49 @@ describe("<EmailFirstSignIn />", () => {
 })
 
 describe("SSO provider management", () => {
+  it("registers an organization settings tab with explicit scope", () => {
+    const plugin = ssoPlugin({ path: "identity", organization: true })
+
+    expect(plugin.organizationTabs?.[0]).toMatchObject({
+      id: "sso",
+      path: "identity",
+      component: OrganizationSsoProviders
+    })
+    expect(ssoPlugin({ organization: false }).organizationTabs).toBeUndefined()
+  })
+
+  it("shows access denied without waiting for the disabled providers query", async () => {
+    const authClient = createMockAuthClient({ memberRole: "member" })
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, staleTime: Infinity },
+        mutations: { retry: false }
+      }
+    })
+    queryClient.setQueryData(authQueryKeys.session, {
+      session: { id: "session-1" },
+      user: { id: "user-1", email: "person@example.com", name: "Person" }
+    })
+
+    const { container } = render(
+      <AuthProvider
+        authClient={authClient}
+        navigate={vi.fn()}
+        plugins={[organizationPlugin(), ssoPlugin({ emailFirst: false })]}
+        queryClient={queryClient}
+      >
+        <OrganizationSsoProviders
+          organizationId="org-1"
+          organizationSlug="acme"
+        />
+      </AuthProvider>
+    )
+
+    await waitFor(() => {
+      expect(container.querySelector("[data-access-denied]")).toBeVisible()
+    })
+  })
+
   it("registers an OIDC provider from the setup form", async () => {
     const user = userEvent.setup()
     const authClient = createMockAuthClient()

--- a/packages/locales/src/de-DE-plugins.ts
+++ b/packages/locales/src/de-DE-plugins.ts
@@ -601,6 +601,7 @@ export const deDEPlugins = {
   } satisfies Translated<SiweLocalization>,
   sso: {
     addProvider: "SSO-Anbieter hinzufügen",
+    cancel: "Abbrechen",
     clientId: "Client-ID",
     clientSecret: "Client-Secret",
     continueWithEmail: "Mit E-Mail-Adresse fortfahren",
@@ -613,20 +614,38 @@ export const deDEPlugins = {
       "Veröffentliche den TXT-Eintrag für jede konfigurierte Domain und bestätige sie anschließend.",
     domainVerificationRequested: "Ein neuer Bestätigungstoken wurde erstellt.",
     domainVerified: "Die Domain des Anbieters wurde bestätigt.",
+    deleteProvider: "Anbieter löschen",
+    deleteProviderDescription:
+      "Benutzer können sich nicht mehr über diesen Anbieter anmelden.",
+    discoveryEndpoint: "Discovery-Endpunkt",
+    editProvider: "Anbieter bearbeiten",
     emailFirstDescription:
       "Gib deine geschäftliche E-Mail-Adresse ein, um fortzufahren.",
     entryPoint: "SSO-URL",
     identityProviderMetadata: "Metadaten-XML des Identitätsanbieters",
     issuer: "Aussteller-URL",
     oidc: "OIDC",
+    noProviders: "Keine SSO-Anbieter",
+    noProvidersDescription:
+      "Füge einen Identitätsanbieter hinzu, um die Organisationsanmeldung zu aktivieren.",
     organizationId: "Organisations-ID",
     providerCreated: "Der SSO-Anbieter wurde hinzugefügt.",
+    providerDeleted: "Der SSO-Anbieter wurde gelöscht.",
     providerId: "Anbieter-ID",
     providerSetup: "SSO-Anbieter einrichten",
     providerSetupDescription:
       "Verbinde einen OpenID-Connect- oder SAML-Identitätsanbieter.",
+    providerList: "Organisations-SSO",
+    providerListDescription:
+      "Verwalte Identitätsanbieter und bestätigte Domains für diese Organisation.",
+    providerAccessDenied:
+      "Nur Organisationsinhaber und Administratoren können SSO-Anbieter verwalten.",
+    providerLoadError: "SSO-Anbieter konnten nicht geladen werden.",
+    providerUpdated: "Der SSO-Anbieter wurde aktualisiert.",
     requestNewToken: "Neuen Token erstellen",
+    retry: "Erneut versuchen",
     saml: "SAML",
+    saveProvider: "Anbieter speichern",
     txtRecordHost: "Host des TXT-Eintrags",
     txtRecordValue: "Wert des TXT-Eintrags",
     useDifferentEmail: "Andere E-Mail-Adresse verwenden",


### PR DESCRIPTION
Add an explicit organization-scoped settings tab for OIDC and SAML providers. Owners and administrators can create, edit, verify, and delete providers without relying on active-organization state.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization SSO provider management, including creation, editing, deletion, and domain verification.
  * Added OIDC and SAML setup with organization-specific provider assignment.
  * Added role-based access controls, loading and empty states, error handling, and retry actions.
  * Added localized organization SSO navigation across supported UI examples.
* **Bug Fixes**
  * Improved domain verification by clearing previous errors and stale tokens when retrying or changing providers.
* **Localization**
  * Added German translations for provider management actions and status messages.
* **Tests**
  * Added coverage for organization SSO navigation and access restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->