### PR TITLE
feat(skills): support TanStack Intent and skills.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,9 @@ jobs:
       # Ensure all publishable packages are built (cache hits when unaffected)
       - run: bun nx run-many -t build --projects 'packages/*'
 
+      - name: Validate agent skills and package contents
+        run: bun nx run workspace:skills-check
+
       # Publish new versions of the packages
       - run: bun nx-cloud record -- bunx pkg-pr-new publish --packageManager=bun './packages/*'
 

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -49,5 +49,8 @@ jobs:
             cp README.md "$(dirname "$package_json")/README.md"
           done
 
+      - name: Validate agent skills and package contents
+        run: bun nx run workspace:skills-check
+
       - name: Publish packages
         run: rm -f bun.lock bun.lockb && npx nx release publish

--- a/README.md
+++ b/README.md
@@ -95,6 +95,20 @@ Read the [Zaidan Solid quick start](https://better-auth-ui.com/docs/zaidan) for 
 
 See the [React reference](https://better-auth-ui.com/docs/react) or [Solid reference](https://better-auth-ui.com/docs/solid) when you need lower-level APIs.
 
+## Agent skills
+
+Better Auth UI publishes the same agent skills through TanStack Intent and [skills.sh](https://skills.sh).
+
+For GitHub installation, select the skill for your application:
+
+```bash
+bunx skills@latest add better-auth-ui/better-auth-ui --full-depth --skill better-auth-ui-react
+```
+
+Skills cover React/shadcn, Solid/Zaidan, HeroUI, core data APIs, and localization. TanStack Intent loads them from installed npm packages.
+
+Read the [agent skills guide](https://better-auth-ui.com/docs/agent-skills) for both installation paths and their version behavior.
+
 ## Development
 
 This repository uses [Bun](https://bun.sh) and [Nx](https://nx.dev).

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Read the [Zaidan Solid quick start](https://better-auth-ui.com/docs/zaidan) for 
 | `@better-auth-ui/react` | React providers, hooks, queries, mutations, and plugin APIs |
 | `@better-auth-ui/heroui` | Ready-to-use React components built with HeroUI |
 | `@better-auth-ui/solid` | Solid providers, hooks, queries, mutations, and plugin APIs |
+| `@better-auth-ui/locales` | Locale bundles, language matching helpers, and the localization skill |
 
 See the [React reference](https://better-auth-ui.com/docs/react) or [Solid reference](https://better-auth-ui.com/docs/solid) when you need lower-level APIs.
 

--- a/_artifacts/domain_map.yaml
+++ b/_artifacts/domain_map.yaml
@@ -1,0 +1,54 @@
+library:
+  name: better-auth-ui
+  repository: https://github.com/better-auth-ui/better-auth-ui
+
+domains:
+  - name: Authentication data and server boundaries
+    slug: core
+    failure_modes:
+      - Share a QueryClient between server requests and expose another user's cache.
+      - Import a server helper into a browser bundle or omit incoming request headers.
+      - Select organization access through session state instead of an explicit slug or ID.
+      - Lose mutation metadata or invent incompatible query keys.
+  - name: React authentication interfaces
+    slug: react
+    failure_modes:
+      - Import copied shadcn components from the React data package.
+      - Confuse raw Better Auth results with unwrapped Query results.
+      - Configure a UI plugin without its matching server and client plugins.
+      - Reject valid plugin routes through an incomplete path allowlist.
+  - name: Solid authentication interfaces
+    slug: solid
+    failure_modes:
+      - Pass React options objects where Solid hooks require accessors.
+      - Lose reactivity through destructuring or a stale organization slug.
+      - Install the React registry into a Solid application.
+  - name: Packaged HeroUI interfaces
+    slug: heroui
+    failure_modes:
+      - Use the primitive provider and omit HeroUI navigation or error presentation.
+      - Omit the Better Auth UI stylesheet or assume it replaces HeroUI styles.
+      - Apply HeroUI v2 contracts to HeroUI v3 components.
+  - name: Localization
+    slug: localization
+    failure_modes:
+      - Import a locale from the root entrypoint or invent an unsupported locale.
+      - Choose different languages during server and browser rendering.
+      - Assume browser provider localization also translates server-rendered emails.
+
+skills:
+  - slug: better-auth-ui-core
+    packages: ["@better-auth-ui/core"]
+    domain: core
+  - slug: better-auth-ui-react
+    packages: ["@better-auth-ui/react"]
+    domain: react
+  - slug: better-auth-ui-solid
+    packages: ["@better-auth-ui/solid"]
+    domain: solid
+  - slug: better-auth-ui-heroui
+    packages: ["@better-auth-ui/heroui"]
+    domain: heroui
+  - slug: better-auth-ui-localization
+    packages: ["@better-auth-ui/locales"]
+    domain: localization

--- a/_artifacts/skill_spec.md
+++ b/_artifacts/skill_spec.md
@@ -1,0 +1,40 @@
+# Better Auth UI skill maintenance
+
+These skills teach application developers how to use the published packages. They do not replace the repository's contributor instructions.
+
+Each package owns one skill. The React skill includes shadcn guidance, and the Solid skill includes Zaidan guidance.
+
+The same files ship in npm tarballs for TanStack Intent and remain available on GitHub for skills.sh. No generated mirror is required.
+
+## Content boundaries
+
+- Keep each skill usable without installing another skill.
+- Put optional UI-specific detail in references inside that skill's directory.
+- Use standard Agent Skills frontmatter, with package and framework information under `metadata`.
+- Describe API boundaries and common mistakes instead of copying the entire reference documentation.
+- Cover React, Solid, shadcn/ui, HeroUI, and Zaidan when shared behavior changes.
+- Keep organization access explicit through slugs or IDs.
+
+`domain_map.yaml` records the task areas and failure modes. `skill_tree.yaml` maps each skill to its package and source files.
+
+## Update a skill
+
+1. Read the source files listed in `skill_tree.yaml` before changing the skill.
+2. Update the owning package's `SKILL.md` and any affected references.
+3. Update the artifacts when ownership, coverage, or source paths change.
+4. Run `bun nx run workspace:skills-check`.
+5. Review the instructions against the installed API, including server/client boundaries and framework-specific behavior.
+
+The check runs Intent validation, validates artifact coverage and local links, and packs every public package.
+
+It loads each skill from the extracted tarball through Intent and installs the public skills through the skills CLI in a temporary project.
+
+These checks prove discovery and packaging. They do not prove that an agent applies the instructions correctly.
+
+## Release behavior
+
+The existing Nx release workflow publishes the package-local `skills` directories. The `tanstack-intent` keyword enables TanStack registry indexing.
+
+Skills installed from GitHub follow their selected Git reference. They do not automatically track a consumer's installed library version.
+
+Keep skill changes in the same release as the API changes they describe. Use the installed package as the authority when current website docs differ.

--- a/_artifacts/skill_tree.yaml
+++ b/_artifacts/skill_tree.yaml
@@ -1,0 +1,47 @@
+library:
+  name: better-auth-ui
+
+skills:
+  - name: better-auth-ui-core
+    package: packages/core
+    path: packages/core/skills/better-auth-ui-core/SKILL.md
+    sources:
+      - packages/core/src/index.ts
+      - packages/core/src/server.ts
+      - packages/core/src/queries/auth/session-query.ts
+      - packages/core/src/lib/setup-mutation-invalidation.ts
+      - apps/docs/content/topics/ui/plugins/organization.mdx
+  - name: better-auth-ui-react
+    package: packages/react
+    path: packages/react/skills/better-auth-ui-react/SKILL.md
+    sources:
+      - packages/react/src/components/auth/auth-provider.tsx
+      - packages/react/src/hooks/queries/use-session.ts
+      - packages/react/src/hooks/mutations/use-sign-in-email.ts
+      - apps/docs/content/docs/react/ssr.mdx
+      - apps/docs/content/docs/shadcn/index.mdx
+  - name: better-auth-ui-solid
+    package: packages/solid
+    path: packages/solid/skills/better-auth-ui-solid/SKILL.md
+    sources:
+      - packages/solid/src/lib/auth-provider.tsx
+      - packages/solid/src/hooks/queries/use-session.ts
+      - packages/solid/src/hooks/mutations/use-sign-in-email.ts
+      - apps/docs/content/docs/solid/ssr.mdx
+      - apps/docs/content/docs/zaidan/index.mdx
+  - name: better-auth-ui-heroui
+    package: packages/heroui
+    path: packages/heroui/skills/better-auth-ui-heroui/SKILL.md
+    sources:
+      - packages/heroui/src/components/auth/auth-provider.tsx
+      - packages/heroui/src/styles.css
+      - apps/docs/content/docs/heroui/index.mdx
+      - apps/docs/content/docs/heroui/plugins/organization.mdx
+  - name: better-auth-ui-localization
+    package: packages/locales
+    path: packages/locales/skills/better-auth-ui-localization/SKILL.md
+    sources:
+      - packages/locales/src/index.ts
+      - packages/locales/src/de-DE.ts
+      - packages/core/src/lib/auth-locale.ts
+      - apps/docs/content/topics/ui/components/auth-provider.mdx

--- a/apps/docs/content/docs/agent-skills.mdx
+++ b/apps/docs/content/docs/agent-skills.mdx
@@ -1,0 +1,89 @@
+---
+title: Agent Skills
+description: Install Better Auth UI guidance through TanStack Intent or skills.sh.
+---
+
+Better Auth UI ships skills for React, Solid, shadcn/ui, HeroUI, Zaidan, core data APIs, and localization.
+
+Choose either TanStack Intent or skills.sh. Both use the same skill files, with different update behavior.
+
+| Install path | Skill source | Updates |
+| --- | --- | --- |
+| TanStack Intent | Installed npm package | Skills change with the library version. |
+| skills.sh | GitHub branch or tag | Skills change independently of installed packages. |
+
+## Install through TanStack Intent
+
+Install the Better Auth UI packages for your application first. Skills are included in package releases that contain a `skills` directory.
+
+Add the Better Auth UI scope to your application's Intent allowlist in `package.json`. Preserve any existing entries:
+
+```json
+{
+  "intent": {
+    "skills": ["@better-auth-ui/*"]
+  }
+}
+```
+
+Install the agent guidance, then list the available skills:
+
+```bash
+bunx @tanstack/intent@latest install
+bunx @tanstack/intent@latest list
+```
+
+Load the skill for your package. For example:
+
+```bash
+bunx @tanstack/intent@latest load @better-auth-ui/react#better-auth-ui-react
+```
+
+Intent reads the skill from the installed package version. If the package has no skills, update it or use the GitHub install path.
+
+Read the [TanStack Intent documentation](https://tanstack.com/intent/latest/docs/overview) for supported agents and project configuration.
+
+## Install through skills.sh
+
+Select the skill for your application:
+
+```bash
+bunx skills@latest add better-auth-ui/better-auth-ui --full-depth --skill better-auth-ui-react
+```
+
+Replace `better-auth-ui-react` with a name from this table:
+
+| Skill | Covers | npm package |
+| --- | --- | --- |
+| `better-auth-ui-react` | React hooks, providers, SSR, and copied shadcn/ui components | `@better-auth-ui/react` |
+| `better-auth-ui-solid` | Solid hooks, providers, SSR, and copied Zaidan components | `@better-auth-ui/solid` |
+| `better-auth-ui-heroui` | Packaged HeroUI components and integration | `@better-auth-ui/heroui` |
+| `better-auth-ui-core` | Query factories, mutations, server helpers, and explicit organization access | `@better-auth-ui/core` |
+| `better-auth-ui-localization` | Locales, message overrides, language matching, and email localization | `@better-auth-ui/locales` |
+
+You can select multiple skills after `--skill`. Each skill also works on its own.
+
+`--full-depth` finds skills inside this monorepo's package directories. `--skill` selects public guidance without installing the repository's internal Nx skills.
+
+To browse without installation, run:
+
+```bash
+bunx skills@latest add better-auth-ui/better-auth-ui --full-depth --list
+```
+
+This list also includes contributor skills. Select the `better-auth-ui-*` names for application development.
+
+For a specific release, use its GitHub tag URL and package directory instead of the repository shorthand. That tag must contain the skills.
+
+The default GitHub install follows the default branch. It does not automatically match the installed Better Auth UI version.
+
+Read the [skills CLI documentation](https://github.com/vercel-labs/skills#install-a-skill) for agent selection and update commands.
+
+## Documentation for agents
+
+Skills provide task guidance and common mistakes. The documentation endpoints provide reference material:
+
+- [llms.txt](https://better-auth-ui.com/llms.txt) lists documentation pages and their Markdown URLs.
+- [llms-full.txt](https://better-auth-ui.com/llms-full.txt) contains the complete documentation text.
+
+When website examples differ from installed package exports, use the installed package as the API authority.

--- a/apps/docs/content/docs/meta.json
+++ b/apps/docs/content/docs/meta.json
@@ -1,6 +1,7 @@
 {
   "pages": [
     "index",
+    "agent-skills",
     "migrations",
     "shadcn",
     "heroui",

--- a/bun.lock
+++ b/bun.lock
@@ -12,9 +12,11 @@
         "@swc-node/register": "~1.12.1",
         "@swc/core": "~1.16.0",
         "@swc/helpers": "~0.5.23",
+        "@tanstack/intent": "0.3.8",
         "@vitejs/plugin-react": "^6.0.5",
         "lefthook": "^2.1.8",
         "nx": "23.1.2",
+        "skills": "1.5.23",
         "typescript": "^6.0.3",
         "vite": "^8.2.1",
         "vite-plugin-dts": "^5.0.3",
@@ -1065,6 +1067,8 @@
 
     "@internationalized/string": ["@internationalized/string@3.2.9", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg=="],
 
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+
     "@jest/diff-sequences": ["@jest/diff-sequences@30.0.1", "", {}, "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw=="],
 
     "@joshwooding/vite-plugin-react-docgen-typescript": ["@joshwooding/vite-plugin-react-docgen-typescript@0.7.0", "", { "dependencies": { "glob": "^13.0.1", "react-docgen-typescript": "^2.2.2" }, "peerDependencies": { "typescript": ">= 4.3.x", "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["typescript"] }, "sha512-qvsTEwEFefhdirGOPnu9Wp6ChfIwy2dBCRuETU3uE+4cC+PFoxMSiiEhxk4lOluA34eARHA0OxqsEUYDqRMgeQ=="],
@@ -1707,6 +1711,8 @@
 
     "@tanstack/history": ["@tanstack/history@1.162.1", "", {}, "sha512-DR9t6lfLVdrjgCwpglrR9DR7Ok8/HlXjcOE+goWXF3zyuLUO/ug7vMbSFxTqrQTtbRghJfyhmIZ0S6LhPIy44w=="],
 
+    "@tanstack/intent": ["@tanstack/intent@0.3.8", "", { "dependencies": { "cac": "^6.7.14", "jsonc-parser": "^3.3.1", "semver": "^7.8.4", "std-env": "^4.1.0", "yaml": "2.9.0" }, "bin": { "intent": "dist/cli.mjs" } }, "sha512-5KXhk+dPqzVHcETuf0Q6l1jasjFS2BJvG4Vw1dakuHEaQ85kZ3oSsOMROsad5w/DsEsQ9q1F00cQzIrk9jPzsQ=="],
+
     "@tanstack/pacer": ["@tanstack/pacer@0.22.0", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.5.0", "@tanstack/store": "^0.11.1" } }, "sha512-Zq23KOn30tFiA6ZYWihs5x++ttHkOIcnIIjRrJq05tGrYx9+iHsmVaj8jb7UJVemEI+JRWGzJ9C+50YV4nRz0w=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.101.4", "", {}, "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw=="],
@@ -2011,6 +2017,8 @@
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
@@ -2040,6 +2048,8 @@
     "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "citty": ["citty@0.2.2", "", {}, "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w=="],
 
@@ -2773,6 +2783,8 @@
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
     "mlly": ["mlly@1.8.2", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA=="],
 
     "motion": ["motion@13.1.1", "", { "dependencies": { "framer-motion": "^13.1.1", "tslib": "^2.4.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-WNZoK6xiF+kkTqkZ5K7FDDh6A8BG4i5Hc7KXtW8gtTxkpJFds+hIOrDaQGKjQj/AE/i4hJqAaUHEqp/Qo02y6Q=="],
@@ -3123,6 +3135,8 @@
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
+    "skills": ["skills@1.5.23", "", { "dependencies": { "tar": "^7.5.20", "yaml": "^2.8.3" }, "bin": { "skills": "bin/cli.mjs", "add-skill": "bin/cli.mjs" } }, "sha512-+hMNBSi35yfX0sKD+ZcRm9y5or7u313OdkcvrRvJAsAzGCaA8wRTu2OmVdN0KRbk9ybqKby5dijkn6OVvNTUmw=="],
+
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
@@ -3228,6 +3242,8 @@
     "tailwindcss": ["tailwindcss@4.3.3", "", {}, "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "tar": ["tar@7.5.22", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA=="],
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
@@ -3403,7 +3419,7 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
-    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
@@ -3724,6 +3740,8 @@
     "fumadocs-ui/shiki": ["shiki@4.4.3", "", { "dependencies": { "@shikijs/core": "4.4.3", "@shikijs/engine-javascript": "4.4.3", "@shikijs/engine-oniguruma": "4.4.3", "@shikijs/langs": "4.4.3", "@shikijs/themes": "4.4.3", "@shikijs/types": "4.4.3", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.5" } }, "sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g=="],
 
     "h3-v2/rou3": ["rou3@0.8.1", "", {}, "sha512-ePa+XGk00/3HuCqrEnK3LxJW7I0SdNg6EFzKUJG73hMAdDcOUC/i/aSz7LSDwLrGr33kal/rqOGydzwl6U7zBA=="],
+
+    "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "@swc-node/register": "~1.12.1",
     "@swc/core": "~1.16.0",
     "@swc/helpers": "~0.5.23",
+    "@tanstack/intent": "0.3.8",
     "@vitejs/plugin-react": "^6.0.5",
     "lefthook": "^2.1.8",
     "nx": "23.1.2",
+    "skills": "1.5.23",
     "typescript": "^6.0.3",
     "vite": "^8.2.1",
     "vite-plugin-dts": "^5.0.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,7 +21,8 @@
   },
   "files": [
     "src",
-    "dist"
+    "dist",
+    "skills"
   ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -259,5 +260,8 @@
   "dependencies": {
     "libphonenumber-js": "^1.13.11",
     "uqr": "^0.1.3"
-  }
+  },
+  "keywords": [
+    "tanstack-intent"
+  ]
 }

--- a/packages/core/skills/better-auth-ui-core/SKILL.md
+++ b/packages/core/skills/better-auth-ui-core/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: better-auth-ui-core
+description: Use Better Auth UI core query and mutation factories, server helpers, and explicit organization access. Use when integrating @better-auth-ui/core with loaders, SSR, custom data layers, or Better Auth plugins.
+license: MIT
+metadata:
+  library: "@better-auth-ui/core"
+---
+
+# Better Auth UI core
+
+Use the installed package exports as the authority for the API version. This skill covers the 1.7 package structure.
+
+## Choose the entrypoint
+
+| Task | Import from |
+| --- | --- |
+| Browser client queries, mutations, cache keys, configuration | `@better-auth-ui/core` |
+| Direct calls to a Better Auth server instance | `@better-auth-ui/core/server` |
+| Optional plugin factories | `@better-auth-ui/core/plugins/<plugin>` |
+| Optional plugin server helpers | `@better-auth-ui/core/plugins/<plugin>/server` |
+
+Keep server imports and the Better Auth server instance outside browser bundles. The core package does not install UI components or routes.
+
+## Queries and mutations
+
+- Use a factory such as `sessionOptions(authClient)` when a Query API needs an options object.
+- Use `ensureSession(queryClient, authClient)` in a loader that needs the session result.
+- Use `prefetchSession(queryClient, authClient)` to warm the cache. It does not return session data or propagate fetch errors.
+- Use `fetchSession(queryClient, authClient)` for a query result with normal Query freshness rules.
+- Read `sessionOptions(authClient).queryKey` or `authQueryKeys` instead of inventing cache keys.
+- Preserve mutation keys and metadata when extending factories such as `signInEmailOptions(authClient)`.
+
+Factories return unwrapped data and reject on errors. Do not treat their results as Better Auth's raw `{ data, error }` response.
+
+Framework `AuthProvider` implementations install mutation invalidation. A custom integration without a provider needs `setupMutationInvalidation(queryClient)` and its cleanup function.
+
+## Server rendering
+
+Create a QueryClient for each server request. Reuse that client across the request's loaders and rendered providers.
+
+Pass incoming headers to server helpers so Better Auth can read the request's cookies:
+
+```ts
+import { ensureSessionServer } from "@better-auth-ui/core/server"
+
+const session = await ensureSessionServer(queryClient, auth, {
+  headers: request.headers
+})
+```
+
+Here, `auth` is the application's Better Auth server instance. `queryClient` belongs to the current request.
+
+The browser equivalent is `ensureSession(queryClient, authClient)`. Server and browser helpers share cache keys for hydration.
+
+Route guards improve navigation behavior. Enforce authentication and authorization again in server endpoints that read or change protected data.
+
+## Plugins and organizations
+
+Configure the Better Auth server plugin and its matching client plugin before using plugin factories. A UI plugin does not enable server endpoints.
+
+Use explicit organization slugs or IDs for organization queries and mutations. Check membership and permissions on the server for that organization.
+
+For UI integrations, pass the route slug to `organizationPlugin({ slug })`. Pass `null` on personal-account routes.
+
+Do not leave the slug `undefined`: that selects session-based organization behavior. Do not use `setActive` to determine access.
+
+Prefer plugin factories and keys for organization cache updates. A changed URL alone does not authorize access to another organization.
+
+## References
+
+- [React data APIs](https://better-auth-ui.com/docs/react)
+- [Solid data APIs](https://better-auth-ui.com/docs/solid)
+- [Server rendering](https://better-auth-ui.com/docs/react/ssr)
+- [Organization routing](https://better-auth-ui.com/docs/shadcn/plugins/organization)
+- [Documentation index](https://better-auth-ui.com/llms.txt)
+
+The website describes the current release. If it differs from the installed package, inspect that package's exports and source before changing imports.

--- a/packages/heroui/package.json
+++ b/packages/heroui/package.json
@@ -8,7 +8,8 @@
   },
   "files": [
     "src",
-    "dist"
+    "dist",
+    "skills"
   ],
   "exports": {
     ".": {
@@ -161,5 +162,8 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "tanstack-intent"
+  ]
 }

--- a/packages/heroui/skills/better-auth-ui-heroui/SKILL.md
+++ b/packages/heroui/skills/better-auth-ui-heroui/SKILL.md
@@ -18,7 +18,7 @@ HeroUI components are packaged React components. They are separate from the copi
 Configure Better Auth and HeroUI v3 first. HeroUI v3 uses React 19 and Tailwind v4.
 
 ```bash
-bun add @better-auth-ui/heroui @better-auth-ui/react @better-auth-ui/core
+bun add @better-auth-ui/heroui @better-auth-ui/react @better-auth-ui/core @better-auth-ui/locales
 ```
 
 Add Better Auth UI's styles to the existing global stylesheet after the application's Tailwind and HeroUI setup:

--- a/packages/heroui/skills/better-auth-ui-heroui/SKILL.md
+++ b/packages/heroui/skills/better-auth-ui-heroui/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: better-auth-ui-heroui
+description: Install and configure packaged Better Auth UI components for HeroUI v3. Use for @better-auth-ui/heroui providers, auth and settings routes, styling, localization, and plugin screens in React applications.
+license: MIT
+metadata:
+  library: "@better-auth-ui/heroui"
+  framework: react
+---
+
+# Better Auth UI for HeroUI
+
+Use the installed package exports as the authority for the API version. This skill covers the 1.7 package structure and HeroUI v3.
+
+HeroUI components are packaged React components. They are separate from the copied shadcn and Solid/Zaidan registries.
+
+## Installation
+
+Configure Better Auth and HeroUI v3 first. HeroUI v3 uses React 19 and Tailwind v4.
+
+```bash
+bun add @better-auth-ui/heroui @better-auth-ui/react @better-auth-ui/core
+```
+
+Add Better Auth UI's styles to the existing global stylesheet after the application's Tailwind and HeroUI setup:
+
+```css
+@import "@better-auth-ui/heroui/styles";
+```
+
+This import supplies Better Auth UI's Tailwind source configuration. It does not replace HeroUI's own stylesheet.
+
+Import `AuthProvider`, `Auth`, `Settings`, and `UserButton` from `@better-auth-ui/heroui`.
+
+## Provider and navigation
+
+Use the HeroUI `AuthProvider` wrapper. It connects HeroUI navigation and error presentation to the shared React provider.
+
+Pass `authClient`, `navigate`, and the application's React Query `queryClient`. Create the auth client with `createAuthClient` from `better-auth/react`.
+
+The navigation callback accepts `{ to, replace? }`. Adapt the framework router to this contract.
+
+For SSR, use a QueryClient per request and share it with loaders and hydration. Keep interactive providers within the appropriate client boundary.
+
+Use hooks such as `useSession(authClient)` from `@better-auth-ui/react`. Hook options are React objects, not Solid accessors.
+
+## Views and plugins
+
+Mount framework routes for auth and settings. Pass the route segment to `<Auth path={path} />` or `<Settings path={path} />`.
+
+The components select views but do not create routes or mount the Better Auth server handler.
+
+Enable the Better Auth server plugin and matching client plugin before registering the HeroUI plugin on `AuthProvider`.
+
+Import UI plugins from `@better-auth-ui/heroui/plugins/<plugin>`. These provide HeroUI screens in addition to the shared plugin behavior.
+
+Include plugin view paths in route validation. Preserve callback, redirect, and invitation search parameters.
+
+For organization screens, pass the route slug to `organizationPlugin({ slug })`. Use `null` on personal-account routes.
+
+Update the plugin configuration when the route changes. Do not use session active-organization state or `setActive` to select authorization scope.
+
+Check organization membership and permissions on the server. UI visibility alone does not enforce access.
+
+## Customization and localization
+
+Prefer public component props, composition, and HeroUI's documented styling API. Do not assume HeroUI v2 component contracts.
+
+Pass a locale from `@better-auth-ui/locales/<language-tag>` to `AuthProvider`. Pass partial `localization` overrides for product-specific wording.
+
+Keep stable page content visible during queries. Show pending states at unresolved values and permission-dependent actions.
+
+## References
+
+- [HeroUI quick start](https://better-auth-ui.com/docs/heroui)
+- [Next.js integration](https://better-auth-ui.com/docs/heroui/integrations/nextjs)
+- [TanStack Start integration](https://better-auth-ui.com/docs/heroui/integrations/tanstack-start)
+- [Organizations](https://better-auth-ui.com/docs/heroui/plugins/organization)
+- [React data APIs and SSR](https://better-auth-ui.com/docs/react)
+- [Documentation index](https://better-auth-ui.com/llms.txt)
+
+Website examples follow the current release. Check the installed package before using an API from newer documentation.

--- a/packages/locales/package.json
+++ b/packages/locales/package.json
@@ -8,7 +8,8 @@
   },
   "files": [
     "src",
-    "dist"
+    "dist",
+    "skills"
   ],
   "sideEffects": false,
   "main": "./dist/index.js",
@@ -46,5 +47,8 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "tanstack-intent"
+  ]
 }

--- a/packages/locales/skills/better-auth-ui-localization/SKILL.md
+++ b/packages/locales/skills/better-auth-ui-localization/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: better-auth-ui-localization
+description: Configure Better Auth UI locales, language matching, message overrides, and SSR language consistency. Use with @better-auth-ui/locales across React, Solid, shadcn/ui, HeroUI, and Zaidan applications.
+license: MIT
+metadata:
+  library: "@better-auth-ui/locales"
+---
+
+# Better Auth UI localization
+
+Use the installed package exports as the authority for the available locales. This skill covers the 1.7 locale API.
+
+## Select a locale
+
+Import locale bundles through their language entrypoints. The root package exports locale helpers and types, not every language bundle.
+
+```ts
+import { matchAuthLocale } from "@better-auth-ui/locales"
+import { deDE } from "@better-auth-ui/locales/de-DE"
+import { enUS } from "@better-auth-ui/locales/en-US"
+
+const locale = matchAuthLocale({
+  requested: request.headers.get("Accept-Language"),
+  supported: [enUS, deDE],
+  fallback: enUS
+})
+```
+
+This example runs on the server. In a client-only application, use `navigator.languages` for `requested`.
+
+The helper matches an exact language tag first, then its base language. It returns the supplied fallback when no supported locale matches.
+
+Do not import a guessed language entrypoint. Check the package exports for supported bundles.
+
+## Configure the provider
+
+Pass the selected `locale` to the application's existing `AuthProvider`. The same locale shape works across all supported UI integrations.
+
+Use `localization` for partial product-specific overrides, such as `{ auth: { signIn: "Sign in to Acme" } }`.
+
+Provider localization overrides take priority over the locale's core messages. Plugin-level localization overrides take priority over locale plugin messages.
+
+Locale bundles include built-in plugin messages. Configure the actual plugins separately: translating a plugin does not enable it.
+
+For SSR, resolve the language from the user's preference or incoming header. Use that same locale on the server and first browser render.
+
+Do not read `navigator` during server rendering. Keep the provider's locale reactive when the user changes language.
+
+## Custom locales and email
+
+Use `defineAuthLocale` with `languageTag`, `localization`, and optional `direction` and `plugins` fields.
+
+Start from the installed core localization shape. Preserve message placeholders such as `{{email}}` and `{{seconds}}` in translated values.
+
+Set the document's language and direction in the application shell. A locale object alone does not configure the entire page.
+
+Email templates do not read the browser's `AuthProvider`. Pass email localization separately in server-side email rendering.
+
+Use the email components for the selected framework. Solid templates do not accept React email components.
+
+## References
+
+- [shadcn AuthProvider](https://better-auth-ui.com/docs/shadcn/components/auth-provider)
+- [HeroUI AuthProvider](https://better-auth-ui.com/docs/heroui/components/auth-provider)
+- [Zaidan AuthProvider](https://better-auth-ui.com/docs/zaidan/components/auth-provider)
+- [Documentation index](https://better-auth-ui.com/llms.txt)
+
+Website examples follow the current release. Check the installed package before using a locale from newer documentation.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -9,7 +9,8 @@
   },
   "files": [
     "src",
-    "dist"
+    "dist",
+    "skills"
   ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -173,5 +174,8 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "tanstack-intent"
+  ]
 }

--- a/packages/react/skills/better-auth-ui-react/SKILL.md
+++ b/packages/react/skills/better-auth-ui-react/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: better-auth-ui-react
+description: Integrate Better Auth UI React providers, hooks, authentication routes, and plugins. Use for @better-auth-ui/react or copied shadcn/ui auth components, including Next.js and TanStack Start applications.
+license: MIT
+metadata:
+  library: "@better-auth-ui/react"
+  framework: react
+---
+
+# Better Auth UI for React
+
+Use the installed package exports as the authority for the API version. This skill covers the 1.7 package structure.
+
+## Select the UI
+
+- For copied shadcn/ui components, read [the shadcn integration](references/shadcn.md).
+- For packaged HeroUI components, use `@better-auth-ui/heroui` and its `better-auth-ui-heroui` skill when available.
+- For a custom interface, use the provider and hooks from `@better-auth-ui/react` directly.
+
+`@better-auth-ui/react` is the shared data layer. It does not export the copied shadcn `Auth`, `Settings`, or `UserButton` components.
+
+## Configure the application
+
+1. Configure Better Auth and mount its handler in the application's server routes.
+2. Create the React client with `createAuthClient` from `better-auth/react`.
+3. Wrap auth consumers with the selected UI's `AuthProvider`.
+4. Pass `authClient`, a router-compatible `navigate`, and the application's `queryClient`.
+5. Configure redirect destinations, UI paths, and plugins to match the application's routes.
+
+The navigation callback receives `{ to, replace? }`. Adapt Next.js `router.push` and `router.replace` to this object instead of passing them directly.
+
+The React provider selects an explicit QueryClient first, then an existing Query context, then a fallback. Pass a request-scoped client for SSR.
+
+Use client boundaries for interactive providers and hooks in Next.js. Keep server configuration, secrets, and `/server` imports outside those boundaries.
+
+## Read and change authentication data
+
+```ts
+import { useSession, useSignInEmail } from "@better-auth-ui/react"
+
+const session = useSession(authClient, { staleTime: 5_000 })
+const signIn = useSignInEmail(authClient)
+```
+
+Call these hooks inside a React component or custom hook. Supply the auth client explicitly.
+
+Queries expose TanStack Query state such as `data`, `isPending`, and `error`. Mutations expose `mutate`, `mutateAsync`, and `isPending`.
+
+Use `useSession` from Better Auth UI when consumers share its Query cache. Better Auth's own `authClient.useSession()` uses a different subscription path.
+
+Import optional hooks from `@better-auth-ui/react/plugins/<plugin>`. Import loader factories and helpers from `@better-auth-ui/core` or its plugin entrypoints.
+
+Keep page headings, navigation, and independent content mounted while queries resolve. Show pending states only for unresolved values and dependent actions.
+
+## Loaders and SSR
+
+Use `ensureSession(queryClient, authClient)` for browser loaders. Use `ensureSessionServer(queryClient, auth, { headers })` from `@better-auth-ui/core/server` on the server.
+
+Create one QueryClient per server request. Pass the same client to loaders, hydration, and `AuthProvider`.
+
+For TanStack Start, use the documented Router/Query SSR integration. For Next.js, keep direct server calls in server-only code.
+
+Do not cache one user's session in a module-level server QueryClient. Enforce permissions in server endpoints as well as route guards.
+
+## Plugins and organizations
+
+Enable each feature in three places when applicable: the Better Auth server, its client plugin, and the selected UI plugin.
+
+Use the UI plugin shipped with the selected component system. Core plugins provide shared behavior but do not supply copied UI views.
+
+Include plugin view paths in route validation. Hardcoded base auth paths can reject valid invitation or two-factor routes.
+
+Select organizations from the route slug or an explicit ID. Pass `organizationPlugin({ slug })`, using `null` for personal-account routes.
+
+Keep this value current when the route changes. Do not use session active-organization state or `setActive` as the source of access.
+
+## References
+
+- [React queries](https://better-auth-ui.com/docs/react/queries)
+- [React mutations](https://better-auth-ui.com/docs/react/mutations)
+- [React SSR](https://better-auth-ui.com/docs/react/ssr)
+- [shadcn Next.js integration](https://better-auth-ui.com/docs/shadcn/integrations/nextjs)
+- [shadcn TanStack Start integration](https://better-auth-ui.com/docs/shadcn/integrations/tanstack-start)
+- [Documentation index](https://better-auth-ui.com/llms.txt)
+
+Website examples follow the current release. Check the installed package before using an API from newer documentation.

--- a/packages/react/skills/better-auth-ui-react/references/shadcn.md
+++ b/packages/react/skills/better-auth-ui-react/references/shadcn.md
@@ -1,0 +1,51 @@
+# Copied shadcn/ui components
+
+Use this reference with the React skill when the application uses shadcn/ui.
+
+## Installation
+
+Inspect the application's `components.json`, aliases, and existing UI primitives before installation. Preserve its Radix or Base UI choice.
+
+Install the auth surface with the project's package runner:
+
+```bash
+bunx --bun shadcn@latest add @better-auth-ui/auth
+```
+
+Add settings and user controls only when the application needs them:
+
+```bash
+bunx --bun shadcn@latest add @better-auth-ui/settings @better-auth-ui/user-button
+```
+
+The registry copies files into the application. Import `AuthProvider`, `Auth`, `Settings`, and `UserButton` from those local files.
+
+Read the generated paths instead of assuming `@/components`. Do not replace local imports with nonexistent exports from `@better-auth-ui/react`.
+
+Use the copied provider wrapper. It adds the UI's error presentation around the shared React provider. Mount the configured Sonner toaster.
+
+## Routing
+
+Mount auth and settings routes that pass their path segment to `<Auth path={path} />` or `<Settings path={path} />`.
+
+These components select a view. They do not create framework routes or mount the Better Auth server handler.
+
+Keep route validation synchronized with base and enabled plugin view paths. Preserve callback query parameters and invitation IDs during navigation.
+
+Pass the application's router link adapter through the copied provider's `Link` prop. Its link contract accepts `href`.
+
+For organization screens, read the organization slug from the route. Pass it to the copied `organizationPlugin`, using `null` on personal-account routes.
+
+## Customization
+
+Review copied files before changes. Preserve consumer customizations when updating registry entries.
+
+Try component props and application composition before modifying UI primitives. Keep form labels, errors, keyboard access, and focus behavior intact.
+
+Use the project's existing shadcn building blocks for new controls. Use `gap-*` for spacing.
+
+## References
+
+- [shadcn quick start](https://better-auth-ui.com/docs/shadcn)
+- [AuthProvider](https://better-auth-ui.com/docs/shadcn/components/auth-provider)
+- [Organizations](https://better-auth-ui.com/docs/shadcn/plugins/organization)

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -22,7 +22,8 @@
   },
   "files": [
     "src",
-    "dist"
+    "dist",
+    "skills"
   ],
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -147,5 +148,8 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "keywords": [
+    "tanstack-intent"
+  ]
 }

--- a/packages/solid/skills/better-auth-ui-solid/SKILL.md
+++ b/packages/solid/skills/better-auth-ui-solid/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: better-auth-ui-solid
+description: Integrate Better Auth UI Solid providers, reactive queries, mutations, SSR, and plugins. Use for @better-auth-ui/solid and copied Zaidan auth components in Solid applications, including TanStack Start.
+license: MIT
+metadata:
+  library: "@better-auth-ui/solid"
+  framework: solid
+---
+
+# Better Auth UI for Solid
+
+Use the installed package exports as the authority for the API version. This skill covers the 1.7 package structure.
+
+For copied UI, read [the Zaidan integration](references/zaidan.md). The Solid package provides the data layer, not the copied `Auth` or `Settings` components.
+
+## Configure the application
+
+1. Configure the Better Auth server and mount its handler.
+2. Create the client with `createAuthClient` from `better-auth/solid`.
+3. Wrap consumers with `AuthProvider` from the selected integration.
+4. Pass `authClient`, `navigate`, and the application's Solid Query `queryClient`.
+5. Add the matching server, client, and UI plugins for optional features.
+
+Use `@tanstack/solid-query`, not React Query. Pass the QueryClient explicitly so loaders and components share one cache.
+
+For SSR, create that client per request. Do not rely on the provider's fallback cache for server rendering.
+
+## Preserve reactivity
+
+Solid hook options use accessors. React hook options use objects. Do not translate one framework's examples without adapting this difference.
+
+```ts
+import { useSession, useSignInEmail } from "@better-auth-ui/solid"
+
+const session = useSession(authClient, () => ({ staleTime: 5_000 }))
+const signIn = useSignInEmail(authClient, () => ({
+  onSuccess: () => navigate({ to: "/settings/account" })
+}))
+```
+
+Call hooks within a Solid owner, such as a component. Read `session.data`, `session.isPending`, and mutation state inside reactive expressions.
+
+Keep reactive props and query results intact. Destructuring them can freeze a value that must change.
+
+Pass an accessor for an optional custom QueryClient argument. Keep dynamic query parameters inside the options accessor.
+
+Use Solid control flow for dependent content. Keep page headings, navigation, and independent content visible while individual queries resolve.
+
+## Server rendering and routes
+
+Use `ensureSession(queryClient, authClient)` from `@better-auth-ui/core` in browser loaders.
+
+Use `ensureSessionServer(queryClient, auth, { headers })` from `@better-auth-ui/core/server` in server-only code.
+
+The server helper needs the Better Auth server instance and incoming request headers. Browser helpers need the Solid auth client.
+
+Pass the same request-scoped QueryClient through loaders, hydration, and `AuthProvider`. Keep server-only imports outside browser bundles.
+
+TanStack Solid Router exposes route data through accessors. Read `Route.useRouteContext()()` and route parameters reactively.
+
+Enforce authorization in protected server endpoints. A component guard or cached session alone does not protect server data.
+
+## Plugins and organizations
+
+Import optional hooks from `@better-auth-ui/solid/plugins/<plugin>`. Import shared factories from the corresponding core plugin entrypoint.
+
+Use Zaidan's copied UI plugin when it must contribute screens. A core plugin does not install Solid component files.
+
+Select organizations through route slugs or explicit IDs. Keep `organizationPlugin({ slug })` synchronized with route changes.
+
+Pass `null` on personal-account routes. `undefined` selects session-based organization behavior, so do not use it for explicit organization access.
+
+Do not call `setActive` to choose authorization scope. Validate membership and permissions for the requested organization on the server.
+
+## References
+
+- [Solid package](https://better-auth-ui.com/docs/solid)
+- [Solid queries](https://better-auth-ui.com/docs/solid/queries)
+- [Solid mutations](https://better-auth-ui.com/docs/solid/mutations)
+- [Solid SSR](https://better-auth-ui.com/docs/solid/ssr)
+- [Documentation index](https://better-auth-ui.com/llms.txt)
+
+Website examples follow the current release. Check the installed package before using an API from newer documentation.

--- a/packages/solid/skills/better-auth-ui-solid/references/zaidan.md
+++ b/packages/solid/skills/better-auth-ui-solid/references/zaidan.md
@@ -1,0 +1,50 @@
+# Copied Zaidan components
+
+Use this reference with the Solid skill when the application needs auth UI components.
+
+## Installation
+
+Prepare Better Auth, Solid, Solid Query, Tailwind v4, and the application's routing first.
+
+```bash
+bun add @better-auth-ui/solid @tanstack/solid-query better-auth solid-js
+bunx --bun shadcn@latest add https://better-auth-ui.com/r/solid/auth.json
+```
+
+Add settings and user controls when required:
+
+```bash
+bunx --bun shadcn@latest add https://better-auth-ui.com/r/solid/settings.json https://better-auth-ui.com/r/solid/user-button.json
+```
+
+Use the `/r/solid/` registry URLs. The `@better-auth-ui/auth` shorthand installs the React shadcn integration.
+
+The registry copies Solid UI primitives, components, and supporting code. Read the generated files and respect the application's aliases.
+
+Import composed UI components and the provider wrapper from their copied local paths. Do not import them from the Solid data package.
+
+## Provider and routes
+
+Use the copied provider wrapper, router link adapter, and toaster. Pass the same Solid Query client used by loaders.
+
+Install the auth and settings routes in the framework. Pass each route's path segment to the corresponding local component.
+
+Include enabled plugin view paths when validating route segments. Preserve search parameters for callbacks, invitations, and redirects.
+
+For organization pages, read the slug reactively and pass it to the copied `organizationPlugin`. Use `null` outside organization routes.
+
+Keep Solid JSX and reactive props intact. Do not copy React hooks, React event types, or HeroUI components into this integration.
+
+## Optional features
+
+Plugin UI entries are separate from server/client plugin registration. For example, the passkey UI is available at `/r/solid/passkey.json`.
+
+Use native Solid email templates from the Solid email entrypoint or the copied Zaidan templates. Do not import React email components.
+
+Preserve local modifications when updating copied registry files. Try consumer props and composition before modifying UI primitives.
+
+## References
+
+- [Zaidan quick start](https://better-auth-ui.com/docs/zaidan)
+- [TanStack Start integration](https://better-auth-ui.com/docs/zaidan/integrations/tanstack-start)
+- [Organizations](https://better-auth-ui.com/docs/zaidan/plugins/organization)

--- a/tools/skills/check.ts
+++ b/tools/skills/check.ts
@@ -1,0 +1,225 @@
+import assert from "node:assert/strict"
+import {
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rm,
+  writeFile
+} from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, relative, resolve } from "node:path"
+import { listIntentSkills, loadIntentSkill } from "@tanstack/intent/core"
+
+type SkillPlan = {
+  skills: {
+    name: string
+    package: string
+    path: string
+    sources: string[]
+  }[]
+}
+
+const root = resolve(import.meta.dir, "../..")
+const bun = process.execPath
+const cli = (name: string) => join(root, "node_modules/.bin", name)
+
+function run(command: string[], cwd = root) {
+  const result = Bun.spawnSync(command, {
+    cwd,
+    env: { ...process.env, CI: "1", DISABLE_TELEMETRY: "1" },
+    stdout: "pipe",
+    stderr: "pipe"
+  })
+  assert.equal(
+    result.exitCode,
+    0,
+    `${command.join(" ")} failed:\n${result.stdout}\n${result.stderr}`
+  )
+}
+
+async function filesIn(directory: string): Promise<string[]> {
+  const entries = await readdir(directory, { withFileTypes: true })
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const path = join(directory, entry.name)
+      assert(
+        !entry.isSymbolicLink(),
+        `Skill files must not be symlinks: ${path}`
+      )
+      return entry.isDirectory() ? filesIn(path) : [path]
+    })
+  )
+  return files.flat().sort()
+}
+
+async function assertSameFiles(source: string, destination: string) {
+  const sourceFiles = await filesIn(source)
+  const destinationFiles = await filesIn(destination)
+  assert.deepEqual(
+    destinationFiles.map((path) => relative(destination, path)),
+    sourceFiles.map((path) => relative(source, path))
+  )
+  for (const path of sourceFiles) {
+    assert.deepEqual(
+      await readFile(join(destination, relative(source, path))),
+      await readFile(path),
+      `Skill file changed during distribution: ${path}`
+    )
+  }
+}
+
+run([bun, cli("intent"), "validate", "--check"])
+
+const tree = Bun.YAML.parse(
+  await readFile(join(root, "_artifacts/skill_tree.yaml"), "utf8")
+) as SkillPlan
+const domainMap = Bun.YAML.parse(
+  await readFile(join(root, "_artifacts/domain_map.yaml"), "utf8")
+) as { skills: { slug: string }[] }
+assert((await readFile(join(root, "_artifacts/skill_spec.md"), "utf8")).trim())
+
+const skillNames = tree.skills.map((skill) => skill.name).sort()
+assert.equal(
+  new Set(skillNames).size,
+  skillNames.length,
+  "Skill names must be unique"
+)
+assert.deepEqual(domainMap.skills.map((skill) => skill.slug).sort(), skillNames)
+
+const packages = []
+for (const entry of await readdir(join(root, "packages"), {
+  withFileTypes: true
+})) {
+  if (!entry.isDirectory()) continue
+  const directory = join(root, "packages", entry.name)
+  const manifest = JSON.parse(
+    await readFile(join(directory, "package.json"), "utf8")
+  )
+  if (manifest.private) continue
+  assert(
+    manifest.files?.includes("skills"),
+    `${manifest.name} must publish skills`
+  )
+  assert(
+    manifest.keywords?.includes("tanstack-intent"),
+    `${manifest.name} must be discoverable`
+  )
+  packages.push({ directory, manifest })
+}
+assert.deepEqual(
+  [...new Set(tree.skills.map((skill) => skill.package))].sort(),
+  packages.map(({ directory }) => relative(root, directory)).sort(),
+  "Every public package needs skill coverage"
+)
+
+for (const skill of tree.skills) {
+  assert.equal(skill.path, `${skill.package}/skills/${skill.name}/SKILL.md`)
+  for (const source of skill.sources) {
+    assert(
+      (await readFile(join(root, source), "utf8")).trim(),
+      `Empty source: ${source}`
+    )
+  }
+  const skillRoot = dirname(join(root, skill.path))
+  for (const file of await filesIn(skillRoot)) {
+    if (!file.endsWith(".md")) continue
+    const content = await readFile(file, "utf8")
+    for (const match of content.matchAll(/\[[^\]]*\]\(([^)]+)\)/g)) {
+      const target = match[1].split("#")[0]
+      if (!target || /^https?:\/\//.test(target)) continue
+      const resolved = resolve(dirname(file), target)
+      assert(
+        !relative(skillRoot, resolved).startsWith(".."),
+        `Reference leaves skill: ${file} -> ${target}`
+      )
+      await readFile(resolved)
+    }
+  }
+}
+
+const temporary = await mkdtemp(join(tmpdir(), "better-auth-ui-skills-"))
+try {
+  const consumer = join(temporary, "consumer")
+  await mkdir(consumer)
+  await writeFile(
+    join(consumer, "package.json"),
+    JSON.stringify({
+      name: "skill-consumer",
+      private: true,
+      dependencies: Object.fromEntries(
+        packages.map(({ manifest }) => [manifest.name, manifest.version])
+      ),
+      intent: { skills: packages.map(({ manifest }) => manifest.name) }
+    })
+  )
+
+  for (const { directory, manifest } of packages) {
+    const archive = join(temporary, `${manifest.name.replaceAll("/", "-")}.tgz`)
+    run([bun, "pm", "pack", "--filename", archive, "--quiet"], directory)
+    const installed = join(consumer, "node_modules", manifest.name)
+    await mkdir(installed, { recursive: true })
+    run(["tar", "-xzf", archive, "--strip-components=1", "-C", installed])
+    await assertSameFiles(join(directory, "skills"), join(installed, "skills"))
+  }
+
+  const discovered = listIntentSkills({ cwd: consumer })
+  assert.deepEqual(
+    discovered.skills.map((skill) => skill.skillName).sort(),
+    skillNames
+  )
+  for (const skill of discovered.skills) {
+    const loaded = loadIntentSkill(skill.use, { cwd: consumer })
+    assert.equal(
+      resolve(consumer, loaded.path),
+      join(
+        consumer,
+        "node_modules",
+        skill.packageName,
+        "skills",
+        skill.skillName,
+        "SKILL.md"
+      )
+    )
+    assert(loaded.content.trim())
+    for (const match of loaded.content.matchAll(/\[[^\]]*\]\(([^)]+)\)/g)) {
+      const target = match[1].split("#")[0]
+      if (!target || /^https?:\/\//.test(target)) continue
+      await readFile(resolve(consumer, target))
+    }
+    const packaged = packages.find(
+      ({ manifest }) => manifest.name === skill.packageName
+    )
+    assert.equal(loaded.version, packaged?.manifest.version)
+  }
+
+  run(
+    [
+      bun,
+      cli("skills"),
+      "add",
+      root,
+      "--full-depth",
+      "--skill",
+      ...skillNames,
+      "--agent",
+      "universal",
+      "--copy",
+      "--yes"
+    ],
+    consumer
+  )
+  const installedSkills = join(consumer, ".agents/skills")
+  assert.deepEqual((await readdir(installedSkills)).sort(), skillNames)
+  for (const skill of tree.skills) {
+    await assertSameFiles(
+      dirname(join(root, skill.path)),
+      join(installedSkills, skill.name)
+    )
+  }
+  console.log(
+    `Validated ${skillNames.length} skills across ${packages.length} npm packages and skills.sh installation.`
+  )
+} finally {
+  await rm(temporary, { recursive: true, force: true })
+}

--- a/tools/workspace/project.json
+++ b/tools/workspace/project.json
@@ -2,6 +2,13 @@
   "name": "workspace",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "targets": {
+    "skills-check": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "bun tools/skills/check.ts",
+        "cwd": "."
+      }
+    },
     "lint": {
       "executor": "nx:run-commands",
       "inputs": ["workspaceLint"],


### PR DESCRIPTION
Closes #386.

AI agents need guidance that matches Better Auth UI's current package APIs and framework boundaries. This adds five package-local skills covering core data APIs, React/shadcn, Solid/Zaidan, HeroUI, and localization.

The same files ship in npm packages for TanStack Intent and install from GitHub through skills.sh. Each public package includes `skills` in its published files and the `tanstack-intent` keyword. No generated content mirror or runtime component changes are required.

The new documentation page and README explain both installation paths, version behavior, and explicit skill selection to avoid installing the repository's internal Nx skills. Authoring artifacts record source files and coverage for future updates.

CI and the npm publish workflow run `workspace:skills-check`. It validates frontmatter, package coverage, local references, and the contents of real package tarballs. It also loads skills through Intent and installs the selected public skills with the skills CLI in a temporary project, checking that all reference files survive.

Validation completed:

- `bun nx run workspace:skills-check`
- `bun nx run workspace:lint`
- `bun x biome check --staged`
- `bun nx run-many -t build --projects 'packages/*'`
- `bun nx run docs:build`, including registry generation, Storybooks, and HTML/Markdown prerendering
- Skill Creator validation for all five skills and checks for 22 documentation destinations
- Lefthook pre-commit checks

The local browser preview was unavailable, so visual verification is not claimed. The production guide prerenders with its tables, code blocks, and links.

GitHub installation becomes available after merge. Intent discovery becomes available when the packages containing these skills are released; registry listing follows each service's normal discovery process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added agent skill guides for Core, React, Solid, HeroUI, and localization workflows.
  * Added installation and usage documentation for agent skills through TanStack Intent and skills.sh.
  * Agent skills are now included in published packages and can be installed into supported projects.

* **Documentation**
  * Added guidance for framework setup, SSR, routing, customization, localization, and component references.
  * Added an Agent Skills page to the documentation navigation.

* **Chores**
  * Added automated validation for skill contents, package distribution, and installation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->