### PR TITLE
feat(dash): add scoped activity explorer

### DIFF
--- a/apps/docs/src/components/auth/dash/activity.tsx
+++ b/apps/docs/src/components/auth/dash/activity.tsx
@@ -26,11 +26,12 @@ import {
   ChevronLeft,
   ChevronRight,
   MonitorDot,
+  Search,
   ShieldCheck,
   UserRound,
   Users
 } from "lucide-react"
-import { Fragment, useState } from "react"
+import { Fragment, useDeferredValue, useMemo, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -51,13 +52,26 @@ import {
   EmptyMedia,
   EmptyTitle
 } from "@/components/ui/empty"
+import { Field, FieldLabel } from "@/components/ui/field"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput
+} from "@/components/ui/input-group"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { dashPlugin } from "@/lib/auth/dash-plugin"
 import { cn } from "@/lib/utils"
 
-type ActivityAccess = "admin-user" | "organization" | "user"
+type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
 
 type ActivityFeedProps = {
   access: ActivityAccess
@@ -71,6 +85,8 @@ export type AdminUserActivityProps = {
   className?: string
   userId: string
 }
+
+export type AdminActivityProps = { className?: string }
 
 export type UserActivityProps = { className?: string }
 
@@ -195,15 +211,28 @@ function ActivityFeed({
   const { authClient } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
   const [page, setPage] = useState(0)
+  const [eventType, setEventType] = useState("all")
+  const [identifier, setIdentifier] = useState("")
+  const deferredIdentifier = useDeferredValue(identifier.trim())
+  const eventOptions = useMemo(
+    () => Object.entries(localization.eventLabels),
+    [localization.eventLabels]
+  )
   const offset = page * pageSize
-  const params = { limit: pageSize, offset, organizationId }
+  const params = {
+    eventType: eventType === "all" ? undefined : eventType,
+    identifier: deferredIdentifier || undefined,
+    limit: pageSize,
+    offset,
+    organizationId
+  }
   const userQuery = useDashAuditLogs(authClient as DashAuthClient, {
     enabled: ready && access === "user",
     params,
     placeholderData: keepPreviousData
   })
   const organizationQuery = useDashAllAuditLogs(authClient as DashAuthClient, {
-    enabled: ready && access === "organization",
+    enabled: ready && (access === "admin" || access === "organization"),
     params,
     placeholderData: keepPreviousData
   })
@@ -212,11 +241,16 @@ function ActivityFeed({
     userId,
     {
       enabled: ready && access === "admin-user",
-      params: { limit: pageSize, offset }
+      params: {
+        eventType: params.eventType,
+        identifier: params.identifier,
+        limit: pageSize,
+        offset
+      }
     }
   )
   const query =
-    access === "organization"
+    access === "admin" || access === "organization"
       ? organizationQuery
       : access === "admin-user"
         ? adminUserQuery
@@ -234,11 +268,13 @@ function ActivityFeed({
       <CardHeader>
         <CardTitle>{localization.activity}</CardTitle>
         <CardDescription>
-          {access === "admin-user"
-            ? localization.adminUserActivityDescription
-            : organizationId
-              ? localization.organizationActivityDescription
-              : localization.activityDescription}
+          {access === "admin"
+            ? localization.adminActivityDescription
+            : access === "admin-user"
+              ? localization.adminUserActivityDescription
+              : organizationId
+                ? localization.organizationActivityDescription
+                : localization.activityDescription}
         </CardDescription>
         {organizationId && (
           <CardAction>
@@ -251,7 +287,52 @@ function ActivityFeed({
         )}
       </CardHeader>
 
-      <CardContent>
+      <CardContent className="flex flex-col gap-4">
+        <div className="grid gap-2 sm:grid-cols-[12rem_minmax(14rem,1fr)]">
+          <Field>
+            <FieldLabel htmlFor="dash-event-type">
+              {localization.eventType}
+            </FieldLabel>
+            <Select
+              value={eventType}
+              onValueChange={(value) => {
+                setEventType(value)
+                setPage(0)
+              }}
+            >
+              <SelectTrigger id="dash-event-type" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{localization.allEvents}</SelectItem>
+                {eventOptions.map(([key, label]) => (
+                  <SelectItem key={key} value={key}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="dash-identifier">
+              {localization.identifier}
+            </FieldLabel>
+            <InputGroup>
+              <InputGroupAddon>
+                <Search />
+              </InputGroupAddon>
+              <InputGroupInput
+                id="dash-identifier"
+                onChange={(event) => {
+                  setIdentifier(event.target.value)
+                  setPage(0)
+                }}
+                placeholder={localization.identifierPlaceholder}
+                value={identifier}
+              />
+            </InputGroup>
+          </Field>
+        </div>
         {showPending ? (
           <ul>
             {generateN(3).map((skeletonId, position) => (
@@ -346,6 +427,11 @@ function ActivityFeed({
 /** Authentication and account activity for a user selected by an administrator. */
 export function AdminUserActivity(props: AdminUserActivityProps) {
   return <ActivityFeed key={props.userId} access="admin-user" {...props} />
+}
+
+/** Activity across every organization the current owner or administrator can manage. */
+export function AdminActivity(props: AdminActivityProps) {
+  return <ActivityFeed access="admin" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/apps/docs/src/lib/auth/dash-plugin.ts
+++ b/apps/docs/src/lib/auth/dash-plugin.ts
@@ -7,6 +7,7 @@ import { Activity } from "lucide-react"
 import { createElement } from "react"
 
 import {
+  AdminActivity,
   AdminUserActivity,
   OrganizationActivity,
   UserActivity
@@ -28,6 +29,14 @@ export const dashPlugin = createAuthPlugin(
       ...core,
       ...(core.admin
         ? {
+            adminTabs: [
+              {
+                id: "activity",
+                path: core.viewPaths.settings.activity,
+                label: activityLabel(core.localization.activity),
+                component: AdminActivity
+              }
+            ],
             adminUserTabs: [
               {
                 id: "activity",

--- a/examples/next-shadcn-example/src/components/auth/dash/activity.tsx
+++ b/examples/next-shadcn-example/src/components/auth/dash/activity.tsx
@@ -26,11 +26,12 @@ import {
   ChevronLeft,
   ChevronRight,
   MonitorDot,
+  Search,
   ShieldCheck,
   UserRound,
   Users
 } from "lucide-react"
-import { Fragment, useState } from "react"
+import { Fragment, useDeferredValue, useMemo, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -51,13 +52,26 @@ import {
   EmptyMedia,
   EmptyTitle
 } from "@/components/ui/empty"
+import { Field, FieldLabel } from "@/components/ui/field"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput
+} from "@/components/ui/input-group"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { dashPlugin } from "@/lib/auth/dash-plugin"
 import { cn } from "@/lib/utils"
 
-type ActivityAccess = "admin-user" | "organization" | "user"
+type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
 
 type ActivityFeedProps = {
   access: ActivityAccess
@@ -71,6 +85,8 @@ export type AdminUserActivityProps = {
   className?: string
   userId: string
 }
+
+export type AdminActivityProps = { className?: string }
 
 export type UserActivityProps = { className?: string }
 
@@ -195,15 +211,28 @@ function ActivityFeed({
   const { authClient } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
   const [page, setPage] = useState(0)
+  const [eventType, setEventType] = useState("all")
+  const [identifier, setIdentifier] = useState("")
+  const deferredIdentifier = useDeferredValue(identifier.trim())
+  const eventOptions = useMemo(
+    () => Object.entries(localization.eventLabels),
+    [localization.eventLabels]
+  )
   const offset = page * pageSize
-  const params = { limit: pageSize, offset, organizationId }
+  const params = {
+    eventType: eventType === "all" ? undefined : eventType,
+    identifier: deferredIdentifier || undefined,
+    limit: pageSize,
+    offset,
+    organizationId
+  }
   const userQuery = useDashAuditLogs(authClient as DashAuthClient, {
     enabled: ready && access === "user",
     params,
     placeholderData: keepPreviousData
   })
   const organizationQuery = useDashAllAuditLogs(authClient as DashAuthClient, {
-    enabled: ready && access === "organization",
+    enabled: ready && (access === "admin" || access === "organization"),
     params,
     placeholderData: keepPreviousData
   })
@@ -212,11 +241,16 @@ function ActivityFeed({
     userId,
     {
       enabled: ready && access === "admin-user",
-      params: { limit: pageSize, offset }
+      params: {
+        eventType: params.eventType,
+        identifier: params.identifier,
+        limit: pageSize,
+        offset
+      }
     }
   )
   const query =
-    access === "organization"
+    access === "admin" || access === "organization"
       ? organizationQuery
       : access === "admin-user"
         ? adminUserQuery
@@ -234,11 +268,13 @@ function ActivityFeed({
       <CardHeader>
         <CardTitle>{localization.activity}</CardTitle>
         <CardDescription>
-          {access === "admin-user"
-            ? localization.adminUserActivityDescription
-            : organizationId
-              ? localization.organizationActivityDescription
-              : localization.activityDescription}
+          {access === "admin"
+            ? localization.adminActivityDescription
+            : access === "admin-user"
+              ? localization.adminUserActivityDescription
+              : organizationId
+                ? localization.organizationActivityDescription
+                : localization.activityDescription}
         </CardDescription>
         {organizationId && (
           <CardAction>
@@ -251,7 +287,52 @@ function ActivityFeed({
         )}
       </CardHeader>
 
-      <CardContent>
+      <CardContent className="flex flex-col gap-4">
+        <div className="grid gap-2 sm:grid-cols-[12rem_minmax(14rem,1fr)]">
+          <Field>
+            <FieldLabel htmlFor="dash-event-type">
+              {localization.eventType}
+            </FieldLabel>
+            <Select
+              value={eventType}
+              onValueChange={(value) => {
+                setEventType(value)
+                setPage(0)
+              }}
+            >
+              <SelectTrigger id="dash-event-type" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{localization.allEvents}</SelectItem>
+                {eventOptions.map(([key, label]) => (
+                  <SelectItem key={key} value={key}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="dash-identifier">
+              {localization.identifier}
+            </FieldLabel>
+            <InputGroup>
+              <InputGroupAddon>
+                <Search />
+              </InputGroupAddon>
+              <InputGroupInput
+                id="dash-identifier"
+                onChange={(event) => {
+                  setIdentifier(event.target.value)
+                  setPage(0)
+                }}
+                placeholder={localization.identifierPlaceholder}
+                value={identifier}
+              />
+            </InputGroup>
+          </Field>
+        </div>
         {showPending ? (
           <ul>
             {generateN(3).map((skeletonId, position) => (
@@ -346,6 +427,11 @@ function ActivityFeed({
 /** Authentication and account activity for a user selected by an administrator. */
 export function AdminUserActivity(props: AdminUserActivityProps) {
   return <ActivityFeed key={props.userId} access="admin-user" {...props} />
+}
+
+/** Activity across every organization the current owner or administrator can manage. */
+export function AdminActivity(props: AdminActivityProps) {
+  return <ActivityFeed access="admin" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/examples/next-shadcn-example/src/lib/auth/dash-plugin.ts
+++ b/examples/next-shadcn-example/src/lib/auth/dash-plugin.ts
@@ -7,6 +7,7 @@ import { Activity } from "lucide-react"
 import { createElement } from "react"
 
 import {
+  AdminActivity,
   AdminUserActivity,
   OrganizationActivity,
   UserActivity
@@ -28,6 +29,14 @@ export const dashPlugin = createAuthPlugin(
       ...core,
       ...(core.admin
         ? {
+            adminTabs: [
+              {
+                id: "activity",
+                path: core.viewPaths.settings.activity,
+                label: activityLabel(core.localization.activity),
+                component: AdminActivity
+              }
+            ],
             adminUserTabs: [
               {
                 id: "activity",

--- a/examples/start-shadcn-baseui-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/dash/activity.tsx
@@ -26,11 +26,12 @@ import {
   ChevronLeft,
   ChevronRight,
   MonitorDot,
+  Search,
   ShieldCheck,
   UserRound,
   Users
 } from "lucide-react"
-import { Fragment, useState } from "react"
+import { Fragment, useDeferredValue, useMemo, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -51,13 +52,26 @@ import {
   EmptyMedia,
   EmptyTitle
 } from "@/components/ui/empty"
+import { Field, FieldLabel } from "@/components/ui/field"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput
+} from "@/components/ui/input-group"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { dashPlugin } from "@/lib/auth/dash-plugin"
 import { cn } from "@/lib/utils"
 
-type ActivityAccess = "admin-user" | "organization" | "user"
+type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
 
 type ActivityFeedProps = {
   access: ActivityAccess
@@ -71,6 +85,8 @@ export type AdminUserActivityProps = {
   className?: string
   userId: string
 }
+
+export type AdminActivityProps = { className?: string }
 
 export type UserActivityProps = { className?: string }
 
@@ -195,15 +211,28 @@ function ActivityFeed({
   const { authClient } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
   const [page, setPage] = useState(0)
+  const [eventType, setEventType] = useState("all")
+  const [identifier, setIdentifier] = useState("")
+  const deferredIdentifier = useDeferredValue(identifier.trim())
+  const eventOptions = useMemo(
+    () => Object.entries(localization.eventLabels),
+    [localization.eventLabels]
+  )
   const offset = page * pageSize
-  const params = { limit: pageSize, offset, organizationId }
+  const params = {
+    eventType: eventType === "all" ? undefined : eventType,
+    identifier: deferredIdentifier || undefined,
+    limit: pageSize,
+    offset,
+    organizationId
+  }
   const userQuery = useDashAuditLogs(authClient as DashAuthClient, {
     enabled: ready && access === "user",
     params,
     placeholderData: keepPreviousData
   })
   const organizationQuery = useDashAllAuditLogs(authClient as DashAuthClient, {
-    enabled: ready && access === "organization",
+    enabled: ready && (access === "admin" || access === "organization"),
     params,
     placeholderData: keepPreviousData
   })
@@ -212,11 +241,16 @@ function ActivityFeed({
     userId,
     {
       enabled: ready && access === "admin-user",
-      params: { limit: pageSize, offset }
+      params: {
+        eventType: params.eventType,
+        identifier: params.identifier,
+        limit: pageSize,
+        offset
+      }
     }
   )
   const query =
-    access === "organization"
+    access === "admin" || access === "organization"
       ? organizationQuery
       : access === "admin-user"
         ? adminUserQuery
@@ -234,11 +268,13 @@ function ActivityFeed({
       <CardHeader>
         <CardTitle>{localization.activity}</CardTitle>
         <CardDescription>
-          {access === "admin-user"
-            ? localization.adminUserActivityDescription
-            : organizationId
-              ? localization.organizationActivityDescription
-              : localization.activityDescription}
+          {access === "admin"
+            ? localization.adminActivityDescription
+            : access === "admin-user"
+              ? localization.adminUserActivityDescription
+              : organizationId
+                ? localization.organizationActivityDescription
+                : localization.activityDescription}
         </CardDescription>
         {organizationId && (
           <CardAction>
@@ -251,7 +287,53 @@ function ActivityFeed({
         )}
       </CardHeader>
 
-      <CardContent>
+      <CardContent className="flex flex-col gap-4">
+        <div className="grid gap-2 sm:grid-cols-[12rem_minmax(14rem,1fr)]">
+          <Field>
+            <FieldLabel htmlFor="dash-event-type">
+              {localization.eventType}
+            </FieldLabel>
+            <Select
+              value={eventType}
+              onValueChange={(value) => {
+                if (!value) return
+                setEventType(value)
+                setPage(0)
+              }}
+            >
+              <SelectTrigger id="dash-event-type" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{localization.allEvents}</SelectItem>
+                {eventOptions.map(([key, label]) => (
+                  <SelectItem key={key} value={key}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="dash-identifier">
+              {localization.identifier}
+            </FieldLabel>
+            <InputGroup>
+              <InputGroupAddon>
+                <Search />
+              </InputGroupAddon>
+              <InputGroupInput
+                id="dash-identifier"
+                onChange={(event) => {
+                  setIdentifier(event.target.value)
+                  setPage(0)
+                }}
+                placeholder={localization.identifierPlaceholder}
+                value={identifier}
+              />
+            </InputGroup>
+          </Field>
+        </div>
         {showPending ? (
           <ul>
             {generateN(3).map((skeletonId, position) => (
@@ -346,6 +428,11 @@ function ActivityFeed({
 /** Authentication and account activity for a user selected by an administrator. */
 export function AdminUserActivity(props: AdminUserActivityProps) {
   return <ActivityFeed key={props.userId} access="admin-user" {...props} />
+}
+
+/** Activity across every organization the current owner or administrator can manage. */
+export function AdminActivity(props: AdminActivityProps) {
+  return <ActivityFeed access="admin" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/examples/start-shadcn-baseui-example/src/lib/auth/dash-plugin.ts
+++ b/examples/start-shadcn-baseui-example/src/lib/auth/dash-plugin.ts
@@ -7,6 +7,7 @@ import { Activity } from "lucide-react"
 import { createElement } from "react"
 
 import {
+  AdminActivity,
   AdminUserActivity,
   OrganizationActivity,
   UserActivity
@@ -28,6 +29,14 @@ export const dashPlugin = createAuthPlugin(
       ...core,
       ...(core.admin
         ? {
+            adminTabs: [
+              {
+                id: "activity",
+                path: core.viewPaths.settings.activity,
+                label: activityLabel(core.localization.activity),
+                component: AdminActivity
+              }
+            ],
             adminUserTabs: [
               {
                 id: "activity",

--- a/examples/start-shadcn-example/registry.json
+++ b/examples/start-shadcn-example/registry.json
@@ -695,7 +695,7 @@
       "name": "dash",
       "type": "registry:component",
       "title": "Dash Activity",
-      "description": "Personal activity and role-aware organization audit logs backed by Better Auth Infrastructure Dash.",
+      "description": "Filtered personal, organization, and administrator audit logs backed by Better Auth Infrastructure Dash.",
       "dependencies": [
         "@better-auth-ui/react@latest",
         "@better-auth-ui/core@latest",
@@ -707,6 +707,9 @@
         "button",
         "card",
         "empty",
+        "field",
+        "input-group",
+        "select",
         "separator",
         "skeleton",
         "spinner"

--- a/examples/start-shadcn-example/scripts/build-registry.ts
+++ b/examples/start-shadcn-example/scripts/build-registry.ts
@@ -28,6 +28,7 @@ const EXPECTED_BASE_UI_OVERRIDES = [
   "src/components/auth/api-key/api-keys.tsx",
   "src/components/auth/api-key/create-api-key-dialog.tsx",
   "src/components/auth/api-key/edit-api-key-dialog.tsx",
+  "src/components/auth/dash/activity.tsx",
   "src/components/auth/organization/invite-member-dialog.tsx",
   "src/components/auth/organization/organization-teams.tsx",
   "src/components/auth/organization/team-switcher.tsx",

--- a/examples/start-shadcn-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-shadcn-example/src/components/auth/dash/activity.tsx
@@ -26,11 +26,12 @@ import {
   ChevronLeft,
   ChevronRight,
   MonitorDot,
+  Search,
   ShieldCheck,
   UserRound,
   Users
 } from "lucide-react"
-import { Fragment, useState } from "react"
+import { Fragment, useDeferredValue, useMemo, useState } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -51,13 +52,26 @@ import {
   EmptyMedia,
   EmptyTitle
 } from "@/components/ui/empty"
+import { Field, FieldLabel } from "@/components/ui/field"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput
+} from "@/components/ui/input-group"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { dashPlugin } from "@/lib/auth/dash-plugin"
 import { cn } from "@/lib/utils"
 
-type ActivityAccess = "admin-user" | "organization" | "user"
+type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
 
 type ActivityFeedProps = {
   access: ActivityAccess
@@ -71,6 +85,8 @@ export type AdminUserActivityProps = {
   className?: string
   userId: string
 }
+
+export type AdminActivityProps = { className?: string }
 
 export type UserActivityProps = { className?: string }
 
@@ -195,15 +211,28 @@ function ActivityFeed({
   const { authClient } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
   const [page, setPage] = useState(0)
+  const [eventType, setEventType] = useState("all")
+  const [identifier, setIdentifier] = useState("")
+  const deferredIdentifier = useDeferredValue(identifier.trim())
+  const eventOptions = useMemo(
+    () => Object.entries(localization.eventLabels),
+    [localization.eventLabels]
+  )
   const offset = page * pageSize
-  const params = { limit: pageSize, offset, organizationId }
+  const params = {
+    eventType: eventType === "all" ? undefined : eventType,
+    identifier: deferredIdentifier || undefined,
+    limit: pageSize,
+    offset,
+    organizationId
+  }
   const userQuery = useDashAuditLogs(authClient as DashAuthClient, {
     enabled: ready && access === "user",
     params,
     placeholderData: keepPreviousData
   })
   const organizationQuery = useDashAllAuditLogs(authClient as DashAuthClient, {
-    enabled: ready && access === "organization",
+    enabled: ready && (access === "admin" || access === "organization"),
     params,
     placeholderData: keepPreviousData
   })
@@ -212,11 +241,16 @@ function ActivityFeed({
     userId,
     {
       enabled: ready && access === "admin-user",
-      params: { limit: pageSize, offset }
+      params: {
+        eventType: params.eventType,
+        identifier: params.identifier,
+        limit: pageSize,
+        offset
+      }
     }
   )
   const query =
-    access === "organization"
+    access === "admin" || access === "organization"
       ? organizationQuery
       : access === "admin-user"
         ? adminUserQuery
@@ -234,11 +268,13 @@ function ActivityFeed({
       <CardHeader>
         <CardTitle>{localization.activity}</CardTitle>
         <CardDescription>
-          {access === "admin-user"
-            ? localization.adminUserActivityDescription
-            : organizationId
-              ? localization.organizationActivityDescription
-              : localization.activityDescription}
+          {access === "admin"
+            ? localization.adminActivityDescription
+            : access === "admin-user"
+              ? localization.adminUserActivityDescription
+              : organizationId
+                ? localization.organizationActivityDescription
+                : localization.activityDescription}
         </CardDescription>
         {organizationId && (
           <CardAction>
@@ -251,7 +287,52 @@ function ActivityFeed({
         )}
       </CardHeader>
 
-      <CardContent>
+      <CardContent className="flex flex-col gap-4">
+        <div className="grid gap-2 sm:grid-cols-[12rem_minmax(14rem,1fr)]">
+          <Field>
+            <FieldLabel htmlFor="dash-event-type">
+              {localization.eventType}
+            </FieldLabel>
+            <Select
+              value={eventType}
+              onValueChange={(value) => {
+                setEventType(value)
+                setPage(0)
+              }}
+            >
+              <SelectTrigger id="dash-event-type" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">{localization.allEvents}</SelectItem>
+                {eventOptions.map(([key, label]) => (
+                  <SelectItem key={key} value={key}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Field>
+          <Field>
+            <FieldLabel htmlFor="dash-identifier">
+              {localization.identifier}
+            </FieldLabel>
+            <InputGroup>
+              <InputGroupAddon>
+                <Search />
+              </InputGroupAddon>
+              <InputGroupInput
+                id="dash-identifier"
+                onChange={(event) => {
+                  setIdentifier(event.target.value)
+                  setPage(0)
+                }}
+                placeholder={localization.identifierPlaceholder}
+                value={identifier}
+              />
+            </InputGroup>
+          </Field>
+        </div>
         {showPending ? (
           <ul>
             {generateN(3).map((skeletonId, position) => (
@@ -346,6 +427,11 @@ function ActivityFeed({
 /** Authentication and account activity for a user selected by an administrator. */
 export function AdminUserActivity(props: AdminUserActivityProps) {
   return <ActivityFeed key={props.userId} access="admin-user" {...props} />
+}
+
+/** Activity across every organization the current owner or administrator can manage. */
+export function AdminActivity(props: AdminActivityProps) {
+  return <ActivityFeed access="admin" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/examples/start-shadcn-example/src/lib/auth/dash-plugin.ts
+++ b/examples/start-shadcn-example/src/lib/auth/dash-plugin.ts
@@ -7,6 +7,7 @@ import { Activity } from "lucide-react"
 import { createElement } from "react"
 
 import {
+  AdminActivity,
   AdminUserActivity,
   OrganizationActivity,
   UserActivity
@@ -28,6 +29,14 @@ export const dashPlugin = createAuthPlugin(
       ...core,
       ...(core.admin
         ? {
+            adminTabs: [
+              {
+                id: "activity",
+                path: core.viewPaths.settings.activity,
+                label: activityLabel(core.localization.activity),
+                component: AdminActivity
+              }
+            ],
             adminUserTabs: [
               {
                 id: "activity",

--- a/examples/start-solid-zaidan-example/registry.manifest.ts
+++ b/examples/start-solid-zaidan-example/registry.manifest.ts
@@ -465,7 +465,7 @@ export const solidRegistryManifest = {
       type: "registry:component",
       title: "Solid Dash Activity",
       description:
-        "Solid personal activity and role-aware organization audit logs backed by Better Auth Infrastructure Dash.",
+        "Filtered Solid personal and organization audit logs, plus an administrator view across organizations the current administrator can manage, backed by Better Auth Infrastructure Dash.",
       dependencies: [...solidAuthDependencies, "@better-auth/infra@latest"],
       registryDependencies: [
         betterAuthSolidRegistryDependency("auth-provider"),

--- a/examples/start-solid-zaidan-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/dash/activity.tsx
@@ -23,11 +23,20 @@ import {
   ChevronLeft,
   ChevronRight,
   MonitorDot,
+  Search,
   ShieldCheck,
   UserRound,
   Users
 } from "lucide-solid"
-import { createEffect, createSignal, For, on, Show } from "solid-js"
+import {
+  createDeferred,
+  createEffect,
+  createMemo,
+  createSignal,
+  For,
+  on,
+  Show
+} from "solid-js"
 import { Dynamic } from "solid-js/web"
 
 import { Badge } from "@/components/ui/badge"
@@ -49,13 +58,20 @@ import {
   EmptyMedia,
   EmptyTitle
 } from "@/components/ui/empty"
+import { Field, FieldLabel } from "@/components/ui/field"
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput
+} from "@/components/ui/input-group"
+import { NativeSelect, NativeSelectOption } from "@/components/ui/native-select"
 import { Separator } from "@/components/ui/separator"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { dashPlugin } from "@/lib/auth/dash-plugin"
 import { cn } from "@/lib/utils"
 
-type ActivityAccess = "admin-user" | "organization" | "user"
+type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
 
 type ActivityFeedProps = {
   access: ActivityAccess
@@ -69,6 +85,8 @@ export type AdminUserActivityProps = {
   class?: string
   userId: string
 }
+
+export type AdminActivityProps = { class?: string }
 
 export type UserActivityProps = { class?: string }
 
@@ -190,6 +208,12 @@ function ActivityFeed(props: ActivityFeedProps) {
   const auth = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
   const [page, setPage] = createSignal(0)
+  const [eventType, setEventType] = createSignal("all")
+  const [identifier, setIdentifier] = createSignal("")
+  const deferredIdentifier = createDeferred(() => identifier().trim())
+  const eventOptions = createMemo(() =>
+    Object.entries(localization.eventLabels)
+  )
   createEffect(
     on(
       () => [props.access, props.organizationId, props.userId] as const,
@@ -199,6 +223,8 @@ function ActivityFeed(props: ActivityFeedProps) {
   )
   const offset = () => page() * pageSize
   const params = () => ({
+    eventType: eventType() === "all" ? undefined : eventType(),
+    identifier: deferredIdentifier() || undefined,
     limit: pageSize,
     offset: offset(),
     organizationId: props.organizationId
@@ -211,7 +237,9 @@ function ActivityFeed(props: ActivityFeedProps) {
   const organizationQuery = useDashAllAuditLogs(
     auth.authClient as DashAuthClient,
     () => ({
-      enabled: (props.ready ?? true) && props.access === "organization",
+      enabled:
+        (props.ready ?? true) &&
+        (props.access === "admin" || props.access === "organization"),
       params: params(),
       placeholderData: keepPreviousData
     })
@@ -221,11 +249,16 @@ function ActivityFeed(props: ActivityFeedProps) {
     () => props.userId,
     () => ({
       enabled: (props.ready ?? true) && props.access === "admin-user",
-      params: { limit: pageSize, offset: offset() }
+      params: {
+        eventType: params().eventType,
+        identifier: params().identifier,
+        limit: pageSize,
+        offset: offset()
+      }
     })
   )
   const query = () =>
-    props.access === "organization"
+    props.access === "admin" || props.access === "organization"
       ? organizationQuery
       : props.access === "admin-user"
         ? adminUserQuery
@@ -242,11 +275,13 @@ function ActivityFeed(props: ActivityFeedProps) {
       <CardHeader>
         <CardTitle>{localization.activity}</CardTitle>
         <CardDescription>
-          {props.access === "admin-user"
-            ? localization.adminUserActivityDescription
-            : props.organizationId
-              ? localization.organizationActivityDescription
-              : localization.activityDescription}
+          {props.access === "admin"
+            ? localization.adminActivityDescription
+            : props.access === "admin-user"
+              ? localization.adminUserActivityDescription
+              : props.organizationId
+                ? localization.organizationActivityDescription
+                : localization.activityDescription}
         </CardDescription>
         <Show when={props.organizationId}>
           <CardAction>
@@ -259,7 +294,50 @@ function ActivityFeed(props: ActivityFeedProps) {
         </Show>
       </CardHeader>
 
-      <CardContent>
+      <CardContent class="flex flex-col gap-4">
+        <div class="grid gap-2 sm:grid-cols-[12rem_minmax(14rem,1fr)]">
+          <Field>
+            <FieldLabel for="solid-dash-event-type">
+              {localization.eventType}
+            </FieldLabel>
+            <NativeSelect
+              id="solid-dash-event-type"
+              onChange={(event) => {
+                setEventType(event.currentTarget.value)
+                setPage(0)
+              }}
+              value={eventType()}
+            >
+              <NativeSelectOption value="all">
+                {localization.allEvents}
+              </NativeSelectOption>
+              <For each={eventOptions()}>
+                {([key, label]) => (
+                  <NativeSelectOption value={key}>{label}</NativeSelectOption>
+                )}
+              </For>
+            </NativeSelect>
+          </Field>
+          <Field>
+            <FieldLabel for="solid-dash-identifier">
+              {localization.identifier}
+            </FieldLabel>
+            <InputGroup>
+              <InputGroupAddon>
+                <Search />
+              </InputGroupAddon>
+              <InputGroupInput
+                id="solid-dash-identifier"
+                onInput={(event) => {
+                  setIdentifier(event.currentTarget.value)
+                  setPage(0)
+                }}
+                placeholder={localization.identifierPlaceholder}
+                value={identifier()}
+              />
+            </InputGroup>
+          </Field>
+        </div>
         <Show
           when={!showPending()}
           fallback={
@@ -377,6 +455,11 @@ function ActivityFeed(props: ActivityFeedProps) {
 /** Authentication and account activity for a user selected by an administrator. */
 export function AdminUserActivity(props: AdminUserActivityProps) {
   return <ActivityFeed access="admin-user" {...props} />
+}
+
+/** Activity across every organization the current owner or administrator can manage. */
+export function AdminActivity(props: AdminActivityProps) {
+  return <ActivityFeed access="admin" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/examples/start-solid-zaidan-example/src/lib/auth/dash-plugin.tsx
+++ b/examples/start-solid-zaidan-example/src/lib/auth/dash-plugin.tsx
@@ -7,6 +7,7 @@ import {
 import { Activity } from "lucide-solid"
 
 import {
+  AdminActivity,
   AdminUserActivity,
   OrganizationActivity,
   UserActivity
@@ -29,6 +30,14 @@ export const dashPlugin = createAuthPlugin(
       localization: core.localization as DashLocalization,
       ...(core.admin
         ? {
+            adminTabs: [
+              {
+                id: "activity",
+                path: core.viewPaths.settings.activity,
+                label: ActivityLabel,
+                component: AdminActivity
+              }
+            ],
             adminUserTabs: [
               {
                 id: "activity",

--- a/packages/core/src/plugins/dash/dash-localization.ts
+++ b/packages/core/src/plugins/dash/dash-localization.ts
@@ -45,6 +45,8 @@ export const dashLocalization = {
   activityDescription: "Review recent authentication and account activity.",
   adminUserActivityDescription:
     "Review recent authentication and account activity for this user.",
+  adminActivityDescription:
+    "Review activity across the organizations you manage.",
   organizationActivityDescription:
     "Review activity you can access for this organization.",
   organizationWide: "Organization-wide",
@@ -58,6 +60,10 @@ export const dashLocalization = {
   paginationRange: "{{from}}–{{to}} of {{total}}",
   previousPage: "Previous page",
   nextPage: "Next page",
+  allEvents: "All events",
+  eventType: "Event type",
+  identifier: "Identifier",
+  identifierPlaceholder: "Filter by email, user ID, or provider",
   unknownEvent: "Activity event",
   eventLabels: dashEventLabels
 }

--- a/packages/heroui/src/components/auth/dash/activity.tsx
+++ b/packages/heroui/src/components/auth/dash/activity.tsx
@@ -37,14 +37,18 @@ import {
   type CardProps,
   Chip,
   cn,
+  Label,
+  ListBox,
+  SearchField,
+  Select,
   Skeleton,
   Spinner
 } from "@heroui/react"
 import { keepPreviousData } from "@tanstack/react-query"
-import { useState } from "react"
+import { useDeferredValue, useMemo, useState } from "react"
 import { dashPlugin } from "../../../lib/auth/dash-plugin"
 
-type ActivityAccess = "admin-user" | "organization" | "user"
+type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
 
 type ActivityFeedProps = {
   access: ActivityAccess
@@ -58,6 +62,11 @@ type ActivityFeedProps = {
 export type AdminUserActivityProps = {
   className?: string
   userId: string
+  variant?: CardProps["variant"]
+}
+
+export type AdminActivityProps = {
+  className?: string
   variant?: CardProps["variant"]
 }
 
@@ -196,16 +205,29 @@ function ActivityFeed({
   const { authClient, locale } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
   const [page, setPage] = useState(0)
+  const [eventType, setEventType] = useState("all")
+  const [identifier, setIdentifier] = useState("")
+  const deferredIdentifier = useDeferredValue(identifier.trim())
+  const eventOptions = useMemo(
+    () => Object.entries(localization.eventLabels),
+    [localization.eventLabels]
+  )
   const numberFormatter = new Intl.NumberFormat(locale.languageTag)
   const offset = page * pageSize
-  const params = { limit: pageSize, offset, organizationId }
+  const params = {
+    eventType: eventType === "all" ? undefined : eventType,
+    identifier: deferredIdentifier || undefined,
+    limit: pageSize,
+    offset,
+    organizationId
+  }
   const userQuery = useDashAuditLogs(authClient as DashAuthClient, {
     enabled: ready && access === "user",
     params,
     placeholderData: keepPreviousData
   })
   const organizationQuery = useDashAllAuditLogs(authClient as DashAuthClient, {
-    enabled: ready && access === "organization",
+    enabled: ready && (access === "admin" || access === "organization"),
     params,
     placeholderData: keepPreviousData
   })
@@ -214,11 +236,16 @@ function ActivityFeed({
     userId,
     {
       enabled: ready && access === "admin-user",
-      params: { limit: pageSize, offset }
+      params: {
+        eventType: params.eventType,
+        identifier: params.identifier,
+        limit: pageSize,
+        offset
+      }
     }
   )
   const query =
-    access === "organization"
+    access === "admin" || access === "organization"
       ? organizationQuery
       : access === "admin-user"
         ? adminUserQuery
@@ -234,11 +261,13 @@ function ActivityFeed({
         <div className="flex min-w-0 flex-col gap-1">
           <h2 className="text-sm font-semibold">{localization.activity}</h2>
           <p className="text-sm text-muted">
-            {access === "admin-user"
-              ? localization.adminUserActivityDescription
-              : organizationId
-                ? localization.organizationActivityDescription
-                : localization.activityDescription}
+            {access === "admin"
+              ? localization.adminActivityDescription
+              : access === "admin-user"
+                ? localization.adminUserActivityDescription
+                : organizationId
+                  ? localization.organizationActivityDescription
+                  : localization.activityDescription}
           </p>
         </div>
 
@@ -249,6 +278,49 @@ function ActivityFeed({
               : localization.personalOnly}
           </Chip>
         )}
+      </div>
+
+      <div className="grid gap-2 sm:grid-cols-[12rem_minmax(14rem,1fr)]">
+        <Select
+          value={eventType}
+          onChange={(value) => {
+            setEventType(String(value))
+            setPage(0)
+          }}
+        >
+          <Label>{localization.eventType}</Label>
+          <Select.Trigger>
+            <Select.Value />
+            <Select.Indicator />
+          </Select.Trigger>
+          <Select.Popover>
+            <ListBox>
+              <ListBox.Item id="all">{localization.allEvents}</ListBox.Item>
+              {eventOptions.map(([key, label]) => (
+                <ListBox.Item id={key} key={key} textValue={label}>
+                  {label}
+                </ListBox.Item>
+              ))}
+            </ListBox>
+          </Select.Popover>
+        </Select>
+        <SearchField
+          aria-label={localization.identifier}
+          value={identifier}
+          onChange={(value) => {
+            setIdentifier(value)
+            setPage(0)
+          }}
+        >
+          <Label>{localization.identifier}</Label>
+          <SearchField.Group>
+            <SearchField.SearchIcon />
+            <SearchField.Input
+              placeholder={localization.identifierPlaceholder}
+            />
+            <SearchField.ClearButton />
+          </SearchField.Group>
+        </SearchField>
       </div>
 
       <Card variant={variant} aria-busy={showPending || isFetching}>
@@ -345,6 +417,11 @@ function ActivityFeed({
 /** Authentication and account activity for a user selected by an administrator. */
 export function AdminUserActivity(props: AdminUserActivityProps) {
   return <ActivityFeed key={props.userId} access="admin-user" {...props} />
+}
+
+/** Activity across every organization the current owner or administrator can manage. */
+export function AdminActivity(props: AdminActivityProps) {
+  return <ActivityFeed access="admin" {...props} />
 }
 
 /** Personal authentication and account activity. */

--- a/packages/heroui/src/lib/auth/dash-plugin.ts
+++ b/packages/heroui/src/lib/auth/dash-plugin.ts
@@ -11,6 +11,7 @@ import {
 import { Pulse } from "@gravity-ui/icons"
 import { createElement } from "react"
 import {
+  AdminActivity,
   AdminUserActivity,
   OrganizationActivity,
   UserActivity
@@ -31,6 +32,14 @@ export const dashPlugin = createAuthPlugin(
     const localizedTabs = (localization: DashLocalization) => ({
       ...(core.admin
         ? {
+            adminTabs: [
+              {
+                id: "activity",
+                path: core.viewPaths.settings.activity,
+                label: activityLabel(localization.activity),
+                component: AdminActivity
+              }
+            ],
             adminUserTabs: [
               {
                 id: "activity",

--- a/packages/heroui/tests/dash.test.tsx
+++ b/packages/heroui/tests/dash.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  AdminActivity,
   OrganizationActivity,
   UserActivity
 } from "../src/components/auth/dash/activity"
@@ -18,6 +19,11 @@ describe("dashPlugin (heroui)", () => {
       path: "history",
       component: OrganizationActivity
     })
+    expect(plugin.adminTabs?.[0]).toMatchObject({
+      id: "activity",
+      path: "history",
+      component: AdminActivity
+    })
   })
 
   it("can expose only one activity surface", () => {
@@ -26,7 +32,9 @@ describe("dashPlugin (heroui)", () => {
 
     expect(personal.settingsTabs).toHaveLength(1)
     expect(personal.organizationTabs).toBeUndefined()
+    expect(personal.adminTabs).toHaveLength(1)
     expect(organization.settingsTabs).toBeUndefined()
     expect(organization.organizationTabs).toHaveLength(1)
+    expect(dashPlugin({ admin: false }).adminTabs).toBeUndefined()
   })
 })

--- a/packages/locales/src/de-DE-plugins.ts
+++ b/packages/locales/src/de-DE-plugins.ts
@@ -222,6 +222,8 @@ export const deDEPlugins = {
       "Prüfe die letzten Authentifizierungs- und Kontoaktivitäten.",
     adminUserActivityDescription:
       "Prüfe die letzten Authentifizierungs- und Kontoaktivitäten für diesen Benutzer.",
+    adminActivityDescription:
+      "Prüfe Aktivitäten in den von dir verwalteten Organisationen.",
     organizationActivityDescription:
       "Prüfe die für dich sichtbaren Aktivitäten dieser Organisation.",
     organizationWide: "Gesamte Organisation",
@@ -236,6 +238,10 @@ export const deDEPlugins = {
     paginationRange: "{{from}}–{{to}} von {{total}}",
     previousPage: "Vorherige Seite",
     nextPage: "Nächste Seite",
+    allEvents: "Alle Ereignisse",
+    eventType: "Ereignistyp",
+    identifier: "Kennung",
+    identifierPlaceholder: "Nach E-Mail, Benutzer-ID oder Anbieter filtern",
     unknownEvent: "Aktivitätsereignis",
     eventLabels: {
       account_linked: "Konto verknüpft",


### PR DESCRIPTION
Add event and identifier filters to every activity surface and expose a top-level admin view for activity across organizations the current user can manage. The view stays within Dash's public client APIs and never implies global audit-log access.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an administrator activity dashboard for reviewing organization-wide audit logs.
  * Added event type and identifier filters, with pagination resetting when filters change.
  * Added administrator activity tabs to supported dashboard integrations and examples.
* **Localization**
  * Added labels and descriptions for administrator activity logs and filtering controls, including German translations.
* **Tests**
  * Added coverage verifying administrator activity is enabled by default and can be disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->