### PR TITLE
feat(core): publish lib/view-paths so third-party plugins can augment view paths

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./lib/view-paths": {
+      "src": "./src/lib/view-paths.ts",
+      "types": "./dist/lib/view-paths.d.ts",
+      "import": "./dist/lib/view-paths.js"
+    },
     "./plugins/admin": {
       "src": "./src/plugins/admin/index.ts",
       "types": "./dist/plugins/admin/index.d.ts",

--- a/packages/core/src/lib/view-paths.ts
+++ b/packages/core/src/lib/view-paths.ts
@@ -1,4 +1,27 @@
 /**
+ * The view-path interfaces below are augmentation points: a plugin adds its
+ * own views by merging into them, which widens `AuthView` / `SettingsView` /
+ * `AdminView` accordingly.
+ *
+ * Built-in plugins augment via the relative specifier (`"../../lib/view-paths"`).
+ * Third-party plugins target the published subpath, which resolves to this
+ * same module:
+ *
+ * ```ts
+ * declare module "@better-auth-ui/core/lib/view-paths" {
+ *   interface SettingsViewPaths {
+ *     cart?: string
+ *   }
+ * }
+ * ```
+ *
+ * Without that subpath the interfaces are only reachable from inside the
+ * package, so external plugins have to cast their view keys even though
+ * `<Settings>` and `<Admin>` already merge every plugin's `viewPaths` at
+ * runtime.
+ */
+
+/**
  * View path segments for authentication routes.
  *
  * @remarks Direct implementations must include the `callback` and `error`

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
     lib: {
       entry: {
         index: "src/index.ts",
+        // Published so third-party plugins can `declare module` against the
+        // same module identity the built-in plugins augment.
+        "lib/view-paths": "src/lib/view-paths.ts",
         "plugins/admin/index": "src/plugins/admin/index.ts",
         "plugins/agent-auth/index": "src/plugins/agent-auth/index.ts",
         "plugins/anonymous/index": "src/plugins/anonymous/index.ts",


### PR DESCRIPTION
## Problem

`SettingsViewPaths`, `AdminViewPaths` and `AuthViewPaths` are the augmentation points that widen `SettingsView` / `AdminView` / `AuthView`. Built-in plugins merge into them through the relative specifier — e.g. `plugins/billing/billing-plugin.ts`:

```ts
declare module "../../lib/view-paths" {
  interface SettingsViewPaths {
    /** @default "billing" */
    billing?: string
  }
}
```

That module isn't reachable from outside the package (`exports` only publishes `.`, `./server` and the plugin subpaths), so a third-party plugin can't do the same. Augmenting the public entry doesn't help:

```ts
declare module "@better-auth-ui/core" {
  interface SettingsViewPaths { cart?: string }   // declares a *new* interface,
}                                                 // it doesn't merge
```

So an external plugin that contributes a settings tab has to cast its own view key:

```ts
settingsTabs: [
  { view: "cart" as SettingsTab["view"], label, component: Cart },
]
```

This is types-only: `<Settings>` and `<Admin>` already merge every plugin's `viewPaths` at runtime and route contributed views correctly. It's only the type surface that's closed to plugins outside the repo.

## Change

Publish the module so external plugins can target the same module identity the built-in ones do:

```ts
declare module "@better-auth-ui/core/lib/view-paths" {
  interface SettingsViewPaths {
    cart?: string
  }
}
```

- `packages/core/package.json` — add the `./lib/view-paths` export (placed right after `.`)
- `packages/core/vite.config.ts` — add the matching build entry so `dist/lib/view-paths.js` is emitted (the declaration file was already produced by `vite-plugin-dts`; only the runtime chunk was missing)
- `packages/core/src/lib/view-paths.ts` — document the augmentation point and show both specifiers

Additive only: no existing export, type or runtime behaviour changes.

## Verification

Built `packages/core` on this branch — `dist/lib/view-paths.js` and `dist/lib/view-paths.d.ts` are both emitted.

Then, in a real consumer app (a third-party plugin contributing `settingsTabs`), with the subpath present:

```ts
declare module "@better-auth-ui/core/lib/view-paths" {
  interface SettingsViewPaths { cart?: string }
}
const view: SettingsTab["view"] = "cart"   // ✅ compiles
```

and with the subpath removed, the same file fails — confirming the export is what makes the merge possible rather than something else in the setup:

```
error TS2664: Invalid module name in augmentation, module
  '@better-auth-ui/core/lib/view-paths' cannot be found.
error TS2322: Type '"cart"' is not assignable to type 'keyof SettingsViewPaths'.
```

## Context

Found while building a third-party plugin that contributes commerce views to `<Settings>` (cart / orders / purchases) and `<Admin>` (orders / entitlements), following the billing and admin plugins as the model. Everything else about the plugin contract worked unchanged — `settingsTabs`, `adminTabs`, `useAuthPlugin`, and view-path merging all behaved exactly as the built-ins do. This was the one place a plugin outside the repo couldn't follow the same path.

Happy to adjust the approach if you'd rather solve it differently — e.g. widening `SettingsView` to `keyof SettingsViewPaths | (string & {})`, which would match how `AdminTab["id"]` and `<Admin view>` are already typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Published a new view-paths module for plugin integrations.
  * Added a stable entry point that allows third-party plugins to extend authentication, settings, and administration view paths with proper type support.

* **Documentation**
  * Documented how plugins can augment the available view-path interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->