### PR TITLE
refactor(auth): expand TanStack form and table usage

### DIFF
--- a/apps/docs/src/components/auth/admin/admin-users.tsx
+++ b/apps/docs/src/components/auth/admin/admin-users.tsx
@@ -27,6 +27,7 @@ import {
   useAdminUserSessions,
   useAdminUsers
 } from "@better-auth-ui/react/plugins/admin"
+import { useForm } from "@tanstack/react-form"
 import { keepPreviousData, useMutation } from "@tanstack/react-query"
 import {
   type ColumnFiltersState,
@@ -677,26 +678,51 @@ function CreateUserDialog({
   const auth = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
   const { data: session } = useSession(auth.authClient)
-  const [password, setPassword] = useState("")
-  const [emailVerified, setEmailVerified] = useState(false)
   const [formError, setFormError] = useState<string>()
-  const [roles, setRoles] = useState([config.defaultRole])
-
-  useEffect(() => {
-    if (!config.allowMultipleRoles) setRoles((current) => current.slice(0, 1))
-  }, [config.allowMultipleRoles])
   const createUser = useMutation(
     createAdminUserOptions(auth.authClient, session?.user.id)
   )
   const canSetRole = useAdminPermission(auth.authClient, {
     user: ["set-role"]
   })
+  const additionalFieldValuesRef = useRef<
+    Record<string, AdditionalFieldValue | null>
+  >({})
+  const form = useForm({
+    defaultValues: {
+      email: "",
+      emailVerified: false,
+      name: "",
+      password: "",
+      roles: [config.defaultRole]
+    },
+    onSubmit: ({ value }) => {
+      createUser.mutate(
+        {
+          data: {
+            ...additionalFieldValuesRef.current,
+            emailVerified: value.emailVerified
+          },
+          email: value.email,
+          name: value.name,
+          password: value.password,
+          ...(canSetRole.data?.success
+            ? { role: asAdminRoles(value.roles) }
+            : {})
+        },
+        { onSuccess: close }
+      )
+    }
+  })
+
+  useEffect(() => {
+    if (!config.allowMultipleRoles)
+      form.setFieldValue("roles", (current) => current.slice(0, 1))
+  }, [config.allowMultipleRoles, form.setFieldValue])
 
   const close = () => {
-    setPassword("")
-    setEmailVerified(false)
+    form.reset()
     setFormError(undefined)
-    setRoles([config.defaultRole])
     createUser.reset()
     onOpenChange(false)
   }
@@ -714,16 +740,8 @@ function CreateUserDialog({
       return
     }
     setFormError(undefined)
-    createUser.mutate(
-      {
-        data: { ...additionalFieldValues, emailVerified },
-        email: String(data.get("email")),
-        name: String(data.get("name")),
-        password,
-        ...(canSetRole.data?.success ? { role: asAdminRoles(roles) } : {})
-      },
-      { onSuccess: close }
-    )
+    additionalFieldValuesRef.current = additionalFieldValues
+    await form.handleSubmit()
   }
 
   return (
@@ -740,43 +758,70 @@ function CreateUserDialog({
             </DialogDescription>
           </DialogHeader>
           <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="admin-create-name">
-                {config.localization.name}
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupInput id="admin-create-name" name="name" required />
-              </InputGroup>
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="admin-create-email">
-                {config.localization.email}
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupInput
-                  autoComplete="off"
-                  id="admin-create-email"
-                  name="email"
-                  required
-                  type="email"
-                />
-              </InputGroup>
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="admin-create-password">
-                {config.localization.password}
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupInput
-                  autoComplete="new-password"
-                  id="admin-create-password"
-                  onChange={(event) => setPassword(event.target.value)}
-                  required
-                  type="password"
-                  value={password}
-                />
-              </InputGroup>
-            </Field>
+            <form.Field name="name">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="admin-create-name">
+                    {config.localization.name}
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupInput
+                      id="admin-create-name"
+                      name={field.name}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      value={field.state.value}
+                    />
+                  </InputGroup>
+                </Field>
+              )}
+            </form.Field>
+            <form.Field name="email">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="admin-create-email">
+                    {config.localization.email}
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupInput
+                      autoComplete="off"
+                      id="admin-create-email"
+                      name={field.name}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      type="email"
+                      value={field.state.value}
+                    />
+                  </InputGroup>
+                </Field>
+              )}
+            </form.Field>
+            <form.Field name="password">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="admin-create-password">
+                    {config.localization.password}
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupInput
+                      autoComplete="new-password"
+                      id="admin-create-password"
+                      name={field.name}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      type="password"
+                      value={field.state.value}
+                    />
+                  </InputGroup>
+                </Field>
+              )}
+            </form.Field>
             {canSetRole.isPending ? (
               <Skeleton className="h-16 w-full" />
             ) : canSetRole.data?.success ? (
@@ -784,58 +829,68 @@ function CreateUserDialog({
                 <FieldLegend variant="label">
                   {config.localization.role}
                 </FieldLegend>
-                {config.allowMultipleRoles ? (
-                  <FieldGroup data-slot="checkbox-group">
-                    {config.roles.map((role) => (
-                      <Field key={role} orientation="horizontal">
-                        <Checkbox
-                          checked={roles.includes(role)}
-                          id={`admin-create-role-${role}`}
-                          onCheckedChange={(checked) => {
-                            const next = checked
-                              ? [...roles, role]
-                              : roles.filter((item) => item !== role)
-                            if (next.length) setRoles(next)
-                          }}
-                        />
-                        <FieldLabel htmlFor={`admin-create-role-${role}`}>
-                          {role}
-                        </FieldLabel>
-                      </Field>
-                    ))}
-                  </FieldGroup>
-                ) : (
-                  <RadioGroup
-                    onValueChange={(role) => setRoles([role])}
-                    value={roles[0] ?? ""}
-                  >
-                    {config.roles.map((role) => (
-                      <Field key={role} orientation="horizontal">
-                        <RadioGroupItem
-                          id={`admin-create-role-${role}`}
-                          value={role}
-                        />
-                        <FieldLabel htmlFor={`admin-create-role-${role}`}>
-                          {role}
-                        </FieldLabel>
-                      </Field>
-                    ))}
-                  </RadioGroup>
-                )}
+                <form.Field name="roles">
+                  {(field) =>
+                    config.allowMultipleRoles ? (
+                      <FieldGroup data-slot="checkbox-group">
+                        {config.roles.map((role) => (
+                          <Field key={role} orientation="horizontal">
+                            <Checkbox
+                              checked={field.state.value.includes(role)}
+                              id={`admin-create-role-${role}`}
+                              onCheckedChange={(checked) => {
+                                const next = checked
+                                  ? [...field.state.value, role]
+                                  : field.state.value.filter(
+                                      (item) => item !== role
+                                    )
+                                if (next.length) field.handleChange(next)
+                              }}
+                            />
+                            <FieldLabel htmlFor={`admin-create-role-${role}`}>
+                              {role}
+                            </FieldLabel>
+                          </Field>
+                        ))}
+                      </FieldGroup>
+                    ) : (
+                      <RadioGroup
+                        onValueChange={(role) => field.handleChange([role])}
+                        value={field.state.value[0] ?? ""}
+                      >
+                        {config.roles.map((role) => (
+                          <Field key={role} orientation="horizontal">
+                            <RadioGroupItem
+                              id={`admin-create-role-${role}`}
+                              value={role}
+                            />
+                            <FieldLabel htmlFor={`admin-create-role-${role}`}>
+                              {role}
+                            </FieldLabel>
+                          </Field>
+                        ))}
+                      </RadioGroup>
+                    )
+                  }
+                </form.Field>
               </FieldSet>
             ) : null}
-            <Field orientation="horizontal">
-              <Switch
-                checked={emailVerified}
-                id="admin-create-email-verified"
-                onCheckedChange={setEmailVerified}
-              />
-              <FieldContent>
-                <FieldLabel htmlFor="admin-create-email-verified">
-                  {config.localization.emailVerified}
-                </FieldLabel>
-              </FieldContent>
-            </Field>
+            <form.Field name="emailVerified">
+              {(field) => (
+                <Field orientation="horizontal">
+                  <Switch
+                    checked={field.state.value}
+                    id="admin-create-email-verified"
+                    onCheckedChange={field.handleChange}
+                  />
+                  <FieldContent>
+                    <FieldLabel htmlFor="admin-create-email-verified">
+                      {config.localization.emailVerified}
+                    </FieldLabel>
+                  </FieldContent>
+                </Field>
+              )}
+            </form.Field>
             {auth.additionalFields?.map((field) => (
               <AdditionalField
                 field={field}
@@ -952,10 +1007,6 @@ function UserInspector({
     },
     { enabled: Boolean(userId) }
   )
-  const [name, setName] = useState("")
-  const [email, setEmail] = useState("")
-  const [emailVerified, setEmailVerified] = useState(false)
-  const [roles, setRoles] = useState([config.defaultRole])
   const [banReason, setBanReason] = useState("")
   const [banDuration, setBanDuration] = useState("")
   const banDurationSeconds = getBanDurationSeconds(banDuration)
@@ -968,22 +1019,6 @@ function UserInspector({
   const updateUser = useMutation(
     updateAdminUserOptions(auth.authClient, actor?.user.id)
   )
-
-  useEffect(() => {
-    setName(user?.name ?? "")
-    setEmail(user?.email ?? "")
-    setEmailVerified(user?.emailVerified ?? false)
-    setRoles(
-      parseAdminRoles(user?.role, config.defaultRole, config.allowMultipleRoles)
-    )
-  }, [
-    config.allowMultipleRoles,
-    config.defaultRole,
-    user?.email,
-    user?.emailVerified,
-    user?.name,
-    user?.role
-  ])
 
   useEffect(() => {
     if (profileUserId.current === user?.id) return
@@ -1018,6 +1053,75 @@ function UserInspector({
   const revokeSessions = useMutation(
     revokeAdminUserSessionsOptions(auth.authClient, actor?.user.id, userId)
   )
+  const profileAdditionalFieldValuesRef = useRef<
+    Record<string, AdditionalFieldValue | null>
+  >({})
+  const profileForm = useForm({
+    defaultValues: {
+      email: "",
+      emailVerified: false,
+      name: "",
+      roles: [config.defaultRole]
+    },
+    onSubmit: async ({ value }) => {
+      if (!user) return
+
+      const mutations: Promise<unknown>[] = []
+      if (canUpdate.data?.success) {
+        mutations.push(
+          updateUser.mutateAsync({
+            userId: user.id,
+            data: {
+              ...profileAdditionalFieldValuesRef.current,
+              name: value.name.trim(),
+              ...(canSetEmail.data?.success
+                ? {
+                    email: value.email.trim(),
+                    emailVerified: value.emailVerified
+                  }
+                : {})
+            }
+          })
+        )
+      }
+      if (canSetRole.data?.success && !isSelf) {
+        mutations.push(
+          setRoleMutation.mutateAsync({
+            userId: user.id,
+            role: asAdminRoles(value.roles)
+          })
+        )
+      }
+
+      try {
+        await Promise.all(mutations)
+        onOpenChange(false)
+      } catch {
+        // Mutation errors are rendered next to the form.
+      }
+    }
+  })
+
+  useEffect(() => {
+    profileForm.reset({
+      email: user?.email ?? "",
+      emailVerified: user?.emailVerified ?? false,
+      name: user?.name ?? "",
+      roles: parseAdminRoles(
+        user?.role,
+        config.defaultRole,
+        config.allowMultipleRoles
+      )
+    })
+  }, [
+    config.allowMultipleRoles,
+    config.defaultRole,
+    profileForm.reset,
+    user?.email,
+    user?.emailVerified,
+    user?.name,
+    user?.role
+  ])
 
   const confirm = () => {
     if (!user) return
@@ -1096,7 +1200,6 @@ function UserInspector({
     event.preventDefault()
     if (!user) return
 
-    const mutations: Promise<unknown>[] = []
     if (canUpdate.data?.success) {
       const formData = new FormData(event.currentTarget)
       let additionalFieldValues: Record<string, AdditionalFieldValue | null>
@@ -1110,34 +1213,10 @@ function UserInspector({
         return
       }
       setProfileError(undefined)
-      mutations.push(
-        updateUser.mutateAsync({
-          userId: user.id,
-          data: {
-            ...additionalFieldValues,
-            name: name.trim(),
-            ...(canSetEmail.data?.success
-              ? { email: email.trim(), emailVerified }
-              : {})
-          }
-        })
-      )
-    }
-    if (canSetRole.data?.success && !isSelf) {
-      mutations.push(
-        setRoleMutation.mutateAsync({
-          userId: user.id,
-          role: asAdminRoles(roles)
-        })
-      )
+      profileAdditionalFieldValuesRef.current = additionalFieldValues
     }
 
-    try {
-      await Promise.all(mutations)
-      onOpenChange(false)
-    } catch {
-      // Mutation errors are rendered next to the form.
-    }
+    await profileForm.handleSubmit()
   }
 
   return (
@@ -1243,107 +1322,136 @@ function UserInspector({
                         {config.localization.profileAndAccess}
                       </h3>
                       <FieldGroup className="grid gap-5 md:grid-cols-2">
-                        <Field>
-                          <FieldLabel htmlFor="admin-user-name">
-                            {config.localization.name}
-                          </FieldLabel>
-                          <InputGroup>
-                            <InputGroupInput
-                              disabled={!canUpdate.data?.success}
-                              id="admin-user-name"
-                              value={name}
-                              onChange={(event) => setName(event.target.value)}
-                            />
-                          </InputGroup>
-                        </Field>
-                        <Field>
-                          <FieldLabel htmlFor="admin-user-email">
-                            {config.localization.email}
-                          </FieldLabel>
-                          <InputGroup>
-                            <InputGroupInput
-                              disabled={
-                                !canUpdate.data?.success ||
-                                !canSetEmail.data?.success
-                              }
-                              id="admin-user-email"
-                              onChange={(event) => setEmail(event.target.value)}
-                              required
-                              type="email"
-                              value={email}
-                            />
-                          </InputGroup>
-                        </Field>
-                        <Field orientation="horizontal">
-                          <Switch
-                            checked={emailVerified}
-                            disabled={
-                              !canUpdate.data?.success ||
-                              !canSetEmail.data?.success
-                            }
-                            id="admin-user-email-verified"
-                            onCheckedChange={setEmailVerified}
-                          />
-                          <FieldContent>
-                            <FieldLabel htmlFor="admin-user-email-verified">
-                              {config.localization.emailVerified}
-                            </FieldLabel>
-                          </FieldContent>
-                        </Field>
+                        <profileForm.Field name="name">
+                          {(field) => (
+                            <Field>
+                              <FieldLabel htmlFor="admin-user-name">
+                                {config.localization.name}
+                              </FieldLabel>
+                              <InputGroup>
+                                <InputGroupInput
+                                  disabled={!canUpdate.data?.success}
+                                  id="admin-user-name"
+                                  name={field.name}
+                                  value={field.state.value}
+                                  onChange={(event) =>
+                                    field.handleChange(event.target.value)
+                                  }
+                                />
+                              </InputGroup>
+                            </Field>
+                          )}
+                        </profileForm.Field>
+                        <profileForm.Field name="email">
+                          {(field) => (
+                            <Field>
+                              <FieldLabel htmlFor="admin-user-email">
+                                {config.localization.email}
+                              </FieldLabel>
+                              <InputGroup>
+                                <InputGroupInput
+                                  disabled={
+                                    !canUpdate.data?.success ||
+                                    !canSetEmail.data?.success
+                                  }
+                                  id="admin-user-email"
+                                  name={field.name}
+                                  onChange={(event) =>
+                                    field.handleChange(event.target.value)
+                                  }
+                                  required
+                                  type="email"
+                                  value={field.state.value}
+                                />
+                              </InputGroup>
+                            </Field>
+                          )}
+                        </profileForm.Field>
+                        <profileForm.Field name="emailVerified">
+                          {(field) => (
+                            <Field orientation="horizontal">
+                              <Switch
+                                checked={field.state.value}
+                                disabled={
+                                  !canUpdate.data?.success ||
+                                  !canSetEmail.data?.success
+                                }
+                                id="admin-user-email-verified"
+                                onCheckedChange={field.handleChange}
+                              />
+                              <FieldContent>
+                                <FieldLabel htmlFor="admin-user-email-verified">
+                                  {config.localization.emailVerified}
+                                </FieldLabel>
+                              </FieldContent>
+                            </Field>
+                          )}
+                        </profileForm.Field>
                         <FieldSet>
                           <FieldLegend variant="label">
                             {config.localization.role}
                           </FieldLegend>
-                          {config.allowMultipleRoles ? (
-                            <FieldGroup
-                              className="flex-row flex-wrap gap-4"
-                              data-slot="checkbox-group"
-                            >
-                              {config.roles.map((item) => (
-                                <Field key={item} orientation="horizontal">
-                                  <Checkbox
-                                    checked={roles.includes(item)}
-                                    disabled={
-                                      isSelf || !canSetRole.data?.success
-                                    }
-                                    id={`admin-user-role-${item}`}
-                                    onCheckedChange={(checked) => {
-                                      const next = checked
-                                        ? [...roles, item]
-                                        : roles.filter((role) => role !== item)
-                                      if (next.length) setRoles(next)
-                                    }}
-                                  />
-                                  <FieldLabel
-                                    htmlFor={`admin-user-role-${item}`}
-                                  >
-                                    {item}
-                                  </FieldLabel>
-                                </Field>
-                              ))}
-                            </FieldGroup>
-                          ) : (
-                            <RadioGroup
-                              className="flex-row flex-wrap gap-4"
-                              disabled={isSelf || !canSetRole.data?.success}
-                              onValueChange={(role) => setRoles([role])}
-                              value={roles[0] ?? ""}
-                            >
-                              {config.roles.map((item) => (
-                                <Field key={item} orientation="horizontal">
-                                  <RadioGroupItem
-                                    id={`admin-user-role-${item}`}
-                                    value={item}
-                                  />
-                                  <FieldLabel
-                                    htmlFor={`admin-user-role-${item}`}
-                                  >
-                                    {item}
-                                  </FieldLabel>
-                                </Field>
-                              ))}
-                            </RadioGroup>
-                          )}
+                          <profileForm.Field name="roles">
+                            {(field) =>
+                              config.allowMultipleRoles ? (
+                                <FieldGroup
+                                  className="flex-row flex-wrap gap-4"
+                                  data-slot="checkbox-group"
+                                >
+                                  {config.roles.map((item) => (
+                                    <Field key={item} orientation="horizontal">
+                                      <Checkbox
+                                        checked={field.state.value.includes(
+                                          item
+                                        )}
+                                        disabled={
+                                          isSelf || !canSetRole.data?.success
+                                        }
+                                        id={`admin-user-role-${item}`}
+                                        onCheckedChange={(checked) => {
+                                          const next = checked
+                                            ? [...field.state.value, item]
+                                            : field.state.value.filter(
+                                                (role) => role !== item
+                                              )
+                                          if (next.length)
+                                            field.handleChange(next)
+                                        }}
+                                      />
+                                      <FieldLabel
+                                        htmlFor={`admin-user-role-${item}`}
+                                      >
+                                        {item}
+                                      </FieldLabel>
+                                    </Field>
+                                  ))}
+                                </FieldGroup>
+                              ) : (
+                                <RadioGroup
+                                  className="flex-row flex-wrap gap-4"
+                                  disabled={isSelf || !canSetRole.data?.success}
+                                  onValueChange={(role) =>
+                                    field.handleChange([role])
+                                  }
+                                  value={field.state.value[0] ?? ""}
+                                >
+                                  {config.roles.map((item) => (
+                                    <Field key={item} orientation="horizontal">
+                                      <RadioGroupItem
+                                        id={`admin-user-role-${item}`}
+                                        value={item}
+                                      />
+                                      <FieldLabel
+                                        htmlFor={`admin-user-role-${item}`}
+                                      >
+                                        {item}
+                                      </FieldLabel>
+                                    </Field>
+                                  ))}
+                                </RadioGroup>
+                              )
+                            }
+                          </profileForm.Field>
                         </FieldSet>
                         {auth.additionalFields?.map((field) => {
                           const value = (
@@ -1508,21 +1616,30 @@ function UserInspector({
                     >
                       {config.localization.cancel}
                     </Button>
-                    <Button
-                      disabled={
-                        !name.trim() ||
-                        !email.trim() ||
-                        updateUser.isPending ||
-                        setRoleMutation.isPending ||
-                        canUpdate.isPending ||
-                        canSetRole.isPending ||
-                        (!canUpdate.data?.success &&
-                          (!canSetRole.data?.success || isSelf))
-                      }
-                      type="submit"
+                    <profileForm.Subscribe
+                      selector={(state) => [
+                        state.values.name,
+                        state.values.email
+                      ]}
                     >
-                      {config.localization.saveChanges}
-                    </Button>
+                      {([name, email]) => (
+                        <Button
+                          disabled={
+                            !name.trim() ||
+                            !email.trim() ||
+                            updateUser.isPending ||
+                            setRoleMutation.isPending ||
+                            canUpdate.isPending ||
+                            canSetRole.isPending ||
+                            (!canUpdate.data?.success &&
+                              (!canSetRole.data?.success || isSelf))
+                          }
+                          type="submit"
+                        >
+                          {config.localization.saveChanges}
+                        </Button>
+                      )}
+                    </profileForm.Subscribe>
                   </div>
                 </form>
               </TabsContent>

--- a/apps/docs/src/components/auth/api-key/api-keys.tsx
+++ b/apps/docs/src/components/auth/api-key/api-keys.tsx
@@ -1,8 +1,21 @@
 "use client"
 
-import type { ApiKeyAuthClient } from "@better-auth-ui/core/plugins/api-key"
+import type {
+  ApiKeyAuthClient,
+  ListedApiKey
+} from "@better-auth-ui/core/plugins/api-key"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useListApiKeys } from "@better-auth-ui/react/plugins/api-key"
+import {
+  createTableHook,
+  functionalUpdate,
+  type PaginationState,
+  rowPaginationFeature,
+  rowSortingFeature,
+  type SortingState,
+  tableFeatures,
+  type Updater
+} from "@tanstack/react-table"
 import { Fragment, useState } from "react"
 
 import { Button } from "@/components/ui/button"
@@ -21,6 +34,20 @@ import { ApiKey } from "./api-key"
 import { ApiKeySkeleton } from "./api-key-skeleton"
 import { ApiKeysEmpty } from "./api-keys-empty"
 import { CreateApiKeyDialog } from "./create-api-key-dialog"
+
+const { createAppColumnHelper, useAppTable: useApiKeyTable } = createTableHook({
+  enableMultiSort: false,
+  enableSortingRemoval: false,
+  sortDescFirst: false,
+  features: tableFeatures({ rowPaginationFeature, rowSortingFeature })
+})
+
+const apiKeyColumnHelper = createAppColumnHelper<ListedApiKey>()
+const apiKeyColumns = apiKeyColumnHelper.columns([
+  apiKeyColumnHelper.accessor("createdAt", { id: "createdAt" }),
+  apiKeyColumnHelper.accessor("name", { id: "name" })
+])
+const EMPTY_API_KEYS: ListedApiKey[] = []
 
 export type ApiKeysProps = {
   className?: string
@@ -47,17 +74,25 @@ export function ApiKeys({
   const { authClient } = useAuth<ApiKeyAuthClient>()
   const { localization: apiKeyLocalization, pageSize } =
     useAuthPlugin(apiKeyPlugin)
-  const [page, setPage] = useState(0)
-  const [sort, setSort] = useState("createdAt:desc")
-  const [sortBy, sortDirection] = sort.split(":") as [string, "asc" | "desc"]
+  const [pagination, setPaginationState] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const [sorting, setSortingState] = useState<SortingState>([
+    { id: "createdAt", desc: true }
+  ])
+  const primarySort = sorting[0]
+  const sortBy = primarySort?.id === "name" ? "name" : "createdAt"
+  const sortDirection = primarySort?.desc ? "desc" : "asc"
+  const sort = `${sortBy}:${sortDirection}`
 
   const { data: listData, isPending: isListPending } = useListApiKeys(
     authClient,
     {
       enabled: !isPendingProp,
       query: {
-        limit: pageSize,
-        offset: page * pageSize,
+        limit: pagination.pageSize,
+        offset: pagination.pageIndex * pagination.pageSize,
         sortBy,
         sortDirection,
         ...(organizationId ? { organizationId, configId: "organization" } : {})
@@ -66,6 +101,22 @@ export function ApiKeys({
   )
 
   const isPending = isPendingProp || isListPending
+  const setPagination = (updater: Updater<PaginationState>) =>
+    setPaginationState((current) => functionalUpdate(updater, current))
+  const setSorting = (updater: Updater<SortingState>) => {
+    setSortingState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const table = useApiKeyTable({
+    columns: apiKeyColumns,
+    data: listData?.apiKeys ?? EMPTY_API_KEYS,
+    getRowId: (apiKey) => apiKey.id,
+    manualPagination: true,
+    manualSorting: true,
+    state: { pagination, sorting },
+    onPaginationChange: setPagination,
+    onSortingChange: setSorting
+  })
 
   const [createOpen, setCreateOpen] = useState(false)
 
@@ -90,8 +141,8 @@ export function ApiKeys({
       <Select
         value={sort}
         onValueChange={(value) => {
-          setSort(value)
-          setPage(0)
+          const [id, direction] = value.split(":")
+          table.setSorting([{ id, desc: direction === "desc" }])
         }}
       >
         <SelectTrigger aria-label={apiKeyLocalization.sortBy}>
@@ -124,11 +175,11 @@ export function ApiKeys({
             />
           ) : (
             <ItemGroup className="gap-0">
-              {listData.apiKeys.map((key, index) => (
-                <Fragment key={key.id}>
+              {table.getRowModel().rows.map((row, index) => (
+                <Fragment key={row.id}>
                   {index > 0 && <ItemSeparator />}
                   <ApiKey
-                    apiKey={key}
+                    apiKey={row.original}
                     hideDelete={hideDelete}
                     hideUpdate={hideUpdate}
                     organizationId={organizationId}
@@ -139,21 +190,22 @@ export function ApiKeys({
           )}
         </CardContent>
       </Card>
-      {(page > 0 || (listData?.apiKeys.length ?? 0) === pageSize) && (
+      {(pagination.pageIndex > 0 ||
+        (listData?.apiKeys.length ?? 0) === pagination.pageSize) && (
         <div className="flex justify-end gap-2">
           <Button
             variant="outline"
             size="sm"
-            disabled={page === 0}
-            onClick={() => setPage((value) => Math.max(0, value - 1))}
+            disabled={!table.getCanPreviousPage()}
+            onClick={() => table.previousPage()}
           >
             {apiKeyLocalization.previousPage}
           </Button>
           <Button
             variant="outline"
             size="sm"
-            disabled={(listData?.apiKeys.length ?? 0) < pageSize}
-            onClick={() => setPage((value) => value + 1)}
+            disabled={(listData?.apiKeys.length ?? 0) < pagination.pageSize}
+            onClick={() => table.nextPage()}
           >
             {apiKeyLocalization.nextPage}
           </Button>

--- a/apps/docs/src/components/auth/dash/activity.tsx
+++ b/apps/docs/src/components/auth/dash/activity.tsx
@@ -21,6 +21,17 @@ import {
 import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
 import { keepPreviousData } from "@tanstack/react-query"
 import {
+  type ColumnFiltersState,
+  columnFilteringFeature,
+  createTableHook,
+  functionalUpdate,
+  globalFilteringFeature,
+  type PaginationState,
+  rowPaginationFeature,
+  tableFeatures,
+  type Updater
+} from "@tanstack/react-table"
+import {
   Activity,
   Building2,
   ChevronLeft,
@@ -73,6 +84,21 @@ import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
 
 type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
+
+const { createAppColumnHelper, useAppTable: useActivityTable } =
+  createTableHook({
+    features: tableFeatures({
+      columnFilteringFeature,
+      globalFilteringFeature,
+      rowPaginationFeature
+    })
+  })
+
+const activityColumnHelper = createAppColumnHelper<DashAuditLog>()
+const activityColumns = activityColumnHelper.columns([
+  activityColumnHelper.accessor("eventType", { id: "eventType" })
+])
+const EMPTY_EVENTS: DashAuditLog[] = []
 
 type ActivityFeedProps = {
   access: ActivityAccess
@@ -211,19 +237,27 @@ function ActivityFeed({
 }: ActivityFeedProps) {
   const { authClient } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
-  const [page, setPage] = useState(0)
-  const [eventType, setEventType] = useState("all")
-  const [identifier, setIdentifier] = useState("")
-  const deferredIdentifier = useDeferredValue(identifier.trim())
+  const [pagination, setPaginationState] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const [columnFilters, setColumnFiltersState] = useState<ColumnFiltersState>(
+    []
+  )
+  const [globalFilter, setGlobalFilterState] = useState("")
+  const eventType = String(
+    columnFilters.find((filter) => filter.id === "eventType")?.value ?? "all"
+  )
+  const deferredIdentifier = useDeferredValue(globalFilter.trim())
   const eventOptions = useMemo(
     () => Object.entries(localization.eventLabels),
     [localization.eventLabels]
   )
-  const offset = page * pageSize
+  const offset = pagination.pageIndex * pagination.pageSize
   const params = {
     eventType: eventType === "all" ? undefined : eventType,
     identifier: deferredIdentifier || undefined,
-    limit: pageSize,
+    limit: pagination.pageSize,
     offset,
     organizationId
   }
@@ -245,7 +279,7 @@ function ActivityFeed({
       params: {
         eventType: params.eventType,
         identifier: params.identifier,
-        limit: pageSize,
+        limit: pagination.pageSize,
         offset
       }
     }
@@ -259,7 +293,28 @@ function ActivityFeed({
   const { data, error, isFetching, isPending } = query
   const showPending = !ready || isPending
   const pageEnd = offset + (data?.events.length ?? 0)
-  const hasNextPage = pageEnd < (data?.total ?? 0)
+  const setPagination = (updater: Updater<PaginationState>) =>
+    setPaginationState((current) => functionalUpdate(updater, current))
+  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
+    setColumnFiltersState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const setGlobalFilter = (updater: Updater<string>) => {
+    setGlobalFilterState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const table = useActivityTable({
+    columns: activityColumns,
+    data: data?.events ?? EMPTY_EVENTS,
+    getRowId: getDashEventKey,
+    manualFiltering: true,
+    manualPagination: true,
+    rowCount: data?.total ?? 0,
+    state: { columnFilters, globalFilter, pagination },
+    onColumnFiltersChange: setColumnFilters,
+    onGlobalFilterChange: setGlobalFilter,
+    onPaginationChange: setPagination
+  })
 
   return (
     <Card
@@ -297,8 +352,9 @@ function ActivityFeed({
             <Select
               value={eventType}
               onValueChange={(value) => {
-                setEventType(value)
-                setPage(0)
+                table
+                  .getColumn("eventType")
+                  ?.setFilterValue(value === "all" ? undefined : value)
               }}
             >
               <SelectTrigger id="dash-event-type" className="w-full">
@@ -325,11 +381,10 @@ function ActivityFeed({
               <InputGroupInput
                 id="dash-identifier"
                 onChange={(event) => {
-                  setIdentifier(event.target.value)
-                  setPage(0)
+                  table.setGlobalFilter(event.target.value)
                 }}
                 placeholder={localization.identifierPlaceholder}
-                value={identifier}
+                value={globalFilter}
               />
             </InputGroup>
           </Field>
@@ -366,10 +421,10 @@ function ActivityFeed({
           </Empty>
         ) : data?.events.length ? (
           <ul>
-            {data.events.map((event, position) => (
-              <Fragment key={getDashEventKey(event)}>
+            {table.getRowModel().rows.map((row, position) => (
+              <Fragment key={row.id}>
                 {position > 0 && <Separator />}
-                <ActivityRow event={event} />
+                <ActivityRow event={row.original} />
               </Fragment>
             ))}
           </ul>
@@ -402,19 +457,19 @@ function ActivityFeed({
           <div className="flex gap-1">
             <Button
               aria-label={localization.previousPage}
-              disabled={isFetching || page === 0}
+              disabled={isFetching || !table.getCanPreviousPage()}
               size="icon-sm"
               variant="ghost"
-              onClick={() => setPage((current) => Math.max(0, current - 1))}
+              onClick={() => table.previousPage()}
             >
               <ChevronLeft />
             </Button>
             <Button
               aria-label={localization.nextPage}
-              disabled={isFetching || !hasNextPage}
+              disabled={isFetching || !table.getCanNextPage()}
               size="icon-sm"
               variant="ghost"
-              onClick={() => setPage((current) => current + 1)}
+              onClick={() => table.nextPage()}
             >
               <ChevronRight />
             </Button>

--- a/apps/docs/src/components/auth/oauth-provider/oauth-clients.tsx
+++ b/apps/docs/src/components/auth/oauth-provider/oauth-clients.tsx
@@ -22,6 +22,7 @@ import {
   useSetOAuthClientDisabled,
   useUpdateOAuthClient
 } from "@better-auth-ui/react/plugins/oauth-provider"
+import { useForm } from "@tanstack/react-form"
 import {
   Check,
   Code2,
@@ -31,7 +32,7 @@ import {
   RotateCcwKey,
   Trash2
 } from "lucide-react"
-import { type SyntheticEvent, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -85,6 +86,15 @@ type ClientAction =
   | { kind: "delete"; client: ManagedOAuthClient }
   | { kind: "rotate"; client: ManagedOAuthClient }
 
+type OAuthClientFormValues = {
+  applicationType: "native" | "web"
+  clientName: string
+  clientUri: string
+  logoUri: string
+  redirectUris: string
+  scope: string
+}
+
 export type OAuthClientsProps = {
   manager: OAuthClientManager
   owner: OAuthClientOwner
@@ -101,6 +111,17 @@ const uniqueLines = (value: string) =>
         .filter(Boolean)
     )
   )
+
+const getOAuthClientFormValues = (
+  client?: ManagedOAuthClient
+): OAuthClientFormValues => ({
+  applicationType: client?.application_type === "native" ? "native" : "web",
+  clientName: client?.client_name ?? "",
+  clientUri: client?.client_uri ?? "",
+  logoUri: client?.logo_uri ?? "",
+  redirectUris: client?.redirect_uris.join("\n") ?? "",
+  scope: client?.scope ?? ""
+})
 
 export function OAuthClients({
   manager,
@@ -124,39 +145,41 @@ export function OAuthClients({
     onError: (error) =>
       toast.error(error instanceof Error ? error.message : String(error))
   })
+  const form = useForm({
+    defaultValues: getOAuthClientFormValues(),
+    onSubmit: async ({ value }) => {
+      const input: OAuthClientInput = {
+        client_name: value.clientName.trim(),
+        application_type: value.applicationType,
+        redirect_uris: uniqueLines(value.redirectUris),
+        client_uri: value.clientUri.trim() || undefined,
+        logo_uri: value.logoUri.trim() || undefined,
+        scope: value.scope.trim() || undefined
+      }
+
+      try {
+        if (editingClient) {
+          await updateClient.mutateAsync({
+            clientId: editingClient.client_id,
+            update: input
+          })
+          setEditorOpen(false)
+          return
+        }
+
+        const client = await createClient.mutateAsync(input)
+        setEditorOpen(false)
+        setSecret(client)
+      } catch {
+        // The mutation keeps its error state for the host application.
+      }
+    }
+  })
 
   const openCreate = () => {
     setEditingClient(undefined)
+    form.reset(getOAuthClientFormValues())
     setEditorOpen(true)
-  }
-
-  const handleEditorSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    const input: OAuthClientInput = {
-      client_name: String(formData.get("clientName") ?? "").trim(),
-      application_type:
-        formData.get("applicationType") === "native" ? "native" : "web",
-      redirect_uris: uniqueLines(String(formData.get("redirectUris") ?? "")),
-      client_uri: String(formData.get("clientUri") ?? "").trim() || undefined,
-      logo_uri: String(formData.get("logoUri") ?? "").trim() || undefined,
-      scope: String(formData.get("scope") ?? "").trim() || undefined
-    }
-
-    if (editingClient) {
-      updateClient.mutate(
-        { clientId: editingClient.client_id, update: input },
-        { onSuccess: () => setEditorOpen(false) }
-      )
-      return
-    }
-
-    createClient.mutate(input, {
-      onSuccess: (client) => {
-        setEditorOpen(false)
-        setSecret(client)
-      }
-    })
   }
 
   const confirmAction = () => {
@@ -263,6 +286,7 @@ export function OAuthClients({
                     aria-label={oauthLocalization.editClient}
                     onClick={() => {
                       setEditingClient(client)
+                      form.reset(getOAuthClientFormValues(client))
                       setEditorOpen(true)
                     }}
                   >
@@ -310,7 +334,13 @@ export function OAuthClients({
 
       <Dialog open={editorOpen} onOpenChange={setEditorOpen}>
         <DialogContent>
-          <form onSubmit={handleEditorSubmit} className="flex flex-col gap-6">
+          <form
+            onSubmit={(event) => {
+              event.preventDefault()
+              void form.handleSubmit()
+            }}
+            className="flex flex-col gap-6"
+          >
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2">
                 {editingClient ? <Pencil /> : <Plus />}
@@ -323,87 +353,118 @@ export function OAuthClients({
               </DialogDescription>
             </DialogHeader>
             <FieldGroup>
-              <Field>
-                <FieldLabel htmlFor="oauth-client-name">
-                  {oauthLocalization.clientName}
-                </FieldLabel>
-                <Input
-                  id="oauth-client-name"
-                  name="clientName"
-                  defaultValue={editingClient?.client_name ?? ""}
-                  required
-                  autoFocus
-                />
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-application-type">
-                  {oauthLocalization.applicationType}
-                </FieldLabel>
-                <Select
-                  name="applicationType"
-                  defaultValue={editingClient?.application_type ?? "web"}
-                >
-                  <SelectTrigger id="oauth-application-type" className="w-full">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="web">
-                      {oauthLocalization.webApplication}
-                    </SelectItem>
-                    <SelectItem value="native">
-                      {oauthLocalization.nativeApplication}
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-redirect-uris">
-                  {oauthLocalization.redirectUrls}
-                </FieldLabel>
-                <Textarea
-                  id="oauth-redirect-uris"
-                  name="redirectUris"
-                  rows={3}
-                  defaultValue={editingClient?.redirect_uris.join("\n") ?? ""}
-                  required
-                />
-                <FieldDescription>
-                  {oauthLocalization.redirectUrlsDescription}
-                </FieldDescription>
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-client-uri">
-                  {oauthLocalization.applicationUrl}
-                </FieldLabel>
-                <Input
-                  id="oauth-client-uri"
-                  name="clientUri"
-                  type="url"
-                  defaultValue={editingClient?.client_uri ?? ""}
-                />
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-logo-uri">
-                  {oauthLocalization.logoUrl}
-                </FieldLabel>
-                <Input
-                  id="oauth-logo-uri"
-                  name="logoUri"
-                  type="url"
-                  defaultValue={editingClient?.logo_uri ?? ""}
-                />
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-scopes">
-                  {oauthLocalization.scopes}
-                </FieldLabel>
-                <Input
-                  id="oauth-scopes"
-                  name="scope"
-                  placeholder="openid profile email"
-                  defaultValue={editingClient?.scope ?? ""}
-                />
-              </Field>
+              <form.Field name="clientName">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="oauth-client-name">
+                      {oauthLocalization.clientName}
+                    </FieldLabel>
+                    <Input
+                      autoFocus
+                      id="oauth-client-name"
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      value={field.state.value}
+                    />
+                  </Field>
+                )}
+              </form.Field>
+              <form.Field name="applicationType">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="oauth-application-type">
+                      {oauthLocalization.applicationType}
+                    </FieldLabel>
+                    <Select
+                      name={field.name}
+                      onValueChange={(value) =>
+                        field.handleChange(value as "native" | "web")
+                      }
+                      value={field.state.value}
+                    >
+                      <SelectTrigger
+                        id="oauth-application-type"
+                        className="w-full"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="web">
+                          {oauthLocalization.webApplication}
+                        </SelectItem>
+                        <SelectItem value="native">
+                          {oauthLocalization.nativeApplication}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </Field>
+                )}
+              </form.Field>
+              <form.Field name="redirectUris">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="oauth-redirect-uris">
+                      {oauthLocalization.redirectUrls}
+                    </FieldLabel>
+                    <Textarea
+                      id="oauth-redirect-uris"
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      rows={3}
+                      value={field.state.value}
+                    />
+                    <FieldDescription>
+                      {oauthLocalization.redirectUrlsDescription}
+                    </FieldDescription>
+                  </Field>
+                )}
+              </form.Field>
+              {(
+                [
+                  [
+                    "clientUri",
+                    "oauth-client-uri",
+                    oauthLocalization.applicationUrl,
+                    "url"
+                  ],
+                  [
+                    "logoUri",
+                    "oauth-logo-uri",
+                    oauthLocalization.logoUrl,
+                    "url"
+                  ],
+                  ["scope", "oauth-scopes", oauthLocalization.scopes, "text"]
+                ] as const
+              ).map(([name, id, label, type]) => (
+                <form.Field key={name} name={name}>
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+                      <Input
+                        id={id}
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        placeholder={
+                          name === "scope" ? "openid profile email" : undefined
+                        }
+                        type={type}
+                        value={field.state.value}
+                      />
+                    </Field>
+                  )}
+                </form.Field>
+              ))}
             </FieldGroup>
             <DialogFooter>
               <DialogClose
@@ -412,17 +473,16 @@ export function OAuthClients({
               >
                 {oauthLocalization.cancel}
               </DialogClose>
-              <Button
-                type="submit"
-                disabled={createClient.isPending || updateClient.isPending}
-              >
-                {(createClient.isPending || updateClient.isPending) && (
-                  <Spinner />
+              <form.Subscribe selector={(state) => state.isSubmitting}>
+                {(isSubmitting) => (
+                  <Button type="submit" disabled={isSubmitting}>
+                    {isSubmitting && <Spinner />}
+                    {editingClient
+                      ? oauthLocalization.saveChanges
+                      : oauthLocalization.createClient}
+                  </Button>
                 )}
-                {editingClient
-                  ? oauthLocalization.saveChanges
-                  : oauthLocalization.createClient}
-              </Button>
+              </form.Subscribe>
             </DialogFooter>
           </form>
         </DialogContent>

--- a/apps/docs/src/components/auth/organization/edit-member-roles-dialog.tsx
+++ b/apps/docs/src/components/auth/organization/edit-member-roles-dialog.tsx
@@ -4,8 +4,9 @@ import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organi
 import { parseMemberRoles } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useUpdateMemberRole } from "@better-auth-ui/react/plugins/organization"
+import { useForm } from "@tanstack/react-form"
 import { ShieldCheck } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
 import { toast } from "sonner"
 
 import { Button, buttonVariants } from "@/components/ui/button"
@@ -71,9 +72,6 @@ export function EditMemberRolesDialog({
   const { authClient, localization } = useAuth<OrganizationAuthClient>()
   const { allowMultipleRoles, localization: organizationLocalization } =
     useAuthPlugin(organizationPlugin)
-  const [selectedRoles, setSelectedRoles] = useState(() =>
-    selectedMemberRoles(member.role, allowMultipleRoles, protectedRole)
-  )
   const { mutate: updateMemberRole, isPending } = useUpdateMemberRole(
     authClient,
     {
@@ -83,16 +81,36 @@ export function EditMemberRolesDialog({
       }
     }
   )
+  const form = useForm({
+    defaultValues: {
+      roles: selectedMemberRoles(member.role, allowMultipleRoles, protectedRole)
+    },
+    onSubmit: ({ value }) => {
+      if (value.roles.length === 0) return
+
+      updateMemberRole({
+        memberId: member.id,
+        organizationId,
+        role: value.roles
+      })
+    }
+  })
 
   useEffect(() => {
     if (open)
-      setSelectedRoles(
-        selectedMemberRoles(member.role, allowMultipleRoles, protectedRole)
-      )
-  }, [allowMultipleRoles, member.role, open, protectedRole])
+      form.reset({
+        roles: selectedMemberRoles(
+          member.role,
+          allowMultipleRoles,
+          protectedRole
+        )
+      })
+  }, [allowMultipleRoles, form.reset, member.role, open, protectedRole])
 
   const toggleRole = (role: string, checked: boolean) => {
-    setSelectedRoles((current) =>
+    const current = form.getFieldValue("roles")
+    form.setFieldValue(
+      "roles",
       checked
         ? current.includes(role)
           ? current
@@ -101,41 +119,6 @@ export function EditMemberRolesDialog({
     )
   }
 
-  const protectedRoleSelected =
-    !allowMultipleRoles &&
-    protectedRoleRemovalDisabled &&
-    protectedRole !== undefined &&
-    selectedRoles.includes(protectedRole)
-  const roleOptions = roles.map(([role, label]) => {
-    const checked = selectedRoles.includes(role)
-    const disabled =
-      isPending ||
-      (allowMultipleRoles && checked && selectedRoles.length === 1) ||
-      (protectedRoleSelected && role !== protectedRole) ||
-      (role === protectedRole && checked && protectedRoleRemovalDisabled)
-    const id = `member-${member.id}-role-${role}`
-
-    return (
-      <FieldLabel htmlFor={id} key={role}>
-        <Field orientation="horizontal" data-disabled={disabled}>
-          <FieldContent>
-            <FieldTitle>{label}</FieldTitle>
-          </FieldContent>
-          {allowMultipleRoles ? (
-            <Checkbox
-              checked={checked}
-              disabled={disabled}
-              id={id}
-              onCheckedChange={(next) => toggleRole(role, next === true)}
-            />
-          ) : (
-            <RadioGroupItem disabled={disabled} id={id} value={role} />
-          )}
-        </Field>
-      </FieldLabel>
-    )
-  })
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
@@ -143,13 +126,7 @@ export function EditMemberRolesDialog({
           className="flex flex-col gap-6"
           onSubmit={(event) => {
             event.preventDefault()
-            if (selectedRoles.length === 0) return
-
-            updateMemberRole({
-              memberId: member.id,
-              organizationId,
-              role: selectedRoles
-            })
+            void form.handleSubmit()
           }}
         >
           <DialogHeader>
@@ -162,34 +139,89 @@ export function EditMemberRolesDialog({
             </DialogDescription>
           </DialogHeader>
 
-          {allowMultipleRoles ? (
-            <div className="flex flex-col gap-2">{roleOptions}</div>
-          ) : (
-            <RadioGroup
-              disabled={isPending}
-              onValueChange={(role) => setSelectedRoles([role])}
-              value={selectedRoles[0] ?? ""}
-            >
-              {roleOptions}
-            </RadioGroup>
-          )}
+          <form.Subscribe selector={(state) => state.values.roles}>
+            {(selectedRoles) => {
+              const protectedRoleSelected =
+                !allowMultipleRoles &&
+                protectedRoleRemovalDisabled &&
+                protectedRole !== undefined &&
+                selectedRoles.includes(protectedRole)
+              const roleOptions = roles.map(([role, label]) => {
+                const checked = selectedRoles.includes(role)
+                const disabled =
+                  isPending ||
+                  (allowMultipleRoles &&
+                    checked &&
+                    selectedRoles.length === 1) ||
+                  (protectedRoleSelected && role !== protectedRole) ||
+                  (role === protectedRole &&
+                    checked &&
+                    protectedRoleRemovalDisabled)
+                const id = `member-${member.id}-role-${role}`
 
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              disabled={isPending}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-            <Button
-              disabled={isPending || selectedRoles.length === 0}
-              type="submit"
-            >
-              {isPending && <Spinner />}
-              {localization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
+                return (
+                  <FieldLabel htmlFor={id} key={role}>
+                    <Field orientation="horizontal" data-disabled={disabled}>
+                      <FieldContent>
+                        <FieldTitle>{label}</FieldTitle>
+                      </FieldContent>
+                      {allowMultipleRoles ? (
+                        <Checkbox
+                          checked={checked}
+                          disabled={disabled}
+                          id={id}
+                          onCheckedChange={(next) =>
+                            toggleRole(role, next === true)
+                          }
+                        />
+                      ) : (
+                        <RadioGroupItem
+                          disabled={disabled}
+                          id={id}
+                          value={role}
+                        />
+                      )}
+                    </Field>
+                  </FieldLabel>
+                )
+              })
+
+              return (
+                <>
+                  {allowMultipleRoles ? (
+                    <div className="flex flex-col gap-2">{roleOptions}</div>
+                  ) : (
+                    <RadioGroup
+                      disabled={isPending}
+                      onValueChange={(role) =>
+                        form.setFieldValue("roles", [role])
+                      }
+                      value={selectedRoles[0] ?? ""}
+                    >
+                      {roleOptions}
+                    </RadioGroup>
+                  )}
+
+                  <DialogFooter>
+                    <DialogClose
+                      className={buttonVariants({ variant: "outline" })}
+                      disabled={isPending}
+                      type="button"
+                    >
+                      {localization.settings.cancel}
+                    </DialogClose>
+                    <Button
+                      disabled={isPending || selectedRoles.length === 0}
+                      type="submit"
+                    >
+                      {isPending && <Spinner />}
+                      {localization.settings.saveChanges}
+                    </Button>
+                  </DialogFooter>
+                </>
+              )
+            }}
+          </form.Subscribe>
         </form>
       </DialogContent>
     </Dialog>

--- a/apps/docs/src/components/auth/reset-password.tsx
+++ b/apps/docs/src/components/auth/reset-password.tsx
@@ -5,8 +5,9 @@ import {
   isPasswordCompromisedError
 } from "@better-auth-ui/core"
 import { useAuth, useResetPassword } from "@better-auth-ui/react"
+import { useForm } from "@tanstack/react-form"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -72,7 +73,6 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     }
   })
 
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
   const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
     useState(false)
@@ -92,29 +92,32 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     }
   }, [localization.auth.invalidResetPasswordToken, navigate, signInURL])
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
+  const form = useForm({
+    defaultValues: { confirmPassword: "", password: "" },
+    onSubmit: ({ value }) => {
+      const searchParams = new URLSearchParams(window.location.search)
+      const token = searchParams.get("token") as string
 
-    const searchParams = new URLSearchParams(window.location.search)
-    const token = searchParams.get("token") as string
+      if (!token) {
+        toast.error(localization.auth.invalidResetPasswordToken)
+        navigate({ to: signInURL })
+        return
+      }
 
-    if (!token) {
-      toast.error(localization.auth.invalidResetPasswordToken)
-      navigate({ to: signInURL })
-      return
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
+        setFieldErrors((current) => ({
+          ...current,
+          confirmPassword: localization.auth.passwordsDoNotMatch
+        }))
+        return
+      }
+
+      resetPassword({ token, newPassword: value.password })
     }
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-    const confirmPassword = formData.get("confirmPassword") as string
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      toast.error(localization.auth.passwordsDoNotMatch)
-      return
-    }
-
-    resetPassword({ token, newPassword: password })
-  }
+  })
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -125,156 +128,175 @@ export function ResetPassword({ className }: ResetPasswordProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            void form.handleSubmit()
+          }}
+        >
           <FieldGroup>
-            <Field data-invalid={!!fieldErrors.password}>
-              <FieldLabel htmlFor="password">
-                {localization.auth.password}
-              </FieldLabel>
+            <form.Field name="password">
+              {(field) => (
+                <Field data-invalid={!!fieldErrors.password}>
+                  <FieldLabel htmlFor="password">
+                    {localization.auth.password}
+                  </FieldLabel>
 
-              <InputGroup>
-                <InputGroupInput
-                  id="password"
-                  name="password"
-                  type={isPasswordVisible ? "text" : "password"}
-                  autoComplete="new-password"
-                  placeholder={localization.auth.newPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                  onChange={(e) => {
-                    setPassword(e.target.value)
+                  <InputGroup>
+                    <InputGroupInput
+                      id="password"
+                      type={isPasswordVisible ? "text" : "password"}
+                      autoComplete="new-password"
+                      placeholder={localization.auth.newPasswordPlaceholder}
+                      required
+                      minLength={emailAndPassword?.minPasswordLength}
+                      maxLength={emailAndPassword?.maxPasswordLength}
+                      disabled={isPending}
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(e) => {
+                        field.handleChange(e.target.value)
+                        setFieldErrors((prev) => ({
+                          ...prev,
+                          password: undefined
+                        }))
+                      }}
+                      onInvalid={(e) => {
+                        e.preventDefault()
+                        const el = e.target as HTMLInputElement
+                        const min = emailAndPassword?.minPasswordLength
+                        const max = emailAndPassword?.maxPasswordLength
+                        const msg = el.validity.valueMissing
+                          ? localization.auth.fieldRequired
+                          : el.validity.tooShort
+                            ? localization.auth.tooShort.replace(
+                                "{{min}}",
+                                String(min)
+                              )
+                            : localization.auth.tooLong.replace(
+                                "{{max}}",
+                                String(max)
+                              )
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      password: undefined
-                    }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
-                    const el = e.target as HTMLInputElement
-                    const min = emailAndPassword?.minPasswordLength
-                    const max = emailAndPassword?.maxPasswordLength
-                    const msg = el.validity.valueMissing
-                      ? localization.auth.fieldRequired
-                      : el.validity.tooShort
-                        ? localization.auth.tooShort.replace(
-                            "{{min}}",
-                            String(min)
-                          )
-                        : localization.auth.tooLong.replace(
-                            "{{max}}",
-                            String(max)
-                          )
+                        setFieldErrors((prev) => ({
+                          ...prev,
+                          password: msg
+                        }))
+                      }}
+                      aria-invalid={!!fieldErrors.password}
+                      value={field.state.value}
+                    />
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      password: msg
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.password}
-                />
+                    <InputGroupAddon align="inline-end">
+                      <InputGroupButton
+                        size="icon-xs"
+                        aria-label={
+                          isPasswordVisible
+                            ? localization.auth.hidePassword
+                            : localization.auth.showPassword
+                        }
+                        title={
+                          isPasswordVisible
+                            ? localization.auth.hidePassword
+                            : localization.auth.showPassword
+                        }
+                        onClick={() => {
+                          setIsPasswordVisible((visible) => !visible)
+                        }}
+                      >
+                        {isPasswordVisible ? <EyeOff /> : <Eye />}
+                      </InputGroupButton>
+                    </InputGroupAddon>
+                  </InputGroup>
 
-                <InputGroupAddon align="inline-end">
-                  <InputGroupButton
-                    size="icon-xs"
-                    aria-label={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    title={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    onClick={() => {
-                      setIsPasswordVisible((visible) => !visible)
-                    }}
-                  >
-                    {isPasswordVisible ? <EyeOff /> : <Eye />}
-                  </InputGroupButton>
-                </InputGroupAddon>
-              </InputGroup>
+                  <FieldError>{fieldErrors.password}</FieldError>
 
-              <FieldError>{fieldErrors.password}</FieldError>
-
-              <PasswordStrengthMeter password={password} />
-            </Field>
+                  <PasswordStrengthMeter password={field.state.value} />
+                </Field>
+              )}
+            </form.Field>
 
             {emailAndPassword?.confirmPassword && (
-              <Field data-invalid={!!fieldErrors.confirmPassword}>
-                <FieldLabel htmlFor="confirmPassword">
-                  {localization.auth.confirmPassword}
-                </FieldLabel>
+              <form.Field name="confirmPassword">
+                {(field) => (
+                  <Field data-invalid={!!fieldErrors.confirmPassword}>
+                    <FieldLabel htmlFor="confirmPassword">
+                      {localization.auth.confirmPassword}
+                    </FieldLabel>
 
-                <InputGroup>
-                  <InputGroupInput
-                    id="confirmPassword"
-                    name="confirmPassword"
-                    type={isConfirmPasswordVisible ? "text" : "password"}
-                    autoComplete="new-password"
-                    placeholder={localization.auth.confirmPasswordPlaceholder}
-                    required
-                    minLength={emailAndPassword?.minPasswordLength}
-                    maxLength={emailAndPassword?.maxPasswordLength}
-                    disabled={isPending}
-                    onChange={() => {
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        confirmPassword: undefined
-                      }))
-                    }}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-                      const el = e.target as HTMLInputElement
-                      const min = emailAndPassword?.minPasswordLength
-                      const max = emailAndPassword?.maxPasswordLength
-                      const msg = el.validity.valueMissing
-                        ? localization.auth.fieldRequired
-                        : el.validity.tooShort
-                          ? localization.auth.tooShort.replace(
-                              "{{min}}",
-                              String(min)
-                            )
-                          : localization.auth.tooLong.replace(
-                              "{{max}}",
-                              String(max)
-                            )
+                    <InputGroup>
+                      <InputGroupInput
+                        id="confirmPassword"
+                        name={field.name}
+                        type={isConfirmPasswordVisible ? "text" : "password"}
+                        autoComplete="new-password"
+                        placeholder={
+                          localization.auth.confirmPasswordPlaceholder
+                        }
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => {
+                          field.handleChange(event.target.value)
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            confirmPassword: undefined
+                          }))
+                        }}
+                        onInvalid={(e) => {
+                          e.preventDefault()
+                          const el = e.target as HTMLInputElement
+                          const min = emailAndPassword?.minPasswordLength
+                          const max = emailAndPassword?.maxPasswordLength
+                          const msg = el.validity.valueMissing
+                            ? localization.auth.fieldRequired
+                            : el.validity.tooShort
+                              ? localization.auth.tooShort.replace(
+                                  "{{min}}",
+                                  String(min)
+                                )
+                              : localization.auth.tooLong.replace(
+                                  "{{max}}",
+                                  String(max)
+                                )
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        confirmPassword: msg
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.confirmPassword}
-                  />
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            confirmPassword: msg
+                          }))
+                        }}
+                        aria-invalid={!!fieldErrors.confirmPassword}
+                        value={field.state.value}
+                      />
 
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      size="icon-xs"
-                      aria-label={
-                        isConfirmPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      title={
-                        isConfirmPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      onClick={() => {
-                        setIsConfirmPasswordVisible((visible) => !visible)
-                      }}
-                    >
-                      {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={
+                            isConfirmPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          title={
+                            isConfirmPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() => {
+                            setIsConfirmPasswordVisible((visible) => !visible)
+                          }}
+                        >
+                          {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
 
-                <FieldError>{fieldErrors.confirmPassword}</FieldError>
-              </Field>
+                    <FieldError>{fieldErrors.confirmPassword}</FieldError>
+                  </Field>
+                )}
+              </form.Field>
             )}
 
             <div className="flex flex-col gap-3">

--- a/apps/docs/src/components/auth/settings/security/change-password.tsx
+++ b/apps/docs/src/components/auth/settings/security/change-password.tsx
@@ -9,8 +9,9 @@ import {
   useRequestPasswordReset,
   useSession
 } from "@better-auth-ui/react"
+import { useForm } from "@tanstack/react-form"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -165,10 +166,6 @@ function ChangePasswordForm({
   session: ReturnType<typeof useSession>["data"]
 }) {
   const { authClient } = useAuth()
-  const [currentPassword, setCurrentPassword] = useState("")
-  const [newPassword, setNewPassword] = useState("")
-  const [confirmPassword, setConfirmPassword] = useState("")
-
   const { mutate: changePassword, isPending } = useChangePassword(authClient, {
     onError: (error) => {
       // The haveIBeenPwned plugin rejects on the password itself, so it
@@ -180,14 +177,10 @@ function ChangePasswordForm({
         }))
       }
 
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
+      form.reset()
     },
     onSuccess: () => {
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
+      form.reset()
       toast.success(localization.settings.changePasswordSuccess)
     }
   })
@@ -204,23 +197,29 @@ function ChangePasswordForm({
     confirmPassword?: string
   }>({})
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useForm({
+    defaultValues: {
+      confirmPassword: "",
+      currentPassword: "",
+      newPassword: ""
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword.confirmPassword &&
+        value.newPassword !== value.confirmPassword
+      ) {
+        form.reset()
+        toast.error(localization.auth.passwordsDoNotMatch)
+        return
+      }
 
-    if (emailAndPassword.confirmPassword && newPassword !== confirmPassword) {
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
-      toast.error(localization.auth.passwordsDoNotMatch)
-      return
+      changePassword({
+        currentPassword: value.currentPassword,
+        newPassword: value.newPassword,
+        revokeOtherSessions: true
+      })
     }
-
-    changePassword({
-      currentPassword,
-      newPassword,
-      revokeOtherSessions: true
-    })
-  }
+  })
 
   return (
     <div>
@@ -228,204 +227,223 @@ function ChangePasswordForm({
         {localization.settings.changePassword}
       </h2>
 
-      <form onSubmit={handleSubmit}>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault()
+          void form.handleSubmit()
+        }}
+      >
         <Card className={cn(className)}>
           <CardContent className="flex flex-col gap-6">
-            <Field data-invalid={!!fieldErrors.currentPassword}>
-              <FieldLabel htmlFor="currentPassword">
-                {localization.settings.currentPassword}
-              </FieldLabel>
+            <form.Field name="currentPassword">
+              {(field) => (
+                <Field data-invalid={!!fieldErrors.currentPassword}>
+                  <FieldLabel htmlFor="currentPassword">
+                    {localization.settings.currentPassword}
+                  </FieldLabel>
 
-              {session ? (
-                <InputGroup>
-                  <InputGroupInput
-                    id="currentPassword"
-                    name="currentPassword"
-                    type={isCurrentPasswordVisible ? "text" : "password"}
-                    autoComplete="current-password"
-                    placeholder={
-                      localization.settings.currentPasswordPlaceholder
-                    }
-                    value={currentPassword}
-                    onChange={(e) => {
-                      setCurrentPassword(e.target.value)
+                  {session ? (
+                    <InputGroup>
+                      <InputGroupInput
+                        id="currentPassword"
+                        name={field.name}
+                        type={isCurrentPasswordVisible ? "text" : "password"}
+                        autoComplete="current-password"
+                        placeholder={
+                          localization.settings.currentPasswordPlaceholder
+                        }
+                        value={field.state.value}
+                        onChange={(e) => {
+                          field.handleChange(e.target.value)
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        currentPassword: undefined
-                      }))
-                    }}
-                    disabled={isPending}
-                    required
-                    onInvalid={(e) => {
-                      e.preventDefault()
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            currentPassword: undefined
+                          }))
+                        }}
+                        disabled={isPending}
+                        required
+                        onInvalid={(e) => {
+                          e.preventDefault()
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        currentPassword: (e.target as HTMLInputElement)
-                          .validationMessage
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.currentPassword}
-                  />
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            currentPassword: (e.target as HTMLInputElement)
+                              .validationMessage
+                          }))
+                        }}
+                        aria-invalid={!!fieldErrors.currentPassword}
+                      />
 
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      size="icon-xs"
-                      aria-label={
-                        isCurrentPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      title={
-                        isCurrentPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      onClick={() => {
-                        setIsCurrentPasswordVisible((visible) => !visible)
-                      }}
-                    >
-                      {isCurrentPasswordVisible ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
-              ) : (
-                <Skeleton>
-                  <Input className="invisible" />
-                </Skeleton>
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={
+                            isCurrentPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          title={
+                            isCurrentPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() => {
+                            setIsCurrentPasswordVisible((visible) => !visible)
+                          }}
+                        >
+                          {isCurrentPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  ) : (
+                    <Skeleton>
+                      <Input className="invisible" />
+                    </Skeleton>
+                  )}
+
+                  <FieldError>{fieldErrors.currentPassword}</FieldError>
+                </Field>
               )}
+            </form.Field>
 
-              <FieldError>{fieldErrors.currentPassword}</FieldError>
-            </Field>
+            <form.Field name="newPassword">
+              {(field) => (
+                <Field data-invalid={!!fieldErrors.newPassword}>
+                  <FieldLabel htmlFor="newPassword">
+                    {localization.auth.newPassword}
+                  </FieldLabel>
 
-            <Field data-invalid={!!fieldErrors.newPassword}>
-              <FieldLabel htmlFor="newPassword">
-                {localization.auth.newPassword}
-              </FieldLabel>
+                  {session ? (
+                    <InputGroup>
+                      <InputGroupInput
+                        id="newPassword"
+                        name={field.name}
+                        type={isNewPasswordVisible ? "text" : "password"}
+                        autoComplete="new-password"
+                        placeholder={localization.auth.newPasswordPlaceholder}
+                        value={field.state.value}
+                        onChange={(e) => {
+                          field.handleChange(e.target.value)
 
-              {session ? (
-                <InputGroup>
-                  <InputGroupInput
-                    id="newPassword"
-                    name="newPassword"
-                    type={isNewPasswordVisible ? "text" : "password"}
-                    autoComplete="new-password"
-                    placeholder={localization.auth.newPasswordPlaceholder}
-                    value={newPassword}
-                    onChange={(e) => {
-                      setNewPassword(e.target.value)
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            newPassword: undefined
+                          }))
+                        }}
+                        minLength={emailAndPassword.minPasswordLength}
+                        maxLength={emailAndPassword.maxPasswordLength}
+                        disabled={isPending}
+                        required
+                        onInvalid={(e) => {
+                          e.preventDefault()
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            newPassword: (e.target as HTMLInputElement)
+                              .validationMessage
+                          }))
+                        }}
+                        aria-invalid={!!fieldErrors.newPassword}
+                      />
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        newPassword: undefined
-                      }))
-                    }}
-                    minLength={emailAndPassword.minPasswordLength}
-                    maxLength={emailAndPassword.maxPasswordLength}
-                    disabled={isPending}
-                    required
-                    onInvalid={(e) => {
-                      e.preventDefault()
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        newPassword: (e.target as HTMLInputElement)
-                          .validationMessage
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.newPassword}
-                  />
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={
+                            isNewPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() =>
+                            setIsNewPasswordVisible((visible) => !visible)
+                          }
+                        >
+                          {isNewPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  ) : (
+                    <Skeleton>
+                      <Input className="invisible" />
+                    </Skeleton>
+                  )}
 
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      size="icon-xs"
-                      aria-label={
-                        isNewPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      onClick={() =>
-                        setIsNewPasswordVisible((visible) => !visible)
-                      }
-                    >
-                      {isNewPasswordVisible ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
-              ) : (
-                <Skeleton>
-                  <Input className="invisible" />
-                </Skeleton>
+                  <FieldError>{fieldErrors.newPassword}</FieldError>
+
+                  <PasswordStrengthMeter password={field.state.value} />
+                </Field>
               )}
-
-              <FieldError>{fieldErrors.newPassword}</FieldError>
-
-              <PasswordStrengthMeter password={newPassword} />
-            </Field>
+            </form.Field>
 
             {emailAndPassword.confirmPassword && (
-              <Field data-invalid={!!fieldErrors.confirmPassword}>
-                <FieldLabel htmlFor="confirmPassword">
-                  {localization.auth.confirmPassword}
-                </FieldLabel>
+              <form.Field name="confirmPassword">
+                {(field) => (
+                  <Field data-invalid={!!fieldErrors.confirmPassword}>
+                    <FieldLabel htmlFor="confirmPassword">
+                      {localization.auth.confirmPassword}
+                    </FieldLabel>
 
-                {session ? (
-                  <InputGroup>
-                    <InputGroupInput
-                      id="confirmPassword"
-                      name="confirmPassword"
-                      type={isConfirmPasswordVisible ? "text" : "password"}
-                      autoComplete="new-password"
-                      placeholder={localization.auth.confirmPasswordPlaceholder}
-                      value={confirmPassword}
-                      onChange={(e) => {
-                        setConfirmPassword(e.target.value)
+                    {session ? (
+                      <InputGroup>
+                        <InputGroupInput
+                          id="confirmPassword"
+                          name={field.name}
+                          type={isConfirmPasswordVisible ? "text" : "password"}
+                          autoComplete="new-password"
+                          placeholder={
+                            localization.auth.confirmPasswordPlaceholder
+                          }
+                          value={field.state.value}
+                          onChange={(e) => {
+                            field.handleChange(e.target.value)
 
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          confirmPassword: undefined
-                        }))
-                      }}
-                      minLength={emailAndPassword.minPasswordLength}
-                      maxLength={emailAndPassword.maxPasswordLength}
-                      disabled={isPending}
-                      required
-                      onInvalid={(e) => {
-                        e.preventDefault()
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              confirmPassword: undefined
+                            }))
+                          }}
+                          minLength={emailAndPassword.minPasswordLength}
+                          maxLength={emailAndPassword.maxPasswordLength}
+                          disabled={isPending}
+                          required
+                          onInvalid={(e) => {
+                            e.preventDefault()
 
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          confirmPassword: (e.target as HTMLInputElement)
-                            .validationMessage
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.confirmPassword}
-                    />
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              confirmPassword: (e.target as HTMLInputElement)
+                                .validationMessage
+                            }))
+                          }}
+                          aria-invalid={!!fieldErrors.confirmPassword}
+                        />
 
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isConfirmPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() =>
-                          setIsConfirmPasswordVisible((visible) => !visible)
-                        }
-                      >
-                        {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                ) : (
-                  <Skeleton>
-                    <Input className="invisible" />
-                  </Skeleton>
+                        <InputGroupAddon align="inline-end">
+                          <InputGroupButton
+                            size="icon-xs"
+                            aria-label={
+                              isConfirmPasswordVisible
+                                ? localization.auth.hidePassword
+                                : localization.auth.showPassword
+                            }
+                            onClick={() =>
+                              setIsConfirmPasswordVisible((visible) => !visible)
+                            }
+                          >
+                            {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
+                          </InputGroupButton>
+                        </InputGroupAddon>
+                      </InputGroup>
+                    ) : (
+                      <Skeleton>
+                        <Input className="invisible" />
+                      </Skeleton>
+                    )}
+
+                    <FieldError>{fieldErrors.confirmPassword}</FieldError>
+                  </Field>
                 )}
-
-                <FieldError>{fieldErrors.confirmPassword}</FieldError>
-              </Field>
+              </form.Field>
             )}
           </CardContent>
 

--- a/apps/docs/src/components/auth/sign-up.tsx
+++ b/apps/docs/src/components/auth/sign-up.tsx
@@ -102,7 +102,8 @@ export function SignUp({
           }))
         }
 
-        form.reset()
+        form.setFieldValue("password", "")
+        form.setFieldValue("confirmPassword", "")
         resetFetchOptions()
       },
       onSuccess: (_data, { email }) => {
@@ -159,7 +160,8 @@ export function SignUp({
         value.password !== value.confirmPassword
       ) {
         toast.error(localization.auth.passwordsDoNotMatch)
-        form.reset()
+        form.setFieldValue("password", "")
+        form.setFieldValue("confirmPassword", "")
         return
       }
 

--- a/apps/docs/src/components/auth/sign-up.tsx
+++ b/apps/docs/src/components/auth/sign-up.tsx
@@ -12,9 +12,10 @@ import {
   useFetchOptions,
   useSignUpEmail
 } from "@better-auth-ui/react"
+import { useForm } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { type FormEvent, useRef, useState } from "react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -88,9 +89,6 @@ export function SignUp({
 
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
 
-  const [password, setPassword] = useState("")
-  const [confirmPassword, setConfirmPassword] = useState("")
-
   const { mutate: signUpEmail, isPending: signUpEmailPending } = useSignUpEmail(
     authClient,
     {
@@ -104,8 +102,7 @@ export function SignUp({
           }))
         }
 
-        setPassword("")
-        setConfirmPassword("")
+        form.reset()
         resetFetchOptions()
       },
       onSuccess: (_data, { email }) => {
@@ -148,21 +145,38 @@ export function SignUp({
     password?: string
     confirmPassword?: string
   }>({})
+  const additionalFieldValuesRef = useRef<Record<string, unknown>>({})
+  const form = useForm({
+    defaultValues: {
+      confirmPassword: "",
+      email: "",
+      name: "",
+      password: ""
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
+        toast.error(localization.auth.passwordsDoNotMatch)
+        form.reset()
+        return
+      }
 
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    // `emailAndPassword.name === false` hides the name field and submits "".
-    const name = (formData.get("name") as string | null) ?? ""
-    const email = formData.get("email") as string
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      toast.error(localization.auth.passwordsDoNotMatch)
-      setPassword("")
-      setConfirmPassword("")
-      return
+      signUpEmail({
+        name: emailAndPassword?.name === false ? "" : value.name,
+        email: value.email,
+        password: value.password,
+        ...additionalFieldValuesRef.current,
+        fetchOptions
+      })
     }
+  })
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const formData = new FormData(event.currentTarget)
 
     const additionalFieldValues: Record<string, unknown> = {}
 
@@ -187,13 +201,8 @@ export function SignUp({
       }
     }
 
-    signUpEmail({
-      name,
-      email,
-      password,
-      ...additionalFieldValues,
-      fetchOptions
-    })
+    additionalFieldValuesRef.current = additionalFieldValues
+    await form.handleSubmit()
   }
 
   const showSeparator =
@@ -228,76 +237,88 @@ export function SignUp({
             <form onSubmit={handleSubmit}>
               <FieldGroup>
                 {emailAndPassword.name !== false && (
-                  <Field data-invalid={!!fieldErrors.name}>
-                    <FieldLabel htmlFor="name">
-                      {localization.auth.name}
-                    </FieldLabel>
+                  <form.Field name="name">
+                    {(field) => (
+                      <Field data-invalid={!!fieldErrors.name}>
+                        <FieldLabel htmlFor="name">
+                          {localization.auth.name}
+                        </FieldLabel>
 
-                    <Input
-                      id="name"
-                      name="name"
-                      type="text"
-                      autoComplete="name"
-                      placeholder={localization.auth.namePlaceholder}
-                      required
-                      disabled={isPending}
-                      onChange={() => {
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          name: undefined
-                        }))
-                      }}
-                      onInvalid={(e) => {
-                        e.preventDefault()
+                        <Input
+                          id="name"
+                          name={field.name}
+                          type="text"
+                          autoComplete="name"
+                          placeholder={localization.auth.namePlaceholder}
+                          required
+                          disabled={isPending}
+                          value={field.state.value}
+                          onChange={(event) => {
+                            field.handleChange(event.target.value)
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              name: undefined
+                            }))
+                          }}
+                          onInvalid={(e) => {
+                            e.preventDefault()
 
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          name: localization.auth.fieldRequired
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.name}
-                    />
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              name: localization.auth.fieldRequired
+                            }))
+                          }}
+                          aria-invalid={!!fieldErrors.name}
+                        />
 
-                    <FieldError>{fieldErrors.name}</FieldError>
-                  </Field>
+                        <FieldError>{fieldErrors.name}</FieldError>
+                      </Field>
+                    )}
+                  </form.Field>
                 )}
 
-                <Field data-invalid={!!fieldErrors.email}>
-                  <FieldLabel htmlFor="email">
-                    {localization.auth.email}
-                  </FieldLabel>
+                <form.Field name="email">
+                  {(field) => (
+                    <Field data-invalid={!!fieldErrors.email}>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
 
-                  <Input
-                    id="email"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    placeholder={localization.auth.emailPlaceholder}
-                    required
-                    disabled={isPending}
-                    onChange={() => {
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: undefined
-                      }))
-                    }}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-                      const el = e.target as HTMLInputElement
-                      const msg = el.validity.valueMissing
-                        ? localization.auth.fieldRequired
-                        : localization.auth.invalidEmail
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onChange={(event) => {
+                          field.handleChange(event.target.value)
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            email: undefined
+                          }))
+                        }}
+                        onInvalid={(e) => {
+                          e.preventDefault()
+                          const el = e.target as HTMLInputElement
+                          const msg = el.validity.valueMissing
+                            ? localization.auth.fieldRequired
+                            : localization.auth.invalidEmail
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: msg
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            email: msg
+                          }))
+                        }}
+                        aria-invalid={!!fieldErrors.email}
+                      />
 
-                  <FieldError>{fieldErrors.email}</FieldError>
-                </Field>
+                      <FieldError>{fieldErrors.email}</FieldError>
+                    </Field>
+                  )}
+                </form.Field>
 
                 {additionalFields?.map(
                   (field) =>
@@ -312,159 +333,171 @@ export function SignUp({
                     )
                 )}
 
-                <Field data-invalid={!!fieldErrors.password}>
-                  <FieldLabel htmlFor="password">
-                    {localization.auth.password}
-                  </FieldLabel>
+                <form.Field name="password">
+                  {(field) => (
+                    <Field data-invalid={!!fieldErrors.password}>
+                      <FieldLabel htmlFor="password">
+                        {localization.auth.password}
+                      </FieldLabel>
 
-                  <InputGroup>
-                    <InputGroupInput
-                      id="password"
-                      name="password"
-                      type={isPasswordVisible ? "text" : "password"}
-                      autoComplete="new-password"
-                      value={password}
-                      onChange={(e) => {
-                        setPassword(e.target.value)
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: undefined
-                        }))
-                      }}
-                      placeholder={localization.auth.passwordPlaceholder}
-                      required
-                      minLength={emailAndPassword?.minPasswordLength}
-                      maxLength={emailAndPassword?.maxPasswordLength}
-                      disabled={isPending}
-                      onInvalid={(e) => {
-                        e.preventDefault()
-                        const el = e.target as HTMLInputElement
-                        const min = emailAndPassword?.minPasswordLength
-                        const max = emailAndPassword?.maxPasswordLength
-                        const msg = el.validity.valueMissing
-                          ? localization.auth.fieldRequired
-                          : el.validity.tooShort
-                            ? localization.auth.tooShort.replace(
-                                "{{min}}",
-                                String(min)
-                              )
-                            : localization.auth.tooLong.replace(
-                                "{{max}}",
-                                String(max)
-                              )
+                      <InputGroup>
+                        <InputGroupInput
+                          id="password"
+                          name={field.name}
+                          type={isPasswordVisible ? "text" : "password"}
+                          autoComplete="new-password"
+                          value={field.state.value}
+                          onChange={(e) => {
+                            field.handleChange(e.target.value)
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              password: undefined
+                            }))
+                          }}
+                          placeholder={localization.auth.passwordPlaceholder}
+                          required
+                          minLength={emailAndPassword?.minPasswordLength}
+                          maxLength={emailAndPassword?.maxPasswordLength}
+                          disabled={isPending}
+                          onInvalid={(e) => {
+                            e.preventDefault()
+                            const el = e.target as HTMLInputElement
+                            const min = emailAndPassword?.minPasswordLength
+                            const max = emailAndPassword?.maxPasswordLength
+                            const msg = el.validity.valueMissing
+                              ? localization.auth.fieldRequired
+                              : el.validity.tooShort
+                                ? localization.auth.tooShort.replace(
+                                    "{{min}}",
+                                    String(min)
+                                  )
+                                : localization.auth.tooLong.replace(
+                                    "{{max}}",
+                                    String(max)
+                                  )
 
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: msg
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.password}
-                    />
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              password: msg
+                            }))
+                          }}
+                          aria-invalid={!!fieldErrors.password}
+                        />
 
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        title={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() => {
-                          setIsPasswordVisible((visible) => !visible)
-                        }}
-                      >
-                        {isPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
+                        <InputGroupAddon align="inline-end">
+                          <InputGroupButton
+                            size="icon-xs"
+                            aria-label={
+                              isPasswordVisible
+                                ? localization.auth.hidePassword
+                                : localization.auth.showPassword
+                            }
+                            title={
+                              isPasswordVisible
+                                ? localization.auth.hidePassword
+                                : localization.auth.showPassword
+                            }
+                            onClick={() => {
+                              setIsPasswordVisible((visible) => !visible)
+                            }}
+                          >
+                            {isPasswordVisible ? <EyeOff /> : <Eye />}
+                          </InputGroupButton>
+                        </InputGroupAddon>
+                      </InputGroup>
 
-                  <FieldError>{fieldErrors.password}</FieldError>
+                      <FieldError>{fieldErrors.password}</FieldError>
 
-                  <PasswordStrengthMeter password={password} />
-                </Field>
+                      <PasswordStrengthMeter password={field.state.value} />
+                    </Field>
+                  )}
+                </form.Field>
 
                 {emailAndPassword?.confirmPassword && (
-                  <Field data-invalid={!!fieldErrors.confirmPassword}>
-                    <FieldLabel htmlFor="confirmPassword">
-                      {localization.auth.confirmPassword}
-                    </FieldLabel>
+                  <form.Field name="confirmPassword">
+                    {(field) => (
+                      <Field data-invalid={!!fieldErrors.confirmPassword}>
+                        <FieldLabel htmlFor="confirmPassword">
+                          {localization.auth.confirmPassword}
+                        </FieldLabel>
 
-                    <InputGroup>
-                      <InputGroupInput
-                        id="confirmPassword"
-                        name="confirmPassword"
-                        type={isConfirmPasswordVisible ? "text" : "password"}
-                        autoComplete="new-password"
-                        value={confirmPassword}
-                        onChange={(e) => {
-                          setConfirmPassword(e.target.value)
+                        <InputGroup>
+                          <InputGroupInput
+                            id="confirmPassword"
+                            name={field.name}
+                            type={
+                              isConfirmPasswordVisible ? "text" : "password"
+                            }
+                            autoComplete="new-password"
+                            value={field.state.value}
+                            onChange={(e) => {
+                              field.handleChange(e.target.value)
 
-                          setFieldErrors((prev) => ({
-                            ...prev,
-                            confirmPassword: undefined
-                          }))
-                        }}
-                        placeholder={
-                          localization.auth.confirmPasswordPlaceholder
-                        }
-                        required
-                        minLength={emailAndPassword?.minPasswordLength}
-                        maxLength={emailAndPassword?.maxPasswordLength}
-                        disabled={isPending}
-                        onInvalid={(e) => {
-                          e.preventDefault()
-                          const el = e.target as HTMLInputElement
-                          const min = emailAndPassword?.minPasswordLength
-                          const max = emailAndPassword?.maxPasswordLength
-                          const msg = el.validity.valueMissing
-                            ? localization.auth.fieldRequired
-                            : el.validity.tooShort
-                              ? localization.auth.tooShort.replace(
-                                  "{{min}}",
-                                  String(min)
+                              setFieldErrors((prev) => ({
+                                ...prev,
+                                confirmPassword: undefined
+                              }))
+                            }}
+                            placeholder={
+                              localization.auth.confirmPasswordPlaceholder
+                            }
+                            required
+                            minLength={emailAndPassword?.minPasswordLength}
+                            maxLength={emailAndPassword?.maxPasswordLength}
+                            disabled={isPending}
+                            onInvalid={(e) => {
+                              e.preventDefault()
+                              const el = e.target as HTMLInputElement
+                              const min = emailAndPassword?.minPasswordLength
+                              const max = emailAndPassword?.maxPasswordLength
+                              const msg = el.validity.valueMissing
+                                ? localization.auth.fieldRequired
+                                : el.validity.tooShort
+                                  ? localization.auth.tooShort.replace(
+                                      "{{min}}",
+                                      String(min)
+                                    )
+                                  : localization.auth.tooLong.replace(
+                                      "{{max}}",
+                                      String(max)
+                                    )
+
+                              setFieldErrors((prev) => ({
+                                ...prev,
+                                confirmPassword: msg
+                              }))
+                            }}
+                            aria-invalid={!!fieldErrors.confirmPassword}
+                          />
+
+                          <InputGroupAddon align="inline-end">
+                            <InputGroupButton
+                              size="icon-xs"
+                              aria-label={
+                                isConfirmPasswordVisible
+                                  ? localization.auth.hidePassword
+                                  : localization.auth.showPassword
+                              }
+                              title={
+                                isConfirmPasswordVisible
+                                  ? localization.auth.hidePassword
+                                  : localization.auth.showPassword
+                              }
+                              onClick={() =>
+                                setIsConfirmPasswordVisible(
+                                  (visible) => !visible
                                 )
-                              : localization.auth.tooLong.replace(
-                                  "{{max}}",
-                                  String(max)
-                                )
+                              }
+                            >
+                              {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
+                            </InputGroupButton>
+                          </InputGroupAddon>
+                        </InputGroup>
 
-                          setFieldErrors((prev) => ({
-                            ...prev,
-                            confirmPassword: msg
-                          }))
-                        }}
-                        aria-invalid={!!fieldErrors.confirmPassword}
-                      />
-
-                      <InputGroupAddon align="inline-end">
-                        <InputGroupButton
-                          size="icon-xs"
-                          aria-label={
-                            isConfirmPasswordVisible
-                              ? localization.auth.hidePassword
-                              : localization.auth.showPassword
-                          }
-                          title={
-                            isConfirmPasswordVisible
-                              ? localization.auth.hidePassword
-                              : localization.auth.showPassword
-                          }
-                          onClick={() =>
-                            setIsConfirmPasswordVisible((visible) => !visible)
-                          }
-                        >
-                          {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
-                        </InputGroupButton>
-                      </InputGroupAddon>
-                    </InputGroup>
-
-                    <FieldError>{fieldErrors.confirmPassword}</FieldError>
-                  </Field>
+                        <FieldError>{fieldErrors.confirmPassword}</FieldError>
+                      </Field>
+                    )}
+                  </form.Field>
                 )}
 
                 {additionalFields?.map(

--- a/apps/docs/src/components/auth/sso/organization-sso-providers.tsx
+++ b/apps/docs/src/components/auth/sso/organization-sso-providers.tsx
@@ -16,9 +16,10 @@ import {
   useSsoProviders,
   useUpdateSsoProvider
 } from "@better-auth-ui/react/plugins/sso"
+import { useForm } from "@tanstack/react-form"
 import type { BetterFetchError } from "better-auth/client"
 import { PencilIcon, Trash2Icon } from "lucide-react"
-import { type FormEvent, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -80,8 +81,27 @@ export type OrganizationSsoProvidersProps = {
 
 const providerSkeletonIds = ["sso-provider-1", "sso-provider-2"]
 
-const readString = (formData: FormData, name: string) =>
-  String(formData.get(name) ?? "").trim()
+type SsoProviderEditorValues = {
+  clientId: string
+  clientSecret: string
+  discoveryEndpoint: string
+  domain: string
+  entryPoint: string
+  identityProviderMetadata: string
+  issuer: string
+}
+
+const getSsoProviderEditorValues = (
+  provider?: SsoProvider
+): SsoProviderEditorValues => ({
+  clientId: "",
+  clientSecret: "",
+  discoveryEndpoint: provider?.oidcConfig?.discoveryEndpoint ?? "",
+  domain: provider?.domain ?? "",
+  entryPoint: provider?.samlConfig?.entryPoint ?? "",
+  identityProviderMetadata: "",
+  issuer: provider?.issuer ?? ""
+})
 
 const getErrorMessage = (error: Error | null) => {
   const authError = error as BetterFetchError | null
@@ -240,7 +260,11 @@ export function OrganizationSsoProviders({
         )}
       </CardContent>
 
-      <EditSsoProviderDialog onOpenChange={setEditing} provider={editing} />
+      <EditSsoProviderDialog
+        key={editing?.providerId ?? "closed"}
+        onOpenChange={setEditing}
+        provider={editing}
+      />
       <DeleteSsoProviderDialog onOpenChange={setDeleting} provider={deleting} />
       <Dialog
         open={Boolean(verifying)}
@@ -277,49 +301,47 @@ function EditSsoProviderDialog({
     update.reset()
     onOpenChange(undefined)
   }
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!provider) return
-    const data = new FormData(event.currentTarget)
-    const clientId = readString(data, "clientId")
-    const clientSecret = readString(data, "clientSecret")
-    const identityProviderMetadata = readString(
-      data,
-      "identityProviderMetadata"
-    )
-    const params = {
-      providerId: provider.providerId,
-      issuer: readString(data, "issuer"),
-      domain: readString(data, "domain"),
-      ...(provider.oidcConfig
-        ? {
-            oidcConfig: {
-              ...(clientId ? { clientId } : {}),
-              ...(clientSecret ? { clientSecret } : {}),
-              discoveryEndpoint:
-                readString(data, "discoveryEndpoint") || undefined
+  const form = useForm({
+    defaultValues: getSsoProviderEditorValues(provider),
+    onSubmit: async ({ value }) => {
+      if (!provider) return
+      const clientId = value.clientId.trim()
+      const clientSecret = value.clientSecret.trim()
+      const identityProviderMetadata = value.identityProviderMetadata.trim()
+      const params = {
+        providerId: provider.providerId,
+        issuer: value.issuer.trim(),
+        domain: value.domain.trim(),
+        ...(provider.oidcConfig
+          ? {
+              oidcConfig: {
+                ...(clientId ? { clientId } : {}),
+                ...(clientSecret ? { clientSecret } : {}),
+                discoveryEndpoint: value.discoveryEndpoint.trim() || undefined
+              }
             }
-          }
-        : {}),
-      ...(provider.samlConfig
-        ? {
-            samlConfig: {
-              entryPoint: readString(data, "entryPoint"),
-              ...(identityProviderMetadata
-                ? { idpMetadata: { metadata: identityProviderMetadata } }
-                : {})
+          : {}),
+        ...(provider.samlConfig
+          ? {
+              samlConfig: {
+                entryPoint: value.entryPoint.trim(),
+                ...(identityProviderMetadata
+                  ? { idpMetadata: { metadata: identityProviderMetadata } }
+                  : {})
+              }
             }
-          }
-        : {})
-    } as UpdateSsoProviderParams
+          : {})
+      } as UpdateSsoProviderParams
 
-    update.mutate(params, {
-      onSuccess: () => {
+      try {
+        await update.mutateAsync(params)
         toast.success(localization.providerUpdated)
         close()
+      } catch {
+        // The mutation error is rendered below the fields.
       }
-    })
-  }
+    }
+  })
 
   return (
     <Dialog
@@ -329,98 +351,148 @@ function EditSsoProviderDialog({
       }}
     >
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
-        <form className="flex flex-col gap-4" onSubmit={submit}>
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void form.handleSubmit()
+          }}
+        >
           <DialogHeader>
             <DialogTitle>{localization.editProvider}</DialogTitle>
             <DialogDescription>{provider?.providerId}</DialogDescription>
           </DialogHeader>
           <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="sso-edit-domain">
-                {localization.domain}
-              </FieldLabel>
-              <Input
-                defaultValue={provider?.domain}
-                id="sso-edit-domain"
-                name="domain"
-                required
-              />
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="sso-edit-issuer">
-                {localization.issuer}
-              </FieldLabel>
-              <Input
-                defaultValue={provider?.issuer}
-                id="sso-edit-issuer"
-                name="issuer"
-                required
-                type="url"
-              />
-            </Field>
+            {(
+              [
+                ["domain", "sso-edit-domain", localization.domain, "text"],
+                ["issuer", "sso-edit-issuer", localization.issuer, "url"]
+              ] as const
+            ).map(([name, id, label, type]) => (
+              <form.Field key={name} name={name}>
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor={id}>{label}</FieldLabel>
+                    <Input
+                      id={id}
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      type={type}
+                      value={field.state.value}
+                    />
+                  </Field>
+                )}
+              </form.Field>
+            ))}
             {provider?.oidcConfig ? (
               <>
-                <Field>
-                  <FieldLabel htmlFor="sso-edit-discovery">
-                    {localization.discoveryEndpoint}
-                  </FieldLabel>
-                  <Input
-                    defaultValue={provider.oidcConfig.discoveryEndpoint}
-                    id="sso-edit-discovery"
-                    name="discoveryEndpoint"
-                    type="url"
-                  />
-                </Field>
+                <form.Field name="discoveryEndpoint">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="sso-edit-discovery">
+                        {localization.discoveryEndpoint}
+                      </FieldLabel>
+                      <Input
+                        id="sso-edit-discovery"
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        type="url"
+                        value={field.state.value}
+                      />
+                    </Field>
+                  )}
+                </form.Field>
                 <div className="grid gap-4 sm:grid-cols-2">
-                  <Field>
-                    <FieldLabel htmlFor="sso-edit-client-id">
-                      {localization.clientId}
-                    </FieldLabel>
-                    <Input
-                      id="sso-edit-client-id"
-                      name="clientId"
-                      placeholder={`••••${provider.oidcConfig.clientIdLastFour}`}
-                    />
-                  </Field>
-                  <Field>
-                    <FieldLabel htmlFor="sso-edit-client-secret">
-                      {localization.clientSecret}
-                    </FieldLabel>
-                    <Input
-                      autoComplete="new-password"
-                      id="sso-edit-client-secret"
-                      name="clientSecret"
-                      type="password"
-                    />
-                  </Field>
+                  {(
+                    [
+                      ["clientId", "sso-edit-client-id", localization.clientId],
+                      [
+                        "clientSecret",
+                        "sso-edit-client-secret",
+                        localization.clientSecret
+                      ]
+                    ] as const
+                  ).map(([name, id, label]) => (
+                    <form.Field key={name} name={name}>
+                      {(field) => (
+                        <Field>
+                          <FieldLabel htmlFor={id}>{label}</FieldLabel>
+                          <Input
+                            autoComplete={
+                              name === "clientSecret"
+                                ? "new-password"
+                                : undefined
+                            }
+                            id={id}
+                            name={field.name}
+                            onBlur={field.handleBlur}
+                            onChange={(event) =>
+                              field.handleChange(event.target.value)
+                            }
+                            placeholder={
+                              name === "clientId"
+                                ? `••••${provider.oidcConfig?.clientIdLastFour}`
+                                : undefined
+                            }
+                            type={name === "clientSecret" ? "password" : "text"}
+                            value={field.state.value}
+                          />
+                        </Field>
+                      )}
+                    </form.Field>
+                  ))}
                 </div>
               </>
             ) : null}
             {provider?.samlConfig ? (
               <>
-                <Field>
-                  <FieldLabel htmlFor="sso-edit-entry-point">
-                    {localization.entryPoint}
-                  </FieldLabel>
-                  <Input
-                    defaultValue={provider.samlConfig.entryPoint}
-                    id="sso-edit-entry-point"
-                    name="entryPoint"
-                    required
-                    type="url"
-                  />
-                </Field>
-                <Field>
-                  <FieldLabel htmlFor="sso-edit-metadata">
-                    {localization.identityProviderMetadata}
-                  </FieldLabel>
-                  <Textarea
-                    className="font-mono text-xs"
-                    id="sso-edit-metadata"
-                    name="identityProviderMetadata"
-                    rows={6}
-                  />
-                </Field>
+                <form.Field name="entryPoint">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="sso-edit-entry-point">
+                        {localization.entryPoint}
+                      </FieldLabel>
+                      <Input
+                        id="sso-edit-entry-point"
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        required
+                        type="url"
+                        value={field.state.value}
+                      />
+                    </Field>
+                  )}
+                </form.Field>
+                <form.Field name="identityProviderMetadata">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="sso-edit-metadata">
+                        {localization.identityProviderMetadata}
+                      </FieldLabel>
+                      <Textarea
+                        className="font-mono text-xs"
+                        id="sso-edit-metadata"
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        rows={6}
+                        value={field.state.value}
+                      />
+                    </Field>
+                  )}
+                </form.Field>
               </>
             ) : null}
           </FieldGroup>
@@ -434,10 +506,14 @@ function EditSsoProviderDialog({
             >
               {localization.cancel}
             </Button>
-            <Button disabled={update.isPending} type="submit">
-              {update.isPending ? <Spinner data-icon="inline-start" /> : null}
-              {localization.saveProvider}
-            </Button>
+            <form.Subscribe selector={(state) => state.isSubmitting}>
+              {(isSubmitting) => (
+                <Button disabled={isSubmitting} type="submit">
+                  {isSubmitting ? <Spinner data-icon="inline-start" /> : null}
+                  {localization.saveProvider}
+                </Button>
+              )}
+            </form.Subscribe>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -27,6 +27,7 @@ import {
   useAdminUserSessions,
   useAdminUsers
 } from "@better-auth-ui/react/plugins/admin"
+import { useForm } from "@tanstack/react-form"
 import { keepPreviousData, useMutation } from "@tanstack/react-query"
 import {
   type ColumnFiltersState,
@@ -677,26 +678,51 @@ function CreateUserDialog({
   const auth = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
   const { data: session } = useSession(auth.authClient)
-  const [password, setPassword] = useState("")
-  const [emailVerified, setEmailVerified] = useState(false)
   const [formError, setFormError] = useState<string>()
-  const [roles, setRoles] = useState([config.defaultRole])
-
-  useEffect(() => {
-    if (!config.allowMultipleRoles) setRoles((current) => current.slice(0, 1))
-  }, [config.allowMultipleRoles])
   const createUser = useMutation(
     createAdminUserOptions(auth.authClient, session?.user.id)
   )
   const canSetRole = useAdminPermission(auth.authClient, {
     user: ["set-role"]
   })
+  const additionalFieldValuesRef = useRef<
+    Record<string, AdditionalFieldValue | null>
+  >({})
+  const form = useForm({
+    defaultValues: {
+      email: "",
+      emailVerified: false,
+      name: "",
+      password: "",
+      roles: [config.defaultRole]
+    },
+    onSubmit: ({ value }) => {
+      createUser.mutate(
+        {
+          data: {
+            ...additionalFieldValuesRef.current,
+            emailVerified: value.emailVerified
+          },
+          email: value.email,
+          name: value.name,
+          password: value.password,
+          ...(canSetRole.data?.success
+            ? { role: asAdminRoles(value.roles) }
+            : {})
+        },
+        { onSuccess: close }
+      )
+    }
+  })
+
+  useEffect(() => {
+    if (!config.allowMultipleRoles)
+      form.setFieldValue("roles", (current) => current.slice(0, 1))
+  }, [config.allowMultipleRoles, form.setFieldValue])
 
   const close = () => {
-    setPassword("")
-    setEmailVerified(false)
+    form.reset()
     setFormError(undefined)
-    setRoles([config.defaultRole])
     createUser.reset()
     onOpenChange(false)
   }
@@ -714,16 +740,8 @@ function CreateUserDialog({
       return
     }
     setFormError(undefined)
-    createUser.mutate(
-      {
-        data: { ...additionalFieldValues, emailVerified },
-        email: String(data.get("email")),
-        name: String(data.get("name")),
-        password,
-        ...(canSetRole.data?.success ? { role: asAdminRoles(roles) } : {})
-      },
-      { onSuccess: close }
-    )
+    additionalFieldValuesRef.current = additionalFieldValues
+    await form.handleSubmit()
   }
 
   return (
@@ -740,43 +758,70 @@ function CreateUserDialog({
             </DialogDescription>
           </DialogHeader>
           <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="admin-create-name">
-                {config.localization.name}
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupInput id="admin-create-name" name="name" required />
-              </InputGroup>
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="admin-create-email">
-                {config.localization.email}
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupInput
-                  autoComplete="off"
-                  id="admin-create-email"
-                  name="email"
-                  required
-                  type="email"
-                />
-              </InputGroup>
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="admin-create-password">
-                {config.localization.password}
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupInput
-                  autoComplete="new-password"
-                  id="admin-create-password"
-                  onChange={(event) => setPassword(event.target.value)}
-                  required
-                  type="password"
-                  value={password}
-                />
-              </InputGroup>
-            </Field>
+            <form.Field name="name">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="admin-create-name">
+                    {config.localization.name}
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupInput
+                      id="admin-create-name"
+                      name={field.name}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      value={field.state.value}
+                    />
+                  </InputGroup>
+                </Field>
+              )}
+            </form.Field>
+            <form.Field name="email">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="admin-create-email">
+                    {config.localization.email}
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupInput
+                      autoComplete="off"
+                      id="admin-create-email"
+                      name={field.name}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      type="email"
+                      value={field.state.value}
+                    />
+                  </InputGroup>
+                </Field>
+              )}
+            </form.Field>
+            <form.Field name="password">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="admin-create-password">
+                    {config.localization.password}
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupInput
+                      autoComplete="new-password"
+                      id="admin-create-password"
+                      name={field.name}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      type="password"
+                      value={field.state.value}
+                    />
+                  </InputGroup>
+                </Field>
+              )}
+            </form.Field>
             {canSetRole.isPending ? (
               <Skeleton className="h-16 w-full" />
             ) : canSetRole.data?.success ? (
@@ -784,58 +829,68 @@ function CreateUserDialog({
                 <FieldLegend variant="label">
                   {config.localization.role}
                 </FieldLegend>
-                {config.allowMultipleRoles ? (
-                  <FieldGroup data-slot="checkbox-group">
-                    {config.roles.map((role) => (
-                      <Field key={role} orientation="horizontal">
-                        <Checkbox
-                          checked={roles.includes(role)}
-                          id={`admin-create-role-${role}`}
-                          onCheckedChange={(checked) => {
-                            const next = checked
-                              ? [...roles, role]
-                              : roles.filter((item) => item !== role)
-                            if (next.length) setRoles(next)
-                          }}
-                        />
-                        <FieldLabel htmlFor={`admin-create-role-${role}`}>
-                          {role}
-                        </FieldLabel>
-                      </Field>
-                    ))}
-                  </FieldGroup>
-                ) : (
-                  <RadioGroup
-                    onValueChange={(role) => setRoles([role])}
-                    value={roles[0] ?? ""}
-                  >
-                    {config.roles.map((role) => (
-                      <Field key={role} orientation="horizontal">
-                        <RadioGroupItem
-                          id={`admin-create-role-${role}`}
-                          value={role}
-                        />
-                        <FieldLabel htmlFor={`admin-create-role-${role}`}>
-                          {role}
-                        </FieldLabel>
-                      </Field>
-                    ))}
-                  </RadioGroup>
-                )}
+                <form.Field name="roles">
+                  {(field) =>
+                    config.allowMultipleRoles ? (
+                      <FieldGroup data-slot="checkbox-group">
+                        {config.roles.map((role) => (
+                          <Field key={role} orientation="horizontal">
+                            <Checkbox
+                              checked={field.state.value.includes(role)}
+                              id={`admin-create-role-${role}`}
+                              onCheckedChange={(checked) => {
+                                const next = checked
+                                  ? [...field.state.value, role]
+                                  : field.state.value.filter(
+                                      (item) => item !== role
+                                    )
+                                if (next.length) field.handleChange(next)
+                              }}
+                            />
+                            <FieldLabel htmlFor={`admin-create-role-${role}`}>
+                              {role}
+                            </FieldLabel>
+                          </Field>
+                        ))}
+                      </FieldGroup>
+                    ) : (
+                      <RadioGroup
+                        onValueChange={(role) => field.handleChange([role])}
+                        value={field.state.value[0] ?? ""}
+                      >
+                        {config.roles.map((role) => (
+                          <Field key={role} orientation="horizontal">
+                            <RadioGroupItem
+                              id={`admin-create-role-${role}`}
+                              value={role}
+                            />
+                            <FieldLabel htmlFor={`admin-create-role-${role}`}>
+                              {role}
+                            </FieldLabel>
+                          </Field>
+                        ))}
+                      </RadioGroup>
+                    )
+                  }
+                </form.Field>
               </FieldSet>
             ) : null}
-            <Field orientation="horizontal">
-              <Switch
-                checked={emailVerified}
-                id="admin-create-email-verified"
-                onCheckedChange={setEmailVerified}
-              />
-              <FieldContent>
-                <FieldLabel htmlFor="admin-create-email-verified">
-                  {config.localization.emailVerified}
-                </FieldLabel>
-              </FieldContent>
-            </Field>
+            <form.Field name="emailVerified">
+              {(field) => (
+                <Field orientation="horizontal">
+                  <Switch
+                    checked={field.state.value}
+                    id="admin-create-email-verified"
+                    onCheckedChange={field.handleChange}
+                  />
+                  <FieldContent>
+                    <FieldLabel htmlFor="admin-create-email-verified">
+                      {config.localization.emailVerified}
+                    </FieldLabel>
+                  </FieldContent>
+                </Field>
+              )}
+            </form.Field>
             {auth.additionalFields?.map((field) => (
               <AdditionalField
                 field={field}
@@ -952,10 +1007,6 @@ function UserInspector({
     },
     { enabled: Boolean(userId) }
   )
-  const [name, setName] = useState("")
-  const [email, setEmail] = useState("")
-  const [emailVerified, setEmailVerified] = useState(false)
-  const [roles, setRoles] = useState([config.defaultRole])
   const [banReason, setBanReason] = useState("")
   const [banDuration, setBanDuration] = useState("")
   const banDurationSeconds = getBanDurationSeconds(banDuration)
@@ -968,22 +1019,6 @@ function UserInspector({
   const updateUser = useMutation(
     updateAdminUserOptions(auth.authClient, actor?.user.id)
   )
-
-  useEffect(() => {
-    setName(user?.name ?? "")
-    setEmail(user?.email ?? "")
-    setEmailVerified(user?.emailVerified ?? false)
-    setRoles(
-      parseAdminRoles(user?.role, config.defaultRole, config.allowMultipleRoles)
-    )
-  }, [
-    config.allowMultipleRoles,
-    config.defaultRole,
-    user?.email,
-    user?.emailVerified,
-    user?.name,
-    user?.role
-  ])
 
   useEffect(() => {
     if (profileUserId.current === user?.id) return
@@ -1018,6 +1053,75 @@ function UserInspector({
   const revokeSessions = useMutation(
     revokeAdminUserSessionsOptions(auth.authClient, actor?.user.id, userId)
   )
+  const profileAdditionalFieldValuesRef = useRef<
+    Record<string, AdditionalFieldValue | null>
+  >({})
+  const profileForm = useForm({
+    defaultValues: {
+      email: "",
+      emailVerified: false,
+      name: "",
+      roles: [config.defaultRole]
+    },
+    onSubmit: async ({ value }) => {
+      if (!user) return
+
+      const mutations: Promise<unknown>[] = []
+      if (canUpdate.data?.success) {
+        mutations.push(
+          updateUser.mutateAsync({
+            userId: user.id,
+            data: {
+              ...profileAdditionalFieldValuesRef.current,
+              name: value.name.trim(),
+              ...(canSetEmail.data?.success
+                ? {
+                    email: value.email.trim(),
+                    emailVerified: value.emailVerified
+                  }
+                : {})
+            }
+          })
+        )
+      }
+      if (canSetRole.data?.success && !isSelf) {
+        mutations.push(
+          setRoleMutation.mutateAsync({
+            userId: user.id,
+            role: asAdminRoles(value.roles)
+          })
+        )
+      }
+
+      try {
+        await Promise.all(mutations)
+        onOpenChange(false)
+      } catch {
+        // Mutation errors are rendered next to the form.
+      }
+    }
+  })
+
+  useEffect(() => {
+    profileForm.reset({
+      email: user?.email ?? "",
+      emailVerified: user?.emailVerified ?? false,
+      name: user?.name ?? "",
+      roles: parseAdminRoles(
+        user?.role,
+        config.defaultRole,
+        config.allowMultipleRoles
+      )
+    })
+  }, [
+    config.allowMultipleRoles,
+    config.defaultRole,
+    profileForm.reset,
+    user?.email,
+    user?.emailVerified,
+    user?.name,
+    user?.role
+  ])
 
   const confirm = () => {
     if (!user) return
@@ -1096,7 +1200,6 @@ function UserInspector({
     event.preventDefault()
     if (!user) return
 
-    const mutations: Promise<unknown>[] = []
     if (canUpdate.data?.success) {
       const formData = new FormData(event.currentTarget)
       let additionalFieldValues: Record<string, AdditionalFieldValue | null>
@@ -1110,34 +1213,10 @@ function UserInspector({
         return
       }
       setProfileError(undefined)
-      mutations.push(
-        updateUser.mutateAsync({
-          userId: user.id,
-          data: {
-            ...additionalFieldValues,
-            name: name.trim(),
-            ...(canSetEmail.data?.success
-              ? { email: email.trim(), emailVerified }
-              : {})
-          }
-        })
-      )
-    }
-    if (canSetRole.data?.success && !isSelf) {
-      mutations.push(
-        setRoleMutation.mutateAsync({
-          userId: user.id,
-          role: asAdminRoles(roles)
-        })
-      )
+      profileAdditionalFieldValuesRef.current = additionalFieldValues
     }
 
-    try {
-      await Promise.all(mutations)
-      onOpenChange(false)
-    } catch {
-      // Mutation errors are rendered next to the form.
-    }
+    await profileForm.handleSubmit()
   }
 
   return (
@@ -1243,107 +1322,136 @@ function UserInspector({
                         {config.localization.profileAndAccess}
                       </h3>
                       <FieldGroup className="grid gap-5 md:grid-cols-2">
-                        <Field>
-                          <FieldLabel htmlFor="admin-user-name">
-                            {config.localization.name}
-                          </FieldLabel>
-                          <InputGroup>
-                            <InputGroupInput
-                              disabled={!canUpdate.data?.success}
-                              id="admin-user-name"
-                              value={name}
-                              onChange={(event) => setName(event.target.value)}
-                            />
-                          </InputGroup>
-                        </Field>
-                        <Field>
-                          <FieldLabel htmlFor="admin-user-email">
-                            {config.localization.email}
-                          </FieldLabel>
-                          <InputGroup>
-                            <InputGroupInput
-                              disabled={
-                                !canUpdate.data?.success ||
-                                !canSetEmail.data?.success
-                              }
-                              id="admin-user-email"
-                              onChange={(event) => setEmail(event.target.value)}
-                              required
-                              type="email"
-                              value={email}
-                            />
-                          </InputGroup>
-                        </Field>
-                        <Field orientation="horizontal">
-                          <Switch
-                            checked={emailVerified}
-                            disabled={
-                              !canUpdate.data?.success ||
-                              !canSetEmail.data?.success
-                            }
-                            id="admin-user-email-verified"
-                            onCheckedChange={setEmailVerified}
-                          />
-                          <FieldContent>
-                            <FieldLabel htmlFor="admin-user-email-verified">
-                              {config.localization.emailVerified}
-                            </FieldLabel>
-                          </FieldContent>
-                        </Field>
+                        <profileForm.Field name="name">
+                          {(field) => (
+                            <Field>
+                              <FieldLabel htmlFor="admin-user-name">
+                                {config.localization.name}
+                              </FieldLabel>
+                              <InputGroup>
+                                <InputGroupInput
+                                  disabled={!canUpdate.data?.success}
+                                  id="admin-user-name"
+                                  name={field.name}
+                                  value={field.state.value}
+                                  onChange={(event) =>
+                                    field.handleChange(event.target.value)
+                                  }
+                                />
+                              </InputGroup>
+                            </Field>
+                          )}
+                        </profileForm.Field>
+                        <profileForm.Field name="email">
+                          {(field) => (
+                            <Field>
+                              <FieldLabel htmlFor="admin-user-email">
+                                {config.localization.email}
+                              </FieldLabel>
+                              <InputGroup>
+                                <InputGroupInput
+                                  disabled={
+                                    !canUpdate.data?.success ||
+                                    !canSetEmail.data?.success
+                                  }
+                                  id="admin-user-email"
+                                  name={field.name}
+                                  onChange={(event) =>
+                                    field.handleChange(event.target.value)
+                                  }
+                                  required
+                                  type="email"
+                                  value={field.state.value}
+                                />
+                              </InputGroup>
+                            </Field>
+                          )}
+                        </profileForm.Field>
+                        <profileForm.Field name="emailVerified">
+                          {(field) => (
+                            <Field orientation="horizontal">
+                              <Switch
+                                checked={field.state.value}
+                                disabled={
+                                  !canUpdate.data?.success ||
+                                  !canSetEmail.data?.success
+                                }
+                                id="admin-user-email-verified"
+                                onCheckedChange={field.handleChange}
+                              />
+                              <FieldContent>
+                                <FieldLabel htmlFor="admin-user-email-verified">
+                                  {config.localization.emailVerified}
+                                </FieldLabel>
+                              </FieldContent>
+                            </Field>
+                          )}
+                        </profileForm.Field>
                         <FieldSet>
                           <FieldLegend variant="label">
                             {config.localization.role}
                           </FieldLegend>
-                          {config.allowMultipleRoles ? (
-                            <FieldGroup
-                              className="flex-row flex-wrap gap-4"
-                              data-slot="checkbox-group"
-                            >
-                              {config.roles.map((item) => (
-                                <Field key={item} orientation="horizontal">
-                                  <Checkbox
-                                    checked={roles.includes(item)}
-                                    disabled={
-                                      isSelf || !canSetRole.data?.success
-                                    }
-                                    id={`admin-user-role-${item}`}
-                                    onCheckedChange={(checked) => {
-                                      const next = checked
-                                        ? [...roles, item]
-                                        : roles.filter((role) => role !== item)
-                                      if (next.length) setRoles(next)
-                                    }}
-                                  />
-                                  <FieldLabel
-                                    htmlFor={`admin-user-role-${item}`}
-                                  >
-                                    {item}
-                                  </FieldLabel>
-                                </Field>
-                              ))}
-                            </FieldGroup>
-                          ) : (
-                            <RadioGroup
-                              className="flex-row flex-wrap gap-4"
-                              disabled={isSelf || !canSetRole.data?.success}
-                              onValueChange={(role) => setRoles([role])}
-                              value={roles[0] ?? ""}
-                            >
-                              {config.roles.map((item) => (
-                                <Field key={item} orientation="horizontal">
-                                  <RadioGroupItem
-                                    id={`admin-user-role-${item}`}
-                                    value={item}
-                                  />
-                                  <FieldLabel
-                                    htmlFor={`admin-user-role-${item}`}
-                                  >
-                                    {item}
-                                  </FieldLabel>
-                                </Field>
-                              ))}
-                            </RadioGroup>
-                          )}
+                          <profileForm.Field name="roles">
+                            {(field) =>
+                              config.allowMultipleRoles ? (
+                                <FieldGroup
+                                  className="flex-row flex-wrap gap-4"
+                                  data-slot="checkbox-group"
+                                >
+                                  {config.roles.map((item) => (
+                                    <Field key={item} orientation="horizontal">
+                                      <Checkbox
+                                        checked={field.state.value.includes(
+                                          item
+                                        )}
+                                        disabled={
+                                          isSelf || !canSetRole.data?.success
+                                        }
+                                        id={`admin-user-role-${item}`}
+                                        onCheckedChange={(checked) => {
+                                          const next = checked
+                                            ? [...field.state.value, item]
+                                            : field.state.value.filter(
+                                                (role) => role !== item
+                                              )
+                                          if (next.length)
+                                            field.handleChange(next)
+                                        }}
+                                      />
+                                      <FieldLabel
+                                        htmlFor={`admin-user-role-${item}`}
+                                      >
+                                        {item}
+                                      </FieldLabel>
+                                    </Field>
+                                  ))}
+                                </FieldGroup>
+                              ) : (
+                                <RadioGroup
+                                  className="flex-row flex-wrap gap-4"
+                                  disabled={isSelf || !canSetRole.data?.success}
+                                  onValueChange={(role) =>
+                                    field.handleChange([role])
+                                  }
+                                  value={field.state.value[0] ?? ""}
+                                >
+                                  {config.roles.map((item) => (
+                                    <Field key={item} orientation="horizontal">
+                                      <RadioGroupItem
+                                        id={`admin-user-role-${item}`}
+                                        value={item}
+                                      />
+                                      <FieldLabel
+                                        htmlFor={`admin-user-role-${item}`}
+                                      >
+                                        {item}
+                                      </FieldLabel>
+                                    </Field>
+                                  ))}
+                                </RadioGroup>
+                              )
+                            }
+                          </profileForm.Field>
                         </FieldSet>
                         {auth.additionalFields?.map((field) => {
                           const value = (
@@ -1508,21 +1616,30 @@ function UserInspector({
                     >
                       {config.localization.cancel}
                     </Button>
-                    <Button
-                      disabled={
-                        !name.trim() ||
-                        !email.trim() ||
-                        updateUser.isPending ||
-                        setRoleMutation.isPending ||
-                        canUpdate.isPending ||
-                        canSetRole.isPending ||
-                        (!canUpdate.data?.success &&
-                          (!canSetRole.data?.success || isSelf))
-                      }
-                      type="submit"
+                    <profileForm.Subscribe
+                      selector={(state) => [
+                        state.values.name,
+                        state.values.email
+                      ]}
                     >
-                      {config.localization.saveChanges}
-                    </Button>
+                      {([name, email]) => (
+                        <Button
+                          disabled={
+                            !name.trim() ||
+                            !email.trim() ||
+                            updateUser.isPending ||
+                            setRoleMutation.isPending ||
+                            canUpdate.isPending ||
+                            canSetRole.isPending ||
+                            (!canUpdate.data?.success &&
+                              (!canSetRole.data?.success || isSelf))
+                          }
+                          type="submit"
+                        >
+                          {config.localization.saveChanges}
+                        </Button>
+                      )}
+                    </profileForm.Subscribe>
                   </div>
                 </form>
               </TabsContent>

--- a/examples/next-shadcn-example/src/components/auth/api-key/api-keys.tsx
+++ b/examples/next-shadcn-example/src/components/auth/api-key/api-keys.tsx
@@ -1,8 +1,21 @@
 "use client"
 
-import type { ApiKeyAuthClient } from "@better-auth-ui/core/plugins/api-key"
+import type {
+  ApiKeyAuthClient,
+  ListedApiKey
+} from "@better-auth-ui/core/plugins/api-key"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useListApiKeys } from "@better-auth-ui/react/plugins/api-key"
+import {
+  createTableHook,
+  functionalUpdate,
+  type PaginationState,
+  rowPaginationFeature,
+  rowSortingFeature,
+  type SortingState,
+  tableFeatures,
+  type Updater
+} from "@tanstack/react-table"
 import { Fragment, useState } from "react"
 
 import { Button } from "@/components/ui/button"
@@ -21,6 +34,20 @@ import { ApiKey } from "./api-key"
 import { ApiKeySkeleton } from "./api-key-skeleton"
 import { ApiKeysEmpty } from "./api-keys-empty"
 import { CreateApiKeyDialog } from "./create-api-key-dialog"
+
+const { createAppColumnHelper, useAppTable: useApiKeyTable } = createTableHook({
+  enableMultiSort: false,
+  enableSortingRemoval: false,
+  sortDescFirst: false,
+  features: tableFeatures({ rowPaginationFeature, rowSortingFeature })
+})
+
+const apiKeyColumnHelper = createAppColumnHelper<ListedApiKey>()
+const apiKeyColumns = apiKeyColumnHelper.columns([
+  apiKeyColumnHelper.accessor("createdAt", { id: "createdAt" }),
+  apiKeyColumnHelper.accessor("name", { id: "name" })
+])
+const EMPTY_API_KEYS: ListedApiKey[] = []
 
 export type ApiKeysProps = {
   className?: string
@@ -47,17 +74,25 @@ export function ApiKeys({
   const { authClient } = useAuth<ApiKeyAuthClient>()
   const { localization: apiKeyLocalization, pageSize } =
     useAuthPlugin(apiKeyPlugin)
-  const [page, setPage] = useState(0)
-  const [sort, setSort] = useState("createdAt:desc")
-  const [sortBy, sortDirection] = sort.split(":") as [string, "asc" | "desc"]
+  const [pagination, setPaginationState] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const [sorting, setSortingState] = useState<SortingState>([
+    { id: "createdAt", desc: true }
+  ])
+  const primarySort = sorting[0]
+  const sortBy = primarySort?.id === "name" ? "name" : "createdAt"
+  const sortDirection = primarySort?.desc ? "desc" : "asc"
+  const sort = `${sortBy}:${sortDirection}`
 
   const { data: listData, isPending: isListPending } = useListApiKeys(
     authClient,
     {
       enabled: !isPendingProp,
       query: {
-        limit: pageSize,
-        offset: page * pageSize,
+        limit: pagination.pageSize,
+        offset: pagination.pageIndex * pagination.pageSize,
         sortBy,
         sortDirection,
         ...(organizationId ? { organizationId, configId: "organization" } : {})
@@ -66,6 +101,22 @@ export function ApiKeys({
   )
 
   const isPending = isPendingProp || isListPending
+  const setPagination = (updater: Updater<PaginationState>) =>
+    setPaginationState((current) => functionalUpdate(updater, current))
+  const setSorting = (updater: Updater<SortingState>) => {
+    setSortingState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const table = useApiKeyTable({
+    columns: apiKeyColumns,
+    data: listData?.apiKeys ?? EMPTY_API_KEYS,
+    getRowId: (apiKey) => apiKey.id,
+    manualPagination: true,
+    manualSorting: true,
+    state: { pagination, sorting },
+    onPaginationChange: setPagination,
+    onSortingChange: setSorting
+  })
 
   const [createOpen, setCreateOpen] = useState(false)
 
@@ -90,8 +141,8 @@ export function ApiKeys({
       <Select
         value={sort}
         onValueChange={(value) => {
-          setSort(value)
-          setPage(0)
+          const [id, direction] = value.split(":")
+          table.setSorting([{ id, desc: direction === "desc" }])
         }}
       >
         <SelectTrigger aria-label={apiKeyLocalization.sortBy}>
@@ -124,11 +175,11 @@ export function ApiKeys({
             />
           ) : (
             <ItemGroup className="gap-0">
-              {listData.apiKeys.map((key, index) => (
-                <Fragment key={key.id}>
+              {table.getRowModel().rows.map((row, index) => (
+                <Fragment key={row.id}>
                   {index > 0 && <ItemSeparator />}
                   <ApiKey
-                    apiKey={key}
+                    apiKey={row.original}
                     hideDelete={hideDelete}
                     hideUpdate={hideUpdate}
                     organizationId={organizationId}
@@ -139,21 +190,22 @@ export function ApiKeys({
           )}
         </CardContent>
       </Card>
-      {(page > 0 || (listData?.apiKeys.length ?? 0) === pageSize) && (
+      {(pagination.pageIndex > 0 ||
+        (listData?.apiKeys.length ?? 0) === pagination.pageSize) && (
         <div className="flex justify-end gap-2">
           <Button
             variant="outline"
             size="sm"
-            disabled={page === 0}
-            onClick={() => setPage((value) => Math.max(0, value - 1))}
+            disabled={!table.getCanPreviousPage()}
+            onClick={() => table.previousPage()}
           >
             {apiKeyLocalization.previousPage}
           </Button>
           <Button
             variant="outline"
             size="sm"
-            disabled={(listData?.apiKeys.length ?? 0) < pageSize}
-            onClick={() => setPage((value) => value + 1)}
+            disabled={(listData?.apiKeys.length ?? 0) < pagination.pageSize}
+            onClick={() => table.nextPage()}
           >
             {apiKeyLocalization.nextPage}
           </Button>

--- a/examples/next-shadcn-example/src/components/auth/dash/activity.tsx
+++ b/examples/next-shadcn-example/src/components/auth/dash/activity.tsx
@@ -21,6 +21,17 @@ import {
 import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
 import { keepPreviousData } from "@tanstack/react-query"
 import {
+  type ColumnFiltersState,
+  columnFilteringFeature,
+  createTableHook,
+  functionalUpdate,
+  globalFilteringFeature,
+  type PaginationState,
+  rowPaginationFeature,
+  tableFeatures,
+  type Updater
+} from "@tanstack/react-table"
+import {
   Activity,
   Building2,
   ChevronLeft,
@@ -73,6 +84,21 @@ import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
 
 type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
+
+const { createAppColumnHelper, useAppTable: useActivityTable } =
+  createTableHook({
+    features: tableFeatures({
+      columnFilteringFeature,
+      globalFilteringFeature,
+      rowPaginationFeature
+    })
+  })
+
+const activityColumnHelper = createAppColumnHelper<DashAuditLog>()
+const activityColumns = activityColumnHelper.columns([
+  activityColumnHelper.accessor("eventType", { id: "eventType" })
+])
+const EMPTY_EVENTS: DashAuditLog[] = []
 
 type ActivityFeedProps = {
   access: ActivityAccess
@@ -211,19 +237,27 @@ function ActivityFeed({
 }: ActivityFeedProps) {
   const { authClient } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
-  const [page, setPage] = useState(0)
-  const [eventType, setEventType] = useState("all")
-  const [identifier, setIdentifier] = useState("")
-  const deferredIdentifier = useDeferredValue(identifier.trim())
+  const [pagination, setPaginationState] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const [columnFilters, setColumnFiltersState] = useState<ColumnFiltersState>(
+    []
+  )
+  const [globalFilter, setGlobalFilterState] = useState("")
+  const eventType = String(
+    columnFilters.find((filter) => filter.id === "eventType")?.value ?? "all"
+  )
+  const deferredIdentifier = useDeferredValue(globalFilter.trim())
   const eventOptions = useMemo(
     () => Object.entries(localization.eventLabels),
     [localization.eventLabels]
   )
-  const offset = page * pageSize
+  const offset = pagination.pageIndex * pagination.pageSize
   const params = {
     eventType: eventType === "all" ? undefined : eventType,
     identifier: deferredIdentifier || undefined,
-    limit: pageSize,
+    limit: pagination.pageSize,
     offset,
     organizationId
   }
@@ -245,7 +279,7 @@ function ActivityFeed({
       params: {
         eventType: params.eventType,
         identifier: params.identifier,
-        limit: pageSize,
+        limit: pagination.pageSize,
         offset
       }
     }
@@ -259,7 +293,28 @@ function ActivityFeed({
   const { data, error, isFetching, isPending } = query
   const showPending = !ready || isPending
   const pageEnd = offset + (data?.events.length ?? 0)
-  const hasNextPage = pageEnd < (data?.total ?? 0)
+  const setPagination = (updater: Updater<PaginationState>) =>
+    setPaginationState((current) => functionalUpdate(updater, current))
+  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
+    setColumnFiltersState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const setGlobalFilter = (updater: Updater<string>) => {
+    setGlobalFilterState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const table = useActivityTable({
+    columns: activityColumns,
+    data: data?.events ?? EMPTY_EVENTS,
+    getRowId: getDashEventKey,
+    manualFiltering: true,
+    manualPagination: true,
+    rowCount: data?.total ?? 0,
+    state: { columnFilters, globalFilter, pagination },
+    onColumnFiltersChange: setColumnFilters,
+    onGlobalFilterChange: setGlobalFilter,
+    onPaginationChange: setPagination
+  })
 
   return (
     <Card
@@ -297,8 +352,9 @@ function ActivityFeed({
             <Select
               value={eventType}
               onValueChange={(value) => {
-                setEventType(value)
-                setPage(0)
+                table
+                  .getColumn("eventType")
+                  ?.setFilterValue(value === "all" ? undefined : value)
               }}
             >
               <SelectTrigger id="dash-event-type" className="w-full">
@@ -325,11 +381,10 @@ function ActivityFeed({
               <InputGroupInput
                 id="dash-identifier"
                 onChange={(event) => {
-                  setIdentifier(event.target.value)
-                  setPage(0)
+                  table.setGlobalFilter(event.target.value)
                 }}
                 placeholder={localization.identifierPlaceholder}
-                value={identifier}
+                value={globalFilter}
               />
             </InputGroup>
           </Field>
@@ -366,10 +421,10 @@ function ActivityFeed({
           </Empty>
         ) : data?.events.length ? (
           <ul>
-            {data.events.map((event, position) => (
-              <Fragment key={getDashEventKey(event)}>
+            {table.getRowModel().rows.map((row, position) => (
+              <Fragment key={row.id}>
                 {position > 0 && <Separator />}
-                <ActivityRow event={event} />
+                <ActivityRow event={row.original} />
               </Fragment>
             ))}
           </ul>
@@ -402,19 +457,19 @@ function ActivityFeed({
           <div className="flex gap-1">
             <Button
               aria-label={localization.previousPage}
-              disabled={isFetching || page === 0}
+              disabled={isFetching || !table.getCanPreviousPage()}
               size="icon-sm"
               variant="ghost"
-              onClick={() => setPage((current) => Math.max(0, current - 1))}
+              onClick={() => table.previousPage()}
             >
               <ChevronLeft />
             </Button>
             <Button
               aria-label={localization.nextPage}
-              disabled={isFetching || !hasNextPage}
+              disabled={isFetching || !table.getCanNextPage()}
               size="icon-sm"
               variant="ghost"
-              onClick={() => setPage((current) => current + 1)}
+              onClick={() => table.nextPage()}
             >
               <ChevronRight />
             </Button>

--- a/examples/next-shadcn-example/src/components/auth/oauth-provider/oauth-clients.tsx
+++ b/examples/next-shadcn-example/src/components/auth/oauth-provider/oauth-clients.tsx
@@ -22,6 +22,7 @@ import {
   useSetOAuthClientDisabled,
   useUpdateOAuthClient
 } from "@better-auth-ui/react/plugins/oauth-provider"
+import { useForm } from "@tanstack/react-form"
 import {
   Check,
   Code2,
@@ -31,7 +32,7 @@ import {
   RotateCcwKey,
   Trash2
 } from "lucide-react"
-import { type SyntheticEvent, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -85,6 +86,15 @@ type ClientAction =
   | { kind: "delete"; client: ManagedOAuthClient }
   | { kind: "rotate"; client: ManagedOAuthClient }
 
+type OAuthClientFormValues = {
+  applicationType: "native" | "web"
+  clientName: string
+  clientUri: string
+  logoUri: string
+  redirectUris: string
+  scope: string
+}
+
 export type OAuthClientsProps = {
   manager: OAuthClientManager
   owner: OAuthClientOwner
@@ -101,6 +111,17 @@ const uniqueLines = (value: string) =>
         .filter(Boolean)
     )
   )
+
+const getOAuthClientFormValues = (
+  client?: ManagedOAuthClient
+): OAuthClientFormValues => ({
+  applicationType: client?.application_type === "native" ? "native" : "web",
+  clientName: client?.client_name ?? "",
+  clientUri: client?.client_uri ?? "",
+  logoUri: client?.logo_uri ?? "",
+  redirectUris: client?.redirect_uris.join("\n") ?? "",
+  scope: client?.scope ?? ""
+})
 
 export function OAuthClients({
   manager,
@@ -124,39 +145,41 @@ export function OAuthClients({
     onError: (error) =>
       toast.error(error instanceof Error ? error.message : String(error))
   })
+  const form = useForm({
+    defaultValues: getOAuthClientFormValues(),
+    onSubmit: async ({ value }) => {
+      const input: OAuthClientInput = {
+        client_name: value.clientName.trim(),
+        application_type: value.applicationType,
+        redirect_uris: uniqueLines(value.redirectUris),
+        client_uri: value.clientUri.trim() || undefined,
+        logo_uri: value.logoUri.trim() || undefined,
+        scope: value.scope.trim() || undefined
+      }
+
+      try {
+        if (editingClient) {
+          await updateClient.mutateAsync({
+            clientId: editingClient.client_id,
+            update: input
+          })
+          setEditorOpen(false)
+          return
+        }
+
+        const client = await createClient.mutateAsync(input)
+        setEditorOpen(false)
+        setSecret(client)
+      } catch {
+        // The mutation keeps its error state for the host application.
+      }
+    }
+  })
 
   const openCreate = () => {
     setEditingClient(undefined)
+    form.reset(getOAuthClientFormValues())
     setEditorOpen(true)
-  }
-
-  const handleEditorSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    const input: OAuthClientInput = {
-      client_name: String(formData.get("clientName") ?? "").trim(),
-      application_type:
-        formData.get("applicationType") === "native" ? "native" : "web",
-      redirect_uris: uniqueLines(String(formData.get("redirectUris") ?? "")),
-      client_uri: String(formData.get("clientUri") ?? "").trim() || undefined,
-      logo_uri: String(formData.get("logoUri") ?? "").trim() || undefined,
-      scope: String(formData.get("scope") ?? "").trim() || undefined
-    }
-
-    if (editingClient) {
-      updateClient.mutate(
-        { clientId: editingClient.client_id, update: input },
-        { onSuccess: () => setEditorOpen(false) }
-      )
-      return
-    }
-
-    createClient.mutate(input, {
-      onSuccess: (client) => {
-        setEditorOpen(false)
-        setSecret(client)
-      }
-    })
   }
 
   const confirmAction = () => {
@@ -263,6 +286,7 @@ export function OAuthClients({
                     aria-label={oauthLocalization.editClient}
                     onClick={() => {
                       setEditingClient(client)
+                      form.reset(getOAuthClientFormValues(client))
                       setEditorOpen(true)
                     }}
                   >
@@ -310,7 +334,13 @@ export function OAuthClients({
 
       <Dialog open={editorOpen} onOpenChange={setEditorOpen}>
         <DialogContent>
-          <form onSubmit={handleEditorSubmit} className="flex flex-col gap-6">
+          <form
+            onSubmit={(event) => {
+              event.preventDefault()
+              void form.handleSubmit()
+            }}
+            className="flex flex-col gap-6"
+          >
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2">
                 {editingClient ? <Pencil /> : <Plus />}
@@ -323,87 +353,118 @@ export function OAuthClients({
               </DialogDescription>
             </DialogHeader>
             <FieldGroup>
-              <Field>
-                <FieldLabel htmlFor="oauth-client-name">
-                  {oauthLocalization.clientName}
-                </FieldLabel>
-                <Input
-                  id="oauth-client-name"
-                  name="clientName"
-                  defaultValue={editingClient?.client_name ?? ""}
-                  required
-                  autoFocus
-                />
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-application-type">
-                  {oauthLocalization.applicationType}
-                </FieldLabel>
-                <Select
-                  name="applicationType"
-                  defaultValue={editingClient?.application_type ?? "web"}
-                >
-                  <SelectTrigger id="oauth-application-type" className="w-full">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="web">
-                      {oauthLocalization.webApplication}
-                    </SelectItem>
-                    <SelectItem value="native">
-                      {oauthLocalization.nativeApplication}
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-redirect-uris">
-                  {oauthLocalization.redirectUrls}
-                </FieldLabel>
-                <Textarea
-                  id="oauth-redirect-uris"
-                  name="redirectUris"
-                  rows={3}
-                  defaultValue={editingClient?.redirect_uris.join("\n") ?? ""}
-                  required
-                />
-                <FieldDescription>
-                  {oauthLocalization.redirectUrlsDescription}
-                </FieldDescription>
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-client-uri">
-                  {oauthLocalization.applicationUrl}
-                </FieldLabel>
-                <Input
-                  id="oauth-client-uri"
-                  name="clientUri"
-                  type="url"
-                  defaultValue={editingClient?.client_uri ?? ""}
-                />
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-logo-uri">
-                  {oauthLocalization.logoUrl}
-                </FieldLabel>
-                <Input
-                  id="oauth-logo-uri"
-                  name="logoUri"
-                  type="url"
-                  defaultValue={editingClient?.logo_uri ?? ""}
-                />
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-scopes">
-                  {oauthLocalization.scopes}
-                </FieldLabel>
-                <Input
-                  id="oauth-scopes"
-                  name="scope"
-                  placeholder="openid profile email"
-                  defaultValue={editingClient?.scope ?? ""}
-                />
-              </Field>
+              <form.Field name="clientName">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="oauth-client-name">
+                      {oauthLocalization.clientName}
+                    </FieldLabel>
+                    <Input
+                      autoFocus
+                      id="oauth-client-name"
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      value={field.state.value}
+                    />
+                  </Field>
+                )}
+              </form.Field>
+              <form.Field name="applicationType">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="oauth-application-type">
+                      {oauthLocalization.applicationType}
+                    </FieldLabel>
+                    <Select
+                      name={field.name}
+                      onValueChange={(value) =>
+                        field.handleChange(value as "native" | "web")
+                      }
+                      value={field.state.value}
+                    >
+                      <SelectTrigger
+                        id="oauth-application-type"
+                        className="w-full"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="web">
+                          {oauthLocalization.webApplication}
+                        </SelectItem>
+                        <SelectItem value="native">
+                          {oauthLocalization.nativeApplication}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </Field>
+                )}
+              </form.Field>
+              <form.Field name="redirectUris">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="oauth-redirect-uris">
+                      {oauthLocalization.redirectUrls}
+                    </FieldLabel>
+                    <Textarea
+                      id="oauth-redirect-uris"
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      rows={3}
+                      value={field.state.value}
+                    />
+                    <FieldDescription>
+                      {oauthLocalization.redirectUrlsDescription}
+                    </FieldDescription>
+                  </Field>
+                )}
+              </form.Field>
+              {(
+                [
+                  [
+                    "clientUri",
+                    "oauth-client-uri",
+                    oauthLocalization.applicationUrl,
+                    "url"
+                  ],
+                  [
+                    "logoUri",
+                    "oauth-logo-uri",
+                    oauthLocalization.logoUrl,
+                    "url"
+                  ],
+                  ["scope", "oauth-scopes", oauthLocalization.scopes, "text"]
+                ] as const
+              ).map(([name, id, label, type]) => (
+                <form.Field key={name} name={name}>
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+                      <Input
+                        id={id}
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        placeholder={
+                          name === "scope" ? "openid profile email" : undefined
+                        }
+                        type={type}
+                        value={field.state.value}
+                      />
+                    </Field>
+                  )}
+                </form.Field>
+              ))}
             </FieldGroup>
             <DialogFooter>
               <DialogClose
@@ -412,17 +473,16 @@ export function OAuthClients({
               >
                 {oauthLocalization.cancel}
               </DialogClose>
-              <Button
-                type="submit"
-                disabled={createClient.isPending || updateClient.isPending}
-              >
-                {(createClient.isPending || updateClient.isPending) && (
-                  <Spinner />
+              <form.Subscribe selector={(state) => state.isSubmitting}>
+                {(isSubmitting) => (
+                  <Button type="submit" disabled={isSubmitting}>
+                    {isSubmitting && <Spinner />}
+                    {editingClient
+                      ? oauthLocalization.saveChanges
+                      : oauthLocalization.createClient}
+                  </Button>
                 )}
-                {editingClient
-                  ? oauthLocalization.saveChanges
-                  : oauthLocalization.createClient}
-              </Button>
+              </form.Subscribe>
             </DialogFooter>
           </form>
         </DialogContent>

--- a/examples/next-shadcn-example/src/components/auth/organization/edit-member-roles-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/edit-member-roles-dialog.tsx
@@ -4,8 +4,9 @@ import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organi
 import { parseMemberRoles } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useUpdateMemberRole } from "@better-auth-ui/react/plugins/organization"
+import { useForm } from "@tanstack/react-form"
 import { ShieldCheck } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
 import { toast } from "sonner"
 
 import { Button, buttonVariants } from "@/components/ui/button"
@@ -71,9 +72,6 @@ export function EditMemberRolesDialog({
   const { authClient, localization } = useAuth<OrganizationAuthClient>()
   const { allowMultipleRoles, localization: organizationLocalization } =
     useAuthPlugin(organizationPlugin)
-  const [selectedRoles, setSelectedRoles] = useState(() =>
-    selectedMemberRoles(member.role, allowMultipleRoles, protectedRole)
-  )
   const { mutate: updateMemberRole, isPending } = useUpdateMemberRole(
     authClient,
     {
@@ -83,16 +81,36 @@ export function EditMemberRolesDialog({
       }
     }
   )
+  const form = useForm({
+    defaultValues: {
+      roles: selectedMemberRoles(member.role, allowMultipleRoles, protectedRole)
+    },
+    onSubmit: ({ value }) => {
+      if (value.roles.length === 0) return
+
+      updateMemberRole({
+        memberId: member.id,
+        organizationId,
+        role: value.roles
+      })
+    }
+  })
 
   useEffect(() => {
     if (open)
-      setSelectedRoles(
-        selectedMemberRoles(member.role, allowMultipleRoles, protectedRole)
-      )
-  }, [allowMultipleRoles, member.role, open, protectedRole])
+      form.reset({
+        roles: selectedMemberRoles(
+          member.role,
+          allowMultipleRoles,
+          protectedRole
+        )
+      })
+  }, [allowMultipleRoles, form.reset, member.role, open, protectedRole])
 
   const toggleRole = (role: string, checked: boolean) => {
-    setSelectedRoles((current) =>
+    const current = form.getFieldValue("roles")
+    form.setFieldValue(
+      "roles",
       checked
         ? current.includes(role)
           ? current
@@ -101,41 +119,6 @@ export function EditMemberRolesDialog({
     )
   }
 
-  const protectedRoleSelected =
-    !allowMultipleRoles &&
-    protectedRoleRemovalDisabled &&
-    protectedRole !== undefined &&
-    selectedRoles.includes(protectedRole)
-  const roleOptions = roles.map(([role, label]) => {
-    const checked = selectedRoles.includes(role)
-    const disabled =
-      isPending ||
-      (allowMultipleRoles && checked && selectedRoles.length === 1) ||
-      (protectedRoleSelected && role !== protectedRole) ||
-      (role === protectedRole && checked && protectedRoleRemovalDisabled)
-    const id = `member-${member.id}-role-${role}`
-
-    return (
-      <FieldLabel htmlFor={id} key={role}>
-        <Field orientation="horizontal" data-disabled={disabled}>
-          <FieldContent>
-            <FieldTitle>{label}</FieldTitle>
-          </FieldContent>
-          {allowMultipleRoles ? (
-            <Checkbox
-              checked={checked}
-              disabled={disabled}
-              id={id}
-              onCheckedChange={(next) => toggleRole(role, next === true)}
-            />
-          ) : (
-            <RadioGroupItem disabled={disabled} id={id} value={role} />
-          )}
-        </Field>
-      </FieldLabel>
-    )
-  })
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
@@ -143,13 +126,7 @@ export function EditMemberRolesDialog({
           className="flex flex-col gap-6"
           onSubmit={(event) => {
             event.preventDefault()
-            if (selectedRoles.length === 0) return
-
-            updateMemberRole({
-              memberId: member.id,
-              organizationId,
-              role: selectedRoles
-            })
+            void form.handleSubmit()
           }}
         >
           <DialogHeader>
@@ -162,34 +139,89 @@ export function EditMemberRolesDialog({
             </DialogDescription>
           </DialogHeader>
 
-          {allowMultipleRoles ? (
-            <div className="flex flex-col gap-2">{roleOptions}</div>
-          ) : (
-            <RadioGroup
-              disabled={isPending}
-              onValueChange={(role) => setSelectedRoles([role])}
-              value={selectedRoles[0] ?? ""}
-            >
-              {roleOptions}
-            </RadioGroup>
-          )}
+          <form.Subscribe selector={(state) => state.values.roles}>
+            {(selectedRoles) => {
+              const protectedRoleSelected =
+                !allowMultipleRoles &&
+                protectedRoleRemovalDisabled &&
+                protectedRole !== undefined &&
+                selectedRoles.includes(protectedRole)
+              const roleOptions = roles.map(([role, label]) => {
+                const checked = selectedRoles.includes(role)
+                const disabled =
+                  isPending ||
+                  (allowMultipleRoles &&
+                    checked &&
+                    selectedRoles.length === 1) ||
+                  (protectedRoleSelected && role !== protectedRole) ||
+                  (role === protectedRole &&
+                    checked &&
+                    protectedRoleRemovalDisabled)
+                const id = `member-${member.id}-role-${role}`
 
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              disabled={isPending}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-            <Button
-              disabled={isPending || selectedRoles.length === 0}
-              type="submit"
-            >
-              {isPending && <Spinner />}
-              {localization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
+                return (
+                  <FieldLabel htmlFor={id} key={role}>
+                    <Field orientation="horizontal" data-disabled={disabled}>
+                      <FieldContent>
+                        <FieldTitle>{label}</FieldTitle>
+                      </FieldContent>
+                      {allowMultipleRoles ? (
+                        <Checkbox
+                          checked={checked}
+                          disabled={disabled}
+                          id={id}
+                          onCheckedChange={(next) =>
+                            toggleRole(role, next === true)
+                          }
+                        />
+                      ) : (
+                        <RadioGroupItem
+                          disabled={disabled}
+                          id={id}
+                          value={role}
+                        />
+                      )}
+                    </Field>
+                  </FieldLabel>
+                )
+              })
+
+              return (
+                <>
+                  {allowMultipleRoles ? (
+                    <div className="flex flex-col gap-2">{roleOptions}</div>
+                  ) : (
+                    <RadioGroup
+                      disabled={isPending}
+                      onValueChange={(role) =>
+                        form.setFieldValue("roles", [role])
+                      }
+                      value={selectedRoles[0] ?? ""}
+                    >
+                      {roleOptions}
+                    </RadioGroup>
+                  )}
+
+                  <DialogFooter>
+                    <DialogClose
+                      className={buttonVariants({ variant: "outline" })}
+                      disabled={isPending}
+                      type="button"
+                    >
+                      {localization.settings.cancel}
+                    </DialogClose>
+                    <Button
+                      disabled={isPending || selectedRoles.length === 0}
+                      type="submit"
+                    >
+                      {isPending && <Spinner />}
+                      {localization.settings.saveChanges}
+                    </Button>
+                  </DialogFooter>
+                </>
+              )
+            }}
+          </form.Subscribe>
         </form>
       </DialogContent>
     </Dialog>

--- a/examples/next-shadcn-example/src/components/auth/reset-password.tsx
+++ b/examples/next-shadcn-example/src/components/auth/reset-password.tsx
@@ -5,8 +5,9 @@ import {
   isPasswordCompromisedError
 } from "@better-auth-ui/core"
 import { useAuth, useResetPassword } from "@better-auth-ui/react"
+import { useForm } from "@tanstack/react-form"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -72,7 +73,6 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     }
   })
 
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
   const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
     useState(false)
@@ -92,29 +92,32 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     }
   }, [localization.auth.invalidResetPasswordToken, navigate, signInURL])
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
+  const form = useForm({
+    defaultValues: { confirmPassword: "", password: "" },
+    onSubmit: ({ value }) => {
+      const searchParams = new URLSearchParams(window.location.search)
+      const token = searchParams.get("token") as string
 
-    const searchParams = new URLSearchParams(window.location.search)
-    const token = searchParams.get("token") as string
+      if (!token) {
+        toast.error(localization.auth.invalidResetPasswordToken)
+        navigate({ to: signInURL })
+        return
+      }
 
-    if (!token) {
-      toast.error(localization.auth.invalidResetPasswordToken)
-      navigate({ to: signInURL })
-      return
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
+        setFieldErrors((current) => ({
+          ...current,
+          confirmPassword: localization.auth.passwordsDoNotMatch
+        }))
+        return
+      }
+
+      resetPassword({ token, newPassword: value.password })
     }
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-    const confirmPassword = formData.get("confirmPassword") as string
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      toast.error(localization.auth.passwordsDoNotMatch)
-      return
-    }
-
-    resetPassword({ token, newPassword: password })
-  }
+  })
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -125,156 +128,175 @@ export function ResetPassword({ className }: ResetPasswordProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            void form.handleSubmit()
+          }}
+        >
           <FieldGroup>
-            <Field data-invalid={!!fieldErrors.password}>
-              <FieldLabel htmlFor="password">
-                {localization.auth.password}
-              </FieldLabel>
+            <form.Field name="password">
+              {(field) => (
+                <Field data-invalid={!!fieldErrors.password}>
+                  <FieldLabel htmlFor="password">
+                    {localization.auth.password}
+                  </FieldLabel>
 
-              <InputGroup>
-                <InputGroupInput
-                  id="password"
-                  name="password"
-                  type={isPasswordVisible ? "text" : "password"}
-                  autoComplete="new-password"
-                  placeholder={localization.auth.newPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                  onChange={(e) => {
-                    setPassword(e.target.value)
+                  <InputGroup>
+                    <InputGroupInput
+                      id="password"
+                      type={isPasswordVisible ? "text" : "password"}
+                      autoComplete="new-password"
+                      placeholder={localization.auth.newPasswordPlaceholder}
+                      required
+                      minLength={emailAndPassword?.minPasswordLength}
+                      maxLength={emailAndPassword?.maxPasswordLength}
+                      disabled={isPending}
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(e) => {
+                        field.handleChange(e.target.value)
+                        setFieldErrors((prev) => ({
+                          ...prev,
+                          password: undefined
+                        }))
+                      }}
+                      onInvalid={(e) => {
+                        e.preventDefault()
+                        const el = e.target as HTMLInputElement
+                        const min = emailAndPassword?.minPasswordLength
+                        const max = emailAndPassword?.maxPasswordLength
+                        const msg = el.validity.valueMissing
+                          ? localization.auth.fieldRequired
+                          : el.validity.tooShort
+                            ? localization.auth.tooShort.replace(
+                                "{{min}}",
+                                String(min)
+                              )
+                            : localization.auth.tooLong.replace(
+                                "{{max}}",
+                                String(max)
+                              )
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      password: undefined
-                    }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
-                    const el = e.target as HTMLInputElement
-                    const min = emailAndPassword?.minPasswordLength
-                    const max = emailAndPassword?.maxPasswordLength
-                    const msg = el.validity.valueMissing
-                      ? localization.auth.fieldRequired
-                      : el.validity.tooShort
-                        ? localization.auth.tooShort.replace(
-                            "{{min}}",
-                            String(min)
-                          )
-                        : localization.auth.tooLong.replace(
-                            "{{max}}",
-                            String(max)
-                          )
+                        setFieldErrors((prev) => ({
+                          ...prev,
+                          password: msg
+                        }))
+                      }}
+                      aria-invalid={!!fieldErrors.password}
+                      value={field.state.value}
+                    />
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      password: msg
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.password}
-                />
+                    <InputGroupAddon align="inline-end">
+                      <InputGroupButton
+                        size="icon-xs"
+                        aria-label={
+                          isPasswordVisible
+                            ? localization.auth.hidePassword
+                            : localization.auth.showPassword
+                        }
+                        title={
+                          isPasswordVisible
+                            ? localization.auth.hidePassword
+                            : localization.auth.showPassword
+                        }
+                        onClick={() => {
+                          setIsPasswordVisible((visible) => !visible)
+                        }}
+                      >
+                        {isPasswordVisible ? <EyeOff /> : <Eye />}
+                      </InputGroupButton>
+                    </InputGroupAddon>
+                  </InputGroup>
 
-                <InputGroupAddon align="inline-end">
-                  <InputGroupButton
-                    size="icon-xs"
-                    aria-label={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    title={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    onClick={() => {
-                      setIsPasswordVisible((visible) => !visible)
-                    }}
-                  >
-                    {isPasswordVisible ? <EyeOff /> : <Eye />}
-                  </InputGroupButton>
-                </InputGroupAddon>
-              </InputGroup>
+                  <FieldError>{fieldErrors.password}</FieldError>
 
-              <FieldError>{fieldErrors.password}</FieldError>
-
-              <PasswordStrengthMeter password={password} />
-            </Field>
+                  <PasswordStrengthMeter password={field.state.value} />
+                </Field>
+              )}
+            </form.Field>
 
             {emailAndPassword?.confirmPassword && (
-              <Field data-invalid={!!fieldErrors.confirmPassword}>
-                <FieldLabel htmlFor="confirmPassword">
-                  {localization.auth.confirmPassword}
-                </FieldLabel>
+              <form.Field name="confirmPassword">
+                {(field) => (
+                  <Field data-invalid={!!fieldErrors.confirmPassword}>
+                    <FieldLabel htmlFor="confirmPassword">
+                      {localization.auth.confirmPassword}
+                    </FieldLabel>
 
-                <InputGroup>
-                  <InputGroupInput
-                    id="confirmPassword"
-                    name="confirmPassword"
-                    type={isConfirmPasswordVisible ? "text" : "password"}
-                    autoComplete="new-password"
-                    placeholder={localization.auth.confirmPasswordPlaceholder}
-                    required
-                    minLength={emailAndPassword?.minPasswordLength}
-                    maxLength={emailAndPassword?.maxPasswordLength}
-                    disabled={isPending}
-                    onChange={() => {
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        confirmPassword: undefined
-                      }))
-                    }}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-                      const el = e.target as HTMLInputElement
-                      const min = emailAndPassword?.minPasswordLength
-                      const max = emailAndPassword?.maxPasswordLength
-                      const msg = el.validity.valueMissing
-                        ? localization.auth.fieldRequired
-                        : el.validity.tooShort
-                          ? localization.auth.tooShort.replace(
-                              "{{min}}",
-                              String(min)
-                            )
-                          : localization.auth.tooLong.replace(
-                              "{{max}}",
-                              String(max)
-                            )
+                    <InputGroup>
+                      <InputGroupInput
+                        id="confirmPassword"
+                        name={field.name}
+                        type={isConfirmPasswordVisible ? "text" : "password"}
+                        autoComplete="new-password"
+                        placeholder={
+                          localization.auth.confirmPasswordPlaceholder
+                        }
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => {
+                          field.handleChange(event.target.value)
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            confirmPassword: undefined
+                          }))
+                        }}
+                        onInvalid={(e) => {
+                          e.preventDefault()
+                          const el = e.target as HTMLInputElement
+                          const min = emailAndPassword?.minPasswordLength
+                          const max = emailAndPassword?.maxPasswordLength
+                          const msg = el.validity.valueMissing
+                            ? localization.auth.fieldRequired
+                            : el.validity.tooShort
+                              ? localization.auth.tooShort.replace(
+                                  "{{min}}",
+                                  String(min)
+                                )
+                              : localization.auth.tooLong.replace(
+                                  "{{max}}",
+                                  String(max)
+                                )
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        confirmPassword: msg
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.confirmPassword}
-                  />
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            confirmPassword: msg
+                          }))
+                        }}
+                        aria-invalid={!!fieldErrors.confirmPassword}
+                        value={field.state.value}
+                      />
 
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      size="icon-xs"
-                      aria-label={
-                        isConfirmPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      title={
-                        isConfirmPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      onClick={() => {
-                        setIsConfirmPasswordVisible((visible) => !visible)
-                      }}
-                    >
-                      {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={
+                            isConfirmPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          title={
+                            isConfirmPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() => {
+                            setIsConfirmPasswordVisible((visible) => !visible)
+                          }}
+                        >
+                          {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
 
-                <FieldError>{fieldErrors.confirmPassword}</FieldError>
-              </Field>
+                    <FieldError>{fieldErrors.confirmPassword}</FieldError>
+                  </Field>
+                )}
+              </form.Field>
             )}
 
             <div className="flex flex-col gap-3">

--- a/examples/next-shadcn-example/src/components/auth/settings/security/change-password.tsx
+++ b/examples/next-shadcn-example/src/components/auth/settings/security/change-password.tsx
@@ -9,8 +9,9 @@ import {
   useRequestPasswordReset,
   useSession
 } from "@better-auth-ui/react"
+import { useForm } from "@tanstack/react-form"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -165,10 +166,6 @@ function ChangePasswordForm({
   session: ReturnType<typeof useSession>["data"]
 }) {
   const { authClient } = useAuth()
-  const [currentPassword, setCurrentPassword] = useState("")
-  const [newPassword, setNewPassword] = useState("")
-  const [confirmPassword, setConfirmPassword] = useState("")
-
   const { mutate: changePassword, isPending } = useChangePassword(authClient, {
     onError: (error) => {
       // The haveIBeenPwned plugin rejects on the password itself, so it
@@ -180,14 +177,10 @@ function ChangePasswordForm({
         }))
       }
 
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
+      form.reset()
     },
     onSuccess: () => {
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
+      form.reset()
       toast.success(localization.settings.changePasswordSuccess)
     }
   })
@@ -204,23 +197,29 @@ function ChangePasswordForm({
     confirmPassword?: string
   }>({})
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useForm({
+    defaultValues: {
+      confirmPassword: "",
+      currentPassword: "",
+      newPassword: ""
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword.confirmPassword &&
+        value.newPassword !== value.confirmPassword
+      ) {
+        form.reset()
+        toast.error(localization.auth.passwordsDoNotMatch)
+        return
+      }
 
-    if (emailAndPassword.confirmPassword && newPassword !== confirmPassword) {
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
-      toast.error(localization.auth.passwordsDoNotMatch)
-      return
+      changePassword({
+        currentPassword: value.currentPassword,
+        newPassword: value.newPassword,
+        revokeOtherSessions: true
+      })
     }
-
-    changePassword({
-      currentPassword,
-      newPassword,
-      revokeOtherSessions: true
-    })
-  }
+  })
 
   return (
     <div>
@@ -228,204 +227,223 @@ function ChangePasswordForm({
         {localization.settings.changePassword}
       </h2>
 
-      <form onSubmit={handleSubmit}>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault()
+          void form.handleSubmit()
+        }}
+      >
         <Card className={cn(className)}>
           <CardContent className="flex flex-col gap-6">
-            <Field data-invalid={!!fieldErrors.currentPassword}>
-              <FieldLabel htmlFor="currentPassword">
-                {localization.settings.currentPassword}
-              </FieldLabel>
+            <form.Field name="currentPassword">
+              {(field) => (
+                <Field data-invalid={!!fieldErrors.currentPassword}>
+                  <FieldLabel htmlFor="currentPassword">
+                    {localization.settings.currentPassword}
+                  </FieldLabel>
 
-              {session ? (
-                <InputGroup>
-                  <InputGroupInput
-                    id="currentPassword"
-                    name="currentPassword"
-                    type={isCurrentPasswordVisible ? "text" : "password"}
-                    autoComplete="current-password"
-                    placeholder={
-                      localization.settings.currentPasswordPlaceholder
-                    }
-                    value={currentPassword}
-                    onChange={(e) => {
-                      setCurrentPassword(e.target.value)
+                  {session ? (
+                    <InputGroup>
+                      <InputGroupInput
+                        id="currentPassword"
+                        name={field.name}
+                        type={isCurrentPasswordVisible ? "text" : "password"}
+                        autoComplete="current-password"
+                        placeholder={
+                          localization.settings.currentPasswordPlaceholder
+                        }
+                        value={field.state.value}
+                        onChange={(e) => {
+                          field.handleChange(e.target.value)
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        currentPassword: undefined
-                      }))
-                    }}
-                    disabled={isPending}
-                    required
-                    onInvalid={(e) => {
-                      e.preventDefault()
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            currentPassword: undefined
+                          }))
+                        }}
+                        disabled={isPending}
+                        required
+                        onInvalid={(e) => {
+                          e.preventDefault()
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        currentPassword: (e.target as HTMLInputElement)
-                          .validationMessage
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.currentPassword}
-                  />
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            currentPassword: (e.target as HTMLInputElement)
+                              .validationMessage
+                          }))
+                        }}
+                        aria-invalid={!!fieldErrors.currentPassword}
+                      />
 
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      size="icon-xs"
-                      aria-label={
-                        isCurrentPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      title={
-                        isCurrentPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      onClick={() => {
-                        setIsCurrentPasswordVisible((visible) => !visible)
-                      }}
-                    >
-                      {isCurrentPasswordVisible ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
-              ) : (
-                <Skeleton>
-                  <Input className="invisible" />
-                </Skeleton>
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={
+                            isCurrentPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          title={
+                            isCurrentPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() => {
+                            setIsCurrentPasswordVisible((visible) => !visible)
+                          }}
+                        >
+                          {isCurrentPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  ) : (
+                    <Skeleton>
+                      <Input className="invisible" />
+                    </Skeleton>
+                  )}
+
+                  <FieldError>{fieldErrors.currentPassword}</FieldError>
+                </Field>
               )}
+            </form.Field>
 
-              <FieldError>{fieldErrors.currentPassword}</FieldError>
-            </Field>
+            <form.Field name="newPassword">
+              {(field) => (
+                <Field data-invalid={!!fieldErrors.newPassword}>
+                  <FieldLabel htmlFor="newPassword">
+                    {localization.auth.newPassword}
+                  </FieldLabel>
 
-            <Field data-invalid={!!fieldErrors.newPassword}>
-              <FieldLabel htmlFor="newPassword">
-                {localization.auth.newPassword}
-              </FieldLabel>
+                  {session ? (
+                    <InputGroup>
+                      <InputGroupInput
+                        id="newPassword"
+                        name={field.name}
+                        type={isNewPasswordVisible ? "text" : "password"}
+                        autoComplete="new-password"
+                        placeholder={localization.auth.newPasswordPlaceholder}
+                        value={field.state.value}
+                        onChange={(e) => {
+                          field.handleChange(e.target.value)
 
-              {session ? (
-                <InputGroup>
-                  <InputGroupInput
-                    id="newPassword"
-                    name="newPassword"
-                    type={isNewPasswordVisible ? "text" : "password"}
-                    autoComplete="new-password"
-                    placeholder={localization.auth.newPasswordPlaceholder}
-                    value={newPassword}
-                    onChange={(e) => {
-                      setNewPassword(e.target.value)
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            newPassword: undefined
+                          }))
+                        }}
+                        minLength={emailAndPassword.minPasswordLength}
+                        maxLength={emailAndPassword.maxPasswordLength}
+                        disabled={isPending}
+                        required
+                        onInvalid={(e) => {
+                          e.preventDefault()
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            newPassword: (e.target as HTMLInputElement)
+                              .validationMessage
+                          }))
+                        }}
+                        aria-invalid={!!fieldErrors.newPassword}
+                      />
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        newPassword: undefined
-                      }))
-                    }}
-                    minLength={emailAndPassword.minPasswordLength}
-                    maxLength={emailAndPassword.maxPasswordLength}
-                    disabled={isPending}
-                    required
-                    onInvalid={(e) => {
-                      e.preventDefault()
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        newPassword: (e.target as HTMLInputElement)
-                          .validationMessage
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.newPassword}
-                  />
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={
+                            isNewPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() =>
+                            setIsNewPasswordVisible((visible) => !visible)
+                          }
+                        >
+                          {isNewPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  ) : (
+                    <Skeleton>
+                      <Input className="invisible" />
+                    </Skeleton>
+                  )}
 
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      size="icon-xs"
-                      aria-label={
-                        isNewPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      onClick={() =>
-                        setIsNewPasswordVisible((visible) => !visible)
-                      }
-                    >
-                      {isNewPasswordVisible ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
-              ) : (
-                <Skeleton>
-                  <Input className="invisible" />
-                </Skeleton>
+                  <FieldError>{fieldErrors.newPassword}</FieldError>
+
+                  <PasswordStrengthMeter password={field.state.value} />
+                </Field>
               )}
-
-              <FieldError>{fieldErrors.newPassword}</FieldError>
-
-              <PasswordStrengthMeter password={newPassword} />
-            </Field>
+            </form.Field>
 
             {emailAndPassword.confirmPassword && (
-              <Field data-invalid={!!fieldErrors.confirmPassword}>
-                <FieldLabel htmlFor="confirmPassword">
-                  {localization.auth.confirmPassword}
-                </FieldLabel>
+              <form.Field name="confirmPassword">
+                {(field) => (
+                  <Field data-invalid={!!fieldErrors.confirmPassword}>
+                    <FieldLabel htmlFor="confirmPassword">
+                      {localization.auth.confirmPassword}
+                    </FieldLabel>
 
-                {session ? (
-                  <InputGroup>
-                    <InputGroupInput
-                      id="confirmPassword"
-                      name="confirmPassword"
-                      type={isConfirmPasswordVisible ? "text" : "password"}
-                      autoComplete="new-password"
-                      placeholder={localization.auth.confirmPasswordPlaceholder}
-                      value={confirmPassword}
-                      onChange={(e) => {
-                        setConfirmPassword(e.target.value)
+                    {session ? (
+                      <InputGroup>
+                        <InputGroupInput
+                          id="confirmPassword"
+                          name={field.name}
+                          type={isConfirmPasswordVisible ? "text" : "password"}
+                          autoComplete="new-password"
+                          placeholder={
+                            localization.auth.confirmPasswordPlaceholder
+                          }
+                          value={field.state.value}
+                          onChange={(e) => {
+                            field.handleChange(e.target.value)
 
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          confirmPassword: undefined
-                        }))
-                      }}
-                      minLength={emailAndPassword.minPasswordLength}
-                      maxLength={emailAndPassword.maxPasswordLength}
-                      disabled={isPending}
-                      required
-                      onInvalid={(e) => {
-                        e.preventDefault()
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              confirmPassword: undefined
+                            }))
+                          }}
+                          minLength={emailAndPassword.minPasswordLength}
+                          maxLength={emailAndPassword.maxPasswordLength}
+                          disabled={isPending}
+                          required
+                          onInvalid={(e) => {
+                            e.preventDefault()
 
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          confirmPassword: (e.target as HTMLInputElement)
-                            .validationMessage
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.confirmPassword}
-                    />
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              confirmPassword: (e.target as HTMLInputElement)
+                                .validationMessage
+                            }))
+                          }}
+                          aria-invalid={!!fieldErrors.confirmPassword}
+                        />
 
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isConfirmPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() =>
-                          setIsConfirmPasswordVisible((visible) => !visible)
-                        }
-                      >
-                        {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                ) : (
-                  <Skeleton>
-                    <Input className="invisible" />
-                  </Skeleton>
+                        <InputGroupAddon align="inline-end">
+                          <InputGroupButton
+                            size="icon-xs"
+                            aria-label={
+                              isConfirmPasswordVisible
+                                ? localization.auth.hidePassword
+                                : localization.auth.showPassword
+                            }
+                            onClick={() =>
+                              setIsConfirmPasswordVisible((visible) => !visible)
+                            }
+                          >
+                            {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
+                          </InputGroupButton>
+                        </InputGroupAddon>
+                      </InputGroup>
+                    ) : (
+                      <Skeleton>
+                        <Input className="invisible" />
+                      </Skeleton>
+                    )}
+
+                    <FieldError>{fieldErrors.confirmPassword}</FieldError>
+                  </Field>
                 )}
-
-                <FieldError>{fieldErrors.confirmPassword}</FieldError>
-              </Field>
+              </form.Field>
             )}
           </CardContent>
 

--- a/examples/next-shadcn-example/src/components/auth/sign-up.tsx
+++ b/examples/next-shadcn-example/src/components/auth/sign-up.tsx
@@ -102,7 +102,8 @@ export function SignUp({
           }))
         }
 
-        form.reset()
+        form.setFieldValue("password", "")
+        form.setFieldValue("confirmPassword", "")
         resetFetchOptions()
       },
       onSuccess: (_data, { email }) => {
@@ -159,7 +160,8 @@ export function SignUp({
         value.password !== value.confirmPassword
       ) {
         toast.error(localization.auth.passwordsDoNotMatch)
-        form.reset()
+        form.setFieldValue("password", "")
+        form.setFieldValue("confirmPassword", "")
         return
       }
 

--- a/examples/next-shadcn-example/src/components/auth/sign-up.tsx
+++ b/examples/next-shadcn-example/src/components/auth/sign-up.tsx
@@ -12,9 +12,10 @@ import {
   useFetchOptions,
   useSignUpEmail
 } from "@better-auth-ui/react"
+import { useForm } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { type FormEvent, useRef, useState } from "react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -88,9 +89,6 @@ export function SignUp({
 
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
 
-  const [password, setPassword] = useState("")
-  const [confirmPassword, setConfirmPassword] = useState("")
-
   const { mutate: signUpEmail, isPending: signUpEmailPending } = useSignUpEmail(
     authClient,
     {
@@ -104,8 +102,7 @@ export function SignUp({
           }))
         }
 
-        setPassword("")
-        setConfirmPassword("")
+        form.reset()
         resetFetchOptions()
       },
       onSuccess: (_data, { email }) => {
@@ -148,21 +145,38 @@ export function SignUp({
     password?: string
     confirmPassword?: string
   }>({})
+  const additionalFieldValuesRef = useRef<Record<string, unknown>>({})
+  const form = useForm({
+    defaultValues: {
+      confirmPassword: "",
+      email: "",
+      name: "",
+      password: ""
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
+        toast.error(localization.auth.passwordsDoNotMatch)
+        form.reset()
+        return
+      }
 
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    // `emailAndPassword.name === false` hides the name field and submits "".
-    const name = (formData.get("name") as string | null) ?? ""
-    const email = formData.get("email") as string
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      toast.error(localization.auth.passwordsDoNotMatch)
-      setPassword("")
-      setConfirmPassword("")
-      return
+      signUpEmail({
+        name: emailAndPassword?.name === false ? "" : value.name,
+        email: value.email,
+        password: value.password,
+        ...additionalFieldValuesRef.current,
+        fetchOptions
+      })
     }
+  })
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const formData = new FormData(event.currentTarget)
 
     const additionalFieldValues: Record<string, unknown> = {}
 
@@ -187,13 +201,8 @@ export function SignUp({
       }
     }
 
-    signUpEmail({
-      name,
-      email,
-      password,
-      ...additionalFieldValues,
-      fetchOptions
-    })
+    additionalFieldValuesRef.current = additionalFieldValues
+    await form.handleSubmit()
   }
 
   const showSeparator =
@@ -228,76 +237,88 @@ export function SignUp({
             <form onSubmit={handleSubmit}>
               <FieldGroup>
                 {emailAndPassword.name !== false && (
-                  <Field data-invalid={!!fieldErrors.name}>
-                    <FieldLabel htmlFor="name">
-                      {localization.auth.name}
-                    </FieldLabel>
+                  <form.Field name="name">
+                    {(field) => (
+                      <Field data-invalid={!!fieldErrors.name}>
+                        <FieldLabel htmlFor="name">
+                          {localization.auth.name}
+                        </FieldLabel>
 
-                    <Input
-                      id="name"
-                      name="name"
-                      type="text"
-                      autoComplete="name"
-                      placeholder={localization.auth.namePlaceholder}
-                      required
-                      disabled={isPending}
-                      onChange={() => {
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          name: undefined
-                        }))
-                      }}
-                      onInvalid={(e) => {
-                        e.preventDefault()
+                        <Input
+                          id="name"
+                          name={field.name}
+                          type="text"
+                          autoComplete="name"
+                          placeholder={localization.auth.namePlaceholder}
+                          required
+                          disabled={isPending}
+                          value={field.state.value}
+                          onChange={(event) => {
+                            field.handleChange(event.target.value)
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              name: undefined
+                            }))
+                          }}
+                          onInvalid={(e) => {
+                            e.preventDefault()
 
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          name: localization.auth.fieldRequired
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.name}
-                    />
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              name: localization.auth.fieldRequired
+                            }))
+                          }}
+                          aria-invalid={!!fieldErrors.name}
+                        />
 
-                    <FieldError>{fieldErrors.name}</FieldError>
-                  </Field>
+                        <FieldError>{fieldErrors.name}</FieldError>
+                      </Field>
+                    )}
+                  </form.Field>
                 )}
 
-                <Field data-invalid={!!fieldErrors.email}>
-                  <FieldLabel htmlFor="email">
-                    {localization.auth.email}
-                  </FieldLabel>
+                <form.Field name="email">
+                  {(field) => (
+                    <Field data-invalid={!!fieldErrors.email}>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
 
-                  <Input
-                    id="email"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    placeholder={localization.auth.emailPlaceholder}
-                    required
-                    disabled={isPending}
-                    onChange={() => {
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: undefined
-                      }))
-                    }}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-                      const el = e.target as HTMLInputElement
-                      const msg = el.validity.valueMissing
-                        ? localization.auth.fieldRequired
-                        : localization.auth.invalidEmail
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onChange={(event) => {
+                          field.handleChange(event.target.value)
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            email: undefined
+                          }))
+                        }}
+                        onInvalid={(e) => {
+                          e.preventDefault()
+                          const el = e.target as HTMLInputElement
+                          const msg = el.validity.valueMissing
+                            ? localization.auth.fieldRequired
+                            : localization.auth.invalidEmail
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: msg
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            email: msg
+                          }))
+                        }}
+                        aria-invalid={!!fieldErrors.email}
+                      />
 
-                  <FieldError>{fieldErrors.email}</FieldError>
-                </Field>
+                      <FieldError>{fieldErrors.email}</FieldError>
+                    </Field>
+                  )}
+                </form.Field>
 
                 {additionalFields?.map(
                   (field) =>
@@ -312,159 +333,171 @@ export function SignUp({
                     )
                 )}
 
-                <Field data-invalid={!!fieldErrors.password}>
-                  <FieldLabel htmlFor="password">
-                    {localization.auth.password}
-                  </FieldLabel>
+                <form.Field name="password">
+                  {(field) => (
+                    <Field data-invalid={!!fieldErrors.password}>
+                      <FieldLabel htmlFor="password">
+                        {localization.auth.password}
+                      </FieldLabel>
 
-                  <InputGroup>
-                    <InputGroupInput
-                      id="password"
-                      name="password"
-                      type={isPasswordVisible ? "text" : "password"}
-                      autoComplete="new-password"
-                      value={password}
-                      onChange={(e) => {
-                        setPassword(e.target.value)
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: undefined
-                        }))
-                      }}
-                      placeholder={localization.auth.passwordPlaceholder}
-                      required
-                      minLength={emailAndPassword?.minPasswordLength}
-                      maxLength={emailAndPassword?.maxPasswordLength}
-                      disabled={isPending}
-                      onInvalid={(e) => {
-                        e.preventDefault()
-                        const el = e.target as HTMLInputElement
-                        const min = emailAndPassword?.minPasswordLength
-                        const max = emailAndPassword?.maxPasswordLength
-                        const msg = el.validity.valueMissing
-                          ? localization.auth.fieldRequired
-                          : el.validity.tooShort
-                            ? localization.auth.tooShort.replace(
-                                "{{min}}",
-                                String(min)
-                              )
-                            : localization.auth.tooLong.replace(
-                                "{{max}}",
-                                String(max)
-                              )
+                      <InputGroup>
+                        <InputGroupInput
+                          id="password"
+                          name={field.name}
+                          type={isPasswordVisible ? "text" : "password"}
+                          autoComplete="new-password"
+                          value={field.state.value}
+                          onChange={(e) => {
+                            field.handleChange(e.target.value)
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              password: undefined
+                            }))
+                          }}
+                          placeholder={localization.auth.passwordPlaceholder}
+                          required
+                          minLength={emailAndPassword?.minPasswordLength}
+                          maxLength={emailAndPassword?.maxPasswordLength}
+                          disabled={isPending}
+                          onInvalid={(e) => {
+                            e.preventDefault()
+                            const el = e.target as HTMLInputElement
+                            const min = emailAndPassword?.minPasswordLength
+                            const max = emailAndPassword?.maxPasswordLength
+                            const msg = el.validity.valueMissing
+                              ? localization.auth.fieldRequired
+                              : el.validity.tooShort
+                                ? localization.auth.tooShort.replace(
+                                    "{{min}}",
+                                    String(min)
+                                  )
+                                : localization.auth.tooLong.replace(
+                                    "{{max}}",
+                                    String(max)
+                                  )
 
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: msg
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.password}
-                    />
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              password: msg
+                            }))
+                          }}
+                          aria-invalid={!!fieldErrors.password}
+                        />
 
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        title={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() => {
-                          setIsPasswordVisible((visible) => !visible)
-                        }}
-                      >
-                        {isPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
+                        <InputGroupAddon align="inline-end">
+                          <InputGroupButton
+                            size="icon-xs"
+                            aria-label={
+                              isPasswordVisible
+                                ? localization.auth.hidePassword
+                                : localization.auth.showPassword
+                            }
+                            title={
+                              isPasswordVisible
+                                ? localization.auth.hidePassword
+                                : localization.auth.showPassword
+                            }
+                            onClick={() => {
+                              setIsPasswordVisible((visible) => !visible)
+                            }}
+                          >
+                            {isPasswordVisible ? <EyeOff /> : <Eye />}
+                          </InputGroupButton>
+                        </InputGroupAddon>
+                      </InputGroup>
 
-                  <FieldError>{fieldErrors.password}</FieldError>
+                      <FieldError>{fieldErrors.password}</FieldError>
 
-                  <PasswordStrengthMeter password={password} />
-                </Field>
+                      <PasswordStrengthMeter password={field.state.value} />
+                    </Field>
+                  )}
+                </form.Field>
 
                 {emailAndPassword?.confirmPassword && (
-                  <Field data-invalid={!!fieldErrors.confirmPassword}>
-                    <FieldLabel htmlFor="confirmPassword">
-                      {localization.auth.confirmPassword}
-                    </FieldLabel>
+                  <form.Field name="confirmPassword">
+                    {(field) => (
+                      <Field data-invalid={!!fieldErrors.confirmPassword}>
+                        <FieldLabel htmlFor="confirmPassword">
+                          {localization.auth.confirmPassword}
+                        </FieldLabel>
 
-                    <InputGroup>
-                      <InputGroupInput
-                        id="confirmPassword"
-                        name="confirmPassword"
-                        type={isConfirmPasswordVisible ? "text" : "password"}
-                        autoComplete="new-password"
-                        value={confirmPassword}
-                        onChange={(e) => {
-                          setConfirmPassword(e.target.value)
+                        <InputGroup>
+                          <InputGroupInput
+                            id="confirmPassword"
+                            name={field.name}
+                            type={
+                              isConfirmPasswordVisible ? "text" : "password"
+                            }
+                            autoComplete="new-password"
+                            value={field.state.value}
+                            onChange={(e) => {
+                              field.handleChange(e.target.value)
 
-                          setFieldErrors((prev) => ({
-                            ...prev,
-                            confirmPassword: undefined
-                          }))
-                        }}
-                        placeholder={
-                          localization.auth.confirmPasswordPlaceholder
-                        }
-                        required
-                        minLength={emailAndPassword?.minPasswordLength}
-                        maxLength={emailAndPassword?.maxPasswordLength}
-                        disabled={isPending}
-                        onInvalid={(e) => {
-                          e.preventDefault()
-                          const el = e.target as HTMLInputElement
-                          const min = emailAndPassword?.minPasswordLength
-                          const max = emailAndPassword?.maxPasswordLength
-                          const msg = el.validity.valueMissing
-                            ? localization.auth.fieldRequired
-                            : el.validity.tooShort
-                              ? localization.auth.tooShort.replace(
-                                  "{{min}}",
-                                  String(min)
+                              setFieldErrors((prev) => ({
+                                ...prev,
+                                confirmPassword: undefined
+                              }))
+                            }}
+                            placeholder={
+                              localization.auth.confirmPasswordPlaceholder
+                            }
+                            required
+                            minLength={emailAndPassword?.minPasswordLength}
+                            maxLength={emailAndPassword?.maxPasswordLength}
+                            disabled={isPending}
+                            onInvalid={(e) => {
+                              e.preventDefault()
+                              const el = e.target as HTMLInputElement
+                              const min = emailAndPassword?.minPasswordLength
+                              const max = emailAndPassword?.maxPasswordLength
+                              const msg = el.validity.valueMissing
+                                ? localization.auth.fieldRequired
+                                : el.validity.tooShort
+                                  ? localization.auth.tooShort.replace(
+                                      "{{min}}",
+                                      String(min)
+                                    )
+                                  : localization.auth.tooLong.replace(
+                                      "{{max}}",
+                                      String(max)
+                                    )
+
+                              setFieldErrors((prev) => ({
+                                ...prev,
+                                confirmPassword: msg
+                              }))
+                            }}
+                            aria-invalid={!!fieldErrors.confirmPassword}
+                          />
+
+                          <InputGroupAddon align="inline-end">
+                            <InputGroupButton
+                              size="icon-xs"
+                              aria-label={
+                                isConfirmPasswordVisible
+                                  ? localization.auth.hidePassword
+                                  : localization.auth.showPassword
+                              }
+                              title={
+                                isConfirmPasswordVisible
+                                  ? localization.auth.hidePassword
+                                  : localization.auth.showPassword
+                              }
+                              onClick={() =>
+                                setIsConfirmPasswordVisible(
+                                  (visible) => !visible
                                 )
-                              : localization.auth.tooLong.replace(
-                                  "{{max}}",
-                                  String(max)
-                                )
+                              }
+                            >
+                              {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
+                            </InputGroupButton>
+                          </InputGroupAddon>
+                        </InputGroup>
 
-                          setFieldErrors((prev) => ({
-                            ...prev,
-                            confirmPassword: msg
-                          }))
-                        }}
-                        aria-invalid={!!fieldErrors.confirmPassword}
-                      />
-
-                      <InputGroupAddon align="inline-end">
-                        <InputGroupButton
-                          size="icon-xs"
-                          aria-label={
-                            isConfirmPasswordVisible
-                              ? localization.auth.hidePassword
-                              : localization.auth.showPassword
-                          }
-                          title={
-                            isConfirmPasswordVisible
-                              ? localization.auth.hidePassword
-                              : localization.auth.showPassword
-                          }
-                          onClick={() =>
-                            setIsConfirmPasswordVisible((visible) => !visible)
-                          }
-                        >
-                          {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
-                        </InputGroupButton>
-                      </InputGroupAddon>
-                    </InputGroup>
-
-                    <FieldError>{fieldErrors.confirmPassword}</FieldError>
-                  </Field>
+                        <FieldError>{fieldErrors.confirmPassword}</FieldError>
+                      </Field>
+                    )}
+                  </form.Field>
                 )}
 
                 {additionalFields?.map(

--- a/examples/next-shadcn-example/src/components/auth/sso/organization-sso-providers.tsx
+++ b/examples/next-shadcn-example/src/components/auth/sso/organization-sso-providers.tsx
@@ -16,9 +16,10 @@ import {
   useSsoProviders,
   useUpdateSsoProvider
 } from "@better-auth-ui/react/plugins/sso"
+import { useForm } from "@tanstack/react-form"
 import type { BetterFetchError } from "better-auth/client"
 import { PencilIcon, Trash2Icon } from "lucide-react"
-import { type FormEvent, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -80,8 +81,27 @@ export type OrganizationSsoProvidersProps = {
 
 const providerSkeletonIds = ["sso-provider-1", "sso-provider-2"]
 
-const readString = (formData: FormData, name: string) =>
-  String(formData.get(name) ?? "").trim()
+type SsoProviderEditorValues = {
+  clientId: string
+  clientSecret: string
+  discoveryEndpoint: string
+  domain: string
+  entryPoint: string
+  identityProviderMetadata: string
+  issuer: string
+}
+
+const getSsoProviderEditorValues = (
+  provider?: SsoProvider
+): SsoProviderEditorValues => ({
+  clientId: "",
+  clientSecret: "",
+  discoveryEndpoint: provider?.oidcConfig?.discoveryEndpoint ?? "",
+  domain: provider?.domain ?? "",
+  entryPoint: provider?.samlConfig?.entryPoint ?? "",
+  identityProviderMetadata: "",
+  issuer: provider?.issuer ?? ""
+})
 
 const getErrorMessage = (error: Error | null) => {
   const authError = error as BetterFetchError | null
@@ -240,7 +260,11 @@ export function OrganizationSsoProviders({
         )}
       </CardContent>
 
-      <EditSsoProviderDialog onOpenChange={setEditing} provider={editing} />
+      <EditSsoProviderDialog
+        key={editing?.providerId ?? "closed"}
+        onOpenChange={setEditing}
+        provider={editing}
+      />
       <DeleteSsoProviderDialog onOpenChange={setDeleting} provider={deleting} />
       <Dialog
         open={Boolean(verifying)}
@@ -277,49 +301,47 @@ function EditSsoProviderDialog({
     update.reset()
     onOpenChange(undefined)
   }
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!provider) return
-    const data = new FormData(event.currentTarget)
-    const clientId = readString(data, "clientId")
-    const clientSecret = readString(data, "clientSecret")
-    const identityProviderMetadata = readString(
-      data,
-      "identityProviderMetadata"
-    )
-    const params = {
-      providerId: provider.providerId,
-      issuer: readString(data, "issuer"),
-      domain: readString(data, "domain"),
-      ...(provider.oidcConfig
-        ? {
-            oidcConfig: {
-              ...(clientId ? { clientId } : {}),
-              ...(clientSecret ? { clientSecret } : {}),
-              discoveryEndpoint:
-                readString(data, "discoveryEndpoint") || undefined
+  const form = useForm({
+    defaultValues: getSsoProviderEditorValues(provider),
+    onSubmit: async ({ value }) => {
+      if (!provider) return
+      const clientId = value.clientId.trim()
+      const clientSecret = value.clientSecret.trim()
+      const identityProviderMetadata = value.identityProviderMetadata.trim()
+      const params = {
+        providerId: provider.providerId,
+        issuer: value.issuer.trim(),
+        domain: value.domain.trim(),
+        ...(provider.oidcConfig
+          ? {
+              oidcConfig: {
+                ...(clientId ? { clientId } : {}),
+                ...(clientSecret ? { clientSecret } : {}),
+                discoveryEndpoint: value.discoveryEndpoint.trim() || undefined
+              }
             }
-          }
-        : {}),
-      ...(provider.samlConfig
-        ? {
-            samlConfig: {
-              entryPoint: readString(data, "entryPoint"),
-              ...(identityProviderMetadata
-                ? { idpMetadata: { metadata: identityProviderMetadata } }
-                : {})
+          : {}),
+        ...(provider.samlConfig
+          ? {
+              samlConfig: {
+                entryPoint: value.entryPoint.trim(),
+                ...(identityProviderMetadata
+                  ? { idpMetadata: { metadata: identityProviderMetadata } }
+                  : {})
+              }
             }
-          }
-        : {})
-    } as UpdateSsoProviderParams
+          : {})
+      } as UpdateSsoProviderParams
 
-    update.mutate(params, {
-      onSuccess: () => {
+      try {
+        await update.mutateAsync(params)
         toast.success(localization.providerUpdated)
         close()
+      } catch {
+        // The mutation error is rendered below the fields.
       }
-    })
-  }
+    }
+  })
 
   return (
     <Dialog
@@ -329,98 +351,148 @@ function EditSsoProviderDialog({
       }}
     >
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
-        <form className="flex flex-col gap-4" onSubmit={submit}>
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void form.handleSubmit()
+          }}
+        >
           <DialogHeader>
             <DialogTitle>{localization.editProvider}</DialogTitle>
             <DialogDescription>{provider?.providerId}</DialogDescription>
           </DialogHeader>
           <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="sso-edit-domain">
-                {localization.domain}
-              </FieldLabel>
-              <Input
-                defaultValue={provider?.domain}
-                id="sso-edit-domain"
-                name="domain"
-                required
-              />
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="sso-edit-issuer">
-                {localization.issuer}
-              </FieldLabel>
-              <Input
-                defaultValue={provider?.issuer}
-                id="sso-edit-issuer"
-                name="issuer"
-                required
-                type="url"
-              />
-            </Field>
+            {(
+              [
+                ["domain", "sso-edit-domain", localization.domain, "text"],
+                ["issuer", "sso-edit-issuer", localization.issuer, "url"]
+              ] as const
+            ).map(([name, id, label, type]) => (
+              <form.Field key={name} name={name}>
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor={id}>{label}</FieldLabel>
+                    <Input
+                      id={id}
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      type={type}
+                      value={field.state.value}
+                    />
+                  </Field>
+                )}
+              </form.Field>
+            ))}
             {provider?.oidcConfig ? (
               <>
-                <Field>
-                  <FieldLabel htmlFor="sso-edit-discovery">
-                    {localization.discoveryEndpoint}
-                  </FieldLabel>
-                  <Input
-                    defaultValue={provider.oidcConfig.discoveryEndpoint}
-                    id="sso-edit-discovery"
-                    name="discoveryEndpoint"
-                    type="url"
-                  />
-                </Field>
+                <form.Field name="discoveryEndpoint">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="sso-edit-discovery">
+                        {localization.discoveryEndpoint}
+                      </FieldLabel>
+                      <Input
+                        id="sso-edit-discovery"
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        type="url"
+                        value={field.state.value}
+                      />
+                    </Field>
+                  )}
+                </form.Field>
                 <div className="grid gap-4 sm:grid-cols-2">
-                  <Field>
-                    <FieldLabel htmlFor="sso-edit-client-id">
-                      {localization.clientId}
-                    </FieldLabel>
-                    <Input
-                      id="sso-edit-client-id"
-                      name="clientId"
-                      placeholder={`••••${provider.oidcConfig.clientIdLastFour}`}
-                    />
-                  </Field>
-                  <Field>
-                    <FieldLabel htmlFor="sso-edit-client-secret">
-                      {localization.clientSecret}
-                    </FieldLabel>
-                    <Input
-                      autoComplete="new-password"
-                      id="sso-edit-client-secret"
-                      name="clientSecret"
-                      type="password"
-                    />
-                  </Field>
+                  {(
+                    [
+                      ["clientId", "sso-edit-client-id", localization.clientId],
+                      [
+                        "clientSecret",
+                        "sso-edit-client-secret",
+                        localization.clientSecret
+                      ]
+                    ] as const
+                  ).map(([name, id, label]) => (
+                    <form.Field key={name} name={name}>
+                      {(field) => (
+                        <Field>
+                          <FieldLabel htmlFor={id}>{label}</FieldLabel>
+                          <Input
+                            autoComplete={
+                              name === "clientSecret"
+                                ? "new-password"
+                                : undefined
+                            }
+                            id={id}
+                            name={field.name}
+                            onBlur={field.handleBlur}
+                            onChange={(event) =>
+                              field.handleChange(event.target.value)
+                            }
+                            placeholder={
+                              name === "clientId"
+                                ? `••••${provider.oidcConfig?.clientIdLastFour}`
+                                : undefined
+                            }
+                            type={name === "clientSecret" ? "password" : "text"}
+                            value={field.state.value}
+                          />
+                        </Field>
+                      )}
+                    </form.Field>
+                  ))}
                 </div>
               </>
             ) : null}
             {provider?.samlConfig ? (
               <>
-                <Field>
-                  <FieldLabel htmlFor="sso-edit-entry-point">
-                    {localization.entryPoint}
-                  </FieldLabel>
-                  <Input
-                    defaultValue={provider.samlConfig.entryPoint}
-                    id="sso-edit-entry-point"
-                    name="entryPoint"
-                    required
-                    type="url"
-                  />
-                </Field>
-                <Field>
-                  <FieldLabel htmlFor="sso-edit-metadata">
-                    {localization.identityProviderMetadata}
-                  </FieldLabel>
-                  <Textarea
-                    className="font-mono text-xs"
-                    id="sso-edit-metadata"
-                    name="identityProviderMetadata"
-                    rows={6}
-                  />
-                </Field>
+                <form.Field name="entryPoint">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="sso-edit-entry-point">
+                        {localization.entryPoint}
+                      </FieldLabel>
+                      <Input
+                        id="sso-edit-entry-point"
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        required
+                        type="url"
+                        value={field.state.value}
+                      />
+                    </Field>
+                  )}
+                </form.Field>
+                <form.Field name="identityProviderMetadata">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="sso-edit-metadata">
+                        {localization.identityProviderMetadata}
+                      </FieldLabel>
+                      <Textarea
+                        className="font-mono text-xs"
+                        id="sso-edit-metadata"
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        rows={6}
+                        value={field.state.value}
+                      />
+                    </Field>
+                  )}
+                </form.Field>
               </>
             ) : null}
           </FieldGroup>
@@ -434,10 +506,14 @@ function EditSsoProviderDialog({
             >
               {localization.cancel}
             </Button>
-            <Button disabled={update.isPending} type="submit">
-              {update.isPending ? <Spinner data-icon="inline-start" /> : null}
-              {localization.saveProvider}
-            </Button>
+            <form.Subscribe selector={(state) => state.isSubmitting}>
+              {(isSubmitting) => (
+                <Button disabled={isSubmitting} type="submit">
+                  {isSubmitting ? <Spinner data-icon="inline-start" /> : null}
+                  {localization.saveProvider}
+                </Button>
+              )}
+            </form.Subscribe>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
@@ -27,6 +27,7 @@ import {
   useAdminUserSessions,
   useAdminUsers
 } from "@better-auth-ui/react/plugins/admin"
+import { useForm } from "@tanstack/react-form"
 import { keepPreviousData, useMutation } from "@tanstack/react-query"
 import {
   type ColumnFiltersState,
@@ -705,26 +706,51 @@ function CreateUserDialog({
   const auth = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
   const { data: session } = useSession(auth.authClient)
-  const [password, setPassword] = useState("")
-  const [emailVerified, setEmailVerified] = useState(false)
   const [formError, setFormError] = useState<string>()
-  const [roles, setRoles] = useState([config.defaultRole])
-
-  useEffect(() => {
-    if (!config.allowMultipleRoles) setRoles((current) => current.slice(0, 1))
-  }, [config.allowMultipleRoles])
   const canSetRole = useAdminPermission(auth.authClient, {
     user: ["set-role"]
   })
   const createUser = useMutation(
     createAdminUserOptions(auth.authClient, session?.user.id)
   )
+  const additionalFieldValuesRef = useRef<
+    Record<string, AdditionalFieldValue | null>
+  >({})
+  const form = useForm({
+    defaultValues: {
+      email: "",
+      emailVerified: false,
+      name: "",
+      password: "",
+      roles: [config.defaultRole]
+    },
+    onSubmit: ({ value }) => {
+      createUser.mutate(
+        {
+          data: {
+            ...additionalFieldValuesRef.current,
+            emailVerified: value.emailVerified
+          },
+          email: value.email,
+          name: value.name,
+          password: value.password,
+          ...(canSetRole.data?.success
+            ? { role: asAdminRoles(value.roles) }
+            : {})
+        },
+        { onSuccess: close }
+      )
+    }
+  })
+
+  useEffect(() => {
+    if (!config.allowMultipleRoles)
+      form.setFieldValue("roles", (current) => current.slice(0, 1))
+  }, [config.allowMultipleRoles, form.setFieldValue])
 
   const close = () => {
-    setPassword("")
-    setEmailVerified(false)
+    form.reset()
     setFormError(undefined)
-    setRoles([config.defaultRole])
     createUser.reset()
     onOpenChange(false)
   }
@@ -742,16 +768,8 @@ function CreateUserDialog({
       return
     }
     setFormError(undefined)
-    createUser.mutate(
-      {
-        data: { ...additionalFieldValues, emailVerified },
-        email: String(data.get("email")),
-        name: String(data.get("name")),
-        password,
-        ...(canSetRole.data?.success ? { role: asAdminRoles(roles) } : {})
-      },
-      { onSuccess: close }
-    )
+    additionalFieldValuesRef.current = additionalFieldValues
+    await form.handleSubmit()
   }
 
   return (
@@ -768,43 +786,70 @@ function CreateUserDialog({
             </DialogDescription>
           </DialogHeader>
           <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="admin-create-name">
-                {config.localization.name}
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupInput id="admin-create-name" name="name" required />
-              </InputGroup>
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="admin-create-email">
-                {config.localization.email}
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupInput
-                  autoComplete="off"
-                  id="admin-create-email"
-                  name="email"
-                  required
-                  type="email"
-                />
-              </InputGroup>
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="admin-create-password">
-                {config.localization.password}
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupInput
-                  autoComplete="new-password"
-                  id="admin-create-password"
-                  onChange={(event) => setPassword(event.target.value)}
-                  required
-                  type="password"
-                  value={password}
-                />
-              </InputGroup>
-            </Field>
+            <form.Field name="name">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="admin-create-name">
+                    {config.localization.name}
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupInput
+                      id="admin-create-name"
+                      name={field.name}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      value={field.state.value}
+                    />
+                  </InputGroup>
+                </Field>
+              )}
+            </form.Field>
+            <form.Field name="email">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="admin-create-email">
+                    {config.localization.email}
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupInput
+                      autoComplete="off"
+                      id="admin-create-email"
+                      name={field.name}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      type="email"
+                      value={field.state.value}
+                    />
+                  </InputGroup>
+                </Field>
+              )}
+            </form.Field>
+            <form.Field name="password">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="admin-create-password">
+                    {config.localization.password}
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupInput
+                      autoComplete="new-password"
+                      id="admin-create-password"
+                      name={field.name}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      type="password"
+                      value={field.state.value}
+                    />
+                  </InputGroup>
+                </Field>
+              )}
+            </form.Field>
             {canSetRole.isPending ? (
               <Skeleton className="h-16 w-full" />
             ) : canSetRole.data?.success ? (
@@ -812,58 +857,68 @@ function CreateUserDialog({
                 <FieldLegend variant="label">
                   {config.localization.role}
                 </FieldLegend>
-                {config.allowMultipleRoles ? (
-                  <FieldGroup data-slot="checkbox-group">
-                    {config.roles.map((role) => (
-                      <Field key={role} orientation="horizontal">
-                        <Checkbox
-                          checked={roles.includes(role)}
-                          id={`admin-create-role-${role}`}
-                          onCheckedChange={(checked) => {
-                            const next = checked
-                              ? [...roles, role]
-                              : roles.filter((item) => item !== role)
-                            if (next.length) setRoles(next)
-                          }}
-                        />
-                        <FieldLabel htmlFor={`admin-create-role-${role}`}>
-                          {role}
-                        </FieldLabel>
-                      </Field>
-                    ))}
-                  </FieldGroup>
-                ) : (
-                  <RadioGroup
-                    onValueChange={(role) => setRoles([role])}
-                    value={roles[0] ?? ""}
-                  >
-                    {config.roles.map((role) => (
-                      <Field key={role} orientation="horizontal">
-                        <RadioGroupItem
-                          id={`admin-create-role-${role}`}
-                          value={role}
-                        />
-                        <FieldLabel htmlFor={`admin-create-role-${role}`}>
-                          {role}
-                        </FieldLabel>
-                      </Field>
-                    ))}
-                  </RadioGroup>
-                )}
+                <form.Field name="roles">
+                  {(field) =>
+                    config.allowMultipleRoles ? (
+                      <FieldGroup data-slot="checkbox-group">
+                        {config.roles.map((role) => (
+                          <Field key={role} orientation="horizontal">
+                            <Checkbox
+                              checked={field.state.value.includes(role)}
+                              id={`admin-create-role-${role}`}
+                              onCheckedChange={(checked) => {
+                                const next = checked
+                                  ? [...field.state.value, role]
+                                  : field.state.value.filter(
+                                      (item) => item !== role
+                                    )
+                                if (next.length) field.handleChange(next)
+                              }}
+                            />
+                            <FieldLabel htmlFor={`admin-create-role-${role}`}>
+                              {role}
+                            </FieldLabel>
+                          </Field>
+                        ))}
+                      </FieldGroup>
+                    ) : (
+                      <RadioGroup
+                        onValueChange={(role) => field.handleChange([role])}
+                        value={field.state.value[0] ?? ""}
+                      >
+                        {config.roles.map((role) => (
+                          <Field key={role} orientation="horizontal">
+                            <RadioGroupItem
+                              id={`admin-create-role-${role}`}
+                              value={role}
+                            />
+                            <FieldLabel htmlFor={`admin-create-role-${role}`}>
+                              {role}
+                            </FieldLabel>
+                          </Field>
+                        ))}
+                      </RadioGroup>
+                    )
+                  }
+                </form.Field>
               </FieldSet>
             ) : null}
-            <Field orientation="horizontal">
-              <Switch
-                checked={emailVerified}
-                id="admin-create-email-verified"
-                onCheckedChange={setEmailVerified}
-              />
-              <FieldContent>
-                <FieldLabel htmlFor="admin-create-email-verified">
-                  {config.localization.emailVerified}
-                </FieldLabel>
-              </FieldContent>
-            </Field>
+            <form.Field name="emailVerified">
+              {(field) => (
+                <Field orientation="horizontal">
+                  <Switch
+                    checked={field.state.value}
+                    id="admin-create-email-verified"
+                    onCheckedChange={field.handleChange}
+                  />
+                  <FieldContent>
+                    <FieldLabel htmlFor="admin-create-email-verified">
+                      {config.localization.emailVerified}
+                    </FieldLabel>
+                  </FieldContent>
+                </Field>
+              )}
+            </form.Field>
             {auth.additionalFields?.map((field) => (
               <AdditionalField
                 field={field}
@@ -980,10 +1035,6 @@ function UserInspector({
     },
     { enabled: Boolean(userId) }
   )
-  const [name, setName] = useState("")
-  const [email, setEmail] = useState("")
-  const [emailVerified, setEmailVerified] = useState(false)
-  const [roles, setRoles] = useState([config.defaultRole])
   const [banReason, setBanReason] = useState("")
   const [banDuration, setBanDuration] = useState("")
   const banDurationSeconds = getBanDurationSeconds(banDuration)
@@ -996,22 +1047,6 @@ function UserInspector({
   const updateUser = useMutation(
     updateAdminUserOptions(auth.authClient, actor?.user.id)
   )
-
-  useEffect(() => {
-    setName(user?.name ?? "")
-    setEmail(user?.email ?? "")
-    setEmailVerified(user?.emailVerified ?? false)
-    setRoles(
-      parseAdminRoles(user?.role, config.defaultRole, config.allowMultipleRoles)
-    )
-  }, [
-    config.allowMultipleRoles,
-    config.defaultRole,
-    user?.email,
-    user?.emailVerified,
-    user?.name,
-    user?.role
-  ])
 
   useEffect(() => {
     if (profileUserId.current === user?.id) return
@@ -1046,6 +1081,75 @@ function UserInspector({
   const revokeSessions = useMutation(
     revokeAdminUserSessionsOptions(auth.authClient, actor?.user.id, userId)
   )
+  const profileAdditionalFieldValuesRef = useRef<
+    Record<string, AdditionalFieldValue | null>
+  >({})
+  const profileForm = useForm({
+    defaultValues: {
+      email: "",
+      emailVerified: false,
+      name: "",
+      roles: [config.defaultRole]
+    },
+    onSubmit: async ({ value }) => {
+      if (!user) return
+
+      const mutations: Promise<unknown>[] = []
+      if (canUpdate.data?.success) {
+        mutations.push(
+          updateUser.mutateAsync({
+            userId: user.id,
+            data: {
+              ...profileAdditionalFieldValuesRef.current,
+              name: value.name.trim(),
+              ...(canSetEmail.data?.success
+                ? {
+                    email: value.email.trim(),
+                    emailVerified: value.emailVerified
+                  }
+                : {})
+            }
+          })
+        )
+      }
+      if (canSetRole.data?.success && !isSelf) {
+        mutations.push(
+          setRoleMutation.mutateAsync({
+            userId: user.id,
+            role: asAdminRoles(value.roles)
+          })
+        )
+      }
+
+      try {
+        await Promise.all(mutations)
+        onOpenChange(false)
+      } catch {
+        // Mutation errors are rendered next to the form.
+      }
+    }
+  })
+
+  useEffect(() => {
+    profileForm.reset({
+      email: user?.email ?? "",
+      emailVerified: user?.emailVerified ?? false,
+      name: user?.name ?? "",
+      roles: parseAdminRoles(
+        user?.role,
+        config.defaultRole,
+        config.allowMultipleRoles
+      )
+    })
+  }, [
+    config.allowMultipleRoles,
+    config.defaultRole,
+    profileForm.reset,
+    user?.email,
+    user?.emailVerified,
+    user?.name,
+    user?.role
+  ])
 
   const confirm = () => {
     if (!user) return
@@ -1124,7 +1228,6 @@ function UserInspector({
     event.preventDefault()
     if (!user) return
 
-    const mutations: Promise<unknown>[] = []
     if (canUpdate.data?.success) {
       const formData = new FormData(event.currentTarget)
       let additionalFieldValues: Record<string, AdditionalFieldValue | null>
@@ -1138,34 +1241,10 @@ function UserInspector({
         return
       }
       setProfileError(undefined)
-      mutations.push(
-        updateUser.mutateAsync({
-          userId: user.id,
-          data: {
-            ...additionalFieldValues,
-            name: name.trim(),
-            ...(canSetEmail.data?.success
-              ? { email: email.trim(), emailVerified }
-              : {})
-          }
-        })
-      )
-    }
-    if (canSetRole.data?.success && !isSelf) {
-      mutations.push(
-        setRoleMutation.mutateAsync({
-          userId: user.id,
-          role: asAdminRoles(roles)
-        })
-      )
+      profileAdditionalFieldValuesRef.current = additionalFieldValues
     }
 
-    try {
-      await Promise.all(mutations)
-      onOpenChange(false)
-    } catch {
-      // Mutation errors are rendered next to the form.
-    }
+    await profileForm.handleSubmit()
   }
 
   return (
@@ -1273,107 +1352,136 @@ function UserInspector({
                         {config.localization.profileAndAccess}
                       </h3>
                       <FieldGroup className="grid gap-5 md:grid-cols-2">
-                        <Field>
-                          <FieldLabel htmlFor="admin-user-name">
-                            {config.localization.name}
-                          </FieldLabel>
-                          <InputGroup>
-                            <InputGroupInput
-                              disabled={!canUpdate.data?.success}
-                              id="admin-user-name"
-                              value={name}
-                              onChange={(event) => setName(event.target.value)}
-                            />
-                          </InputGroup>
-                        </Field>
-                        <Field>
-                          <FieldLabel htmlFor="admin-user-email">
-                            {config.localization.email}
-                          </FieldLabel>
-                          <InputGroup>
-                            <InputGroupInput
-                              disabled={
-                                !canUpdate.data?.success ||
-                                !canSetEmail.data?.success
-                              }
-                              id="admin-user-email"
-                              onChange={(event) => setEmail(event.target.value)}
-                              required
-                              type="email"
-                              value={email}
-                            />
-                          </InputGroup>
-                        </Field>
-                        <Field orientation="horizontal">
-                          <Switch
-                            checked={emailVerified}
-                            disabled={
-                              !canUpdate.data?.success ||
-                              !canSetEmail.data?.success
-                            }
-                            id="admin-user-email-verified"
-                            onCheckedChange={setEmailVerified}
-                          />
-                          <FieldContent>
-                            <FieldLabel htmlFor="admin-user-email-verified">
-                              {config.localization.emailVerified}
-                            </FieldLabel>
-                          </FieldContent>
-                        </Field>
+                        <profileForm.Field name="name">
+                          {(field) => (
+                            <Field>
+                              <FieldLabel htmlFor="admin-user-name">
+                                {config.localization.name}
+                              </FieldLabel>
+                              <InputGroup>
+                                <InputGroupInput
+                                  disabled={!canUpdate.data?.success}
+                                  id="admin-user-name"
+                                  name={field.name}
+                                  value={field.state.value}
+                                  onChange={(event) =>
+                                    field.handleChange(event.target.value)
+                                  }
+                                />
+                              </InputGroup>
+                            </Field>
+                          )}
+                        </profileForm.Field>
+                        <profileForm.Field name="email">
+                          {(field) => (
+                            <Field>
+                              <FieldLabel htmlFor="admin-user-email">
+                                {config.localization.email}
+                              </FieldLabel>
+                              <InputGroup>
+                                <InputGroupInput
+                                  disabled={
+                                    !canUpdate.data?.success ||
+                                    !canSetEmail.data?.success
+                                  }
+                                  id="admin-user-email"
+                                  name={field.name}
+                                  onChange={(event) =>
+                                    field.handleChange(event.target.value)
+                                  }
+                                  required
+                                  type="email"
+                                  value={field.state.value}
+                                />
+                              </InputGroup>
+                            </Field>
+                          )}
+                        </profileForm.Field>
+                        <profileForm.Field name="emailVerified">
+                          {(field) => (
+                            <Field orientation="horizontal">
+                              <Switch
+                                checked={field.state.value}
+                                disabled={
+                                  !canUpdate.data?.success ||
+                                  !canSetEmail.data?.success
+                                }
+                                id="admin-user-email-verified"
+                                onCheckedChange={field.handleChange}
+                              />
+                              <FieldContent>
+                                <FieldLabel htmlFor="admin-user-email-verified">
+                                  {config.localization.emailVerified}
+                                </FieldLabel>
+                              </FieldContent>
+                            </Field>
+                          )}
+                        </profileForm.Field>
                         <FieldSet>
                           <FieldLegend variant="label">
                             {config.localization.role}
                           </FieldLegend>
-                          {config.allowMultipleRoles ? (
-                            <FieldGroup
-                              className="flex-row flex-wrap gap-4"
-                              data-slot="checkbox-group"
-                            >
-                              {config.roles.map((item) => (
-                                <Field key={item} orientation="horizontal">
-                                  <Checkbox
-                                    checked={roles.includes(item)}
-                                    disabled={
-                                      isSelf || !canSetRole.data?.success
-                                    }
-                                    id={`admin-user-role-${item}`}
-                                    onCheckedChange={(checked) => {
-                                      const next = checked
-                                        ? [...roles, item]
-                                        : roles.filter((role) => role !== item)
-                                      if (next.length) setRoles(next)
-                                    }}
-                                  />
-                                  <FieldLabel
-                                    htmlFor={`admin-user-role-${item}`}
-                                  >
-                                    {item}
-                                  </FieldLabel>
-                                </Field>
-                              ))}
-                            </FieldGroup>
-                          ) : (
-                            <RadioGroup
-                              className="flex-row flex-wrap gap-4"
-                              disabled={isSelf || !canSetRole.data?.success}
-                              onValueChange={(role) => setRoles([role])}
-                              value={roles[0] ?? ""}
-                            >
-                              {config.roles.map((item) => (
-                                <Field key={item} orientation="horizontal">
-                                  <RadioGroupItem
-                                    id={`admin-user-role-${item}`}
-                                    value={item}
-                                  />
-                                  <FieldLabel
-                                    htmlFor={`admin-user-role-${item}`}
-                                  >
-                                    {item}
-                                  </FieldLabel>
-                                </Field>
-                              ))}
-                            </RadioGroup>
-                          )}
+                          <profileForm.Field name="roles">
+                            {(field) =>
+                              config.allowMultipleRoles ? (
+                                <FieldGroup
+                                  className="flex-row flex-wrap gap-4"
+                                  data-slot="checkbox-group"
+                                >
+                                  {config.roles.map((item) => (
+                                    <Field key={item} orientation="horizontal">
+                                      <Checkbox
+                                        checked={field.state.value.includes(
+                                          item
+                                        )}
+                                        disabled={
+                                          isSelf || !canSetRole.data?.success
+                                        }
+                                        id={`admin-user-role-${item}`}
+                                        onCheckedChange={(checked) => {
+                                          const next = checked
+                                            ? [...field.state.value, item]
+                                            : field.state.value.filter(
+                                                (role) => role !== item
+                                              )
+                                          if (next.length)
+                                            field.handleChange(next)
+                                        }}
+                                      />
+                                      <FieldLabel
+                                        htmlFor={`admin-user-role-${item}`}
+                                      >
+                                        {item}
+                                      </FieldLabel>
+                                    </Field>
+                                  ))}
+                                </FieldGroup>
+                              ) : (
+                                <RadioGroup
+                                  className="flex-row flex-wrap gap-4"
+                                  disabled={isSelf || !canSetRole.data?.success}
+                                  onValueChange={(role) =>
+                                    field.handleChange([role])
+                                  }
+                                  value={field.state.value[0] ?? ""}
+                                >
+                                  {config.roles.map((item) => (
+                                    <Field key={item} orientation="horizontal">
+                                      <RadioGroupItem
+                                        id={`admin-user-role-${item}`}
+                                        value={item}
+                                      />
+                                      <FieldLabel
+                                        htmlFor={`admin-user-role-${item}`}
+                                      >
+                                        {item}
+                                      </FieldLabel>
+                                    </Field>
+                                  ))}
+                                </RadioGroup>
+                              )
+                            }
+                          </profileForm.Field>
                         </FieldSet>
                         {auth.additionalFields?.map((field) => {
                           const value = (
@@ -1538,21 +1646,30 @@ function UserInspector({
                     >
                       {config.localization.cancel}
                     </Button>
-                    <Button
-                      disabled={
-                        !name.trim() ||
-                        !email.trim() ||
-                        updateUser.isPending ||
-                        setRoleMutation.isPending ||
-                        canUpdate.isPending ||
-                        canSetRole.isPending ||
-                        (!canUpdate.data?.success &&
-                          (!canSetRole.data?.success || isSelf))
-                      }
-                      type="submit"
+                    <profileForm.Subscribe
+                      selector={(state) => [
+                        state.values.name,
+                        state.values.email
+                      ]}
                     >
-                      {config.localization.saveChanges}
-                    </Button>
+                      {([name, email]) => (
+                        <Button
+                          disabled={
+                            !name.trim() ||
+                            !email.trim() ||
+                            updateUser.isPending ||
+                            setRoleMutation.isPending ||
+                            canUpdate.isPending ||
+                            canSetRole.isPending ||
+                            (!canUpdate.data?.success &&
+                              (!canSetRole.data?.success || isSelf))
+                          }
+                          type="submit"
+                        >
+                          {config.localization.saveChanges}
+                        </Button>
+                      )}
+                    </profileForm.Subscribe>
                   </div>
                 </form>
               </TabsContent>

--- a/examples/start-shadcn-baseui-example/src/components/auth/api-key/api-keys.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/api-key/api-keys.tsx
@@ -1,8 +1,21 @@
 "use client"
 
-import type { ApiKeyAuthClient } from "@better-auth-ui/core/plugins/api-key"
+import type {
+  ApiKeyAuthClient,
+  ListedApiKey
+} from "@better-auth-ui/core/plugins/api-key"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useListApiKeys } from "@better-auth-ui/react/plugins/api-key"
+import {
+  createTableHook,
+  functionalUpdate,
+  type PaginationState,
+  rowPaginationFeature,
+  rowSortingFeature,
+  type SortingState,
+  tableFeatures,
+  type Updater
+} from "@tanstack/react-table"
 import { Fragment, useState } from "react"
 
 import { Button } from "@/components/ui/button"
@@ -22,6 +35,20 @@ import { ApiKey } from "./api-key"
 import { ApiKeySkeleton } from "./api-key-skeleton"
 import { ApiKeysEmpty } from "./api-keys-empty"
 import { CreateApiKeyDialog } from "./create-api-key-dialog"
+
+const { createAppColumnHelper, useAppTable: useApiKeyTable } = createTableHook({
+  enableMultiSort: false,
+  enableSortingRemoval: false,
+  sortDescFirst: false,
+  features: tableFeatures({ rowPaginationFeature, rowSortingFeature })
+})
+
+const apiKeyColumnHelper = createAppColumnHelper<ListedApiKey>()
+const apiKeyColumns = apiKeyColumnHelper.columns([
+  apiKeyColumnHelper.accessor("createdAt", { id: "createdAt" }),
+  apiKeyColumnHelper.accessor("name", { id: "name" })
+])
+const EMPTY_API_KEYS: ListedApiKey[] = []
 
 export type ApiKeysProps = {
   className?: string
@@ -48,9 +75,17 @@ export function ApiKeys({
   const { authClient } = useAuth<ApiKeyAuthClient>()
   const { localization: apiKeyLocalization, pageSize } =
     useAuthPlugin(apiKeyPlugin)
-  const [page, setPage] = useState(0)
-  const [sort, setSort] = useState("createdAt:desc")
-  const [sortBy, sortDirection] = sort.split(":") as [string, "asc" | "desc"]
+  const [pagination, setPaginationState] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const [sorting, setSortingState] = useState<SortingState>([
+    { id: "createdAt", desc: true }
+  ])
+  const primarySort = sorting[0]
+  const sortBy = primarySort?.id === "name" ? "name" : "createdAt"
+  const sortDirection = primarySort?.desc ? "desc" : "asc"
+  const sort = `${sortBy}:${sortDirection}`
   const sortItems = [
     { label: apiKeyLocalization.newest, value: "createdAt:desc" },
     { label: apiKeyLocalization.oldest, value: "createdAt:asc" },
@@ -63,8 +98,8 @@ export function ApiKeys({
     {
       enabled: !isPendingProp,
       query: {
-        limit: pageSize,
-        offset: page * pageSize,
+        limit: pagination.pageSize,
+        offset: pagination.pageIndex * pagination.pageSize,
         sortBy,
         sortDirection,
         ...(organizationId ? { organizationId, configId: "organization" } : {})
@@ -73,6 +108,22 @@ export function ApiKeys({
   )
 
   const isPending = isPendingProp || isListPending
+  const setPagination = (updater: Updater<PaginationState>) =>
+    setPaginationState((current) => functionalUpdate(updater, current))
+  const setSorting = (updater: Updater<SortingState>) => {
+    setSortingState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const table = useApiKeyTable({
+    columns: apiKeyColumns,
+    data: listData?.apiKeys ?? EMPTY_API_KEYS,
+    getRowId: (apiKey) => apiKey.id,
+    manualPagination: true,
+    manualSorting: true,
+    state: { pagination, sorting },
+    onPaginationChange: setPagination,
+    onSortingChange: setSorting
+  })
 
   const [createOpen, setCreateOpen] = useState(false)
 
@@ -98,8 +149,8 @@ export function ApiKeys({
         items={sortItems}
         value={sort}
         onValueChange={(value) => {
-          setSort(value ?? "createdAt:desc")
-          setPage(0)
+          const [id, direction] = (value ?? "createdAt:desc").split(":")
+          table.setSorting([{ id, desc: direction === "desc" }])
         }}
       >
         <SelectTrigger aria-label={apiKeyLocalization.sortBy}>
@@ -127,11 +178,11 @@ export function ApiKeys({
             />
           ) : (
             <ItemGroup className="gap-0">
-              {listData.apiKeys.map((key, index) => (
-                <Fragment key={key.id}>
+              {table.getRowModel().rows.map((row, index) => (
+                <Fragment key={row.id}>
                   {index > 0 && <ItemSeparator />}
                   <ApiKey
-                    apiKey={key}
+                    apiKey={row.original}
                     hideDelete={hideDelete}
                     hideUpdate={hideUpdate}
                     organizationId={organizationId}
@@ -142,21 +193,22 @@ export function ApiKeys({
           )}
         </CardContent>
       </Card>
-      {(page > 0 || (listData?.apiKeys.length ?? 0) === pageSize) && (
+      {(pagination.pageIndex > 0 ||
+        (listData?.apiKeys.length ?? 0) === pagination.pageSize) && (
         <div className="flex justify-end gap-2">
           <Button
             variant="outline"
             size="sm"
-            disabled={page === 0}
-            onClick={() => setPage((value) => Math.max(0, value - 1))}
+            disabled={!table.getCanPreviousPage()}
+            onClick={() => table.previousPage()}
           >
             {apiKeyLocalization.previousPage}
           </Button>
           <Button
             variant="outline"
             size="sm"
-            disabled={(listData?.apiKeys.length ?? 0) < pageSize}
-            onClick={() => setPage((value) => value + 1)}
+            disabled={(listData?.apiKeys.length ?? 0) < pagination.pageSize}
+            onClick={() => table.nextPage()}
           >
             {apiKeyLocalization.nextPage}
           </Button>

--- a/examples/start-shadcn-baseui-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/dash/activity.tsx
@@ -21,6 +21,17 @@ import {
 import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
 import { keepPreviousData } from "@tanstack/react-query"
 import {
+  type ColumnFiltersState,
+  columnFilteringFeature,
+  createTableHook,
+  functionalUpdate,
+  globalFilteringFeature,
+  type PaginationState,
+  rowPaginationFeature,
+  tableFeatures,
+  type Updater
+} from "@tanstack/react-table"
+import {
   Activity,
   Building2,
   ChevronLeft,
@@ -74,6 +85,21 @@ import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
 
 type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
+
+const { createAppColumnHelper, useAppTable: useActivityTable } =
+  createTableHook({
+    features: tableFeatures({
+      columnFilteringFeature,
+      globalFilteringFeature,
+      rowPaginationFeature
+    })
+  })
+
+const activityColumnHelper = createAppColumnHelper<DashAuditLog>()
+const activityColumns = activityColumnHelper.columns([
+  activityColumnHelper.accessor("eventType", { id: "eventType" })
+])
+const EMPTY_EVENTS: DashAuditLog[] = []
 
 type ActivityFeedProps = {
   access: ActivityAccess
@@ -212,10 +238,18 @@ function ActivityFeed({
 }: ActivityFeedProps) {
   const { authClient } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
-  const [page, setPage] = useState(0)
-  const [eventType, setEventType] = useState("all")
-  const [identifier, setIdentifier] = useState("")
-  const deferredIdentifier = useDeferredValue(identifier.trim())
+  const [pagination, setPaginationState] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const [columnFilters, setColumnFiltersState] = useState<ColumnFiltersState>(
+    []
+  )
+  const [globalFilter, setGlobalFilterState] = useState("")
+  const eventType = String(
+    columnFilters.find((filter) => filter.id === "eventType")?.value ?? "all"
+  )
+  const deferredIdentifier = useDeferredValue(globalFilter.trim())
   const eventOptions = useMemo(
     () => Object.entries(localization.eventLabels),
     [localization.eventLabels]
@@ -224,11 +258,11 @@ function ActivityFeed({
     { label: localization.allEvents, value: "all" },
     ...eventOptions.map(([value, label]) => ({ label, value }))
   ]
-  const offset = page * pageSize
+  const offset = pagination.pageIndex * pagination.pageSize
   const params = {
     eventType: eventType === "all" ? undefined : eventType,
     identifier: deferredIdentifier || undefined,
-    limit: pageSize,
+    limit: pagination.pageSize,
     offset,
     organizationId
   }
@@ -250,7 +284,7 @@ function ActivityFeed({
       params: {
         eventType: params.eventType,
         identifier: params.identifier,
-        limit: pageSize,
+        limit: pagination.pageSize,
         offset
       }
     }
@@ -264,7 +298,28 @@ function ActivityFeed({
   const { data, error, isFetching, isPending } = query
   const showPending = !ready || isPending
   const pageEnd = offset + (data?.events.length ?? 0)
-  const hasNextPage = pageEnd < (data?.total ?? 0)
+  const setPagination = (updater: Updater<PaginationState>) =>
+    setPaginationState((current) => functionalUpdate(updater, current))
+  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
+    setColumnFiltersState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const setGlobalFilter = (updater: Updater<string>) => {
+    setGlobalFilterState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const table = useActivityTable({
+    columns: activityColumns,
+    data: data?.events ?? EMPTY_EVENTS,
+    getRowId: getDashEventKey,
+    manualFiltering: true,
+    manualPagination: true,
+    rowCount: data?.total ?? 0,
+    state: { columnFilters, globalFilter, pagination },
+    onColumnFiltersChange: setColumnFilters,
+    onGlobalFilterChange: setGlobalFilter,
+    onPaginationChange: setPagination
+  })
 
   return (
     <Card
@@ -304,8 +359,9 @@ function ActivityFeed({
               value={eventType}
               onValueChange={(value) => {
                 if (!value) return
-                setEventType(value)
-                setPage(0)
+                table
+                  .getColumn("eventType")
+                  ?.setFilterValue(value === "all" ? undefined : value)
               }}
             >
               <SelectTrigger id="dash-event-type" className="w-full">
@@ -333,11 +389,10 @@ function ActivityFeed({
               <InputGroupInput
                 id="dash-identifier"
                 onChange={(event) => {
-                  setIdentifier(event.target.value)
-                  setPage(0)
+                  table.setGlobalFilter(event.target.value)
                 }}
                 placeholder={localization.identifierPlaceholder}
-                value={identifier}
+                value={globalFilter}
               />
             </InputGroup>
           </Field>
@@ -374,10 +429,10 @@ function ActivityFeed({
           </Empty>
         ) : data?.events.length ? (
           <ul>
-            {data.events.map((event, position) => (
-              <Fragment key={getDashEventKey(event)}>
+            {table.getRowModel().rows.map((row, position) => (
+              <Fragment key={row.id}>
                 {position > 0 && <Separator />}
-                <ActivityRow event={event} />
+                <ActivityRow event={row.original} />
               </Fragment>
             ))}
           </ul>
@@ -410,19 +465,19 @@ function ActivityFeed({
           <div className="flex gap-1">
             <Button
               aria-label={localization.previousPage}
-              disabled={isFetching || page === 0}
+              disabled={isFetching || !table.getCanPreviousPage()}
               size="icon-sm"
               variant="ghost"
-              onClick={() => setPage((current) => Math.max(0, current - 1))}
+              onClick={() => table.previousPage()}
             >
               <ChevronLeft />
             </Button>
             <Button
               aria-label={localization.nextPage}
-              disabled={isFetching || !hasNextPage}
+              disabled={isFetching || !table.getCanNextPage()}
               size="icon-sm"
               variant="ghost"
-              onClick={() => setPage((current) => current + 1)}
+              onClick={() => table.nextPage()}
             >
               <ChevronRight />
             </Button>

--- a/examples/start-shadcn-baseui-example/src/components/auth/oauth-provider/oauth-clients.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/oauth-provider/oauth-clients.tsx
@@ -22,6 +22,7 @@ import {
   useSetOAuthClientDisabled,
   useUpdateOAuthClient
 } from "@better-auth-ui/react/plugins/oauth-provider"
+import { useForm } from "@tanstack/react-form"
 import {
   Check,
   Code2,
@@ -31,7 +32,7 @@ import {
   RotateCcwKey,
   Trash2
 } from "lucide-react"
-import { type SyntheticEvent, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -86,6 +87,15 @@ type ClientAction =
   | { kind: "delete"; client: ManagedOAuthClient }
   | { kind: "rotate"; client: ManagedOAuthClient }
 
+type OAuthClientFormValues = {
+  applicationType: "native" | "web"
+  clientName: string
+  clientUri: string
+  logoUri: string
+  redirectUris: string
+  scope: string
+}
+
 export type OAuthClientsProps = {
   manager: OAuthClientManager
   owner: OAuthClientOwner
@@ -102,6 +112,17 @@ const uniqueLines = (value: string) =>
         .filter(Boolean)
     )
   )
+
+const getOAuthClientFormValues = (
+  client?: ManagedOAuthClient
+): OAuthClientFormValues => ({
+  applicationType: client?.application_type === "native" ? "native" : "web",
+  clientName: client?.client_name ?? "",
+  clientUri: client?.client_uri ?? "",
+  logoUri: client?.logo_uri ?? "",
+  redirectUris: client?.redirect_uris.join("\n") ?? "",
+  scope: client?.scope ?? ""
+})
 
 export function OAuthClients({
   manager,
@@ -129,39 +150,40 @@ export function OAuthClients({
     onError: (error) =>
       toast.error(error instanceof Error ? error.message : String(error))
   })
+  const form = useForm({
+    defaultValues: getOAuthClientFormValues(),
+    onSubmit: async ({ value }) => {
+      const input: OAuthClientInput = {
+        client_name: value.clientName.trim(),
+        application_type: value.applicationType,
+        redirect_uris: uniqueLines(value.redirectUris),
+        client_uri: value.clientUri.trim() || undefined,
+        logo_uri: value.logoUri.trim() || undefined,
+        scope: value.scope.trim() || undefined
+      }
+
+      try {
+        if (editingClient) {
+          await updateClient.mutateAsync({
+            clientId: editingClient.client_id,
+            update: input
+          })
+          setEditorOpen(false)
+          return
+        }
+        const client = await createClient.mutateAsync(input)
+        setEditorOpen(false)
+        setSecret(client)
+      } catch {
+        // The mutation keeps its error state for the host application.
+      }
+    }
+  })
 
   const openCreate = () => {
     setEditingClient(undefined)
+    form.reset(getOAuthClientFormValues())
     setEditorOpen(true)
-  }
-
-  const handleEditorSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    const input: OAuthClientInput = {
-      client_name: String(formData.get("clientName") ?? "").trim(),
-      application_type:
-        formData.get("applicationType") === "native" ? "native" : "web",
-      redirect_uris: uniqueLines(String(formData.get("redirectUris") ?? "")),
-      client_uri: String(formData.get("clientUri") ?? "").trim() || undefined,
-      logo_uri: String(formData.get("logoUri") ?? "").trim() || undefined,
-      scope: String(formData.get("scope") ?? "").trim() || undefined
-    }
-
-    if (editingClient) {
-      updateClient.mutate(
-        { clientId: editingClient.client_id, update: input },
-        { onSuccess: () => setEditorOpen(false) }
-      )
-      return
-    }
-
-    createClient.mutate(input, {
-      onSuccess: (client) => {
-        setEditorOpen(false)
-        setSecret(client)
-      }
-    })
   }
 
   const confirmAction = () => {
@@ -268,6 +290,7 @@ export function OAuthClients({
                     aria-label={oauthLocalization.editClient}
                     onClick={() => {
                       setEditingClient(client)
+                      form.reset(getOAuthClientFormValues(client))
                       setEditorOpen(true)
                     }}
                   >
@@ -315,7 +338,13 @@ export function OAuthClients({
 
       <Dialog open={editorOpen} onOpenChange={setEditorOpen}>
         <DialogContent>
-          <form onSubmit={handleEditorSubmit} className="flex flex-col gap-6">
+          <form
+            onSubmit={(event) => {
+              event.preventDefault()
+              void form.handleSubmit()
+            }}
+            className="flex flex-col gap-6"
+          >
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2">
                 {editingClient ? <Pencil /> : <Plus />}
@@ -328,89 +357,120 @@ export function OAuthClients({
               </DialogDescription>
             </DialogHeader>
             <FieldGroup>
-              <Field>
-                <FieldLabel htmlFor="oauth-client-name">
-                  {oauthLocalization.clientName}
-                </FieldLabel>
-                <Input
-                  id="oauth-client-name"
-                  name="clientName"
-                  defaultValue={editingClient?.client_name ?? ""}
-                  required
-                  autoFocus
-                />
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-application-type">
-                  {oauthLocalization.applicationType}
-                </FieldLabel>
-                <Select
-                  items={applicationTypeItems}
-                  name="applicationType"
-                  defaultValue={editingClient?.application_type ?? "web"}
-                >
-                  <SelectTrigger id="oauth-application-type" className="w-full">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      {applicationTypeItems.map((item) => (
-                        <SelectItem key={item.value} value={item.value}>
-                          {item.label}
-                        </SelectItem>
-                      ))}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-redirect-uris">
-                  {oauthLocalization.redirectUrls}
-                </FieldLabel>
-                <Textarea
-                  id="oauth-redirect-uris"
-                  name="redirectUris"
-                  rows={3}
-                  defaultValue={editingClient?.redirect_uris.join("\n") ?? ""}
-                  required
-                />
-                <FieldDescription>
-                  {oauthLocalization.redirectUrlsDescription}
-                </FieldDescription>
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-client-uri">
-                  {oauthLocalization.applicationUrl}
-                </FieldLabel>
-                <Input
-                  id="oauth-client-uri"
-                  name="clientUri"
-                  type="url"
-                  defaultValue={editingClient?.client_uri ?? ""}
-                />
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-logo-uri">
-                  {oauthLocalization.logoUrl}
-                </FieldLabel>
-                <Input
-                  id="oauth-logo-uri"
-                  name="logoUri"
-                  type="url"
-                  defaultValue={editingClient?.logo_uri ?? ""}
-                />
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-scopes">
-                  {oauthLocalization.scopes}
-                </FieldLabel>
-                <Input
-                  id="oauth-scopes"
-                  name="scope"
-                  placeholder="openid profile email"
-                  defaultValue={editingClient?.scope ?? ""}
-                />
-              </Field>
+              <form.Field name="clientName">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="oauth-client-name">
+                      {oauthLocalization.clientName}
+                    </FieldLabel>
+                    <Input
+                      autoFocus
+                      id="oauth-client-name"
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      value={field.state.value}
+                    />
+                  </Field>
+                )}
+              </form.Field>
+              <form.Field name="applicationType">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="oauth-application-type">
+                      {oauthLocalization.applicationType}
+                    </FieldLabel>
+                    <Select
+                      items={applicationTypeItems}
+                      name={field.name}
+                      onValueChange={(value) =>
+                        field.handleChange((value ?? "web") as "native" | "web")
+                      }
+                      value={field.state.value}
+                    >
+                      <SelectTrigger
+                        id="oauth-application-type"
+                        className="w-full"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          {applicationTypeItems.map((item) => (
+                            <SelectItem key={item.value} value={item.value}>
+                              {item.label}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                  </Field>
+                )}
+              </form.Field>
+              <form.Field name="redirectUris">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="oauth-redirect-uris">
+                      {oauthLocalization.redirectUrls}
+                    </FieldLabel>
+                    <Textarea
+                      id="oauth-redirect-uris"
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      rows={3}
+                      value={field.state.value}
+                    />
+                    <FieldDescription>
+                      {oauthLocalization.redirectUrlsDescription}
+                    </FieldDescription>
+                  </Field>
+                )}
+              </form.Field>
+              {(
+                [
+                  [
+                    "clientUri",
+                    "oauth-client-uri",
+                    oauthLocalization.applicationUrl,
+                    "url"
+                  ],
+                  [
+                    "logoUri",
+                    "oauth-logo-uri",
+                    oauthLocalization.logoUrl,
+                    "url"
+                  ],
+                  ["scope", "oauth-scopes", oauthLocalization.scopes, "text"]
+                ] as const
+              ).map(([name, id, label, type]) => (
+                <form.Field key={name} name={name}>
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+                      <Input
+                        id={id}
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        placeholder={
+                          name === "scope" ? "openid profile email" : undefined
+                        }
+                        type={type}
+                        value={field.state.value}
+                      />
+                    </Field>
+                  )}
+                </form.Field>
+              ))}
             </FieldGroup>
             <DialogFooter>
               <DialogClose
@@ -419,17 +479,16 @@ export function OAuthClients({
               >
                 {oauthLocalization.cancel}
               </DialogClose>
-              <Button
-                type="submit"
-                disabled={createClient.isPending || updateClient.isPending}
-              >
-                {(createClient.isPending || updateClient.isPending) && (
-                  <Spinner />
+              <form.Subscribe selector={(state) => state.isSubmitting}>
+                {(isSubmitting) => (
+                  <Button type="submit" disabled={isSubmitting}>
+                    {isSubmitting && <Spinner />}
+                    {editingClient
+                      ? oauthLocalization.saveChanges
+                      : oauthLocalization.createClient}
+                  </Button>
                 )}
-                {editingClient
-                  ? oauthLocalization.saveChanges
-                  : oauthLocalization.createClient}
-              </Button>
+              </form.Subscribe>
             </DialogFooter>
           </form>
         </DialogContent>

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/edit-member-roles-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/edit-member-roles-dialog.tsx
@@ -4,8 +4,9 @@ import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organi
 import { parseMemberRoles } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useUpdateMemberRole } from "@better-auth-ui/react/plugins/organization"
+import { useForm } from "@tanstack/react-form"
 import { ShieldCheck } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
 import { toast } from "sonner"
 
 import { Button, buttonVariants } from "@/components/ui/button"
@@ -71,9 +72,6 @@ export function EditMemberRolesDialog({
   const { authClient, localization } = useAuth<OrganizationAuthClient>()
   const { allowMultipleRoles, localization: organizationLocalization } =
     useAuthPlugin(organizationPlugin)
-  const [selectedRoles, setSelectedRoles] = useState(() =>
-    selectedMemberRoles(member.role, allowMultipleRoles, protectedRole)
-  )
   const { mutate: updateMemberRole, isPending } = useUpdateMemberRole(
     authClient,
     {
@@ -83,16 +81,36 @@ export function EditMemberRolesDialog({
       }
     }
   )
+  const form = useForm({
+    defaultValues: {
+      roles: selectedMemberRoles(member.role, allowMultipleRoles, protectedRole)
+    },
+    onSubmit: ({ value }) => {
+      if (value.roles.length === 0) return
+
+      updateMemberRole({
+        memberId: member.id,
+        organizationId,
+        role: value.roles
+      })
+    }
+  })
 
   useEffect(() => {
     if (open)
-      setSelectedRoles(
-        selectedMemberRoles(member.role, allowMultipleRoles, protectedRole)
-      )
-  }, [allowMultipleRoles, member.role, open, protectedRole])
+      form.reset({
+        roles: selectedMemberRoles(
+          member.role,
+          allowMultipleRoles,
+          protectedRole
+        )
+      })
+  }, [allowMultipleRoles, form.reset, member.role, open, protectedRole])
 
   const toggleRole = (role: string, checked: boolean) => {
-    setSelectedRoles((current) =>
+    const current = form.getFieldValue("roles")
+    form.setFieldValue(
+      "roles",
       checked
         ? current.includes(role)
           ? current
@@ -101,41 +119,6 @@ export function EditMemberRolesDialog({
     )
   }
 
-  const protectedRoleSelected =
-    !allowMultipleRoles &&
-    protectedRoleRemovalDisabled &&
-    protectedRole !== undefined &&
-    selectedRoles.includes(protectedRole)
-  const roleOptions = roles.map(([role, label]) => {
-    const checked = selectedRoles.includes(role)
-    const disabled =
-      isPending ||
-      (allowMultipleRoles && checked && selectedRoles.length === 1) ||
-      (protectedRoleSelected && role !== protectedRole) ||
-      (role === protectedRole && checked && protectedRoleRemovalDisabled)
-    const id = `member-${member.id}-role-${role}`
-
-    return (
-      <FieldLabel htmlFor={id} key={role}>
-        <Field orientation="horizontal" data-disabled={disabled}>
-          <FieldContent>
-            <FieldTitle>{label}</FieldTitle>
-          </FieldContent>
-          {allowMultipleRoles ? (
-            <Checkbox
-              checked={checked}
-              disabled={disabled}
-              id={id}
-              onCheckedChange={(next) => toggleRole(role, next === true)}
-            />
-          ) : (
-            <RadioGroupItem disabled={disabled} id={id} value={role} />
-          )}
-        </Field>
-      </FieldLabel>
-    )
-  })
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
@@ -143,13 +126,7 @@ export function EditMemberRolesDialog({
           className="flex flex-col gap-6"
           onSubmit={(event) => {
             event.preventDefault()
-            if (selectedRoles.length === 0) return
-
-            updateMemberRole({
-              memberId: member.id,
-              organizationId,
-              role: selectedRoles
-            })
+            void form.handleSubmit()
           }}
         >
           <DialogHeader>
@@ -162,34 +139,89 @@ export function EditMemberRolesDialog({
             </DialogDescription>
           </DialogHeader>
 
-          {allowMultipleRoles ? (
-            <div className="flex flex-col gap-2">{roleOptions}</div>
-          ) : (
-            <RadioGroup
-              disabled={isPending}
-              onValueChange={(role) => setSelectedRoles([role])}
-              value={selectedRoles[0] ?? ""}
-            >
-              {roleOptions}
-            </RadioGroup>
-          )}
+          <form.Subscribe selector={(state) => state.values.roles}>
+            {(selectedRoles) => {
+              const protectedRoleSelected =
+                !allowMultipleRoles &&
+                protectedRoleRemovalDisabled &&
+                protectedRole !== undefined &&
+                selectedRoles.includes(protectedRole)
+              const roleOptions = roles.map(([role, label]) => {
+                const checked = selectedRoles.includes(role)
+                const disabled =
+                  isPending ||
+                  (allowMultipleRoles &&
+                    checked &&
+                    selectedRoles.length === 1) ||
+                  (protectedRoleSelected && role !== protectedRole) ||
+                  (role === protectedRole &&
+                    checked &&
+                    protectedRoleRemovalDisabled)
+                const id = `member-${member.id}-role-${role}`
 
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              disabled={isPending}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-            <Button
-              disabled={isPending || selectedRoles.length === 0}
-              type="submit"
-            >
-              {isPending && <Spinner />}
-              {localization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
+                return (
+                  <FieldLabel htmlFor={id} key={role}>
+                    <Field orientation="horizontal" data-disabled={disabled}>
+                      <FieldContent>
+                        <FieldTitle>{label}</FieldTitle>
+                      </FieldContent>
+                      {allowMultipleRoles ? (
+                        <Checkbox
+                          checked={checked}
+                          disabled={disabled}
+                          id={id}
+                          onCheckedChange={(next) =>
+                            toggleRole(role, next === true)
+                          }
+                        />
+                      ) : (
+                        <RadioGroupItem
+                          disabled={disabled}
+                          id={id}
+                          value={role}
+                        />
+                      )}
+                    </Field>
+                  </FieldLabel>
+                )
+              })
+
+              return (
+                <>
+                  {allowMultipleRoles ? (
+                    <div className="flex flex-col gap-2">{roleOptions}</div>
+                  ) : (
+                    <RadioGroup
+                      disabled={isPending}
+                      onValueChange={(role) =>
+                        form.setFieldValue("roles", [role])
+                      }
+                      value={selectedRoles[0] ?? ""}
+                    >
+                      {roleOptions}
+                    </RadioGroup>
+                  )}
+
+                  <DialogFooter>
+                    <DialogClose
+                      className={buttonVariants({ variant: "outline" })}
+                      disabled={isPending}
+                      type="button"
+                    >
+                      {localization.settings.cancel}
+                    </DialogClose>
+                    <Button
+                      disabled={isPending || selectedRoles.length === 0}
+                      type="submit"
+                    >
+                      {isPending && <Spinner />}
+                      {localization.settings.saveChanges}
+                    </Button>
+                  </DialogFooter>
+                </>
+              )
+            }}
+          </form.Subscribe>
         </form>
       </DialogContent>
     </Dialog>

--- a/examples/start-shadcn-baseui-example/src/components/auth/reset-password.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/reset-password.tsx
@@ -5,8 +5,9 @@ import {
   isPasswordCompromisedError
 } from "@better-auth-ui/core"
 import { useAuth, useResetPassword } from "@better-auth-ui/react"
+import { useForm } from "@tanstack/react-form"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -72,7 +73,6 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     }
   })
 
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
   const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
     useState(false)
@@ -92,29 +92,32 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     }
   }, [localization.auth.invalidResetPasswordToken, navigate, signInURL])
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
+  const form = useForm({
+    defaultValues: { confirmPassword: "", password: "" },
+    onSubmit: ({ value }) => {
+      const searchParams = new URLSearchParams(window.location.search)
+      const token = searchParams.get("token") as string
 
-    const searchParams = new URLSearchParams(window.location.search)
-    const token = searchParams.get("token") as string
+      if (!token) {
+        toast.error(localization.auth.invalidResetPasswordToken)
+        navigate({ to: signInURL })
+        return
+      }
 
-    if (!token) {
-      toast.error(localization.auth.invalidResetPasswordToken)
-      navigate({ to: signInURL })
-      return
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
+        setFieldErrors((current) => ({
+          ...current,
+          confirmPassword: localization.auth.passwordsDoNotMatch
+        }))
+        return
+      }
+
+      resetPassword({ token, newPassword: value.password })
     }
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-    const confirmPassword = formData.get("confirmPassword") as string
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      toast.error(localization.auth.passwordsDoNotMatch)
-      return
-    }
-
-    resetPassword({ token, newPassword: password })
-  }
+  })
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -125,156 +128,175 @@ export function ResetPassword({ className }: ResetPasswordProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            void form.handleSubmit()
+          }}
+        >
           <FieldGroup>
-            <Field data-invalid={!!fieldErrors.password}>
-              <FieldLabel htmlFor="password">
-                {localization.auth.password}
-              </FieldLabel>
+            <form.Field name="password">
+              {(field) => (
+                <Field data-invalid={!!fieldErrors.password}>
+                  <FieldLabel htmlFor="password">
+                    {localization.auth.password}
+                  </FieldLabel>
 
-              <InputGroup>
-                <InputGroupInput
-                  id="password"
-                  name="password"
-                  type={isPasswordVisible ? "text" : "password"}
-                  autoComplete="new-password"
-                  placeholder={localization.auth.newPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                  onChange={(e) => {
-                    setPassword(e.target.value)
+                  <InputGroup>
+                    <InputGroupInput
+                      id="password"
+                      type={isPasswordVisible ? "text" : "password"}
+                      autoComplete="new-password"
+                      placeholder={localization.auth.newPasswordPlaceholder}
+                      required
+                      minLength={emailAndPassword?.minPasswordLength}
+                      maxLength={emailAndPassword?.maxPasswordLength}
+                      disabled={isPending}
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(e) => {
+                        field.handleChange(e.target.value)
+                        setFieldErrors((prev) => ({
+                          ...prev,
+                          password: undefined
+                        }))
+                      }}
+                      onInvalid={(e) => {
+                        e.preventDefault()
+                        const el = e.target as HTMLInputElement
+                        const min = emailAndPassword?.minPasswordLength
+                        const max = emailAndPassword?.maxPasswordLength
+                        const msg = el.validity.valueMissing
+                          ? localization.auth.fieldRequired
+                          : el.validity.tooShort
+                            ? localization.auth.tooShort.replace(
+                                "{{min}}",
+                                String(min)
+                              )
+                            : localization.auth.tooLong.replace(
+                                "{{max}}",
+                                String(max)
+                              )
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      password: undefined
-                    }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
-                    const el = e.target as HTMLInputElement
-                    const min = emailAndPassword?.minPasswordLength
-                    const max = emailAndPassword?.maxPasswordLength
-                    const msg = el.validity.valueMissing
-                      ? localization.auth.fieldRequired
-                      : el.validity.tooShort
-                        ? localization.auth.tooShort.replace(
-                            "{{min}}",
-                            String(min)
-                          )
-                        : localization.auth.tooLong.replace(
-                            "{{max}}",
-                            String(max)
-                          )
+                        setFieldErrors((prev) => ({
+                          ...prev,
+                          password: msg
+                        }))
+                      }}
+                      aria-invalid={!!fieldErrors.password}
+                      value={field.state.value}
+                    />
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      password: msg
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.password}
-                />
+                    <InputGroupAddon align="inline-end">
+                      <InputGroupButton
+                        size="icon-xs"
+                        aria-label={
+                          isPasswordVisible
+                            ? localization.auth.hidePassword
+                            : localization.auth.showPassword
+                        }
+                        title={
+                          isPasswordVisible
+                            ? localization.auth.hidePassword
+                            : localization.auth.showPassword
+                        }
+                        onClick={() => {
+                          setIsPasswordVisible((visible) => !visible)
+                        }}
+                      >
+                        {isPasswordVisible ? <EyeOff /> : <Eye />}
+                      </InputGroupButton>
+                    </InputGroupAddon>
+                  </InputGroup>
 
-                <InputGroupAddon align="inline-end">
-                  <InputGroupButton
-                    size="icon-xs"
-                    aria-label={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    title={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    onClick={() => {
-                      setIsPasswordVisible((visible) => !visible)
-                    }}
-                  >
-                    {isPasswordVisible ? <EyeOff /> : <Eye />}
-                  </InputGroupButton>
-                </InputGroupAddon>
-              </InputGroup>
+                  <FieldError>{fieldErrors.password}</FieldError>
 
-              <FieldError>{fieldErrors.password}</FieldError>
-
-              <PasswordStrengthMeter password={password} />
-            </Field>
+                  <PasswordStrengthMeter password={field.state.value} />
+                </Field>
+              )}
+            </form.Field>
 
             {emailAndPassword?.confirmPassword && (
-              <Field data-invalid={!!fieldErrors.confirmPassword}>
-                <FieldLabel htmlFor="confirmPassword">
-                  {localization.auth.confirmPassword}
-                </FieldLabel>
+              <form.Field name="confirmPassword">
+                {(field) => (
+                  <Field data-invalid={!!fieldErrors.confirmPassword}>
+                    <FieldLabel htmlFor="confirmPassword">
+                      {localization.auth.confirmPassword}
+                    </FieldLabel>
 
-                <InputGroup>
-                  <InputGroupInput
-                    id="confirmPassword"
-                    name="confirmPassword"
-                    type={isConfirmPasswordVisible ? "text" : "password"}
-                    autoComplete="new-password"
-                    placeholder={localization.auth.confirmPasswordPlaceholder}
-                    required
-                    minLength={emailAndPassword?.minPasswordLength}
-                    maxLength={emailAndPassword?.maxPasswordLength}
-                    disabled={isPending}
-                    onChange={() => {
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        confirmPassword: undefined
-                      }))
-                    }}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-                      const el = e.target as HTMLInputElement
-                      const min = emailAndPassword?.minPasswordLength
-                      const max = emailAndPassword?.maxPasswordLength
-                      const msg = el.validity.valueMissing
-                        ? localization.auth.fieldRequired
-                        : el.validity.tooShort
-                          ? localization.auth.tooShort.replace(
-                              "{{min}}",
-                              String(min)
-                            )
-                          : localization.auth.tooLong.replace(
-                              "{{max}}",
-                              String(max)
-                            )
+                    <InputGroup>
+                      <InputGroupInput
+                        id="confirmPassword"
+                        name={field.name}
+                        type={isConfirmPasswordVisible ? "text" : "password"}
+                        autoComplete="new-password"
+                        placeholder={
+                          localization.auth.confirmPasswordPlaceholder
+                        }
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => {
+                          field.handleChange(event.target.value)
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            confirmPassword: undefined
+                          }))
+                        }}
+                        onInvalid={(e) => {
+                          e.preventDefault()
+                          const el = e.target as HTMLInputElement
+                          const min = emailAndPassword?.minPasswordLength
+                          const max = emailAndPassword?.maxPasswordLength
+                          const msg = el.validity.valueMissing
+                            ? localization.auth.fieldRequired
+                            : el.validity.tooShort
+                              ? localization.auth.tooShort.replace(
+                                  "{{min}}",
+                                  String(min)
+                                )
+                              : localization.auth.tooLong.replace(
+                                  "{{max}}",
+                                  String(max)
+                                )
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        confirmPassword: msg
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.confirmPassword}
-                  />
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            confirmPassword: msg
+                          }))
+                        }}
+                        aria-invalid={!!fieldErrors.confirmPassword}
+                        value={field.state.value}
+                      />
 
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      size="icon-xs"
-                      aria-label={
-                        isConfirmPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      title={
-                        isConfirmPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      onClick={() => {
-                        setIsConfirmPasswordVisible((visible) => !visible)
-                      }}
-                    >
-                      {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={
+                            isConfirmPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          title={
+                            isConfirmPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() => {
+                            setIsConfirmPasswordVisible((visible) => !visible)
+                          }}
+                        >
+                          {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
 
-                <FieldError>{fieldErrors.confirmPassword}</FieldError>
-              </Field>
+                    <FieldError>{fieldErrors.confirmPassword}</FieldError>
+                  </Field>
+                )}
+              </form.Field>
             )}
 
             <div className="flex flex-col gap-3">

--- a/examples/start-shadcn-baseui-example/src/components/auth/settings/security/change-password.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/settings/security/change-password.tsx
@@ -9,8 +9,9 @@ import {
   useRequestPasswordReset,
   useSession
 } from "@better-auth-ui/react"
+import { useForm } from "@tanstack/react-form"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -165,10 +166,6 @@ function ChangePasswordForm({
   session: ReturnType<typeof useSession>["data"]
 }) {
   const { authClient } = useAuth()
-  const [currentPassword, setCurrentPassword] = useState("")
-  const [newPassword, setNewPassword] = useState("")
-  const [confirmPassword, setConfirmPassword] = useState("")
-
   const { mutate: changePassword, isPending } = useChangePassword(authClient, {
     onError: (error) => {
       // The haveIBeenPwned plugin rejects on the password itself, so it
@@ -180,14 +177,10 @@ function ChangePasswordForm({
         }))
       }
 
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
+      form.reset()
     },
     onSuccess: () => {
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
+      form.reset()
       toast.success(localization.settings.changePasswordSuccess)
     }
   })
@@ -204,23 +197,29 @@ function ChangePasswordForm({
     confirmPassword?: string
   }>({})
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useForm({
+    defaultValues: {
+      confirmPassword: "",
+      currentPassword: "",
+      newPassword: ""
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword.confirmPassword &&
+        value.newPassword !== value.confirmPassword
+      ) {
+        form.reset()
+        toast.error(localization.auth.passwordsDoNotMatch)
+        return
+      }
 
-    if (emailAndPassword.confirmPassword && newPassword !== confirmPassword) {
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
-      toast.error(localization.auth.passwordsDoNotMatch)
-      return
+      changePassword({
+        currentPassword: value.currentPassword,
+        newPassword: value.newPassword,
+        revokeOtherSessions: true
+      })
     }
-
-    changePassword({
-      currentPassword,
-      newPassword,
-      revokeOtherSessions: true
-    })
-  }
+  })
 
   return (
     <div>
@@ -228,204 +227,223 @@ function ChangePasswordForm({
         {localization.settings.changePassword}
       </h2>
 
-      <form onSubmit={handleSubmit}>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault()
+          void form.handleSubmit()
+        }}
+      >
         <Card className={cn(className)}>
           <CardContent className="flex flex-col gap-6">
-            <Field data-invalid={!!fieldErrors.currentPassword}>
-              <FieldLabel htmlFor="currentPassword">
-                {localization.settings.currentPassword}
-              </FieldLabel>
+            <form.Field name="currentPassword">
+              {(field) => (
+                <Field data-invalid={!!fieldErrors.currentPassword}>
+                  <FieldLabel htmlFor="currentPassword">
+                    {localization.settings.currentPassword}
+                  </FieldLabel>
 
-              {session ? (
-                <InputGroup>
-                  <InputGroupInput
-                    id="currentPassword"
-                    name="currentPassword"
-                    type={isCurrentPasswordVisible ? "text" : "password"}
-                    autoComplete="current-password"
-                    placeholder={
-                      localization.settings.currentPasswordPlaceholder
-                    }
-                    value={currentPassword}
-                    onChange={(e) => {
-                      setCurrentPassword(e.target.value)
+                  {session ? (
+                    <InputGroup>
+                      <InputGroupInput
+                        id="currentPassword"
+                        name={field.name}
+                        type={isCurrentPasswordVisible ? "text" : "password"}
+                        autoComplete="current-password"
+                        placeholder={
+                          localization.settings.currentPasswordPlaceholder
+                        }
+                        value={field.state.value}
+                        onChange={(e) => {
+                          field.handleChange(e.target.value)
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        currentPassword: undefined
-                      }))
-                    }}
-                    disabled={isPending}
-                    required
-                    onInvalid={(e) => {
-                      e.preventDefault()
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            currentPassword: undefined
+                          }))
+                        }}
+                        disabled={isPending}
+                        required
+                        onInvalid={(e) => {
+                          e.preventDefault()
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        currentPassword: (e.target as HTMLInputElement)
-                          .validationMessage
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.currentPassword}
-                  />
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            currentPassword: (e.target as HTMLInputElement)
+                              .validationMessage
+                          }))
+                        }}
+                        aria-invalid={!!fieldErrors.currentPassword}
+                      />
 
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      size="icon-xs"
-                      aria-label={
-                        isCurrentPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      title={
-                        isCurrentPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      onClick={() => {
-                        setIsCurrentPasswordVisible((visible) => !visible)
-                      }}
-                    >
-                      {isCurrentPasswordVisible ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
-              ) : (
-                <Skeleton>
-                  <Input className="invisible" />
-                </Skeleton>
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={
+                            isCurrentPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          title={
+                            isCurrentPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() => {
+                            setIsCurrentPasswordVisible((visible) => !visible)
+                          }}
+                        >
+                          {isCurrentPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  ) : (
+                    <Skeleton>
+                      <Input className="invisible" />
+                    </Skeleton>
+                  )}
+
+                  <FieldError>{fieldErrors.currentPassword}</FieldError>
+                </Field>
               )}
+            </form.Field>
 
-              <FieldError>{fieldErrors.currentPassword}</FieldError>
-            </Field>
+            <form.Field name="newPassword">
+              {(field) => (
+                <Field data-invalid={!!fieldErrors.newPassword}>
+                  <FieldLabel htmlFor="newPassword">
+                    {localization.auth.newPassword}
+                  </FieldLabel>
 
-            <Field data-invalid={!!fieldErrors.newPassword}>
-              <FieldLabel htmlFor="newPassword">
-                {localization.auth.newPassword}
-              </FieldLabel>
+                  {session ? (
+                    <InputGroup>
+                      <InputGroupInput
+                        id="newPassword"
+                        name={field.name}
+                        type={isNewPasswordVisible ? "text" : "password"}
+                        autoComplete="new-password"
+                        placeholder={localization.auth.newPasswordPlaceholder}
+                        value={field.state.value}
+                        onChange={(e) => {
+                          field.handleChange(e.target.value)
 
-              {session ? (
-                <InputGroup>
-                  <InputGroupInput
-                    id="newPassword"
-                    name="newPassword"
-                    type={isNewPasswordVisible ? "text" : "password"}
-                    autoComplete="new-password"
-                    placeholder={localization.auth.newPasswordPlaceholder}
-                    value={newPassword}
-                    onChange={(e) => {
-                      setNewPassword(e.target.value)
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            newPassword: undefined
+                          }))
+                        }}
+                        minLength={emailAndPassword.minPasswordLength}
+                        maxLength={emailAndPassword.maxPasswordLength}
+                        disabled={isPending}
+                        required
+                        onInvalid={(e) => {
+                          e.preventDefault()
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            newPassword: (e.target as HTMLInputElement)
+                              .validationMessage
+                          }))
+                        }}
+                        aria-invalid={!!fieldErrors.newPassword}
+                      />
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        newPassword: undefined
-                      }))
-                    }}
-                    minLength={emailAndPassword.minPasswordLength}
-                    maxLength={emailAndPassword.maxPasswordLength}
-                    disabled={isPending}
-                    required
-                    onInvalid={(e) => {
-                      e.preventDefault()
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        newPassword: (e.target as HTMLInputElement)
-                          .validationMessage
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.newPassword}
-                  />
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={
+                            isNewPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() =>
+                            setIsNewPasswordVisible((visible) => !visible)
+                          }
+                        >
+                          {isNewPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  ) : (
+                    <Skeleton>
+                      <Input className="invisible" />
+                    </Skeleton>
+                  )}
 
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      size="icon-xs"
-                      aria-label={
-                        isNewPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      onClick={() =>
-                        setIsNewPasswordVisible((visible) => !visible)
-                      }
-                    >
-                      {isNewPasswordVisible ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
-              ) : (
-                <Skeleton>
-                  <Input className="invisible" />
-                </Skeleton>
+                  <FieldError>{fieldErrors.newPassword}</FieldError>
+
+                  <PasswordStrengthMeter password={field.state.value} />
+                </Field>
               )}
-
-              <FieldError>{fieldErrors.newPassword}</FieldError>
-
-              <PasswordStrengthMeter password={newPassword} />
-            </Field>
+            </form.Field>
 
             {emailAndPassword.confirmPassword && (
-              <Field data-invalid={!!fieldErrors.confirmPassword}>
-                <FieldLabel htmlFor="confirmPassword">
-                  {localization.auth.confirmPassword}
-                </FieldLabel>
+              <form.Field name="confirmPassword">
+                {(field) => (
+                  <Field data-invalid={!!fieldErrors.confirmPassword}>
+                    <FieldLabel htmlFor="confirmPassword">
+                      {localization.auth.confirmPassword}
+                    </FieldLabel>
 
-                {session ? (
-                  <InputGroup>
-                    <InputGroupInput
-                      id="confirmPassword"
-                      name="confirmPassword"
-                      type={isConfirmPasswordVisible ? "text" : "password"}
-                      autoComplete="new-password"
-                      placeholder={localization.auth.confirmPasswordPlaceholder}
-                      value={confirmPassword}
-                      onChange={(e) => {
-                        setConfirmPassword(e.target.value)
+                    {session ? (
+                      <InputGroup>
+                        <InputGroupInput
+                          id="confirmPassword"
+                          name={field.name}
+                          type={isConfirmPasswordVisible ? "text" : "password"}
+                          autoComplete="new-password"
+                          placeholder={
+                            localization.auth.confirmPasswordPlaceholder
+                          }
+                          value={field.state.value}
+                          onChange={(e) => {
+                            field.handleChange(e.target.value)
 
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          confirmPassword: undefined
-                        }))
-                      }}
-                      minLength={emailAndPassword.minPasswordLength}
-                      maxLength={emailAndPassword.maxPasswordLength}
-                      disabled={isPending}
-                      required
-                      onInvalid={(e) => {
-                        e.preventDefault()
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              confirmPassword: undefined
+                            }))
+                          }}
+                          minLength={emailAndPassword.minPasswordLength}
+                          maxLength={emailAndPassword.maxPasswordLength}
+                          disabled={isPending}
+                          required
+                          onInvalid={(e) => {
+                            e.preventDefault()
 
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          confirmPassword: (e.target as HTMLInputElement)
-                            .validationMessage
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.confirmPassword}
-                    />
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              confirmPassword: (e.target as HTMLInputElement)
+                                .validationMessage
+                            }))
+                          }}
+                          aria-invalid={!!fieldErrors.confirmPassword}
+                        />
 
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isConfirmPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() =>
-                          setIsConfirmPasswordVisible((visible) => !visible)
-                        }
-                      >
-                        {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                ) : (
-                  <Skeleton>
-                    <Input className="invisible" />
-                  </Skeleton>
+                        <InputGroupAddon align="inline-end">
+                          <InputGroupButton
+                            size="icon-xs"
+                            aria-label={
+                              isConfirmPasswordVisible
+                                ? localization.auth.hidePassword
+                                : localization.auth.showPassword
+                            }
+                            onClick={() =>
+                              setIsConfirmPasswordVisible((visible) => !visible)
+                            }
+                          >
+                            {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
+                          </InputGroupButton>
+                        </InputGroupAddon>
+                      </InputGroup>
+                    ) : (
+                      <Skeleton>
+                        <Input className="invisible" />
+                      </Skeleton>
+                    )}
+
+                    <FieldError>{fieldErrors.confirmPassword}</FieldError>
+                  </Field>
                 )}
-
-                <FieldError>{fieldErrors.confirmPassword}</FieldError>
-              </Field>
+              </form.Field>
             )}
           </CardContent>
 

--- a/examples/start-shadcn-baseui-example/src/components/auth/sign-up.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/sign-up.tsx
@@ -102,7 +102,8 @@ export function SignUp({
           }))
         }
 
-        form.reset()
+        form.setFieldValue("password", "")
+        form.setFieldValue("confirmPassword", "")
         resetFetchOptions()
       },
       onSuccess: (_data, { email }) => {
@@ -159,7 +160,8 @@ export function SignUp({
         value.password !== value.confirmPassword
       ) {
         toast.error(localization.auth.passwordsDoNotMatch)
-        form.reset()
+        form.setFieldValue("password", "")
+        form.setFieldValue("confirmPassword", "")
         return
       }
 

--- a/examples/start-shadcn-baseui-example/src/components/auth/sign-up.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/sign-up.tsx
@@ -12,9 +12,10 @@ import {
   useFetchOptions,
   useSignUpEmail
 } from "@better-auth-ui/react"
+import { useForm } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { type FormEvent, useRef, useState } from "react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -88,9 +89,6 @@ export function SignUp({
 
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
 
-  const [password, setPassword] = useState("")
-  const [confirmPassword, setConfirmPassword] = useState("")
-
   const { mutate: signUpEmail, isPending: signUpEmailPending } = useSignUpEmail(
     authClient,
     {
@@ -104,8 +102,7 @@ export function SignUp({
           }))
         }
 
-        setPassword("")
-        setConfirmPassword("")
+        form.reset()
         resetFetchOptions()
       },
       onSuccess: (_data, { email }) => {
@@ -148,21 +145,38 @@ export function SignUp({
     password?: string
     confirmPassword?: string
   }>({})
+  const additionalFieldValuesRef = useRef<Record<string, unknown>>({})
+  const form = useForm({
+    defaultValues: {
+      confirmPassword: "",
+      email: "",
+      name: "",
+      password: ""
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
+        toast.error(localization.auth.passwordsDoNotMatch)
+        form.reset()
+        return
+      }
 
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    // `emailAndPassword.name === false` hides the name field and submits "".
-    const name = (formData.get("name") as string | null) ?? ""
-    const email = formData.get("email") as string
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      toast.error(localization.auth.passwordsDoNotMatch)
-      setPassword("")
-      setConfirmPassword("")
-      return
+      signUpEmail({
+        name: emailAndPassword?.name === false ? "" : value.name,
+        email: value.email,
+        password: value.password,
+        ...additionalFieldValuesRef.current,
+        fetchOptions
+      })
     }
+  })
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const formData = new FormData(event.currentTarget)
 
     const additionalFieldValues: Record<string, unknown> = {}
 
@@ -187,13 +201,8 @@ export function SignUp({
       }
     }
 
-    signUpEmail({
-      name,
-      email,
-      password,
-      ...additionalFieldValues,
-      fetchOptions
-    })
+    additionalFieldValuesRef.current = additionalFieldValues
+    await form.handleSubmit()
   }
 
   const showSeparator =
@@ -228,76 +237,88 @@ export function SignUp({
             <form onSubmit={handleSubmit}>
               <FieldGroup>
                 {emailAndPassword.name !== false && (
-                  <Field data-invalid={!!fieldErrors.name}>
-                    <FieldLabel htmlFor="name">
-                      {localization.auth.name}
-                    </FieldLabel>
+                  <form.Field name="name">
+                    {(field) => (
+                      <Field data-invalid={!!fieldErrors.name}>
+                        <FieldLabel htmlFor="name">
+                          {localization.auth.name}
+                        </FieldLabel>
 
-                    <Input
-                      id="name"
-                      name="name"
-                      type="text"
-                      autoComplete="name"
-                      placeholder={localization.auth.namePlaceholder}
-                      required
-                      disabled={isPending}
-                      onChange={() => {
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          name: undefined
-                        }))
-                      }}
-                      onInvalid={(e) => {
-                        e.preventDefault()
+                        <Input
+                          id="name"
+                          name={field.name}
+                          type="text"
+                          autoComplete="name"
+                          placeholder={localization.auth.namePlaceholder}
+                          required
+                          disabled={isPending}
+                          value={field.state.value}
+                          onChange={(event) => {
+                            field.handleChange(event.target.value)
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              name: undefined
+                            }))
+                          }}
+                          onInvalid={(e) => {
+                            e.preventDefault()
 
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          name: localization.auth.fieldRequired
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.name}
-                    />
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              name: localization.auth.fieldRequired
+                            }))
+                          }}
+                          aria-invalid={!!fieldErrors.name}
+                        />
 
-                    <FieldError>{fieldErrors.name}</FieldError>
-                  </Field>
+                        <FieldError>{fieldErrors.name}</FieldError>
+                      </Field>
+                    )}
+                  </form.Field>
                 )}
 
-                <Field data-invalid={!!fieldErrors.email}>
-                  <FieldLabel htmlFor="email">
-                    {localization.auth.email}
-                  </FieldLabel>
+                <form.Field name="email">
+                  {(field) => (
+                    <Field data-invalid={!!fieldErrors.email}>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
 
-                  <Input
-                    id="email"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    placeholder={localization.auth.emailPlaceholder}
-                    required
-                    disabled={isPending}
-                    onChange={() => {
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: undefined
-                      }))
-                    }}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-                      const el = e.target as HTMLInputElement
-                      const msg = el.validity.valueMissing
-                        ? localization.auth.fieldRequired
-                        : localization.auth.invalidEmail
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onChange={(event) => {
+                          field.handleChange(event.target.value)
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            email: undefined
+                          }))
+                        }}
+                        onInvalid={(e) => {
+                          e.preventDefault()
+                          const el = e.target as HTMLInputElement
+                          const msg = el.validity.valueMissing
+                            ? localization.auth.fieldRequired
+                            : localization.auth.invalidEmail
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: msg
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            email: msg
+                          }))
+                        }}
+                        aria-invalid={!!fieldErrors.email}
+                      />
 
-                  <FieldError>{fieldErrors.email}</FieldError>
-                </Field>
+                      <FieldError>{fieldErrors.email}</FieldError>
+                    </Field>
+                  )}
+                </form.Field>
 
                 {additionalFields?.map(
                   (field) =>
@@ -312,159 +333,171 @@ export function SignUp({
                     )
                 )}
 
-                <Field data-invalid={!!fieldErrors.password}>
-                  <FieldLabel htmlFor="password">
-                    {localization.auth.password}
-                  </FieldLabel>
+                <form.Field name="password">
+                  {(field) => (
+                    <Field data-invalid={!!fieldErrors.password}>
+                      <FieldLabel htmlFor="password">
+                        {localization.auth.password}
+                      </FieldLabel>
 
-                  <InputGroup>
-                    <InputGroupInput
-                      id="password"
-                      name="password"
-                      type={isPasswordVisible ? "text" : "password"}
-                      autoComplete="new-password"
-                      value={password}
-                      onChange={(e) => {
-                        setPassword(e.target.value)
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: undefined
-                        }))
-                      }}
-                      placeholder={localization.auth.passwordPlaceholder}
-                      required
-                      minLength={emailAndPassword?.minPasswordLength}
-                      maxLength={emailAndPassword?.maxPasswordLength}
-                      disabled={isPending}
-                      onInvalid={(e) => {
-                        e.preventDefault()
-                        const el = e.target as HTMLInputElement
-                        const min = emailAndPassword?.minPasswordLength
-                        const max = emailAndPassword?.maxPasswordLength
-                        const msg = el.validity.valueMissing
-                          ? localization.auth.fieldRequired
-                          : el.validity.tooShort
-                            ? localization.auth.tooShort.replace(
-                                "{{min}}",
-                                String(min)
-                              )
-                            : localization.auth.tooLong.replace(
-                                "{{max}}",
-                                String(max)
-                              )
+                      <InputGroup>
+                        <InputGroupInput
+                          id="password"
+                          name={field.name}
+                          type={isPasswordVisible ? "text" : "password"}
+                          autoComplete="new-password"
+                          value={field.state.value}
+                          onChange={(e) => {
+                            field.handleChange(e.target.value)
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              password: undefined
+                            }))
+                          }}
+                          placeholder={localization.auth.passwordPlaceholder}
+                          required
+                          minLength={emailAndPassword?.minPasswordLength}
+                          maxLength={emailAndPassword?.maxPasswordLength}
+                          disabled={isPending}
+                          onInvalid={(e) => {
+                            e.preventDefault()
+                            const el = e.target as HTMLInputElement
+                            const min = emailAndPassword?.minPasswordLength
+                            const max = emailAndPassword?.maxPasswordLength
+                            const msg = el.validity.valueMissing
+                              ? localization.auth.fieldRequired
+                              : el.validity.tooShort
+                                ? localization.auth.tooShort.replace(
+                                    "{{min}}",
+                                    String(min)
+                                  )
+                                : localization.auth.tooLong.replace(
+                                    "{{max}}",
+                                    String(max)
+                                  )
 
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: msg
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.password}
-                    />
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              password: msg
+                            }))
+                          }}
+                          aria-invalid={!!fieldErrors.password}
+                        />
 
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        title={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() => {
-                          setIsPasswordVisible((visible) => !visible)
-                        }}
-                      >
-                        {isPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
+                        <InputGroupAddon align="inline-end">
+                          <InputGroupButton
+                            size="icon-xs"
+                            aria-label={
+                              isPasswordVisible
+                                ? localization.auth.hidePassword
+                                : localization.auth.showPassword
+                            }
+                            title={
+                              isPasswordVisible
+                                ? localization.auth.hidePassword
+                                : localization.auth.showPassword
+                            }
+                            onClick={() => {
+                              setIsPasswordVisible((visible) => !visible)
+                            }}
+                          >
+                            {isPasswordVisible ? <EyeOff /> : <Eye />}
+                          </InputGroupButton>
+                        </InputGroupAddon>
+                      </InputGroup>
 
-                  <FieldError>{fieldErrors.password}</FieldError>
+                      <FieldError>{fieldErrors.password}</FieldError>
 
-                  <PasswordStrengthMeter password={password} />
-                </Field>
+                      <PasswordStrengthMeter password={field.state.value} />
+                    </Field>
+                  )}
+                </form.Field>
 
                 {emailAndPassword?.confirmPassword && (
-                  <Field data-invalid={!!fieldErrors.confirmPassword}>
-                    <FieldLabel htmlFor="confirmPassword">
-                      {localization.auth.confirmPassword}
-                    </FieldLabel>
+                  <form.Field name="confirmPassword">
+                    {(field) => (
+                      <Field data-invalid={!!fieldErrors.confirmPassword}>
+                        <FieldLabel htmlFor="confirmPassword">
+                          {localization.auth.confirmPassword}
+                        </FieldLabel>
 
-                    <InputGroup>
-                      <InputGroupInput
-                        id="confirmPassword"
-                        name="confirmPassword"
-                        type={isConfirmPasswordVisible ? "text" : "password"}
-                        autoComplete="new-password"
-                        value={confirmPassword}
-                        onChange={(e) => {
-                          setConfirmPassword(e.target.value)
+                        <InputGroup>
+                          <InputGroupInput
+                            id="confirmPassword"
+                            name={field.name}
+                            type={
+                              isConfirmPasswordVisible ? "text" : "password"
+                            }
+                            autoComplete="new-password"
+                            value={field.state.value}
+                            onChange={(e) => {
+                              field.handleChange(e.target.value)
 
-                          setFieldErrors((prev) => ({
-                            ...prev,
-                            confirmPassword: undefined
-                          }))
-                        }}
-                        placeholder={
-                          localization.auth.confirmPasswordPlaceholder
-                        }
-                        required
-                        minLength={emailAndPassword?.minPasswordLength}
-                        maxLength={emailAndPassword?.maxPasswordLength}
-                        disabled={isPending}
-                        onInvalid={(e) => {
-                          e.preventDefault()
-                          const el = e.target as HTMLInputElement
-                          const min = emailAndPassword?.minPasswordLength
-                          const max = emailAndPassword?.maxPasswordLength
-                          const msg = el.validity.valueMissing
-                            ? localization.auth.fieldRequired
-                            : el.validity.tooShort
-                              ? localization.auth.tooShort.replace(
-                                  "{{min}}",
-                                  String(min)
+                              setFieldErrors((prev) => ({
+                                ...prev,
+                                confirmPassword: undefined
+                              }))
+                            }}
+                            placeholder={
+                              localization.auth.confirmPasswordPlaceholder
+                            }
+                            required
+                            minLength={emailAndPassword?.minPasswordLength}
+                            maxLength={emailAndPassword?.maxPasswordLength}
+                            disabled={isPending}
+                            onInvalid={(e) => {
+                              e.preventDefault()
+                              const el = e.target as HTMLInputElement
+                              const min = emailAndPassword?.minPasswordLength
+                              const max = emailAndPassword?.maxPasswordLength
+                              const msg = el.validity.valueMissing
+                                ? localization.auth.fieldRequired
+                                : el.validity.tooShort
+                                  ? localization.auth.tooShort.replace(
+                                      "{{min}}",
+                                      String(min)
+                                    )
+                                  : localization.auth.tooLong.replace(
+                                      "{{max}}",
+                                      String(max)
+                                    )
+
+                              setFieldErrors((prev) => ({
+                                ...prev,
+                                confirmPassword: msg
+                              }))
+                            }}
+                            aria-invalid={!!fieldErrors.confirmPassword}
+                          />
+
+                          <InputGroupAddon align="inline-end">
+                            <InputGroupButton
+                              size="icon-xs"
+                              aria-label={
+                                isConfirmPasswordVisible
+                                  ? localization.auth.hidePassword
+                                  : localization.auth.showPassword
+                              }
+                              title={
+                                isConfirmPasswordVisible
+                                  ? localization.auth.hidePassword
+                                  : localization.auth.showPassword
+                              }
+                              onClick={() =>
+                                setIsConfirmPasswordVisible(
+                                  (visible) => !visible
                                 )
-                              : localization.auth.tooLong.replace(
-                                  "{{max}}",
-                                  String(max)
-                                )
+                              }
+                            >
+                              {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
+                            </InputGroupButton>
+                          </InputGroupAddon>
+                        </InputGroup>
 
-                          setFieldErrors((prev) => ({
-                            ...prev,
-                            confirmPassword: msg
-                          }))
-                        }}
-                        aria-invalid={!!fieldErrors.confirmPassword}
-                      />
-
-                      <InputGroupAddon align="inline-end">
-                        <InputGroupButton
-                          size="icon-xs"
-                          aria-label={
-                            isConfirmPasswordVisible
-                              ? localization.auth.hidePassword
-                              : localization.auth.showPassword
-                          }
-                          title={
-                            isConfirmPasswordVisible
-                              ? localization.auth.hidePassword
-                              : localization.auth.showPassword
-                          }
-                          onClick={() =>
-                            setIsConfirmPasswordVisible((visible) => !visible)
-                          }
-                        >
-                          {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
-                        </InputGroupButton>
-                      </InputGroupAddon>
-                    </InputGroup>
-
-                    <FieldError>{fieldErrors.confirmPassword}</FieldError>
-                  </Field>
+                        <FieldError>{fieldErrors.confirmPassword}</FieldError>
+                      </Field>
+                    )}
+                  </form.Field>
                 )}
 
                 {additionalFields?.map(

--- a/examples/start-shadcn-baseui-example/src/components/auth/sso/organization-sso-providers.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/sso/organization-sso-providers.tsx
@@ -16,9 +16,10 @@ import {
   useSsoProviders,
   useUpdateSsoProvider
 } from "@better-auth-ui/react/plugins/sso"
+import { useForm } from "@tanstack/react-form"
 import type { BetterFetchError } from "better-auth/client"
 import { PencilIcon, Trash2Icon } from "lucide-react"
-import { type FormEvent, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -80,8 +81,27 @@ export type OrganizationSsoProvidersProps = {
 
 const providerSkeletonIds = ["sso-provider-1", "sso-provider-2"]
 
-const readString = (formData: FormData, name: string) =>
-  String(formData.get(name) ?? "").trim()
+type SsoProviderEditorValues = {
+  clientId: string
+  clientSecret: string
+  discoveryEndpoint: string
+  domain: string
+  entryPoint: string
+  identityProviderMetadata: string
+  issuer: string
+}
+
+const getSsoProviderEditorValues = (
+  provider?: SsoProvider
+): SsoProviderEditorValues => ({
+  clientId: "",
+  clientSecret: "",
+  discoveryEndpoint: provider?.oidcConfig?.discoveryEndpoint ?? "",
+  domain: provider?.domain ?? "",
+  entryPoint: provider?.samlConfig?.entryPoint ?? "",
+  identityProviderMetadata: "",
+  issuer: provider?.issuer ?? ""
+})
 
 const getErrorMessage = (error: Error | null) => {
   const authError = error as BetterFetchError | null
@@ -240,7 +260,11 @@ export function OrganizationSsoProviders({
         )}
       </CardContent>
 
-      <EditSsoProviderDialog onOpenChange={setEditing} provider={editing} />
+      <EditSsoProviderDialog
+        key={editing?.providerId ?? "closed"}
+        onOpenChange={setEditing}
+        provider={editing}
+      />
       <DeleteSsoProviderDialog onOpenChange={setDeleting} provider={deleting} />
       <Dialog
         open={Boolean(verifying)}
@@ -277,49 +301,47 @@ function EditSsoProviderDialog({
     update.reset()
     onOpenChange(undefined)
   }
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!provider) return
-    const data = new FormData(event.currentTarget)
-    const clientId = readString(data, "clientId")
-    const clientSecret = readString(data, "clientSecret")
-    const identityProviderMetadata = readString(
-      data,
-      "identityProviderMetadata"
-    )
-    const params = {
-      providerId: provider.providerId,
-      issuer: readString(data, "issuer"),
-      domain: readString(data, "domain"),
-      ...(provider.oidcConfig
-        ? {
-            oidcConfig: {
-              ...(clientId ? { clientId } : {}),
-              ...(clientSecret ? { clientSecret } : {}),
-              discoveryEndpoint:
-                readString(data, "discoveryEndpoint") || undefined
+  const form = useForm({
+    defaultValues: getSsoProviderEditorValues(provider),
+    onSubmit: async ({ value }) => {
+      if (!provider) return
+      const clientId = value.clientId.trim()
+      const clientSecret = value.clientSecret.trim()
+      const identityProviderMetadata = value.identityProviderMetadata.trim()
+      const params = {
+        providerId: provider.providerId,
+        issuer: value.issuer.trim(),
+        domain: value.domain.trim(),
+        ...(provider.oidcConfig
+          ? {
+              oidcConfig: {
+                ...(clientId ? { clientId } : {}),
+                ...(clientSecret ? { clientSecret } : {}),
+                discoveryEndpoint: value.discoveryEndpoint.trim() || undefined
+              }
             }
-          }
-        : {}),
-      ...(provider.samlConfig
-        ? {
-            samlConfig: {
-              entryPoint: readString(data, "entryPoint"),
-              ...(identityProviderMetadata
-                ? { idpMetadata: { metadata: identityProviderMetadata } }
-                : {})
+          : {}),
+        ...(provider.samlConfig
+          ? {
+              samlConfig: {
+                entryPoint: value.entryPoint.trim(),
+                ...(identityProviderMetadata
+                  ? { idpMetadata: { metadata: identityProviderMetadata } }
+                  : {})
+              }
             }
-          }
-        : {})
-    } as UpdateSsoProviderParams
+          : {})
+      } as UpdateSsoProviderParams
 
-    update.mutate(params, {
-      onSuccess: () => {
+      try {
+        await update.mutateAsync(params)
         toast.success(localization.providerUpdated)
         close()
+      } catch {
+        // The mutation error is rendered below the fields.
       }
-    })
-  }
+    }
+  })
 
   return (
     <Dialog
@@ -329,98 +351,148 @@ function EditSsoProviderDialog({
       }}
     >
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
-        <form className="flex flex-col gap-4" onSubmit={submit}>
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void form.handleSubmit()
+          }}
+        >
           <DialogHeader>
             <DialogTitle>{localization.editProvider}</DialogTitle>
             <DialogDescription>{provider?.providerId}</DialogDescription>
           </DialogHeader>
           <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="sso-edit-domain">
-                {localization.domain}
-              </FieldLabel>
-              <Input
-                defaultValue={provider?.domain}
-                id="sso-edit-domain"
-                name="domain"
-                required
-              />
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="sso-edit-issuer">
-                {localization.issuer}
-              </FieldLabel>
-              <Input
-                defaultValue={provider?.issuer}
-                id="sso-edit-issuer"
-                name="issuer"
-                required
-                type="url"
-              />
-            </Field>
+            {(
+              [
+                ["domain", "sso-edit-domain", localization.domain, "text"],
+                ["issuer", "sso-edit-issuer", localization.issuer, "url"]
+              ] as const
+            ).map(([name, id, label, type]) => (
+              <form.Field key={name} name={name}>
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor={id}>{label}</FieldLabel>
+                    <Input
+                      id={id}
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      type={type}
+                      value={field.state.value}
+                    />
+                  </Field>
+                )}
+              </form.Field>
+            ))}
             {provider?.oidcConfig ? (
               <>
-                <Field>
-                  <FieldLabel htmlFor="sso-edit-discovery">
-                    {localization.discoveryEndpoint}
-                  </FieldLabel>
-                  <Input
-                    defaultValue={provider.oidcConfig.discoveryEndpoint}
-                    id="sso-edit-discovery"
-                    name="discoveryEndpoint"
-                    type="url"
-                  />
-                </Field>
+                <form.Field name="discoveryEndpoint">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="sso-edit-discovery">
+                        {localization.discoveryEndpoint}
+                      </FieldLabel>
+                      <Input
+                        id="sso-edit-discovery"
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        type="url"
+                        value={field.state.value}
+                      />
+                    </Field>
+                  )}
+                </form.Field>
                 <div className="grid gap-4 sm:grid-cols-2">
-                  <Field>
-                    <FieldLabel htmlFor="sso-edit-client-id">
-                      {localization.clientId}
-                    </FieldLabel>
-                    <Input
-                      id="sso-edit-client-id"
-                      name="clientId"
-                      placeholder={`••••${provider.oidcConfig.clientIdLastFour}`}
-                    />
-                  </Field>
-                  <Field>
-                    <FieldLabel htmlFor="sso-edit-client-secret">
-                      {localization.clientSecret}
-                    </FieldLabel>
-                    <Input
-                      autoComplete="new-password"
-                      id="sso-edit-client-secret"
-                      name="clientSecret"
-                      type="password"
-                    />
-                  </Field>
+                  {(
+                    [
+                      ["clientId", "sso-edit-client-id", localization.clientId],
+                      [
+                        "clientSecret",
+                        "sso-edit-client-secret",
+                        localization.clientSecret
+                      ]
+                    ] as const
+                  ).map(([name, id, label]) => (
+                    <form.Field key={name} name={name}>
+                      {(field) => (
+                        <Field>
+                          <FieldLabel htmlFor={id}>{label}</FieldLabel>
+                          <Input
+                            autoComplete={
+                              name === "clientSecret"
+                                ? "new-password"
+                                : undefined
+                            }
+                            id={id}
+                            name={field.name}
+                            onBlur={field.handleBlur}
+                            onChange={(event) =>
+                              field.handleChange(event.target.value)
+                            }
+                            placeholder={
+                              name === "clientId"
+                                ? `••••${provider.oidcConfig?.clientIdLastFour}`
+                                : undefined
+                            }
+                            type={name === "clientSecret" ? "password" : "text"}
+                            value={field.state.value}
+                          />
+                        </Field>
+                      )}
+                    </form.Field>
+                  ))}
                 </div>
               </>
             ) : null}
             {provider?.samlConfig ? (
               <>
-                <Field>
-                  <FieldLabel htmlFor="sso-edit-entry-point">
-                    {localization.entryPoint}
-                  </FieldLabel>
-                  <Input
-                    defaultValue={provider.samlConfig.entryPoint}
-                    id="sso-edit-entry-point"
-                    name="entryPoint"
-                    required
-                    type="url"
-                  />
-                </Field>
-                <Field>
-                  <FieldLabel htmlFor="sso-edit-metadata">
-                    {localization.identityProviderMetadata}
-                  </FieldLabel>
-                  <Textarea
-                    className="font-mono text-xs"
-                    id="sso-edit-metadata"
-                    name="identityProviderMetadata"
-                    rows={6}
-                  />
-                </Field>
+                <form.Field name="entryPoint">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="sso-edit-entry-point">
+                        {localization.entryPoint}
+                      </FieldLabel>
+                      <Input
+                        id="sso-edit-entry-point"
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        required
+                        type="url"
+                        value={field.state.value}
+                      />
+                    </Field>
+                  )}
+                </form.Field>
+                <form.Field name="identityProviderMetadata">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="sso-edit-metadata">
+                        {localization.identityProviderMetadata}
+                      </FieldLabel>
+                      <Textarea
+                        className="font-mono text-xs"
+                        id="sso-edit-metadata"
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        rows={6}
+                        value={field.state.value}
+                      />
+                    </Field>
+                  )}
+                </form.Field>
               </>
             ) : null}
           </FieldGroup>
@@ -434,10 +506,14 @@ function EditSsoProviderDialog({
             >
               {localization.cancel}
             </Button>
-            <Button disabled={update.isPending} type="submit">
-              {update.isPending ? <Spinner data-icon="inline-start" /> : null}
-              {localization.saveProvider}
-            </Button>
+            <form.Subscribe selector={(state) => state.isSubmitting}>
+              {(isSubmitting) => (
+                <Button disabled={isSubmitting} type="submit">
+                  {isSubmitting ? <Spinner data-icon="inline-start" /> : null}
+                  {localization.saveProvider}
+                </Button>
+              )}
+            </form.Subscribe>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -27,6 +27,7 @@ import {
   useAdminUserSessions,
   useAdminUsers
 } from "@better-auth-ui/react/plugins/admin"
+import { useForm } from "@tanstack/react-form"
 import { keepPreviousData, useMutation } from "@tanstack/react-query"
 import {
   type ColumnFiltersState,
@@ -677,26 +678,51 @@ function CreateUserDialog({
   const auth = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
   const { data: session } = useSession(auth.authClient)
-  const [password, setPassword] = useState("")
-  const [emailVerified, setEmailVerified] = useState(false)
   const [formError, setFormError] = useState<string>()
-  const [roles, setRoles] = useState([config.defaultRole])
-
-  useEffect(() => {
-    if (!config.allowMultipleRoles) setRoles((current) => current.slice(0, 1))
-  }, [config.allowMultipleRoles])
   const createUser = useMutation(
     createAdminUserOptions(auth.authClient, session?.user.id)
   )
   const canSetRole = useAdminPermission(auth.authClient, {
     user: ["set-role"]
   })
+  const additionalFieldValuesRef = useRef<
+    Record<string, AdditionalFieldValue | null>
+  >({})
+  const form = useForm({
+    defaultValues: {
+      email: "",
+      emailVerified: false,
+      name: "",
+      password: "",
+      roles: [config.defaultRole]
+    },
+    onSubmit: ({ value }) => {
+      createUser.mutate(
+        {
+          data: {
+            ...additionalFieldValuesRef.current,
+            emailVerified: value.emailVerified
+          },
+          email: value.email,
+          name: value.name,
+          password: value.password,
+          ...(canSetRole.data?.success
+            ? { role: asAdminRoles(value.roles) }
+            : {})
+        },
+        { onSuccess: close }
+      )
+    }
+  })
+
+  useEffect(() => {
+    if (!config.allowMultipleRoles)
+      form.setFieldValue("roles", (current) => current.slice(0, 1))
+  }, [config.allowMultipleRoles, form.setFieldValue])
 
   const close = () => {
-    setPassword("")
-    setEmailVerified(false)
+    form.reset()
     setFormError(undefined)
-    setRoles([config.defaultRole])
     createUser.reset()
     onOpenChange(false)
   }
@@ -714,16 +740,8 @@ function CreateUserDialog({
       return
     }
     setFormError(undefined)
-    createUser.mutate(
-      {
-        data: { ...additionalFieldValues, emailVerified },
-        email: String(data.get("email")),
-        name: String(data.get("name")),
-        password,
-        ...(canSetRole.data?.success ? { role: asAdminRoles(roles) } : {})
-      },
-      { onSuccess: close }
-    )
+    additionalFieldValuesRef.current = additionalFieldValues
+    await form.handleSubmit()
   }
 
   return (
@@ -740,43 +758,70 @@ function CreateUserDialog({
             </DialogDescription>
           </DialogHeader>
           <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="admin-create-name">
-                {config.localization.name}
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupInput id="admin-create-name" name="name" required />
-              </InputGroup>
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="admin-create-email">
-                {config.localization.email}
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupInput
-                  autoComplete="off"
-                  id="admin-create-email"
-                  name="email"
-                  required
-                  type="email"
-                />
-              </InputGroup>
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="admin-create-password">
-                {config.localization.password}
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupInput
-                  autoComplete="new-password"
-                  id="admin-create-password"
-                  onChange={(event) => setPassword(event.target.value)}
-                  required
-                  type="password"
-                  value={password}
-                />
-              </InputGroup>
-            </Field>
+            <form.Field name="name">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="admin-create-name">
+                    {config.localization.name}
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupInput
+                      id="admin-create-name"
+                      name={field.name}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      value={field.state.value}
+                    />
+                  </InputGroup>
+                </Field>
+              )}
+            </form.Field>
+            <form.Field name="email">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="admin-create-email">
+                    {config.localization.email}
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupInput
+                      autoComplete="off"
+                      id="admin-create-email"
+                      name={field.name}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      type="email"
+                      value={field.state.value}
+                    />
+                  </InputGroup>
+                </Field>
+              )}
+            </form.Field>
+            <form.Field name="password">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor="admin-create-password">
+                    {config.localization.password}
+                  </FieldLabel>
+                  <InputGroup>
+                    <InputGroupInput
+                      autoComplete="new-password"
+                      id="admin-create-password"
+                      name={field.name}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      type="password"
+                      value={field.state.value}
+                    />
+                  </InputGroup>
+                </Field>
+              )}
+            </form.Field>
             {canSetRole.isPending ? (
               <Skeleton className="h-16 w-full" />
             ) : canSetRole.data?.success ? (
@@ -784,58 +829,68 @@ function CreateUserDialog({
                 <FieldLegend variant="label">
                   {config.localization.role}
                 </FieldLegend>
-                {config.allowMultipleRoles ? (
-                  <FieldGroup data-slot="checkbox-group">
-                    {config.roles.map((role) => (
-                      <Field key={role} orientation="horizontal">
-                        <Checkbox
-                          checked={roles.includes(role)}
-                          id={`admin-create-role-${role}`}
-                          onCheckedChange={(checked) => {
-                            const next = checked
-                              ? [...roles, role]
-                              : roles.filter((item) => item !== role)
-                            if (next.length) setRoles(next)
-                          }}
-                        />
-                        <FieldLabel htmlFor={`admin-create-role-${role}`}>
-                          {role}
-                        </FieldLabel>
-                      </Field>
-                    ))}
-                  </FieldGroup>
-                ) : (
-                  <RadioGroup
-                    onValueChange={(role) => setRoles([role])}
-                    value={roles[0] ?? ""}
-                  >
-                    {config.roles.map((role) => (
-                      <Field key={role} orientation="horizontal">
-                        <RadioGroupItem
-                          id={`admin-create-role-${role}`}
-                          value={role}
-                        />
-                        <FieldLabel htmlFor={`admin-create-role-${role}`}>
-                          {role}
-                        </FieldLabel>
-                      </Field>
-                    ))}
-                  </RadioGroup>
-                )}
+                <form.Field name="roles">
+                  {(field) =>
+                    config.allowMultipleRoles ? (
+                      <FieldGroup data-slot="checkbox-group">
+                        {config.roles.map((role) => (
+                          <Field key={role} orientation="horizontal">
+                            <Checkbox
+                              checked={field.state.value.includes(role)}
+                              id={`admin-create-role-${role}`}
+                              onCheckedChange={(checked) => {
+                                const next = checked
+                                  ? [...field.state.value, role]
+                                  : field.state.value.filter(
+                                      (item) => item !== role
+                                    )
+                                if (next.length) field.handleChange(next)
+                              }}
+                            />
+                            <FieldLabel htmlFor={`admin-create-role-${role}`}>
+                              {role}
+                            </FieldLabel>
+                          </Field>
+                        ))}
+                      </FieldGroup>
+                    ) : (
+                      <RadioGroup
+                        onValueChange={(role) => field.handleChange([role])}
+                        value={field.state.value[0] ?? ""}
+                      >
+                        {config.roles.map((role) => (
+                          <Field key={role} orientation="horizontal">
+                            <RadioGroupItem
+                              id={`admin-create-role-${role}`}
+                              value={role}
+                            />
+                            <FieldLabel htmlFor={`admin-create-role-${role}`}>
+                              {role}
+                            </FieldLabel>
+                          </Field>
+                        ))}
+                      </RadioGroup>
+                    )
+                  }
+                </form.Field>
               </FieldSet>
             ) : null}
-            <Field orientation="horizontal">
-              <Switch
-                checked={emailVerified}
-                id="admin-create-email-verified"
-                onCheckedChange={setEmailVerified}
-              />
-              <FieldContent>
-                <FieldLabel htmlFor="admin-create-email-verified">
-                  {config.localization.emailVerified}
-                </FieldLabel>
-              </FieldContent>
-            </Field>
+            <form.Field name="emailVerified">
+              {(field) => (
+                <Field orientation="horizontal">
+                  <Switch
+                    checked={field.state.value}
+                    id="admin-create-email-verified"
+                    onCheckedChange={field.handleChange}
+                  />
+                  <FieldContent>
+                    <FieldLabel htmlFor="admin-create-email-verified">
+                      {config.localization.emailVerified}
+                    </FieldLabel>
+                  </FieldContent>
+                </Field>
+              )}
+            </form.Field>
             {auth.additionalFields?.map((field) => (
               <AdditionalField
                 field={field}
@@ -952,10 +1007,6 @@ function UserInspector({
     },
     { enabled: Boolean(userId) }
   )
-  const [name, setName] = useState("")
-  const [email, setEmail] = useState("")
-  const [emailVerified, setEmailVerified] = useState(false)
-  const [roles, setRoles] = useState([config.defaultRole])
   const [banReason, setBanReason] = useState("")
   const [banDuration, setBanDuration] = useState("")
   const banDurationSeconds = getBanDurationSeconds(banDuration)
@@ -968,22 +1019,6 @@ function UserInspector({
   const updateUser = useMutation(
     updateAdminUserOptions(auth.authClient, actor?.user.id)
   )
-
-  useEffect(() => {
-    setName(user?.name ?? "")
-    setEmail(user?.email ?? "")
-    setEmailVerified(user?.emailVerified ?? false)
-    setRoles(
-      parseAdminRoles(user?.role, config.defaultRole, config.allowMultipleRoles)
-    )
-  }, [
-    config.allowMultipleRoles,
-    config.defaultRole,
-    user?.email,
-    user?.emailVerified,
-    user?.name,
-    user?.role
-  ])
 
   useEffect(() => {
     if (profileUserId.current === user?.id) return
@@ -1018,6 +1053,75 @@ function UserInspector({
   const revokeSessions = useMutation(
     revokeAdminUserSessionsOptions(auth.authClient, actor?.user.id, userId)
   )
+  const profileAdditionalFieldValuesRef = useRef<
+    Record<string, AdditionalFieldValue | null>
+  >({})
+  const profileForm = useForm({
+    defaultValues: {
+      email: "",
+      emailVerified: false,
+      name: "",
+      roles: [config.defaultRole]
+    },
+    onSubmit: async ({ value }) => {
+      if (!user) return
+
+      const mutations: Promise<unknown>[] = []
+      if (canUpdate.data?.success) {
+        mutations.push(
+          updateUser.mutateAsync({
+            userId: user.id,
+            data: {
+              ...profileAdditionalFieldValuesRef.current,
+              name: value.name.trim(),
+              ...(canSetEmail.data?.success
+                ? {
+                    email: value.email.trim(),
+                    emailVerified: value.emailVerified
+                  }
+                : {})
+            }
+          })
+        )
+      }
+      if (canSetRole.data?.success && !isSelf) {
+        mutations.push(
+          setRoleMutation.mutateAsync({
+            userId: user.id,
+            role: asAdminRoles(value.roles)
+          })
+        )
+      }
+
+      try {
+        await Promise.all(mutations)
+        onOpenChange(false)
+      } catch {
+        // Mutation errors are rendered next to the form.
+      }
+    }
+  })
+
+  useEffect(() => {
+    profileForm.reset({
+      email: user?.email ?? "",
+      emailVerified: user?.emailVerified ?? false,
+      name: user?.name ?? "",
+      roles: parseAdminRoles(
+        user?.role,
+        config.defaultRole,
+        config.allowMultipleRoles
+      )
+    })
+  }, [
+    config.allowMultipleRoles,
+    config.defaultRole,
+    profileForm.reset,
+    user?.email,
+    user?.emailVerified,
+    user?.name,
+    user?.role
+  ])
 
   const confirm = () => {
     if (!user) return
@@ -1096,7 +1200,6 @@ function UserInspector({
     event.preventDefault()
     if (!user) return
 
-    const mutations: Promise<unknown>[] = []
     if (canUpdate.data?.success) {
       const formData = new FormData(event.currentTarget)
       let additionalFieldValues: Record<string, AdditionalFieldValue | null>
@@ -1110,34 +1213,10 @@ function UserInspector({
         return
       }
       setProfileError(undefined)
-      mutations.push(
-        updateUser.mutateAsync({
-          userId: user.id,
-          data: {
-            ...additionalFieldValues,
-            name: name.trim(),
-            ...(canSetEmail.data?.success
-              ? { email: email.trim(), emailVerified }
-              : {})
-          }
-        })
-      )
-    }
-    if (canSetRole.data?.success && !isSelf) {
-      mutations.push(
-        setRoleMutation.mutateAsync({
-          userId: user.id,
-          role: asAdminRoles(roles)
-        })
-      )
+      profileAdditionalFieldValuesRef.current = additionalFieldValues
     }
 
-    try {
-      await Promise.all(mutations)
-      onOpenChange(false)
-    } catch {
-      // Mutation errors are rendered next to the form.
-    }
+    await profileForm.handleSubmit()
   }
 
   return (
@@ -1243,107 +1322,136 @@ function UserInspector({
                         {config.localization.profileAndAccess}
                       </h3>
                       <FieldGroup className="grid gap-5 md:grid-cols-2">
-                        <Field>
-                          <FieldLabel htmlFor="admin-user-name">
-                            {config.localization.name}
-                          </FieldLabel>
-                          <InputGroup>
-                            <InputGroupInput
-                              disabled={!canUpdate.data?.success}
-                              id="admin-user-name"
-                              value={name}
-                              onChange={(event) => setName(event.target.value)}
-                            />
-                          </InputGroup>
-                        </Field>
-                        <Field>
-                          <FieldLabel htmlFor="admin-user-email">
-                            {config.localization.email}
-                          </FieldLabel>
-                          <InputGroup>
-                            <InputGroupInput
-                              disabled={
-                                !canUpdate.data?.success ||
-                                !canSetEmail.data?.success
-                              }
-                              id="admin-user-email"
-                              onChange={(event) => setEmail(event.target.value)}
-                              required
-                              type="email"
-                              value={email}
-                            />
-                          </InputGroup>
-                        </Field>
-                        <Field orientation="horizontal">
-                          <Switch
-                            checked={emailVerified}
-                            disabled={
-                              !canUpdate.data?.success ||
-                              !canSetEmail.data?.success
-                            }
-                            id="admin-user-email-verified"
-                            onCheckedChange={setEmailVerified}
-                          />
-                          <FieldContent>
-                            <FieldLabel htmlFor="admin-user-email-verified">
-                              {config.localization.emailVerified}
-                            </FieldLabel>
-                          </FieldContent>
-                        </Field>
+                        <profileForm.Field name="name">
+                          {(field) => (
+                            <Field>
+                              <FieldLabel htmlFor="admin-user-name">
+                                {config.localization.name}
+                              </FieldLabel>
+                              <InputGroup>
+                                <InputGroupInput
+                                  disabled={!canUpdate.data?.success}
+                                  id="admin-user-name"
+                                  name={field.name}
+                                  value={field.state.value}
+                                  onChange={(event) =>
+                                    field.handleChange(event.target.value)
+                                  }
+                                />
+                              </InputGroup>
+                            </Field>
+                          )}
+                        </profileForm.Field>
+                        <profileForm.Field name="email">
+                          {(field) => (
+                            <Field>
+                              <FieldLabel htmlFor="admin-user-email">
+                                {config.localization.email}
+                              </FieldLabel>
+                              <InputGroup>
+                                <InputGroupInput
+                                  disabled={
+                                    !canUpdate.data?.success ||
+                                    !canSetEmail.data?.success
+                                  }
+                                  id="admin-user-email"
+                                  name={field.name}
+                                  onChange={(event) =>
+                                    field.handleChange(event.target.value)
+                                  }
+                                  required
+                                  type="email"
+                                  value={field.state.value}
+                                />
+                              </InputGroup>
+                            </Field>
+                          )}
+                        </profileForm.Field>
+                        <profileForm.Field name="emailVerified">
+                          {(field) => (
+                            <Field orientation="horizontal">
+                              <Switch
+                                checked={field.state.value}
+                                disabled={
+                                  !canUpdate.data?.success ||
+                                  !canSetEmail.data?.success
+                                }
+                                id="admin-user-email-verified"
+                                onCheckedChange={field.handleChange}
+                              />
+                              <FieldContent>
+                                <FieldLabel htmlFor="admin-user-email-verified">
+                                  {config.localization.emailVerified}
+                                </FieldLabel>
+                              </FieldContent>
+                            </Field>
+                          )}
+                        </profileForm.Field>
                         <FieldSet>
                           <FieldLegend variant="label">
                             {config.localization.role}
                           </FieldLegend>
-                          {config.allowMultipleRoles ? (
-                            <FieldGroup
-                              className="flex-row flex-wrap gap-4"
-                              data-slot="checkbox-group"
-                            >
-                              {config.roles.map((item) => (
-                                <Field key={item} orientation="horizontal">
-                                  <Checkbox
-                                    checked={roles.includes(item)}
-                                    disabled={
-                                      isSelf || !canSetRole.data?.success
-                                    }
-                                    id={`admin-user-role-${item}`}
-                                    onCheckedChange={(checked) => {
-                                      const next = checked
-                                        ? [...roles, item]
-                                        : roles.filter((role) => role !== item)
-                                      if (next.length) setRoles(next)
-                                    }}
-                                  />
-                                  <FieldLabel
-                                    htmlFor={`admin-user-role-${item}`}
-                                  >
-                                    {item}
-                                  </FieldLabel>
-                                </Field>
-                              ))}
-                            </FieldGroup>
-                          ) : (
-                            <RadioGroup
-                              className="flex-row flex-wrap gap-4"
-                              disabled={isSelf || !canSetRole.data?.success}
-                              onValueChange={(role) => setRoles([role])}
-                              value={roles[0] ?? ""}
-                            >
-                              {config.roles.map((item) => (
-                                <Field key={item} orientation="horizontal">
-                                  <RadioGroupItem
-                                    id={`admin-user-role-${item}`}
-                                    value={item}
-                                  />
-                                  <FieldLabel
-                                    htmlFor={`admin-user-role-${item}`}
-                                  >
-                                    {item}
-                                  </FieldLabel>
-                                </Field>
-                              ))}
-                            </RadioGroup>
-                          )}
+                          <profileForm.Field name="roles">
+                            {(field) =>
+                              config.allowMultipleRoles ? (
+                                <FieldGroup
+                                  className="flex-row flex-wrap gap-4"
+                                  data-slot="checkbox-group"
+                                >
+                                  {config.roles.map((item) => (
+                                    <Field key={item} orientation="horizontal">
+                                      <Checkbox
+                                        checked={field.state.value.includes(
+                                          item
+                                        )}
+                                        disabled={
+                                          isSelf || !canSetRole.data?.success
+                                        }
+                                        id={`admin-user-role-${item}`}
+                                        onCheckedChange={(checked) => {
+                                          const next = checked
+                                            ? [...field.state.value, item]
+                                            : field.state.value.filter(
+                                                (role) => role !== item
+                                              )
+                                          if (next.length)
+                                            field.handleChange(next)
+                                        }}
+                                      />
+                                      <FieldLabel
+                                        htmlFor={`admin-user-role-${item}`}
+                                      >
+                                        {item}
+                                      </FieldLabel>
+                                    </Field>
+                                  ))}
+                                </FieldGroup>
+                              ) : (
+                                <RadioGroup
+                                  className="flex-row flex-wrap gap-4"
+                                  disabled={isSelf || !canSetRole.data?.success}
+                                  onValueChange={(role) =>
+                                    field.handleChange([role])
+                                  }
+                                  value={field.state.value[0] ?? ""}
+                                >
+                                  {config.roles.map((item) => (
+                                    <Field key={item} orientation="horizontal">
+                                      <RadioGroupItem
+                                        id={`admin-user-role-${item}`}
+                                        value={item}
+                                      />
+                                      <FieldLabel
+                                        htmlFor={`admin-user-role-${item}`}
+                                      >
+                                        {item}
+                                      </FieldLabel>
+                                    </Field>
+                                  ))}
+                                </RadioGroup>
+                              )
+                            }
+                          </profileForm.Field>
                         </FieldSet>
                         {auth.additionalFields?.map((field) => {
                           const value = (
@@ -1508,21 +1616,30 @@ function UserInspector({
                     >
                       {config.localization.cancel}
                     </Button>
-                    <Button
-                      disabled={
-                        !name.trim() ||
-                        !email.trim() ||
-                        updateUser.isPending ||
-                        setRoleMutation.isPending ||
-                        canUpdate.isPending ||
-                        canSetRole.isPending ||
-                        (!canUpdate.data?.success &&
-                          (!canSetRole.data?.success || isSelf))
-                      }
-                      type="submit"
+                    <profileForm.Subscribe
+                      selector={(state) => [
+                        state.values.name,
+                        state.values.email
+                      ]}
                     >
-                      {config.localization.saveChanges}
-                    </Button>
+                      {([name, email]) => (
+                        <Button
+                          disabled={
+                            !name.trim() ||
+                            !email.trim() ||
+                            updateUser.isPending ||
+                            setRoleMutation.isPending ||
+                            canUpdate.isPending ||
+                            canSetRole.isPending ||
+                            (!canUpdate.data?.success &&
+                              (!canSetRole.data?.success || isSelf))
+                          }
+                          type="submit"
+                        >
+                          {config.localization.saveChanges}
+                        </Button>
+                      )}
+                    </profileForm.Subscribe>
                   </div>
                 </form>
               </TabsContent>

--- a/examples/start-shadcn-example/src/components/auth/api-key/api-keys.tsx
+++ b/examples/start-shadcn-example/src/components/auth/api-key/api-keys.tsx
@@ -1,8 +1,21 @@
 "use client"
 
-import type { ApiKeyAuthClient } from "@better-auth-ui/core/plugins/api-key"
+import type {
+  ApiKeyAuthClient,
+  ListedApiKey
+} from "@better-auth-ui/core/plugins/api-key"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useListApiKeys } from "@better-auth-ui/react/plugins/api-key"
+import {
+  createTableHook,
+  functionalUpdate,
+  type PaginationState,
+  rowPaginationFeature,
+  rowSortingFeature,
+  type SortingState,
+  tableFeatures,
+  type Updater
+} from "@tanstack/react-table"
 import { Fragment, useState } from "react"
 
 import { Button } from "@/components/ui/button"
@@ -21,6 +34,20 @@ import { ApiKey } from "./api-key"
 import { ApiKeySkeleton } from "./api-key-skeleton"
 import { ApiKeysEmpty } from "./api-keys-empty"
 import { CreateApiKeyDialog } from "./create-api-key-dialog"
+
+const { createAppColumnHelper, useAppTable: useApiKeyTable } = createTableHook({
+  enableMultiSort: false,
+  enableSortingRemoval: false,
+  sortDescFirst: false,
+  features: tableFeatures({ rowPaginationFeature, rowSortingFeature })
+})
+
+const apiKeyColumnHelper = createAppColumnHelper<ListedApiKey>()
+const apiKeyColumns = apiKeyColumnHelper.columns([
+  apiKeyColumnHelper.accessor("createdAt", { id: "createdAt" }),
+  apiKeyColumnHelper.accessor("name", { id: "name" })
+])
+const EMPTY_API_KEYS: ListedApiKey[] = []
 
 export type ApiKeysProps = {
   className?: string
@@ -47,17 +74,25 @@ export function ApiKeys({
   const { authClient } = useAuth<ApiKeyAuthClient>()
   const { localization: apiKeyLocalization, pageSize } =
     useAuthPlugin(apiKeyPlugin)
-  const [page, setPage] = useState(0)
-  const [sort, setSort] = useState("createdAt:desc")
-  const [sortBy, sortDirection] = sort.split(":") as [string, "asc" | "desc"]
+  const [pagination, setPaginationState] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const [sorting, setSortingState] = useState<SortingState>([
+    { id: "createdAt", desc: true }
+  ])
+  const primarySort = sorting[0]
+  const sortBy = primarySort?.id === "name" ? "name" : "createdAt"
+  const sortDirection = primarySort?.desc ? "desc" : "asc"
+  const sort = `${sortBy}:${sortDirection}`
 
   const { data: listData, isPending: isListPending } = useListApiKeys(
     authClient,
     {
       enabled: !isPendingProp,
       query: {
-        limit: pageSize,
-        offset: page * pageSize,
+        limit: pagination.pageSize,
+        offset: pagination.pageIndex * pagination.pageSize,
         sortBy,
         sortDirection,
         ...(organizationId ? { organizationId, configId: "organization" } : {})
@@ -66,6 +101,22 @@ export function ApiKeys({
   )
 
   const isPending = isPendingProp || isListPending
+  const setPagination = (updater: Updater<PaginationState>) =>
+    setPaginationState((current) => functionalUpdate(updater, current))
+  const setSorting = (updater: Updater<SortingState>) => {
+    setSortingState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const table = useApiKeyTable({
+    columns: apiKeyColumns,
+    data: listData?.apiKeys ?? EMPTY_API_KEYS,
+    getRowId: (apiKey) => apiKey.id,
+    manualPagination: true,
+    manualSorting: true,
+    state: { pagination, sorting },
+    onPaginationChange: setPagination,
+    onSortingChange: setSorting
+  })
 
   const [createOpen, setCreateOpen] = useState(false)
 
@@ -90,8 +141,8 @@ export function ApiKeys({
       <Select
         value={sort}
         onValueChange={(value) => {
-          setSort(value)
-          setPage(0)
+          const [id, direction] = value.split(":")
+          table.setSorting([{ id, desc: direction === "desc" }])
         }}
       >
         <SelectTrigger aria-label={apiKeyLocalization.sortBy}>
@@ -124,11 +175,11 @@ export function ApiKeys({
             />
           ) : (
             <ItemGroup className="gap-0">
-              {listData.apiKeys.map((key, index) => (
-                <Fragment key={key.id}>
+              {table.getRowModel().rows.map((row, index) => (
+                <Fragment key={row.id}>
                   {index > 0 && <ItemSeparator />}
                   <ApiKey
-                    apiKey={key}
+                    apiKey={row.original}
                     hideDelete={hideDelete}
                     hideUpdate={hideUpdate}
                     organizationId={organizationId}
@@ -139,21 +190,22 @@ export function ApiKeys({
           )}
         </CardContent>
       </Card>
-      {(page > 0 || (listData?.apiKeys.length ?? 0) === pageSize) && (
+      {(pagination.pageIndex > 0 ||
+        (listData?.apiKeys.length ?? 0) === pagination.pageSize) && (
         <div className="flex justify-end gap-2">
           <Button
             variant="outline"
             size="sm"
-            disabled={page === 0}
-            onClick={() => setPage((value) => Math.max(0, value - 1))}
+            disabled={!table.getCanPreviousPage()}
+            onClick={() => table.previousPage()}
           >
             {apiKeyLocalization.previousPage}
           </Button>
           <Button
             variant="outline"
             size="sm"
-            disabled={(listData?.apiKeys.length ?? 0) < pageSize}
-            onClick={() => setPage((value) => value + 1)}
+            disabled={(listData?.apiKeys.length ?? 0) < pagination.pageSize}
+            onClick={() => table.nextPage()}
           >
             {apiKeyLocalization.nextPage}
           </Button>

--- a/examples/start-shadcn-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-shadcn-example/src/components/auth/dash/activity.tsx
@@ -21,6 +21,17 @@ import {
 import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
 import { keepPreviousData } from "@tanstack/react-query"
 import {
+  type ColumnFiltersState,
+  columnFilteringFeature,
+  createTableHook,
+  functionalUpdate,
+  globalFilteringFeature,
+  type PaginationState,
+  rowPaginationFeature,
+  tableFeatures,
+  type Updater
+} from "@tanstack/react-table"
+import {
   Activity,
   Building2,
   ChevronLeft,
@@ -73,6 +84,21 @@ import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
 
 type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
+
+const { createAppColumnHelper, useAppTable: useActivityTable } =
+  createTableHook({
+    features: tableFeatures({
+      columnFilteringFeature,
+      globalFilteringFeature,
+      rowPaginationFeature
+    })
+  })
+
+const activityColumnHelper = createAppColumnHelper<DashAuditLog>()
+const activityColumns = activityColumnHelper.columns([
+  activityColumnHelper.accessor("eventType", { id: "eventType" })
+])
+const EMPTY_EVENTS: DashAuditLog[] = []
 
 type ActivityFeedProps = {
   access: ActivityAccess
@@ -211,19 +237,27 @@ function ActivityFeed({
 }: ActivityFeedProps) {
   const { authClient } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
-  const [page, setPage] = useState(0)
-  const [eventType, setEventType] = useState("all")
-  const [identifier, setIdentifier] = useState("")
-  const deferredIdentifier = useDeferredValue(identifier.trim())
+  const [pagination, setPaginationState] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const [columnFilters, setColumnFiltersState] = useState<ColumnFiltersState>(
+    []
+  )
+  const [globalFilter, setGlobalFilterState] = useState("")
+  const eventType = String(
+    columnFilters.find((filter) => filter.id === "eventType")?.value ?? "all"
+  )
+  const deferredIdentifier = useDeferredValue(globalFilter.trim())
   const eventOptions = useMemo(
     () => Object.entries(localization.eventLabels),
     [localization.eventLabels]
   )
-  const offset = page * pageSize
+  const offset = pagination.pageIndex * pagination.pageSize
   const params = {
     eventType: eventType === "all" ? undefined : eventType,
     identifier: deferredIdentifier || undefined,
-    limit: pageSize,
+    limit: pagination.pageSize,
     offset,
     organizationId
   }
@@ -245,7 +279,7 @@ function ActivityFeed({
       params: {
         eventType: params.eventType,
         identifier: params.identifier,
-        limit: pageSize,
+        limit: pagination.pageSize,
         offset
       }
     }
@@ -259,7 +293,28 @@ function ActivityFeed({
   const { data, error, isFetching, isPending } = query
   const showPending = !ready || isPending
   const pageEnd = offset + (data?.events.length ?? 0)
-  const hasNextPage = pageEnd < (data?.total ?? 0)
+  const setPagination = (updater: Updater<PaginationState>) =>
+    setPaginationState((current) => functionalUpdate(updater, current))
+  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
+    setColumnFiltersState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const setGlobalFilter = (updater: Updater<string>) => {
+    setGlobalFilterState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const table = useActivityTable({
+    columns: activityColumns,
+    data: data?.events ?? EMPTY_EVENTS,
+    getRowId: getDashEventKey,
+    manualFiltering: true,
+    manualPagination: true,
+    rowCount: data?.total ?? 0,
+    state: { columnFilters, globalFilter, pagination },
+    onColumnFiltersChange: setColumnFilters,
+    onGlobalFilterChange: setGlobalFilter,
+    onPaginationChange: setPagination
+  })
 
   return (
     <Card
@@ -297,8 +352,9 @@ function ActivityFeed({
             <Select
               value={eventType}
               onValueChange={(value) => {
-                setEventType(value)
-                setPage(0)
+                table
+                  .getColumn("eventType")
+                  ?.setFilterValue(value === "all" ? undefined : value)
               }}
             >
               <SelectTrigger id="dash-event-type" className="w-full">
@@ -325,11 +381,10 @@ function ActivityFeed({
               <InputGroupInput
                 id="dash-identifier"
                 onChange={(event) => {
-                  setIdentifier(event.target.value)
-                  setPage(0)
+                  table.setGlobalFilter(event.target.value)
                 }}
                 placeholder={localization.identifierPlaceholder}
-                value={identifier}
+                value={globalFilter}
               />
             </InputGroup>
           </Field>
@@ -366,10 +421,10 @@ function ActivityFeed({
           </Empty>
         ) : data?.events.length ? (
           <ul>
-            {data.events.map((event, position) => (
-              <Fragment key={getDashEventKey(event)}>
+            {table.getRowModel().rows.map((row, position) => (
+              <Fragment key={row.id}>
                 {position > 0 && <Separator />}
-                <ActivityRow event={event} />
+                <ActivityRow event={row.original} />
               </Fragment>
             ))}
           </ul>
@@ -402,19 +457,19 @@ function ActivityFeed({
           <div className="flex gap-1">
             <Button
               aria-label={localization.previousPage}
-              disabled={isFetching || page === 0}
+              disabled={isFetching || !table.getCanPreviousPage()}
               size="icon-sm"
               variant="ghost"
-              onClick={() => setPage((current) => Math.max(0, current - 1))}
+              onClick={() => table.previousPage()}
             >
               <ChevronLeft />
             </Button>
             <Button
               aria-label={localization.nextPage}
-              disabled={isFetching || !hasNextPage}
+              disabled={isFetching || !table.getCanNextPage()}
               size="icon-sm"
               variant="ghost"
-              onClick={() => setPage((current) => current + 1)}
+              onClick={() => table.nextPage()}
             >
               <ChevronRight />
             </Button>

--- a/examples/start-shadcn-example/src/components/auth/oauth-provider/oauth-clients.tsx
+++ b/examples/start-shadcn-example/src/components/auth/oauth-provider/oauth-clients.tsx
@@ -22,6 +22,7 @@ import {
   useSetOAuthClientDisabled,
   useUpdateOAuthClient
 } from "@better-auth-ui/react/plugins/oauth-provider"
+import { useForm } from "@tanstack/react-form"
 import {
   Check,
   Code2,
@@ -31,7 +32,7 @@ import {
   RotateCcwKey,
   Trash2
 } from "lucide-react"
-import { type SyntheticEvent, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -85,6 +86,15 @@ type ClientAction =
   | { kind: "delete"; client: ManagedOAuthClient }
   | { kind: "rotate"; client: ManagedOAuthClient }
 
+type OAuthClientFormValues = {
+  applicationType: "native" | "web"
+  clientName: string
+  clientUri: string
+  logoUri: string
+  redirectUris: string
+  scope: string
+}
+
 export type OAuthClientsProps = {
   manager: OAuthClientManager
   owner: OAuthClientOwner
@@ -101,6 +111,17 @@ const uniqueLines = (value: string) =>
         .filter(Boolean)
     )
   )
+
+const getOAuthClientFormValues = (
+  client?: ManagedOAuthClient
+): OAuthClientFormValues => ({
+  applicationType: client?.application_type === "native" ? "native" : "web",
+  clientName: client?.client_name ?? "",
+  clientUri: client?.client_uri ?? "",
+  logoUri: client?.logo_uri ?? "",
+  redirectUris: client?.redirect_uris.join("\n") ?? "",
+  scope: client?.scope ?? ""
+})
 
 export function OAuthClients({
   manager,
@@ -124,39 +145,41 @@ export function OAuthClients({
     onError: (error) =>
       toast.error(error instanceof Error ? error.message : String(error))
   })
+  const form = useForm({
+    defaultValues: getOAuthClientFormValues(),
+    onSubmit: async ({ value }) => {
+      const input: OAuthClientInput = {
+        client_name: value.clientName.trim(),
+        application_type: value.applicationType,
+        redirect_uris: uniqueLines(value.redirectUris),
+        client_uri: value.clientUri.trim() || undefined,
+        logo_uri: value.logoUri.trim() || undefined,
+        scope: value.scope.trim() || undefined
+      }
+
+      try {
+        if (editingClient) {
+          await updateClient.mutateAsync({
+            clientId: editingClient.client_id,
+            update: input
+          })
+          setEditorOpen(false)
+          return
+        }
+
+        const client = await createClient.mutateAsync(input)
+        setEditorOpen(false)
+        setSecret(client)
+      } catch {
+        // The mutation keeps its error state for the host application.
+      }
+    }
+  })
 
   const openCreate = () => {
     setEditingClient(undefined)
+    form.reset(getOAuthClientFormValues())
     setEditorOpen(true)
-  }
-
-  const handleEditorSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    const input: OAuthClientInput = {
-      client_name: String(formData.get("clientName") ?? "").trim(),
-      application_type:
-        formData.get("applicationType") === "native" ? "native" : "web",
-      redirect_uris: uniqueLines(String(formData.get("redirectUris") ?? "")),
-      client_uri: String(formData.get("clientUri") ?? "").trim() || undefined,
-      logo_uri: String(formData.get("logoUri") ?? "").trim() || undefined,
-      scope: String(formData.get("scope") ?? "").trim() || undefined
-    }
-
-    if (editingClient) {
-      updateClient.mutate(
-        { clientId: editingClient.client_id, update: input },
-        { onSuccess: () => setEditorOpen(false) }
-      )
-      return
-    }
-
-    createClient.mutate(input, {
-      onSuccess: (client) => {
-        setEditorOpen(false)
-        setSecret(client)
-      }
-    })
   }
 
   const confirmAction = () => {
@@ -263,6 +286,7 @@ export function OAuthClients({
                     aria-label={oauthLocalization.editClient}
                     onClick={() => {
                       setEditingClient(client)
+                      form.reset(getOAuthClientFormValues(client))
                       setEditorOpen(true)
                     }}
                   >
@@ -310,7 +334,13 @@ export function OAuthClients({
 
       <Dialog open={editorOpen} onOpenChange={setEditorOpen}>
         <DialogContent>
-          <form onSubmit={handleEditorSubmit} className="flex flex-col gap-6">
+          <form
+            onSubmit={(event) => {
+              event.preventDefault()
+              void form.handleSubmit()
+            }}
+            className="flex flex-col gap-6"
+          >
             <DialogHeader>
               <DialogTitle className="flex items-center gap-2">
                 {editingClient ? <Pencil /> : <Plus />}
@@ -323,87 +353,118 @@ export function OAuthClients({
               </DialogDescription>
             </DialogHeader>
             <FieldGroup>
-              <Field>
-                <FieldLabel htmlFor="oauth-client-name">
-                  {oauthLocalization.clientName}
-                </FieldLabel>
-                <Input
-                  id="oauth-client-name"
-                  name="clientName"
-                  defaultValue={editingClient?.client_name ?? ""}
-                  required
-                  autoFocus
-                />
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-application-type">
-                  {oauthLocalization.applicationType}
-                </FieldLabel>
-                <Select
-                  name="applicationType"
-                  defaultValue={editingClient?.application_type ?? "web"}
-                >
-                  <SelectTrigger id="oauth-application-type" className="w-full">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="web">
-                      {oauthLocalization.webApplication}
-                    </SelectItem>
-                    <SelectItem value="native">
-                      {oauthLocalization.nativeApplication}
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-redirect-uris">
-                  {oauthLocalization.redirectUrls}
-                </FieldLabel>
-                <Textarea
-                  id="oauth-redirect-uris"
-                  name="redirectUris"
-                  rows={3}
-                  defaultValue={editingClient?.redirect_uris.join("\n") ?? ""}
-                  required
-                />
-                <FieldDescription>
-                  {oauthLocalization.redirectUrlsDescription}
-                </FieldDescription>
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-client-uri">
-                  {oauthLocalization.applicationUrl}
-                </FieldLabel>
-                <Input
-                  id="oauth-client-uri"
-                  name="clientUri"
-                  type="url"
-                  defaultValue={editingClient?.client_uri ?? ""}
-                />
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-logo-uri">
-                  {oauthLocalization.logoUrl}
-                </FieldLabel>
-                <Input
-                  id="oauth-logo-uri"
-                  name="logoUri"
-                  type="url"
-                  defaultValue={editingClient?.logo_uri ?? ""}
-                />
-              </Field>
-              <Field>
-                <FieldLabel htmlFor="oauth-scopes">
-                  {oauthLocalization.scopes}
-                </FieldLabel>
-                <Input
-                  id="oauth-scopes"
-                  name="scope"
-                  placeholder="openid profile email"
-                  defaultValue={editingClient?.scope ?? ""}
-                />
-              </Field>
+              <form.Field name="clientName">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="oauth-client-name">
+                      {oauthLocalization.clientName}
+                    </FieldLabel>
+                    <Input
+                      autoFocus
+                      id="oauth-client-name"
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      value={field.state.value}
+                    />
+                  </Field>
+                )}
+              </form.Field>
+              <form.Field name="applicationType">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="oauth-application-type">
+                      {oauthLocalization.applicationType}
+                    </FieldLabel>
+                    <Select
+                      name={field.name}
+                      onValueChange={(value) =>
+                        field.handleChange(value as "native" | "web")
+                      }
+                      value={field.state.value}
+                    >
+                      <SelectTrigger
+                        id="oauth-application-type"
+                        className="w-full"
+                      >
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="web">
+                          {oauthLocalization.webApplication}
+                        </SelectItem>
+                        <SelectItem value="native">
+                          {oauthLocalization.nativeApplication}
+                        </SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </Field>
+                )}
+              </form.Field>
+              <form.Field name="redirectUris">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="oauth-redirect-uris">
+                      {oauthLocalization.redirectUrls}
+                    </FieldLabel>
+                    <Textarea
+                      id="oauth-redirect-uris"
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      rows={3}
+                      value={field.state.value}
+                    />
+                    <FieldDescription>
+                      {oauthLocalization.redirectUrlsDescription}
+                    </FieldDescription>
+                  </Field>
+                )}
+              </form.Field>
+              {(
+                [
+                  [
+                    "clientUri",
+                    "oauth-client-uri",
+                    oauthLocalization.applicationUrl,
+                    "url"
+                  ],
+                  [
+                    "logoUri",
+                    "oauth-logo-uri",
+                    oauthLocalization.logoUrl,
+                    "url"
+                  ],
+                  ["scope", "oauth-scopes", oauthLocalization.scopes, "text"]
+                ] as const
+              ).map(([name, id, label, type]) => (
+                <form.Field key={name} name={name}>
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor={id}>{label}</FieldLabel>
+                      <Input
+                        id={id}
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        placeholder={
+                          name === "scope" ? "openid profile email" : undefined
+                        }
+                        type={type}
+                        value={field.state.value}
+                      />
+                    </Field>
+                  )}
+                </form.Field>
+              ))}
             </FieldGroup>
             <DialogFooter>
               <DialogClose
@@ -412,17 +473,16 @@ export function OAuthClients({
               >
                 {oauthLocalization.cancel}
               </DialogClose>
-              <Button
-                type="submit"
-                disabled={createClient.isPending || updateClient.isPending}
-              >
-                {(createClient.isPending || updateClient.isPending) && (
-                  <Spinner />
+              <form.Subscribe selector={(state) => state.isSubmitting}>
+                {(isSubmitting) => (
+                  <Button type="submit" disabled={isSubmitting}>
+                    {isSubmitting && <Spinner />}
+                    {editingClient
+                      ? oauthLocalization.saveChanges
+                      : oauthLocalization.createClient}
+                  </Button>
                 )}
-                {editingClient
-                  ? oauthLocalization.saveChanges
-                  : oauthLocalization.createClient}
-              </Button>
+              </form.Subscribe>
             </DialogFooter>
           </form>
         </DialogContent>

--- a/examples/start-shadcn-example/src/components/auth/organization/edit-member-roles-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/edit-member-roles-dialog.tsx
@@ -4,8 +4,9 @@ import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organi
 import { parseMemberRoles } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useUpdateMemberRole } from "@better-auth-ui/react/plugins/organization"
+import { useForm } from "@tanstack/react-form"
 import { ShieldCheck } from "lucide-react"
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
 import { toast } from "sonner"
 
 import { Button, buttonVariants } from "@/components/ui/button"
@@ -71,9 +72,6 @@ export function EditMemberRolesDialog({
   const { authClient, localization } = useAuth<OrganizationAuthClient>()
   const { allowMultipleRoles, localization: organizationLocalization } =
     useAuthPlugin(organizationPlugin)
-  const [selectedRoles, setSelectedRoles] = useState(() =>
-    selectedMemberRoles(member.role, allowMultipleRoles, protectedRole)
-  )
   const { mutate: updateMemberRole, isPending } = useUpdateMemberRole(
     authClient,
     {
@@ -83,16 +81,36 @@ export function EditMemberRolesDialog({
       }
     }
   )
+  const form = useForm({
+    defaultValues: {
+      roles: selectedMemberRoles(member.role, allowMultipleRoles, protectedRole)
+    },
+    onSubmit: ({ value }) => {
+      if (value.roles.length === 0) return
+
+      updateMemberRole({
+        memberId: member.id,
+        organizationId,
+        role: value.roles
+      })
+    }
+  })
 
   useEffect(() => {
     if (open)
-      setSelectedRoles(
-        selectedMemberRoles(member.role, allowMultipleRoles, protectedRole)
-      )
-  }, [allowMultipleRoles, member.role, open, protectedRole])
+      form.reset({
+        roles: selectedMemberRoles(
+          member.role,
+          allowMultipleRoles,
+          protectedRole
+        )
+      })
+  }, [allowMultipleRoles, form.reset, member.role, open, protectedRole])
 
   const toggleRole = (role: string, checked: boolean) => {
-    setSelectedRoles((current) =>
+    const current = form.getFieldValue("roles")
+    form.setFieldValue(
+      "roles",
       checked
         ? current.includes(role)
           ? current
@@ -101,41 +119,6 @@ export function EditMemberRolesDialog({
     )
   }
 
-  const protectedRoleSelected =
-    !allowMultipleRoles &&
-    protectedRoleRemovalDisabled &&
-    protectedRole !== undefined &&
-    selectedRoles.includes(protectedRole)
-  const roleOptions = roles.map(([role, label]) => {
-    const checked = selectedRoles.includes(role)
-    const disabled =
-      isPending ||
-      (allowMultipleRoles && checked && selectedRoles.length === 1) ||
-      (protectedRoleSelected && role !== protectedRole) ||
-      (role === protectedRole && checked && protectedRoleRemovalDisabled)
-    const id = `member-${member.id}-role-${role}`
-
-    return (
-      <FieldLabel htmlFor={id} key={role}>
-        <Field orientation="horizontal" data-disabled={disabled}>
-          <FieldContent>
-            <FieldTitle>{label}</FieldTitle>
-          </FieldContent>
-          {allowMultipleRoles ? (
-            <Checkbox
-              checked={checked}
-              disabled={disabled}
-              id={id}
-              onCheckedChange={(next) => toggleRole(role, next === true)}
-            />
-          ) : (
-            <RadioGroupItem disabled={disabled} id={id} value={role} />
-          )}
-        </Field>
-      </FieldLabel>
-    )
-  })
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
@@ -143,13 +126,7 @@ export function EditMemberRolesDialog({
           className="flex flex-col gap-6"
           onSubmit={(event) => {
             event.preventDefault()
-            if (selectedRoles.length === 0) return
-
-            updateMemberRole({
-              memberId: member.id,
-              organizationId,
-              role: selectedRoles
-            })
+            void form.handleSubmit()
           }}
         >
           <DialogHeader>
@@ -162,34 +139,89 @@ export function EditMemberRolesDialog({
             </DialogDescription>
           </DialogHeader>
 
-          {allowMultipleRoles ? (
-            <div className="flex flex-col gap-2">{roleOptions}</div>
-          ) : (
-            <RadioGroup
-              disabled={isPending}
-              onValueChange={(role) => setSelectedRoles([role])}
-              value={selectedRoles[0] ?? ""}
-            >
-              {roleOptions}
-            </RadioGroup>
-          )}
+          <form.Subscribe selector={(state) => state.values.roles}>
+            {(selectedRoles) => {
+              const protectedRoleSelected =
+                !allowMultipleRoles &&
+                protectedRoleRemovalDisabled &&
+                protectedRole !== undefined &&
+                selectedRoles.includes(protectedRole)
+              const roleOptions = roles.map(([role, label]) => {
+                const checked = selectedRoles.includes(role)
+                const disabled =
+                  isPending ||
+                  (allowMultipleRoles &&
+                    checked &&
+                    selectedRoles.length === 1) ||
+                  (protectedRoleSelected && role !== protectedRole) ||
+                  (role === protectedRole &&
+                    checked &&
+                    protectedRoleRemovalDisabled)
+                const id = `member-${member.id}-role-${role}`
 
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              disabled={isPending}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-            <Button
-              disabled={isPending || selectedRoles.length === 0}
-              type="submit"
-            >
-              {isPending && <Spinner />}
-              {localization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
+                return (
+                  <FieldLabel htmlFor={id} key={role}>
+                    <Field orientation="horizontal" data-disabled={disabled}>
+                      <FieldContent>
+                        <FieldTitle>{label}</FieldTitle>
+                      </FieldContent>
+                      {allowMultipleRoles ? (
+                        <Checkbox
+                          checked={checked}
+                          disabled={disabled}
+                          id={id}
+                          onCheckedChange={(next) =>
+                            toggleRole(role, next === true)
+                          }
+                        />
+                      ) : (
+                        <RadioGroupItem
+                          disabled={disabled}
+                          id={id}
+                          value={role}
+                        />
+                      )}
+                    </Field>
+                  </FieldLabel>
+                )
+              })
+
+              return (
+                <>
+                  {allowMultipleRoles ? (
+                    <div className="flex flex-col gap-2">{roleOptions}</div>
+                  ) : (
+                    <RadioGroup
+                      disabled={isPending}
+                      onValueChange={(role) =>
+                        form.setFieldValue("roles", [role])
+                      }
+                      value={selectedRoles[0] ?? ""}
+                    >
+                      {roleOptions}
+                    </RadioGroup>
+                  )}
+
+                  <DialogFooter>
+                    <DialogClose
+                      className={buttonVariants({ variant: "outline" })}
+                      disabled={isPending}
+                      type="button"
+                    >
+                      {localization.settings.cancel}
+                    </DialogClose>
+                    <Button
+                      disabled={isPending || selectedRoles.length === 0}
+                      type="submit"
+                    >
+                      {isPending && <Spinner />}
+                      {localization.settings.saveChanges}
+                    </Button>
+                  </DialogFooter>
+                </>
+              )
+            }}
+          </form.Subscribe>
         </form>
       </DialogContent>
     </Dialog>

--- a/examples/start-shadcn-example/src/components/auth/reset-password.tsx
+++ b/examples/start-shadcn-example/src/components/auth/reset-password.tsx
@@ -5,8 +5,9 @@ import {
   isPasswordCompromisedError
 } from "@better-auth-ui/core"
 import { useAuth, useResetPassword } from "@better-auth-ui/react"
+import { useForm } from "@tanstack/react-form"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -72,7 +73,6 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     }
   })
 
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
   const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
     useState(false)
@@ -92,29 +92,32 @@ export function ResetPassword({ className }: ResetPasswordProps) {
     }
   }, [localization.auth.invalidResetPasswordToken, navigate, signInURL])
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
+  const form = useForm({
+    defaultValues: { confirmPassword: "", password: "" },
+    onSubmit: ({ value }) => {
+      const searchParams = new URLSearchParams(window.location.search)
+      const token = searchParams.get("token") as string
 
-    const searchParams = new URLSearchParams(window.location.search)
-    const token = searchParams.get("token") as string
+      if (!token) {
+        toast.error(localization.auth.invalidResetPasswordToken)
+        navigate({ to: signInURL })
+        return
+      }
 
-    if (!token) {
-      toast.error(localization.auth.invalidResetPasswordToken)
-      navigate({ to: signInURL })
-      return
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
+        setFieldErrors((current) => ({
+          ...current,
+          confirmPassword: localization.auth.passwordsDoNotMatch
+        }))
+        return
+      }
+
+      resetPassword({ token, newPassword: value.password })
     }
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-    const confirmPassword = formData.get("confirmPassword") as string
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      toast.error(localization.auth.passwordsDoNotMatch)
-      return
-    }
-
-    resetPassword({ token, newPassword: password })
-  }
+  })
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -125,156 +128,175 @@ export function ResetPassword({ className }: ResetPasswordProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            void form.handleSubmit()
+          }}
+        >
           <FieldGroup>
-            <Field data-invalid={!!fieldErrors.password}>
-              <FieldLabel htmlFor="password">
-                {localization.auth.password}
-              </FieldLabel>
+            <form.Field name="password">
+              {(field) => (
+                <Field data-invalid={!!fieldErrors.password}>
+                  <FieldLabel htmlFor="password">
+                    {localization.auth.password}
+                  </FieldLabel>
 
-              <InputGroup>
-                <InputGroupInput
-                  id="password"
-                  name="password"
-                  type={isPasswordVisible ? "text" : "password"}
-                  autoComplete="new-password"
-                  placeholder={localization.auth.newPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                  onChange={(e) => {
-                    setPassword(e.target.value)
+                  <InputGroup>
+                    <InputGroupInput
+                      id="password"
+                      type={isPasswordVisible ? "text" : "password"}
+                      autoComplete="new-password"
+                      placeholder={localization.auth.newPasswordPlaceholder}
+                      required
+                      minLength={emailAndPassword?.minPasswordLength}
+                      maxLength={emailAndPassword?.maxPasswordLength}
+                      disabled={isPending}
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(e) => {
+                        field.handleChange(e.target.value)
+                        setFieldErrors((prev) => ({
+                          ...prev,
+                          password: undefined
+                        }))
+                      }}
+                      onInvalid={(e) => {
+                        e.preventDefault()
+                        const el = e.target as HTMLInputElement
+                        const min = emailAndPassword?.minPasswordLength
+                        const max = emailAndPassword?.maxPasswordLength
+                        const msg = el.validity.valueMissing
+                          ? localization.auth.fieldRequired
+                          : el.validity.tooShort
+                            ? localization.auth.tooShort.replace(
+                                "{{min}}",
+                                String(min)
+                              )
+                            : localization.auth.tooLong.replace(
+                                "{{max}}",
+                                String(max)
+                              )
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      password: undefined
-                    }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
-                    const el = e.target as HTMLInputElement
-                    const min = emailAndPassword?.minPasswordLength
-                    const max = emailAndPassword?.maxPasswordLength
-                    const msg = el.validity.valueMissing
-                      ? localization.auth.fieldRequired
-                      : el.validity.tooShort
-                        ? localization.auth.tooShort.replace(
-                            "{{min}}",
-                            String(min)
-                          )
-                        : localization.auth.tooLong.replace(
-                            "{{max}}",
-                            String(max)
-                          )
+                        setFieldErrors((prev) => ({
+                          ...prev,
+                          password: msg
+                        }))
+                      }}
+                      aria-invalid={!!fieldErrors.password}
+                      value={field.state.value}
+                    />
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      password: msg
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.password}
-                />
+                    <InputGroupAddon align="inline-end">
+                      <InputGroupButton
+                        size="icon-xs"
+                        aria-label={
+                          isPasswordVisible
+                            ? localization.auth.hidePassword
+                            : localization.auth.showPassword
+                        }
+                        title={
+                          isPasswordVisible
+                            ? localization.auth.hidePassword
+                            : localization.auth.showPassword
+                        }
+                        onClick={() => {
+                          setIsPasswordVisible((visible) => !visible)
+                        }}
+                      >
+                        {isPasswordVisible ? <EyeOff /> : <Eye />}
+                      </InputGroupButton>
+                    </InputGroupAddon>
+                  </InputGroup>
 
-                <InputGroupAddon align="inline-end">
-                  <InputGroupButton
-                    size="icon-xs"
-                    aria-label={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    title={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    onClick={() => {
-                      setIsPasswordVisible((visible) => !visible)
-                    }}
-                  >
-                    {isPasswordVisible ? <EyeOff /> : <Eye />}
-                  </InputGroupButton>
-                </InputGroupAddon>
-              </InputGroup>
+                  <FieldError>{fieldErrors.password}</FieldError>
 
-              <FieldError>{fieldErrors.password}</FieldError>
-
-              <PasswordStrengthMeter password={password} />
-            </Field>
+                  <PasswordStrengthMeter password={field.state.value} />
+                </Field>
+              )}
+            </form.Field>
 
             {emailAndPassword?.confirmPassword && (
-              <Field data-invalid={!!fieldErrors.confirmPassword}>
-                <FieldLabel htmlFor="confirmPassword">
-                  {localization.auth.confirmPassword}
-                </FieldLabel>
+              <form.Field name="confirmPassword">
+                {(field) => (
+                  <Field data-invalid={!!fieldErrors.confirmPassword}>
+                    <FieldLabel htmlFor="confirmPassword">
+                      {localization.auth.confirmPassword}
+                    </FieldLabel>
 
-                <InputGroup>
-                  <InputGroupInput
-                    id="confirmPassword"
-                    name="confirmPassword"
-                    type={isConfirmPasswordVisible ? "text" : "password"}
-                    autoComplete="new-password"
-                    placeholder={localization.auth.confirmPasswordPlaceholder}
-                    required
-                    minLength={emailAndPassword?.minPasswordLength}
-                    maxLength={emailAndPassword?.maxPasswordLength}
-                    disabled={isPending}
-                    onChange={() => {
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        confirmPassword: undefined
-                      }))
-                    }}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-                      const el = e.target as HTMLInputElement
-                      const min = emailAndPassword?.minPasswordLength
-                      const max = emailAndPassword?.maxPasswordLength
-                      const msg = el.validity.valueMissing
-                        ? localization.auth.fieldRequired
-                        : el.validity.tooShort
-                          ? localization.auth.tooShort.replace(
-                              "{{min}}",
-                              String(min)
-                            )
-                          : localization.auth.tooLong.replace(
-                              "{{max}}",
-                              String(max)
-                            )
+                    <InputGroup>
+                      <InputGroupInput
+                        id="confirmPassword"
+                        name={field.name}
+                        type={isConfirmPasswordVisible ? "text" : "password"}
+                        autoComplete="new-password"
+                        placeholder={
+                          localization.auth.confirmPasswordPlaceholder
+                        }
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => {
+                          field.handleChange(event.target.value)
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            confirmPassword: undefined
+                          }))
+                        }}
+                        onInvalid={(e) => {
+                          e.preventDefault()
+                          const el = e.target as HTMLInputElement
+                          const min = emailAndPassword?.minPasswordLength
+                          const max = emailAndPassword?.maxPasswordLength
+                          const msg = el.validity.valueMissing
+                            ? localization.auth.fieldRequired
+                            : el.validity.tooShort
+                              ? localization.auth.tooShort.replace(
+                                  "{{min}}",
+                                  String(min)
+                                )
+                              : localization.auth.tooLong.replace(
+                                  "{{max}}",
+                                  String(max)
+                                )
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        confirmPassword: msg
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.confirmPassword}
-                  />
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            confirmPassword: msg
+                          }))
+                        }}
+                        aria-invalid={!!fieldErrors.confirmPassword}
+                        value={field.state.value}
+                      />
 
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      size="icon-xs"
-                      aria-label={
-                        isConfirmPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      title={
-                        isConfirmPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      onClick={() => {
-                        setIsConfirmPasswordVisible((visible) => !visible)
-                      }}
-                    >
-                      {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={
+                            isConfirmPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          title={
+                            isConfirmPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() => {
+                            setIsConfirmPasswordVisible((visible) => !visible)
+                          }}
+                        >
+                          {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
 
-                <FieldError>{fieldErrors.confirmPassword}</FieldError>
-              </Field>
+                    <FieldError>{fieldErrors.confirmPassword}</FieldError>
+                  </Field>
+                )}
+              </form.Field>
             )}
 
             <div className="flex flex-col gap-3">

--- a/examples/start-shadcn-example/src/components/auth/settings/security/change-password.tsx
+++ b/examples/start-shadcn-example/src/components/auth/settings/security/change-password.tsx
@@ -9,8 +9,9 @@ import {
   useRequestPasswordReset,
   useSession
 } from "@better-auth-ui/react"
+import { useForm } from "@tanstack/react-form"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -165,10 +166,6 @@ function ChangePasswordForm({
   session: ReturnType<typeof useSession>["data"]
 }) {
   const { authClient } = useAuth()
-  const [currentPassword, setCurrentPassword] = useState("")
-  const [newPassword, setNewPassword] = useState("")
-  const [confirmPassword, setConfirmPassword] = useState("")
-
   const { mutate: changePassword, isPending } = useChangePassword(authClient, {
     onError: (error) => {
       // The haveIBeenPwned plugin rejects on the password itself, so it
@@ -180,14 +177,10 @@ function ChangePasswordForm({
         }))
       }
 
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
+      form.reset()
     },
     onSuccess: () => {
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
+      form.reset()
       toast.success(localization.settings.changePasswordSuccess)
     }
   })
@@ -204,23 +197,29 @@ function ChangePasswordForm({
     confirmPassword?: string
   }>({})
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useForm({
+    defaultValues: {
+      confirmPassword: "",
+      currentPassword: "",
+      newPassword: ""
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword.confirmPassword &&
+        value.newPassword !== value.confirmPassword
+      ) {
+        form.reset()
+        toast.error(localization.auth.passwordsDoNotMatch)
+        return
+      }
 
-    if (emailAndPassword.confirmPassword && newPassword !== confirmPassword) {
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
-      toast.error(localization.auth.passwordsDoNotMatch)
-      return
+      changePassword({
+        currentPassword: value.currentPassword,
+        newPassword: value.newPassword,
+        revokeOtherSessions: true
+      })
     }
-
-    changePassword({
-      currentPassword,
-      newPassword,
-      revokeOtherSessions: true
-    })
-  }
+  })
 
   return (
     <div>
@@ -228,204 +227,223 @@ function ChangePasswordForm({
         {localization.settings.changePassword}
       </h2>
 
-      <form onSubmit={handleSubmit}>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault()
+          void form.handleSubmit()
+        }}
+      >
         <Card className={cn(className)}>
           <CardContent className="flex flex-col gap-6">
-            <Field data-invalid={!!fieldErrors.currentPassword}>
-              <FieldLabel htmlFor="currentPassword">
-                {localization.settings.currentPassword}
-              </FieldLabel>
+            <form.Field name="currentPassword">
+              {(field) => (
+                <Field data-invalid={!!fieldErrors.currentPassword}>
+                  <FieldLabel htmlFor="currentPassword">
+                    {localization.settings.currentPassword}
+                  </FieldLabel>
 
-              {session ? (
-                <InputGroup>
-                  <InputGroupInput
-                    id="currentPassword"
-                    name="currentPassword"
-                    type={isCurrentPasswordVisible ? "text" : "password"}
-                    autoComplete="current-password"
-                    placeholder={
-                      localization.settings.currentPasswordPlaceholder
-                    }
-                    value={currentPassword}
-                    onChange={(e) => {
-                      setCurrentPassword(e.target.value)
+                  {session ? (
+                    <InputGroup>
+                      <InputGroupInput
+                        id="currentPassword"
+                        name={field.name}
+                        type={isCurrentPasswordVisible ? "text" : "password"}
+                        autoComplete="current-password"
+                        placeholder={
+                          localization.settings.currentPasswordPlaceholder
+                        }
+                        value={field.state.value}
+                        onChange={(e) => {
+                          field.handleChange(e.target.value)
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        currentPassword: undefined
-                      }))
-                    }}
-                    disabled={isPending}
-                    required
-                    onInvalid={(e) => {
-                      e.preventDefault()
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            currentPassword: undefined
+                          }))
+                        }}
+                        disabled={isPending}
+                        required
+                        onInvalid={(e) => {
+                          e.preventDefault()
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        currentPassword: (e.target as HTMLInputElement)
-                          .validationMessage
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.currentPassword}
-                  />
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            currentPassword: (e.target as HTMLInputElement)
+                              .validationMessage
+                          }))
+                        }}
+                        aria-invalid={!!fieldErrors.currentPassword}
+                      />
 
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      size="icon-xs"
-                      aria-label={
-                        isCurrentPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      title={
-                        isCurrentPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      onClick={() => {
-                        setIsCurrentPasswordVisible((visible) => !visible)
-                      }}
-                    >
-                      {isCurrentPasswordVisible ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
-              ) : (
-                <Skeleton>
-                  <Input className="invisible" />
-                </Skeleton>
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={
+                            isCurrentPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          title={
+                            isCurrentPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() => {
+                            setIsCurrentPasswordVisible((visible) => !visible)
+                          }}
+                        >
+                          {isCurrentPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  ) : (
+                    <Skeleton>
+                      <Input className="invisible" />
+                    </Skeleton>
+                  )}
+
+                  <FieldError>{fieldErrors.currentPassword}</FieldError>
+                </Field>
               )}
+            </form.Field>
 
-              <FieldError>{fieldErrors.currentPassword}</FieldError>
-            </Field>
+            <form.Field name="newPassword">
+              {(field) => (
+                <Field data-invalid={!!fieldErrors.newPassword}>
+                  <FieldLabel htmlFor="newPassword">
+                    {localization.auth.newPassword}
+                  </FieldLabel>
 
-            <Field data-invalid={!!fieldErrors.newPassword}>
-              <FieldLabel htmlFor="newPassword">
-                {localization.auth.newPassword}
-              </FieldLabel>
+                  {session ? (
+                    <InputGroup>
+                      <InputGroupInput
+                        id="newPassword"
+                        name={field.name}
+                        type={isNewPasswordVisible ? "text" : "password"}
+                        autoComplete="new-password"
+                        placeholder={localization.auth.newPasswordPlaceholder}
+                        value={field.state.value}
+                        onChange={(e) => {
+                          field.handleChange(e.target.value)
 
-              {session ? (
-                <InputGroup>
-                  <InputGroupInput
-                    id="newPassword"
-                    name="newPassword"
-                    type={isNewPasswordVisible ? "text" : "password"}
-                    autoComplete="new-password"
-                    placeholder={localization.auth.newPasswordPlaceholder}
-                    value={newPassword}
-                    onChange={(e) => {
-                      setNewPassword(e.target.value)
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            newPassword: undefined
+                          }))
+                        }}
+                        minLength={emailAndPassword.minPasswordLength}
+                        maxLength={emailAndPassword.maxPasswordLength}
+                        disabled={isPending}
+                        required
+                        onInvalid={(e) => {
+                          e.preventDefault()
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            newPassword: (e.target as HTMLInputElement)
+                              .validationMessage
+                          }))
+                        }}
+                        aria-invalid={!!fieldErrors.newPassword}
+                      />
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        newPassword: undefined
-                      }))
-                    }}
-                    minLength={emailAndPassword.minPasswordLength}
-                    maxLength={emailAndPassword.maxPasswordLength}
-                    disabled={isPending}
-                    required
-                    onInvalid={(e) => {
-                      e.preventDefault()
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        newPassword: (e.target as HTMLInputElement)
-                          .validationMessage
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.newPassword}
-                  />
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={
+                            isNewPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() =>
+                            setIsNewPasswordVisible((visible) => !visible)
+                          }
+                        >
+                          {isNewPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  ) : (
+                    <Skeleton>
+                      <Input className="invisible" />
+                    </Skeleton>
+                  )}
 
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      size="icon-xs"
-                      aria-label={
-                        isNewPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
-                      }
-                      onClick={() =>
-                        setIsNewPasswordVisible((visible) => !visible)
-                      }
-                    >
-                      {isNewPasswordVisible ? <EyeOff /> : <Eye />}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
-              ) : (
-                <Skeleton>
-                  <Input className="invisible" />
-                </Skeleton>
+                  <FieldError>{fieldErrors.newPassword}</FieldError>
+
+                  <PasswordStrengthMeter password={field.state.value} />
+                </Field>
               )}
-
-              <FieldError>{fieldErrors.newPassword}</FieldError>
-
-              <PasswordStrengthMeter password={newPassword} />
-            </Field>
+            </form.Field>
 
             {emailAndPassword.confirmPassword && (
-              <Field data-invalid={!!fieldErrors.confirmPassword}>
-                <FieldLabel htmlFor="confirmPassword">
-                  {localization.auth.confirmPassword}
-                </FieldLabel>
+              <form.Field name="confirmPassword">
+                {(field) => (
+                  <Field data-invalid={!!fieldErrors.confirmPassword}>
+                    <FieldLabel htmlFor="confirmPassword">
+                      {localization.auth.confirmPassword}
+                    </FieldLabel>
 
-                {session ? (
-                  <InputGroup>
-                    <InputGroupInput
-                      id="confirmPassword"
-                      name="confirmPassword"
-                      type={isConfirmPasswordVisible ? "text" : "password"}
-                      autoComplete="new-password"
-                      placeholder={localization.auth.confirmPasswordPlaceholder}
-                      value={confirmPassword}
-                      onChange={(e) => {
-                        setConfirmPassword(e.target.value)
+                    {session ? (
+                      <InputGroup>
+                        <InputGroupInput
+                          id="confirmPassword"
+                          name={field.name}
+                          type={isConfirmPasswordVisible ? "text" : "password"}
+                          autoComplete="new-password"
+                          placeholder={
+                            localization.auth.confirmPasswordPlaceholder
+                          }
+                          value={field.state.value}
+                          onChange={(e) => {
+                            field.handleChange(e.target.value)
 
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          confirmPassword: undefined
-                        }))
-                      }}
-                      minLength={emailAndPassword.minPasswordLength}
-                      maxLength={emailAndPassword.maxPasswordLength}
-                      disabled={isPending}
-                      required
-                      onInvalid={(e) => {
-                        e.preventDefault()
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              confirmPassword: undefined
+                            }))
+                          }}
+                          minLength={emailAndPassword.minPasswordLength}
+                          maxLength={emailAndPassword.maxPasswordLength}
+                          disabled={isPending}
+                          required
+                          onInvalid={(e) => {
+                            e.preventDefault()
 
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          confirmPassword: (e.target as HTMLInputElement)
-                            .validationMessage
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.confirmPassword}
-                    />
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              confirmPassword: (e.target as HTMLInputElement)
+                                .validationMessage
+                            }))
+                          }}
+                          aria-invalid={!!fieldErrors.confirmPassword}
+                        />
 
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isConfirmPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() =>
-                          setIsConfirmPasswordVisible((visible) => !visible)
-                        }
-                      >
-                        {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                ) : (
-                  <Skeleton>
-                    <Input className="invisible" />
-                  </Skeleton>
+                        <InputGroupAddon align="inline-end">
+                          <InputGroupButton
+                            size="icon-xs"
+                            aria-label={
+                              isConfirmPasswordVisible
+                                ? localization.auth.hidePassword
+                                : localization.auth.showPassword
+                            }
+                            onClick={() =>
+                              setIsConfirmPasswordVisible((visible) => !visible)
+                            }
+                          >
+                            {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
+                          </InputGroupButton>
+                        </InputGroupAddon>
+                      </InputGroup>
+                    ) : (
+                      <Skeleton>
+                        <Input className="invisible" />
+                      </Skeleton>
+                    )}
+
+                    <FieldError>{fieldErrors.confirmPassword}</FieldError>
+                  </Field>
                 )}
-
-                <FieldError>{fieldErrors.confirmPassword}</FieldError>
-              </Field>
+              </form.Field>
             )}
           </CardContent>
 

--- a/examples/start-shadcn-example/src/components/auth/sign-up.tsx
+++ b/examples/start-shadcn-example/src/components/auth/sign-up.tsx
@@ -102,7 +102,8 @@ export function SignUp({
           }))
         }
 
-        form.reset()
+        form.setFieldValue("password", "")
+        form.setFieldValue("confirmPassword", "")
         resetFetchOptions()
       },
       onSuccess: (_data, { email }) => {
@@ -159,7 +160,8 @@ export function SignUp({
         value.password !== value.confirmPassword
       ) {
         toast.error(localization.auth.passwordsDoNotMatch)
-        form.reset()
+        form.setFieldValue("password", "")
+        form.setFieldValue("confirmPassword", "")
         return
       }
 

--- a/examples/start-shadcn-example/src/components/auth/sign-up.tsx
+++ b/examples/start-shadcn-example/src/components/auth/sign-up.tsx
@@ -12,9 +12,10 @@ import {
   useFetchOptions,
   useSignUpEmail
 } from "@better-auth-ui/react"
+import { useForm } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { type FormEvent, useRef, useState } from "react"
 import { toast } from "sonner"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
@@ -88,9 +89,6 @@ export function SignUp({
 
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
 
-  const [password, setPassword] = useState("")
-  const [confirmPassword, setConfirmPassword] = useState("")
-
   const { mutate: signUpEmail, isPending: signUpEmailPending } = useSignUpEmail(
     authClient,
     {
@@ -104,8 +102,7 @@ export function SignUp({
           }))
         }
 
-        setPassword("")
-        setConfirmPassword("")
+        form.reset()
         resetFetchOptions()
       },
       onSuccess: (_data, { email }) => {
@@ -148,21 +145,38 @@ export function SignUp({
     password?: string
     confirmPassword?: string
   }>({})
+  const additionalFieldValuesRef = useRef<Record<string, unknown>>({})
+  const form = useForm({
+    defaultValues: {
+      confirmPassword: "",
+      email: "",
+      name: "",
+      password: ""
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
+        toast.error(localization.auth.passwordsDoNotMatch)
+        form.reset()
+        return
+      }
 
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    // `emailAndPassword.name === false` hides the name field and submits "".
-    const name = (formData.get("name") as string | null) ?? ""
-    const email = formData.get("email") as string
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      toast.error(localization.auth.passwordsDoNotMatch)
-      setPassword("")
-      setConfirmPassword("")
-      return
+      signUpEmail({
+        name: emailAndPassword?.name === false ? "" : value.name,
+        email: value.email,
+        password: value.password,
+        ...additionalFieldValuesRef.current,
+        fetchOptions
+      })
     }
+  })
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const formData = new FormData(event.currentTarget)
 
     const additionalFieldValues: Record<string, unknown> = {}
 
@@ -187,13 +201,8 @@ export function SignUp({
       }
     }
 
-    signUpEmail({
-      name,
-      email,
-      password,
-      ...additionalFieldValues,
-      fetchOptions
-    })
+    additionalFieldValuesRef.current = additionalFieldValues
+    await form.handleSubmit()
   }
 
   const showSeparator =
@@ -228,76 +237,88 @@ export function SignUp({
             <form onSubmit={handleSubmit}>
               <FieldGroup>
                 {emailAndPassword.name !== false && (
-                  <Field data-invalid={!!fieldErrors.name}>
-                    <FieldLabel htmlFor="name">
-                      {localization.auth.name}
-                    </FieldLabel>
+                  <form.Field name="name">
+                    {(field) => (
+                      <Field data-invalid={!!fieldErrors.name}>
+                        <FieldLabel htmlFor="name">
+                          {localization.auth.name}
+                        </FieldLabel>
 
-                    <Input
-                      id="name"
-                      name="name"
-                      type="text"
-                      autoComplete="name"
-                      placeholder={localization.auth.namePlaceholder}
-                      required
-                      disabled={isPending}
-                      onChange={() => {
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          name: undefined
-                        }))
-                      }}
-                      onInvalid={(e) => {
-                        e.preventDefault()
+                        <Input
+                          id="name"
+                          name={field.name}
+                          type="text"
+                          autoComplete="name"
+                          placeholder={localization.auth.namePlaceholder}
+                          required
+                          disabled={isPending}
+                          value={field.state.value}
+                          onChange={(event) => {
+                            field.handleChange(event.target.value)
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              name: undefined
+                            }))
+                          }}
+                          onInvalid={(e) => {
+                            e.preventDefault()
 
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          name: localization.auth.fieldRequired
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.name}
-                    />
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              name: localization.auth.fieldRequired
+                            }))
+                          }}
+                          aria-invalid={!!fieldErrors.name}
+                        />
 
-                    <FieldError>{fieldErrors.name}</FieldError>
-                  </Field>
+                        <FieldError>{fieldErrors.name}</FieldError>
+                      </Field>
+                    )}
+                  </form.Field>
                 )}
 
-                <Field data-invalid={!!fieldErrors.email}>
-                  <FieldLabel htmlFor="email">
-                    {localization.auth.email}
-                  </FieldLabel>
+                <form.Field name="email">
+                  {(field) => (
+                    <Field data-invalid={!!fieldErrors.email}>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
 
-                  <Input
-                    id="email"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    placeholder={localization.auth.emailPlaceholder}
-                    required
-                    disabled={isPending}
-                    onChange={() => {
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: undefined
-                      }))
-                    }}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-                      const el = e.target as HTMLInputElement
-                      const msg = el.validity.valueMissing
-                        ? localization.auth.fieldRequired
-                        : localization.auth.invalidEmail
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onChange={(event) => {
+                          field.handleChange(event.target.value)
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            email: undefined
+                          }))
+                        }}
+                        onInvalid={(e) => {
+                          e.preventDefault()
+                          const el = e.target as HTMLInputElement
+                          const msg = el.validity.valueMissing
+                            ? localization.auth.fieldRequired
+                            : localization.auth.invalidEmail
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: msg
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
+                          setFieldErrors((prev) => ({
+                            ...prev,
+                            email: msg
+                          }))
+                        }}
+                        aria-invalid={!!fieldErrors.email}
+                      />
 
-                  <FieldError>{fieldErrors.email}</FieldError>
-                </Field>
+                      <FieldError>{fieldErrors.email}</FieldError>
+                    </Field>
+                  )}
+                </form.Field>
 
                 {additionalFields?.map(
                   (field) =>
@@ -312,159 +333,171 @@ export function SignUp({
                     )
                 )}
 
-                <Field data-invalid={!!fieldErrors.password}>
-                  <FieldLabel htmlFor="password">
-                    {localization.auth.password}
-                  </FieldLabel>
+                <form.Field name="password">
+                  {(field) => (
+                    <Field data-invalid={!!fieldErrors.password}>
+                      <FieldLabel htmlFor="password">
+                        {localization.auth.password}
+                      </FieldLabel>
 
-                  <InputGroup>
-                    <InputGroupInput
-                      id="password"
-                      name="password"
-                      type={isPasswordVisible ? "text" : "password"}
-                      autoComplete="new-password"
-                      value={password}
-                      onChange={(e) => {
-                        setPassword(e.target.value)
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: undefined
-                        }))
-                      }}
-                      placeholder={localization.auth.passwordPlaceholder}
-                      required
-                      minLength={emailAndPassword?.minPasswordLength}
-                      maxLength={emailAndPassword?.maxPasswordLength}
-                      disabled={isPending}
-                      onInvalid={(e) => {
-                        e.preventDefault()
-                        const el = e.target as HTMLInputElement
-                        const min = emailAndPassword?.minPasswordLength
-                        const max = emailAndPassword?.maxPasswordLength
-                        const msg = el.validity.valueMissing
-                          ? localization.auth.fieldRequired
-                          : el.validity.tooShort
-                            ? localization.auth.tooShort.replace(
-                                "{{min}}",
-                                String(min)
-                              )
-                            : localization.auth.tooLong.replace(
-                                "{{max}}",
-                                String(max)
-                              )
+                      <InputGroup>
+                        <InputGroupInput
+                          id="password"
+                          name={field.name}
+                          type={isPasswordVisible ? "text" : "password"}
+                          autoComplete="new-password"
+                          value={field.state.value}
+                          onChange={(e) => {
+                            field.handleChange(e.target.value)
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              password: undefined
+                            }))
+                          }}
+                          placeholder={localization.auth.passwordPlaceholder}
+                          required
+                          minLength={emailAndPassword?.minPasswordLength}
+                          maxLength={emailAndPassword?.maxPasswordLength}
+                          disabled={isPending}
+                          onInvalid={(e) => {
+                            e.preventDefault()
+                            const el = e.target as HTMLInputElement
+                            const min = emailAndPassword?.minPasswordLength
+                            const max = emailAndPassword?.maxPasswordLength
+                            const msg = el.validity.valueMissing
+                              ? localization.auth.fieldRequired
+                              : el.validity.tooShort
+                                ? localization.auth.tooShort.replace(
+                                    "{{min}}",
+                                    String(min)
+                                  )
+                                : localization.auth.tooLong.replace(
+                                    "{{max}}",
+                                    String(max)
+                                  )
 
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: msg
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.password}
-                    />
+                            setFieldErrors((prev) => ({
+                              ...prev,
+                              password: msg
+                            }))
+                          }}
+                          aria-invalid={!!fieldErrors.password}
+                        />
 
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        title={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() => {
-                          setIsPasswordVisible((visible) => !visible)
-                        }}
-                      >
-                        {isPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
+                        <InputGroupAddon align="inline-end">
+                          <InputGroupButton
+                            size="icon-xs"
+                            aria-label={
+                              isPasswordVisible
+                                ? localization.auth.hidePassword
+                                : localization.auth.showPassword
+                            }
+                            title={
+                              isPasswordVisible
+                                ? localization.auth.hidePassword
+                                : localization.auth.showPassword
+                            }
+                            onClick={() => {
+                              setIsPasswordVisible((visible) => !visible)
+                            }}
+                          >
+                            {isPasswordVisible ? <EyeOff /> : <Eye />}
+                          </InputGroupButton>
+                        </InputGroupAddon>
+                      </InputGroup>
 
-                  <FieldError>{fieldErrors.password}</FieldError>
+                      <FieldError>{fieldErrors.password}</FieldError>
 
-                  <PasswordStrengthMeter password={password} />
-                </Field>
+                      <PasswordStrengthMeter password={field.state.value} />
+                    </Field>
+                  )}
+                </form.Field>
 
                 {emailAndPassword?.confirmPassword && (
-                  <Field data-invalid={!!fieldErrors.confirmPassword}>
-                    <FieldLabel htmlFor="confirmPassword">
-                      {localization.auth.confirmPassword}
-                    </FieldLabel>
+                  <form.Field name="confirmPassword">
+                    {(field) => (
+                      <Field data-invalid={!!fieldErrors.confirmPassword}>
+                        <FieldLabel htmlFor="confirmPassword">
+                          {localization.auth.confirmPassword}
+                        </FieldLabel>
 
-                    <InputGroup>
-                      <InputGroupInput
-                        id="confirmPassword"
-                        name="confirmPassword"
-                        type={isConfirmPasswordVisible ? "text" : "password"}
-                        autoComplete="new-password"
-                        value={confirmPassword}
-                        onChange={(e) => {
-                          setConfirmPassword(e.target.value)
+                        <InputGroup>
+                          <InputGroupInput
+                            id="confirmPassword"
+                            name={field.name}
+                            type={
+                              isConfirmPasswordVisible ? "text" : "password"
+                            }
+                            autoComplete="new-password"
+                            value={field.state.value}
+                            onChange={(e) => {
+                              field.handleChange(e.target.value)
 
-                          setFieldErrors((prev) => ({
-                            ...prev,
-                            confirmPassword: undefined
-                          }))
-                        }}
-                        placeholder={
-                          localization.auth.confirmPasswordPlaceholder
-                        }
-                        required
-                        minLength={emailAndPassword?.minPasswordLength}
-                        maxLength={emailAndPassword?.maxPasswordLength}
-                        disabled={isPending}
-                        onInvalid={(e) => {
-                          e.preventDefault()
-                          const el = e.target as HTMLInputElement
-                          const min = emailAndPassword?.minPasswordLength
-                          const max = emailAndPassword?.maxPasswordLength
-                          const msg = el.validity.valueMissing
-                            ? localization.auth.fieldRequired
-                            : el.validity.tooShort
-                              ? localization.auth.tooShort.replace(
-                                  "{{min}}",
-                                  String(min)
+                              setFieldErrors((prev) => ({
+                                ...prev,
+                                confirmPassword: undefined
+                              }))
+                            }}
+                            placeholder={
+                              localization.auth.confirmPasswordPlaceholder
+                            }
+                            required
+                            minLength={emailAndPassword?.minPasswordLength}
+                            maxLength={emailAndPassword?.maxPasswordLength}
+                            disabled={isPending}
+                            onInvalid={(e) => {
+                              e.preventDefault()
+                              const el = e.target as HTMLInputElement
+                              const min = emailAndPassword?.minPasswordLength
+                              const max = emailAndPassword?.maxPasswordLength
+                              const msg = el.validity.valueMissing
+                                ? localization.auth.fieldRequired
+                                : el.validity.tooShort
+                                  ? localization.auth.tooShort.replace(
+                                      "{{min}}",
+                                      String(min)
+                                    )
+                                  : localization.auth.tooLong.replace(
+                                      "{{max}}",
+                                      String(max)
+                                    )
+
+                              setFieldErrors((prev) => ({
+                                ...prev,
+                                confirmPassword: msg
+                              }))
+                            }}
+                            aria-invalid={!!fieldErrors.confirmPassword}
+                          />
+
+                          <InputGroupAddon align="inline-end">
+                            <InputGroupButton
+                              size="icon-xs"
+                              aria-label={
+                                isConfirmPasswordVisible
+                                  ? localization.auth.hidePassword
+                                  : localization.auth.showPassword
+                              }
+                              title={
+                                isConfirmPasswordVisible
+                                  ? localization.auth.hidePassword
+                                  : localization.auth.showPassword
+                              }
+                              onClick={() =>
+                                setIsConfirmPasswordVisible(
+                                  (visible) => !visible
                                 )
-                              : localization.auth.tooLong.replace(
-                                  "{{max}}",
-                                  String(max)
-                                )
+                              }
+                            >
+                              {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
+                            </InputGroupButton>
+                          </InputGroupAddon>
+                        </InputGroup>
 
-                          setFieldErrors((prev) => ({
-                            ...prev,
-                            confirmPassword: msg
-                          }))
-                        }}
-                        aria-invalid={!!fieldErrors.confirmPassword}
-                      />
-
-                      <InputGroupAddon align="inline-end">
-                        <InputGroupButton
-                          size="icon-xs"
-                          aria-label={
-                            isConfirmPasswordVisible
-                              ? localization.auth.hidePassword
-                              : localization.auth.showPassword
-                          }
-                          title={
-                            isConfirmPasswordVisible
-                              ? localization.auth.hidePassword
-                              : localization.auth.showPassword
-                          }
-                          onClick={() =>
-                            setIsConfirmPasswordVisible((visible) => !visible)
-                          }
-                        >
-                          {isConfirmPasswordVisible ? <EyeOff /> : <Eye />}
-                        </InputGroupButton>
-                      </InputGroupAddon>
-                    </InputGroup>
-
-                    <FieldError>{fieldErrors.confirmPassword}</FieldError>
-                  </Field>
+                        <FieldError>{fieldErrors.confirmPassword}</FieldError>
+                      </Field>
+                    )}
+                  </form.Field>
                 )}
 
                 {additionalFields?.map(

--- a/examples/start-shadcn-example/src/components/auth/sso/organization-sso-providers.tsx
+++ b/examples/start-shadcn-example/src/components/auth/sso/organization-sso-providers.tsx
@@ -16,9 +16,10 @@ import {
   useSsoProviders,
   useUpdateSsoProvider
 } from "@better-auth-ui/react/plugins/sso"
+import { useForm } from "@tanstack/react-form"
 import type { BetterFetchError } from "better-auth/client"
 import { PencilIcon, Trash2Icon } from "lucide-react"
-import { type FormEvent, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -80,8 +81,27 @@ export type OrganizationSsoProvidersProps = {
 
 const providerSkeletonIds = ["sso-provider-1", "sso-provider-2"]
 
-const readString = (formData: FormData, name: string) =>
-  String(formData.get(name) ?? "").trim()
+type SsoProviderEditorValues = {
+  clientId: string
+  clientSecret: string
+  discoveryEndpoint: string
+  domain: string
+  entryPoint: string
+  identityProviderMetadata: string
+  issuer: string
+}
+
+const getSsoProviderEditorValues = (
+  provider?: SsoProvider
+): SsoProviderEditorValues => ({
+  clientId: "",
+  clientSecret: "",
+  discoveryEndpoint: provider?.oidcConfig?.discoveryEndpoint ?? "",
+  domain: provider?.domain ?? "",
+  entryPoint: provider?.samlConfig?.entryPoint ?? "",
+  identityProviderMetadata: "",
+  issuer: provider?.issuer ?? ""
+})
 
 const getErrorMessage = (error: Error | null) => {
   const authError = error as BetterFetchError | null
@@ -240,7 +260,11 @@ export function OrganizationSsoProviders({
         )}
       </CardContent>
 
-      <EditSsoProviderDialog onOpenChange={setEditing} provider={editing} />
+      <EditSsoProviderDialog
+        key={editing?.providerId ?? "closed"}
+        onOpenChange={setEditing}
+        provider={editing}
+      />
       <DeleteSsoProviderDialog onOpenChange={setDeleting} provider={deleting} />
       <Dialog
         open={Boolean(verifying)}
@@ -277,49 +301,47 @@ function EditSsoProviderDialog({
     update.reset()
     onOpenChange(undefined)
   }
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!provider) return
-    const data = new FormData(event.currentTarget)
-    const clientId = readString(data, "clientId")
-    const clientSecret = readString(data, "clientSecret")
-    const identityProviderMetadata = readString(
-      data,
-      "identityProviderMetadata"
-    )
-    const params = {
-      providerId: provider.providerId,
-      issuer: readString(data, "issuer"),
-      domain: readString(data, "domain"),
-      ...(provider.oidcConfig
-        ? {
-            oidcConfig: {
-              ...(clientId ? { clientId } : {}),
-              ...(clientSecret ? { clientSecret } : {}),
-              discoveryEndpoint:
-                readString(data, "discoveryEndpoint") || undefined
+  const form = useForm({
+    defaultValues: getSsoProviderEditorValues(provider),
+    onSubmit: async ({ value }) => {
+      if (!provider) return
+      const clientId = value.clientId.trim()
+      const clientSecret = value.clientSecret.trim()
+      const identityProviderMetadata = value.identityProviderMetadata.trim()
+      const params = {
+        providerId: provider.providerId,
+        issuer: value.issuer.trim(),
+        domain: value.domain.trim(),
+        ...(provider.oidcConfig
+          ? {
+              oidcConfig: {
+                ...(clientId ? { clientId } : {}),
+                ...(clientSecret ? { clientSecret } : {}),
+                discoveryEndpoint: value.discoveryEndpoint.trim() || undefined
+              }
             }
-          }
-        : {}),
-      ...(provider.samlConfig
-        ? {
-            samlConfig: {
-              entryPoint: readString(data, "entryPoint"),
-              ...(identityProviderMetadata
-                ? { idpMetadata: { metadata: identityProviderMetadata } }
-                : {})
+          : {}),
+        ...(provider.samlConfig
+          ? {
+              samlConfig: {
+                entryPoint: value.entryPoint.trim(),
+                ...(identityProviderMetadata
+                  ? { idpMetadata: { metadata: identityProviderMetadata } }
+                  : {})
+              }
             }
-          }
-        : {})
-    } as UpdateSsoProviderParams
+          : {})
+      } as UpdateSsoProviderParams
 
-    update.mutate(params, {
-      onSuccess: () => {
+      try {
+        await update.mutateAsync(params)
         toast.success(localization.providerUpdated)
         close()
+      } catch {
+        // The mutation error is rendered below the fields.
       }
-    })
-  }
+    }
+  })
 
   return (
     <Dialog
@@ -329,98 +351,148 @@ function EditSsoProviderDialog({
       }}
     >
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-xl">
-        <form className="flex flex-col gap-4" onSubmit={submit}>
+        <form
+          className="flex flex-col gap-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void form.handleSubmit()
+          }}
+        >
           <DialogHeader>
             <DialogTitle>{localization.editProvider}</DialogTitle>
             <DialogDescription>{provider?.providerId}</DialogDescription>
           </DialogHeader>
           <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="sso-edit-domain">
-                {localization.domain}
-              </FieldLabel>
-              <Input
-                defaultValue={provider?.domain}
-                id="sso-edit-domain"
-                name="domain"
-                required
-              />
-            </Field>
-            <Field>
-              <FieldLabel htmlFor="sso-edit-issuer">
-                {localization.issuer}
-              </FieldLabel>
-              <Input
-                defaultValue={provider?.issuer}
-                id="sso-edit-issuer"
-                name="issuer"
-                required
-                type="url"
-              />
-            </Field>
+            {(
+              [
+                ["domain", "sso-edit-domain", localization.domain, "text"],
+                ["issuer", "sso-edit-issuer", localization.issuer, "url"]
+              ] as const
+            ).map(([name, id, label, type]) => (
+              <form.Field key={name} name={name}>
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor={id}>{label}</FieldLabel>
+                    <Input
+                      id={id}
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      required
+                      type={type}
+                      value={field.state.value}
+                    />
+                  </Field>
+                )}
+              </form.Field>
+            ))}
             {provider?.oidcConfig ? (
               <>
-                <Field>
-                  <FieldLabel htmlFor="sso-edit-discovery">
-                    {localization.discoveryEndpoint}
-                  </FieldLabel>
-                  <Input
-                    defaultValue={provider.oidcConfig.discoveryEndpoint}
-                    id="sso-edit-discovery"
-                    name="discoveryEndpoint"
-                    type="url"
-                  />
-                </Field>
+                <form.Field name="discoveryEndpoint">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="sso-edit-discovery">
+                        {localization.discoveryEndpoint}
+                      </FieldLabel>
+                      <Input
+                        id="sso-edit-discovery"
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        type="url"
+                        value={field.state.value}
+                      />
+                    </Field>
+                  )}
+                </form.Field>
                 <div className="grid gap-4 sm:grid-cols-2">
-                  <Field>
-                    <FieldLabel htmlFor="sso-edit-client-id">
-                      {localization.clientId}
-                    </FieldLabel>
-                    <Input
-                      id="sso-edit-client-id"
-                      name="clientId"
-                      placeholder={`••••${provider.oidcConfig.clientIdLastFour}`}
-                    />
-                  </Field>
-                  <Field>
-                    <FieldLabel htmlFor="sso-edit-client-secret">
-                      {localization.clientSecret}
-                    </FieldLabel>
-                    <Input
-                      autoComplete="new-password"
-                      id="sso-edit-client-secret"
-                      name="clientSecret"
-                      type="password"
-                    />
-                  </Field>
+                  {(
+                    [
+                      ["clientId", "sso-edit-client-id", localization.clientId],
+                      [
+                        "clientSecret",
+                        "sso-edit-client-secret",
+                        localization.clientSecret
+                      ]
+                    ] as const
+                  ).map(([name, id, label]) => (
+                    <form.Field key={name} name={name}>
+                      {(field) => (
+                        <Field>
+                          <FieldLabel htmlFor={id}>{label}</FieldLabel>
+                          <Input
+                            autoComplete={
+                              name === "clientSecret"
+                                ? "new-password"
+                                : undefined
+                            }
+                            id={id}
+                            name={field.name}
+                            onBlur={field.handleBlur}
+                            onChange={(event) =>
+                              field.handleChange(event.target.value)
+                            }
+                            placeholder={
+                              name === "clientId"
+                                ? `••••${provider.oidcConfig?.clientIdLastFour}`
+                                : undefined
+                            }
+                            type={name === "clientSecret" ? "password" : "text"}
+                            value={field.state.value}
+                          />
+                        </Field>
+                      )}
+                    </form.Field>
+                  ))}
                 </div>
               </>
             ) : null}
             {provider?.samlConfig ? (
               <>
-                <Field>
-                  <FieldLabel htmlFor="sso-edit-entry-point">
-                    {localization.entryPoint}
-                  </FieldLabel>
-                  <Input
-                    defaultValue={provider.samlConfig.entryPoint}
-                    id="sso-edit-entry-point"
-                    name="entryPoint"
-                    required
-                    type="url"
-                  />
-                </Field>
-                <Field>
-                  <FieldLabel htmlFor="sso-edit-metadata">
-                    {localization.identityProviderMetadata}
-                  </FieldLabel>
-                  <Textarea
-                    className="font-mono text-xs"
-                    id="sso-edit-metadata"
-                    name="identityProviderMetadata"
-                    rows={6}
-                  />
-                </Field>
+                <form.Field name="entryPoint">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="sso-edit-entry-point">
+                        {localization.entryPoint}
+                      </FieldLabel>
+                      <Input
+                        id="sso-edit-entry-point"
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        required
+                        type="url"
+                        value={field.state.value}
+                      />
+                    </Field>
+                  )}
+                </form.Field>
+                <form.Field name="identityProviderMetadata">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="sso-edit-metadata">
+                        {localization.identityProviderMetadata}
+                      </FieldLabel>
+                      <Textarea
+                        className="font-mono text-xs"
+                        id="sso-edit-metadata"
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        rows={6}
+                        value={field.state.value}
+                      />
+                    </Field>
+                  )}
+                </form.Field>
               </>
             ) : null}
           </FieldGroup>
@@ -434,10 +506,14 @@ function EditSsoProviderDialog({
             >
               {localization.cancel}
             </Button>
-            <Button disabled={update.isPending} type="submit">
-              {update.isPending ? <Spinner data-icon="inline-start" /> : null}
-              {localization.saveProvider}
-            </Button>
+            <form.Subscribe selector={(state) => state.isSubmitting}>
+              {(isSubmitting) => (
+                <Button disabled={isSubmitting} type="submit">
+                  {isSubmitting ? <Spinner data-icon="inline-start" /> : null}
+                  {localization.saveProvider}
+                </Button>
+              )}
+            </form.Subscribe>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
@@ -27,6 +27,7 @@ import {
   useUpdateAdminUser
 } from "@better-auth-ui/solid/plugins/admin"
 import { createDebounce } from "@solid-primitives/debounce"
+import { createForm } from "@tanstack/solid-form"
 import {
   type ColumnFiltersState,
   functionalUpdate,
@@ -619,27 +620,52 @@ function CreateUserDialog(props: {
   const canSetRole = useAdminPermission(authClient, () => ({
     user: ["set-role"]
   }))
-  const [emailVerified, setEmailVerified] = createSignal(false)
   const [formError, setFormError] = createSignal<string>()
-  const [roles, setRoles] = createSignal([config().defaultRole])
+  let additionalFieldValues: Record<string, AdditionalFieldValue | null> = {}
+  const form = createForm(() => ({
+    defaultValues: {
+      email: "",
+      emailVerified: false,
+      name: "",
+      password: "",
+      roles: [config().defaultRole]
+    },
+    onSubmit: ({ value }) => {
+      createUser.mutate(
+        {
+          data: {
+            ...additionalFieldValues,
+            emailVerified: value.emailVerified
+          },
+          email: value.email,
+          name: value.name,
+          password: value.password,
+          ...(canSetRole.data?.success
+            ? { role: asAdminRoles(value.roles) }
+            : {})
+        },
+        { onSuccess: close }
+      )
+    }
+  }))
 
   createEffect(() => {
-    if (!config().allowMultipleRoles) setRoles((current) => current.slice(0, 1))
+    if (!config().allowMultipleRoles)
+      form.setFieldValue("roles", (current) => current.slice(0, 1))
   })
 
   const close = () => {
     createUser.reset()
-    setEmailVerified(false)
+    form.reset()
     setFormError(undefined)
-    setRoles([config().defaultRole])
     props.onOpenChange(false)
   }
   const submit = async (event: SubmitEvent) => {
     event.preventDefault()
     const data = new FormData(event.currentTarget as HTMLFormElement)
-    let additionalFieldValues: Record<string, AdditionalFieldValue | null>
+    let values: Record<string, AdditionalFieldValue | null>
     try {
-      additionalFieldValues = await parseAdditionalFieldValues(
+      values = await parseAdditionalFieldValues(
         auth.additionalFields ?? [],
         data
       )
@@ -648,16 +674,8 @@ function CreateUserDialog(props: {
       return
     }
     setFormError(undefined)
-    createUser.mutate(
-      {
-        data: { ...additionalFieldValues, emailVerified: emailVerified() },
-        email: String(data.get("email")),
-        name: String(data.get("name")),
-        password: String(data.get("password")),
-        ...(canSetRole.data?.success ? { role: asAdminRoles(roles()) } : {})
-      },
-      { onSuccess: close }
-    )
+    additionalFieldValues = values
+    await form.handleSubmit()
   }
 
   return (
@@ -673,36 +691,64 @@ function CreateUserDialog(props: {
               {config().localization.usersDescription}
             </DialogDescription>
           </DialogHeader>
-          <Field>
-            <FieldLabel for="solid-admin-create-name">
-              {config().localization.name}
-            </FieldLabel>
-            <Input id="solid-admin-create-name" name="name" required />
-          </Field>
-          <Field>
-            <FieldLabel for="solid-admin-create-email">
-              {config().localization.email}
-            </FieldLabel>
-            <Input
-              autocomplete="off"
-              id="solid-admin-create-email"
-              name="email"
-              required
-              type="email"
-            />
-          </Field>
-          <Field>
-            <FieldLabel for="solid-admin-create-password">
-              {config().localization.password}
-            </FieldLabel>
-            <Input
-              autocomplete="new-password"
-              id="solid-admin-create-password"
-              name="password"
-              required
-              type="password"
-            />
-          </Field>
+          <form.Field name="name">
+            {(field) => (
+              <Field>
+                <FieldLabel for="solid-admin-create-name">
+                  {config().localization.name}
+                </FieldLabel>
+                <Input
+                  id="solid-admin-create-name"
+                  name={field().name}
+                  onInput={(event) =>
+                    field().handleChange(event.currentTarget.value)
+                  }
+                  required
+                  value={field().state.value}
+                />
+              </Field>
+            )}
+          </form.Field>
+          <form.Field name="email">
+            {(field) => (
+              <Field>
+                <FieldLabel for="solid-admin-create-email">
+                  {config().localization.email}
+                </FieldLabel>
+                <Input
+                  autocomplete="off"
+                  id="solid-admin-create-email"
+                  name={field().name}
+                  onInput={(event) =>
+                    field().handleChange(event.currentTarget.value)
+                  }
+                  required
+                  type="email"
+                  value={field().state.value}
+                />
+              </Field>
+            )}
+          </form.Field>
+          <form.Field name="password">
+            {(field) => (
+              <Field>
+                <FieldLabel for="solid-admin-create-password">
+                  {config().localization.password}
+                </FieldLabel>
+                <Input
+                  autocomplete="new-password"
+                  id="solid-admin-create-password"
+                  name={field().name}
+                  onInput={(event) =>
+                    field().handleChange(event.currentTarget.value)
+                  }
+                  required
+                  type="password"
+                  value={field().state.value}
+                />
+              </Field>
+            )}
+          </form.Field>
           <Show
             fallback={
               <Show when={canSetRole.isPending}>
@@ -711,69 +757,81 @@ function CreateUserDialog(props: {
             }
             when={canSetRole.data?.success}
           >
-            <FieldSet>
-              <FieldLegend variant="label">
-                {config().localization.role}
-              </FieldLegend>
-              <Show
-                when={config().allowMultipleRoles}
-                fallback={
-                  <RadioGroup
-                    onChange={(role) => setRoles([role])}
-                    value={roles()[0] ?? ""}
+            <form.Field name="roles">
+              {(field) => (
+                <FieldSet>
+                  <FieldLegend variant="label">
+                    {config().localization.role}
+                  </FieldLegend>
+                  <Show
+                    when={config().allowMultipleRoles}
+                    fallback={
+                      <RadioGroup
+                        onChange={(role) => field().handleChange([role])}
+                        value={field().state.value[0] ?? ""}
+                      >
+                        <For each={config().roles}>
+                          {(role) => (
+                            <Field orientation="horizontal">
+                              <RadioGroupItem
+                                id={`solid-admin-create-role-${role}`}
+                                value={role}
+                              />
+                              <FieldLabel
+                                for={`solid-admin-create-role-${role}`}
+                              >
+                                {role}
+                              </FieldLabel>
+                            </Field>
+                          )}
+                        </For>
+                      </RadioGroup>
+                    }
                   >
-                    <For each={config().roles}>
-                      {(role) => (
-                        <Field orientation="horizontal">
-                          <RadioGroupItem
-                            id={`solid-admin-create-role-${role}`}
-                            value={role}
-                          />
-                          <FieldLabel for={`solid-admin-create-role-${role}`}>
-                            {role}
-                          </FieldLabel>
-                        </Field>
-                      )}
-                    </For>
-                  </RadioGroup>
-                }
-              >
-                <FieldGroup data-slot="checkbox-group">
-                  <For each={config().roles}>
-                    {(role) => (
-                      <Field orientation="horizontal">
-                        <Checkbox
-                          checked={roles().includes(role)}
-                          id={`solid-admin-create-role-${role}`}
-                          onChange={(checked) => {
-                            const next = checked
-                              ? [...roles(), role]
-                              : roles().filter((item) => item !== role)
-                            if (next.length) setRoles(next)
-                          }}
-                        />
-                        <FieldLabel for={`solid-admin-create-role-${role}`}>
-                          {role}
-                        </FieldLabel>
-                      </Field>
-                    )}
-                  </For>
-                </FieldGroup>
-              </Show>
-            </FieldSet>
+                    <FieldGroup data-slot="checkbox-group">
+                      <For each={config().roles}>
+                        {(role) => (
+                          <Field orientation="horizontal">
+                            <Checkbox
+                              checked={field().state.value.includes(role)}
+                              id={`solid-admin-create-role-${role}`}
+                              onChange={(checked) => {
+                                const next = checked
+                                  ? [...field().state.value, role]
+                                  : field().state.value.filter(
+                                      (item) => item !== role
+                                    )
+                                if (next.length) field().handleChange(next)
+                              }}
+                            />
+                            <FieldLabel for={`solid-admin-create-role-${role}`}>
+                              {role}
+                            </FieldLabel>
+                          </Field>
+                        )}
+                      </For>
+                    </FieldGroup>
+                  </Show>
+                </FieldSet>
+              )}
+            </form.Field>
           </Show>
-          <Field orientation="horizontal">
-            <Switch
-              checked={emailVerified()}
-              id="solid-admin-create-email-verified"
-              onChange={setEmailVerified}
-            />
-            <FieldContent>
-              <FieldLabel for="solid-admin-create-email-verified">
-                {config().localization.emailVerified}
-              </FieldLabel>
-            </FieldContent>
-          </Field>
+          <form.Field name="emailVerified">
+            {(field) => (
+              <Field orientation="horizontal">
+                <Switch
+                  checked={field().state.value}
+                  id="solid-admin-create-email-verified"
+                  onChange={field().handleChange}
+                />
+                <FieldContent>
+                  <FieldLabel for="solid-admin-create-email-verified">
+                    {config().localization.emailVerified}
+                  </FieldLabel>
+                </FieldContent>
+              </Field>
+            )}
+          </form.Field>
           <For each={auth.additionalFields}>
             {(field) => (
               <AdditionalField
@@ -872,10 +930,6 @@ function UserDialog(props: {
     () => ({ session: ["revoke"] }),
     enabled
   )
-  const [name, setName] = createSignal("")
-  const [email, setEmail] = createSignal("")
-  const [emailVerified, setEmailVerified] = createSignal(false)
-  const [roles, setRoles] = createSignal([config().defaultRole])
   const [banReason, setBanReason] = createSignal("")
   const [banDuration, setBanDuration] = createSignal("")
   const banDurationSeconds = createMemo(() =>
@@ -905,6 +959,56 @@ function UserDialog(props: {
   const remove = useRemoveAdminUser(authClient)
   const revokeSession = useRevokeAdminUserSession(authClient, props.userId)
   const revokeSessions = useRevokeAdminUserSessions(authClient, props.userId)
+  let profileAdditionalFieldValues: Record<
+    string,
+    AdditionalFieldValue | null
+  > = {}
+  const profileForm = createForm(() => ({
+    defaultValues: {
+      email: "",
+      emailVerified: false,
+      name: "",
+      roles: [config().defaultRole]
+    },
+    onSubmit: async ({ value }) => {
+      const selectedUser = detail()
+      if (!selectedUser) return
+
+      const mutations: Promise<unknown>[] = []
+      if (canUpdate.data?.success) {
+        mutations.push(
+          updateUser.mutateAsync({
+            userId: selectedUser.id,
+            data: {
+              ...profileAdditionalFieldValues,
+              name: value.name.trim(),
+              ...(canSetEmail.data?.success
+                ? {
+                    email: value.email.trim(),
+                    emailVerified: value.emailVerified
+                  }
+                : {})
+            }
+          })
+        )
+      }
+      if (canSetRole.data?.success && !isSelf()) {
+        mutations.push(
+          setRoleMutation.mutateAsync({
+            userId: selectedUser.id,
+            role: asAdminRoles(value.roles)
+          })
+        )
+      }
+
+      try {
+        await Promise.all(mutations)
+        props.onOpenChange(false)
+      } catch {
+        // Mutation errors are rendered next to the form.
+      }
+    }
+  }))
 
   createEffect(
     on(
@@ -917,16 +1021,16 @@ function UserDialog(props: {
           detail()?.role
         ] as const,
       ([userEmail, userEmailVerified, _userId, userName, userRole]) => {
-        setName(userName ?? "")
-        setEmail(userEmail ?? "")
-        setEmailVerified(userEmailVerified ?? false)
-        setRoles(
-          parseAdminRoles(
+        profileForm.reset({
+          email: userEmail ?? "",
+          emailVerified: userEmailVerified ?? false,
+          name: userName ?? "",
+          roles: parseAdminRoles(
             userRole,
             config().defaultRole,
             config().allowMultipleRoles
           )
-        )
+        })
         setProfileError(undefined)
       }
     )
@@ -1011,7 +1115,6 @@ function UserDialog(props: {
     const selectedUser = detail()
     if (!selectedUser) return
 
-    const mutations: Promise<unknown>[] = []
     if (canUpdate.data?.success) {
       const formData = new FormData(event.currentTarget as HTMLFormElement)
       let additionalFieldValues: Record<string, AdditionalFieldValue | null>
@@ -1025,34 +1128,10 @@ function UserDialog(props: {
         return
       }
       setProfileError(undefined)
-      mutations.push(
-        updateUser.mutateAsync({
-          userId: selectedUser.id,
-          data: {
-            ...additionalFieldValues,
-            name: name().trim(),
-            ...(canSetEmail.data?.success
-              ? { email: email().trim(), emailVerified: emailVerified() }
-              : {})
-          }
-        })
-      )
-    }
-    if (canSetRole.data?.success && !isSelf()) {
-      mutations.push(
-        setRoleMutation.mutateAsync({
-          userId: selectedUser.id,
-          role: asAdminRoles(roles())
-        })
-      )
+      profileAdditionalFieldValues = additionalFieldValues
     }
 
-    try {
-      await Promise.all(mutations)
-      props.onOpenChange(false)
-    } catch {
-      // Mutation errors are rendered next to the form.
-    }
+    await profileForm.handleSubmit()
   }
 
   return (
@@ -1178,120 +1257,150 @@ function UserDialog(props: {
                             {config().localization.profileAndAccess}
                           </h3>
                           <FieldGroup class="grid gap-5 md:grid-cols-2">
-                            <Field>
-                              <FieldLabel for="solid-admin-user-name">
-                                {config().localization.name}
-                              </FieldLabel>
-                              <Input
-                                disabled={!canUpdate.data?.success}
-                                id="solid-admin-user-name"
-                                value={name()}
-                                onInput={(event) =>
-                                  setName(event.currentTarget.value)
-                                }
-                              />
-                            </Field>
-                            <Field>
-                              <FieldLabel for="solid-admin-user-email">
-                                {config().localization.email}
-                              </FieldLabel>
-                              <Input
-                                disabled={
-                                  !canUpdate.data?.success ||
-                                  !canSetEmail.data?.success
-                                }
-                                id="solid-admin-user-email"
-                                onInput={(event) =>
-                                  setEmail(event.currentTarget.value)
-                                }
-                                required
-                                type="email"
-                                value={email()}
-                              />
-                            </Field>
-                            <Field orientation="horizontal">
-                              <Switch
-                                checked={emailVerified()}
-                                disabled={
-                                  !canUpdate.data?.success ||
-                                  !canSetEmail.data?.success
-                                }
-                                id="solid-admin-user-email-verified"
-                                onChange={setEmailVerified}
-                              />
-                              <FieldContent>
-                                <FieldLabel for="solid-admin-user-email-verified">
-                                  {config().localization.emailVerified}
-                                </FieldLabel>
-                              </FieldContent>
-                            </Field>
-                            <FieldSet>
-                              <FieldLegend variant="label">
-                                {config().localization.role}
-                              </FieldLegend>
-                              <Show
-                                when={config().allowMultipleRoles}
-                                fallback={
-                                  <RadioGroup
-                                    class="flex-row flex-wrap gap-4"
-                                    disabled={
-                                      isSelf() || !canSetRole.data?.success
+                            <profileForm.Field name="name">
+                              {(field) => (
+                                <Field>
+                                  <FieldLabel for="solid-admin-user-name">
+                                    {config().localization.name}
+                                  </FieldLabel>
+                                  <Input
+                                    disabled={!canUpdate.data?.success}
+                                    id="solid-admin-user-name"
+                                    name={field().name}
+                                    value={field().state.value}
+                                    onInput={(event) =>
+                                      field().handleChange(
+                                        event.currentTarget.value
+                                      )
                                     }
-                                    onChange={(role) => setRoles([role])}
-                                    value={roles()[0] ?? ""}
+                                  />
+                                </Field>
+                              )}
+                            </profileForm.Field>
+                            <profileForm.Field name="email">
+                              {(field) => (
+                                <Field>
+                                  <FieldLabel for="solid-admin-user-email">
+                                    {config().localization.email}
+                                  </FieldLabel>
+                                  <Input
+                                    disabled={
+                                      !canUpdate.data?.success ||
+                                      !canSetEmail.data?.success
+                                    }
+                                    id="solid-admin-user-email"
+                                    name={field().name}
+                                    onInput={(event) =>
+                                      field().handleChange(
+                                        event.currentTarget.value
+                                      )
+                                    }
+                                    required
+                                    type="email"
+                                    value={field().state.value}
+                                  />
+                                </Field>
+                              )}
+                            </profileForm.Field>
+                            <profileForm.Field name="emailVerified">
+                              {(field) => (
+                                <Field orientation="horizontal">
+                                  <Switch
+                                    checked={field().state.value}
+                                    disabled={
+                                      !canUpdate.data?.success ||
+                                      !canSetEmail.data?.success
+                                    }
+                                    id="solid-admin-user-email-verified"
+                                    onChange={field().handleChange}
+                                  />
+                                  <FieldContent>
+                                    <FieldLabel for="solid-admin-user-email-verified">
+                                      {config().localization.emailVerified}
+                                    </FieldLabel>
+                                  </FieldContent>
+                                </Field>
+                              )}
+                            </profileForm.Field>
+                            <profileForm.Field name="roles">
+                              {(field) => (
+                                <FieldSet>
+                                  <FieldLegend variant="label">
+                                    {config().localization.role}
+                                  </FieldLegend>
+                                  <Show
+                                    when={config().allowMultipleRoles}
+                                    fallback={
+                                      <RadioGroup
+                                        class="flex-row flex-wrap gap-4"
+                                        disabled={
+                                          isSelf() || !canSetRole.data?.success
+                                        }
+                                        onChange={(role) =>
+                                          field().handleChange([role])
+                                        }
+                                        value={field().state.value[0] ?? ""}
+                                      >
+                                        <For each={config().roles}>
+                                          {(item) => (
+                                            <Field orientation="horizontal">
+                                              <RadioGroupItem
+                                                id={`solid-admin-user-role-${item}`}
+                                                value={item}
+                                              />
+                                              <FieldLabel
+                                                for={`solid-admin-user-role-${item}`}
+                                              >
+                                                {item}
+                                              </FieldLabel>
+                                            </Field>
+                                          )}
+                                        </For>
+                                      </RadioGroup>
+                                    }
                                   >
-                                    <For each={config().roles}>
-                                      {(item) => (
-                                        <Field orientation="horizontal">
-                                          <RadioGroupItem
-                                            id={`solid-admin-user-role-${item}`}
-                                            value={item}
-                                          />
-                                          <FieldLabel
-                                            for={`solid-admin-user-role-${item}`}
-                                          >
-                                            {item}
-                                          </FieldLabel>
-                                        </Field>
-                                      )}
-                                    </For>
-                                  </RadioGroup>
-                                }
-                              >
-                                <FieldGroup
-                                  class="flex-row flex-wrap gap-4"
-                                  data-slot="checkbox-group"
-                                >
-                                  <For each={config().roles}>
-                                    {(item) => (
-                                      <Field orientation="horizontal">
-                                        <Checkbox
-                                          checked={roles().includes(item)}
-                                          disabled={
-                                            isSelf() ||
-                                            !canSetRole.data?.success
-                                          }
-                                          id={`solid-admin-user-role-${item}`}
-                                          onChange={(checked) => {
-                                            const next = checked
-                                              ? [...roles(), item]
-                                              : roles().filter(
-                                                  (role) => role !== item
-                                                )
-                                            if (next.length) setRoles(next)
-                                          }}
-                                        />
-                                        <FieldLabel
-                                          for={`solid-admin-user-role-${item}`}
-                                        >
-                                          {item}
-                                        </FieldLabel>
-                                      </Field>
-                                    )}
-                                  </For>
-                                </FieldGroup>
-                              </Show>
-                            </FieldSet>
+                                    <FieldGroup
+                                      class="flex-row flex-wrap gap-4"
+                                      data-slot="checkbox-group"
+                                    >
+                                      <For each={config().roles}>
+                                        {(item) => (
+                                          <Field orientation="horizontal">
+                                            <Checkbox
+                                              checked={field().state.value.includes(
+                                                item
+                                              )}
+                                              disabled={
+                                                isSelf() ||
+                                                !canSetRole.data?.success
+                                              }
+                                              id={`solid-admin-user-role-${item}`}
+                                              onChange={(checked) => {
+                                                const next = checked
+                                                  ? [
+                                                      ...field().state.value,
+                                                      item
+                                                    ]
+                                                  : field().state.value.filter(
+                                                      (role) => role !== item
+                                                    )
+                                                if (next.length)
+                                                  field().handleChange(next)
+                                              }}
+                                            />
+                                            <FieldLabel
+                                              for={`solid-admin-user-role-${item}`}
+                                            >
+                                              {item}
+                                            </FieldLabel>
+                                          </Field>
+                                        )}
+                                      </For>
+                                    </FieldGroup>
+                                  </Show>
+                                </FieldSet>
+                              )}
+                            </profileForm.Field>
                             <For each={auth.additionalFields}>
                               {(field) => {
                                 const value = () =>
@@ -1479,21 +1588,29 @@ function UserDialog(props: {
                         >
                           {config().localization.cancel}
                         </Button>
-                        <Button
-                          disabled={
-                            !name().trim() ||
-                            !email().trim() ||
-                            updateUser.isPending ||
-                            setRoleMutation.isPending ||
-                            canUpdate.isPending ||
-                            canSetRole.isPending ||
-                            (!canUpdate.data?.success &&
-                              (!canSetRole.data?.success || isSelf()))
+                        <profileForm.Subscribe
+                          selector={(state) =>
+                            [state.values.name, state.values.email] as const
                           }
-                          type="submit"
                         >
-                          {config().localization.saveChanges}
-                        </Button>
+                          {(values) => (
+                            <Button
+                              disabled={
+                                !values()[0].trim() ||
+                                !values()[1].trim() ||
+                                updateUser.isPending ||
+                                setRoleMutation.isPending ||
+                                canUpdate.isPending ||
+                                canSetRole.isPending ||
+                                (!canUpdate.data?.success &&
+                                  (!canSetRole.data?.success || isSelf()))
+                              }
+                              type="submit"
+                            >
+                              {config().localization.saveChanges}
+                            </Button>
+                          )}
+                        </profileForm.Subscribe>
                       </div>
                     </form>
                   </TabsContent>

--- a/examples/start-solid-zaidan-example/src/components/auth/api-key/api-keys.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/api-key/api-keys.tsx
@@ -1,13 +1,25 @@
-import type { ApiKeyAuthClient } from "@better-auth-ui/core/plugins/api-key"
-import { apiKeyLocalization } from "@better-auth-ui/core/plugins/api-key"
+import {
+  type ApiKeyAuthClient,
+  apiKeyLocalization,
+  type ListedApiKey
+} from "@better-auth-ui/core/plugins/api-key"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import { useListApiKeys } from "@better-auth-ui/solid/plugins/api-key"
+import {
+  createTableHook,
+  functionalUpdate,
+  type PaginationState,
+  rowPaginationFeature,
+  rowSortingFeature,
+  type SortingState,
+  tableFeatures,
+  type Updater
+} from "@tanstack/solid-table"
 import { createSignal, For, Show } from "solid-js"
 import { ApiKey } from "@/components/auth/api-key/api-key"
 import { ApiKeySkeleton } from "@/components/auth/api-key/api-key-skeleton"
 import { ApiKeysEmpty } from "@/components/auth/api-key/api-keys-empty"
 import { CreateApiKeyDialog } from "@/components/auth/api-key/create-api-key-dialog"
-import type { ListedApiKey } from "@/components/auth/settings/shared/types"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
@@ -22,6 +34,21 @@ import {
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
 import { cn } from "@/lib/utils"
 
+const { createAppColumnHelper, createAppTable: createApiKeyTable } =
+  createTableHook({
+    enableMultiSort: false,
+    enableSortingRemoval: false,
+    sortDescFirst: false,
+    features: tableFeatures({ rowPaginationFeature, rowSortingFeature })
+  })
+
+const apiKeyColumnHelper = createAppColumnHelper<ListedApiKey>()
+const apiKeyColumns = apiKeyColumnHelper.columns([
+  apiKeyColumnHelper.accessor("createdAt", { id: "createdAt" }),
+  apiKeyColumnHelper.accessor("name", { id: "name" })
+])
+const EMPTY_API_KEYS: ListedApiKey[] = []
+
 export type ApiKeysProps = {
   class?: string
   organizationId?: string
@@ -35,12 +62,30 @@ export function ApiKeys(props: ApiKeysProps = {}) {
   const auth = useAuth<ApiKeyAuthClient>()
   const config = useAuthPlugin(apiKeyPlugin)
   const [isCreateDialogOpen, setIsCreateDialogOpen] = createSignal(false)
-  const [page, setPage] = createSignal(0)
-  const [sort, setSort] = createSignal({
-    id: "createdAt:desc",
-    label: apiKeyLocalization.newest
-  })
   const pageSize = config.pageSize
+  const [pagination, setPaginationState] = createSignal<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const [sorting, setSortingState] = createSignal<SortingState>([
+    { id: "createdAt", desc: true }
+  ])
+  const sort = () => {
+    const primarySort = sorting()[0]
+    const id = primarySort?.id === "name" ? "name" : "createdAt"
+    const direction = primarySort?.desc ? "desc" : "asc"
+    return {
+      id: `${id}:${direction}`,
+      label:
+        id === "name"
+          ? direction === "desc"
+            ? apiKeyLocalization.nameDescending
+            : apiKeyLocalization.nameAscending
+          : direction === "desc"
+            ? apiKeyLocalization.newest
+            : apiKeyLocalization.oldest
+    }
+  }
   const listParams = () => ({
     enabled: !props.isPending,
     query: {
@@ -50,8 +95,8 @@ export function ApiKeys(props: ApiKeysProps = {}) {
             configId: "organization" as const
           }
         : {}),
-      limit: pageSize,
-      offset: page() * pageSize,
+      limit: pagination().pageSize,
+      offset: pagination().pageIndex * pagination().pageSize,
       sortBy: sort().id.split(":")[0],
       sortDirection: sort().id.split(":")[1] as "asc" | "desc"
     }
@@ -59,6 +104,26 @@ export function ApiKeys(props: ApiKeysProps = {}) {
   const apiKeys = useListApiKeys(auth.authClient, () => listParams() ?? {})
   const keys = () => apiKeys.data?.apiKeys ?? []
   const pending = () => Boolean(props.isPending || apiKeys.isPending)
+  const setPagination = (updater: Updater<PaginationState>) =>
+    setPaginationState((current) => functionalUpdate(updater, current))
+  const setSorting = (updater: Updater<SortingState>) => {
+    setSortingState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const table = createApiKeyTable({
+    columns: apiKeyColumns,
+    get data() {
+      return apiKeys.data?.apiKeys ?? EMPTY_API_KEYS
+    },
+    get state() {
+      return { pagination: pagination(), sorting: sorting() }
+    },
+    getRowId: (apiKey) => apiKey.id,
+    manualPagination: true,
+    manualSorting: true,
+    onPaginationChange: setPagination,
+    onSortingChange: setSorting
+  })
 
   return (
     <div class={cn("flex flex-col gap-3", props.class)}>
@@ -98,8 +163,8 @@ export function ApiKeys(props: ApiKeysProps = {}) {
         value={sort()}
         onChange={(value) => {
           if (value) {
-            setSort(value)
-            setPage(0)
+            const [id, direction] = value.id.split(":")
+            table.setSorting([{ id, desc: direction === "desc" }])
           }
         }}
         itemComponent={(itemProps) => (
@@ -131,14 +196,14 @@ export function ApiKeys(props: ApiKeysProps = {}) {
               }
             >
               <ItemGroup class="gap-0">
-                <For each={keys()}>
-                  {(apiKey, index) => (
+                <For each={table.getRowModel().rows}>
+                  {(row, index) => (
                     <>
                       <Show when={index() > 0}>
                         <ItemSeparator />
                       </Show>
                       <ApiKey
-                        apiKey={apiKey as ListedApiKey}
+                        apiKey={row.original}
                         hideDelete={props.hideDelete}
                         hideUpdate={props.hideUpdate}
                         organizationId={props.organizationId}
@@ -151,21 +216,25 @@ export function ApiKeys(props: ApiKeysProps = {}) {
           </Show>
         </CardContent>
       </Card>
-      <Show when={page() > 0 || keys().length === pageSize}>
+      <Show
+        when={
+          pagination().pageIndex > 0 || keys().length === pagination().pageSize
+        }
+      >
         <div class="flex justify-end gap-2">
           <Button
             size="sm"
             variant="outline"
-            disabled={page() === 0}
-            onClick={() => setPage((value) => Math.max(0, value - 1))}
+            disabled={!table.getCanPreviousPage()}
+            onClick={() => table.previousPage()}
           >
             {apiKeyLocalization.previousPage}
           </Button>
           <Button
             size="sm"
             variant="outline"
-            disabled={keys().length < pageSize}
-            onClick={() => setPage((value) => value + 1)}
+            disabled={keys().length < pagination().pageSize}
+            onClick={() => table.nextPage()}
           >
             {apiKeyLocalization.nextPage}
           </Button>

--- a/examples/start-solid-zaidan-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/dash/activity.tsx
@@ -3,6 +3,7 @@ import {
   type DashAuthClient,
   formatDashEventName,
   getDashEventDetail,
+  getDashEventKey,
   getDashEventLocation
 } from "@better-auth-ui/core/plugins/dash"
 import {
@@ -17,6 +18,17 @@ import {
 } from "@better-auth-ui/solid/plugins/dash"
 import { useActiveMemberRole } from "@better-auth-ui/solid/plugins/organization"
 import { keepPreviousData } from "@tanstack/solid-query"
+import {
+  type ColumnFiltersState,
+  columnFilteringFeature,
+  createTableHook,
+  functionalUpdate,
+  globalFilteringFeature,
+  type PaginationState,
+  rowPaginationFeature,
+  tableFeatures,
+  type Updater
+} from "@tanstack/solid-table"
 import {
   Activity,
   Building2,
@@ -73,6 +85,21 @@ import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
 
 type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
+
+const { createAppColumnHelper, createAppTable: createActivityTable } =
+  createTableHook({
+    features: tableFeatures({
+      columnFilteringFeature,
+      globalFilteringFeature,
+      rowPaginationFeature
+    })
+  })
+
+const activityColumnHelper = createAppColumnHelper<DashAuditLog>()
+const activityColumns = activityColumnHelper.columns([
+  activityColumnHelper.accessor("eventType", { id: "eventType" })
+])
+const EMPTY_EVENTS: DashAuditLog[] = []
 
 type ActivityFeedProps = {
   access: ActivityAccess
@@ -208,25 +235,34 @@ function ActivityRowSkeleton() {
 function ActivityFeed(props: ActivityFeedProps) {
   const auth = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
-  const [page, setPage] = createSignal(0)
-  const [eventType, setEventType] = createSignal("all")
-  const [identifier, setIdentifier] = createSignal("")
-  const deferredIdentifier = createDeferred(() => identifier().trim())
+  const [pagination, setPaginationState] = createSignal<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const [columnFilters, setColumnFiltersState] =
+    createSignal<ColumnFiltersState>([])
+  const [globalFilter, setGlobalFilterState] = createSignal("")
+  const eventType = () =>
+    String(
+      columnFilters().find((filter) => filter.id === "eventType")?.value ??
+        "all"
+    )
+  const deferredIdentifier = createDeferred(() => globalFilter().trim())
   const eventOptions = createMemo(() =>
     Object.entries(localization.eventLabels)
   )
   createEffect(
     on(
       () => [props.access, props.organizationId, props.userId] as const,
-      () => setPage(0),
+      () => setPaginationState((current) => ({ ...current, pageIndex: 0 })),
       { defer: true }
     )
   )
-  const offset = () => page() * pageSize
+  const offset = () => pagination().pageIndex * pagination().pageSize
   const params = () => ({
     eventType: eventType() === "all" ? undefined : eventType(),
     identifier: deferredIdentifier() || undefined,
-    limit: pageSize,
+    limit: pagination().pageSize,
     offset: offset(),
     organizationId: props.organizationId
   })
@@ -253,7 +289,7 @@ function ActivityFeed(props: ActivityFeedProps) {
       params: {
         eventType: params().eventType,
         identifier: params().identifier,
-        limit: pageSize,
+        limit: pagination().pageSize,
         offset: offset()
       }
     })
@@ -266,7 +302,38 @@ function ActivityFeed(props: ActivityFeedProps) {
         : userQuery
   const showPending = () => !(props.ready ?? true) || query().isPending
   const pageEnd = () => offset() + (query().data?.events.length ?? 0)
-  const hasNextPage = () => pageEnd() < (query().data?.total ?? 0)
+  const setPagination = (updater: Updater<PaginationState>) =>
+    setPaginationState((current) => functionalUpdate(updater, current))
+  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
+    setColumnFiltersState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const setGlobalFilter = (updater: Updater<string>) => {
+    setGlobalFilterState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const table = createActivityTable({
+    columns: activityColumns,
+    get data() {
+      return query().data?.events ?? EMPTY_EVENTS
+    },
+    get rowCount() {
+      return query().data?.total ?? 0
+    },
+    get state() {
+      return {
+        columnFilters: columnFilters(),
+        globalFilter: globalFilter(),
+        pagination: pagination()
+      }
+    },
+    getRowId: getDashEventKey,
+    manualFiltering: true,
+    manualPagination: true,
+    onColumnFiltersChange: setColumnFilters,
+    onGlobalFilterChange: setGlobalFilter,
+    onPaginationChange: setPagination
+  })
 
   return (
     <Card
@@ -304,8 +371,10 @@ function ActivityFeed(props: ActivityFeedProps) {
             <NativeSelect
               id="solid-dash-event-type"
               onChange={(event) => {
-                setEventType(event.currentTarget.value)
-                setPage(0)
+                const value = event.currentTarget.value
+                table
+                  .getColumn("eventType")
+                  ?.setFilterValue(value === "all" ? undefined : value)
               }}
               value={eventType()}
             >
@@ -330,11 +399,10 @@ function ActivityFeed(props: ActivityFeedProps) {
               <InputGroupInput
                 id="solid-dash-identifier"
                 onInput={(event) => {
-                  setIdentifier(event.currentTarget.value)
-                  setPage(0)
+                  table.setGlobalFilter(event.currentTarget.value)
                 }}
                 placeholder={localization.identifierPlaceholder}
-                value={identifier()}
+                value={globalFilter()}
               />
             </InputGroup>
           </Field>
@@ -398,13 +466,13 @@ function ActivityFeed(props: ActivityFeedProps) {
               }
             >
               <ul>
-                <For each={query().data?.events ?? []}>
-                  {(event, position) => (
+                <For each={table.getRowModel().rows}>
+                  {(row, position) => (
                     <>
                       <Show when={position() > 0}>
                         <Separator />
                       </Show>
-                      <ActivityRow event={event} />
+                      <ActivityRow event={row.original} />
                     </>
                   )}
                 </For>
@@ -430,8 +498,8 @@ function ActivityFeed(props: ActivityFeedProps) {
           <div class="flex gap-1">
             <Button
               aria-label={localization.previousPage}
-              disabled={query().isFetching || page() === 0}
-              onClick={() => setPage((current) => Math.max(0, current - 1))}
+              disabled={query().isFetching || !table.getCanPreviousPage()}
+              onClick={() => table.previousPage()}
               size="icon-sm"
               variant="ghost"
             >
@@ -439,8 +507,8 @@ function ActivityFeed(props: ActivityFeedProps) {
             </Button>
             <Button
               aria-label={localization.nextPage}
-              disabled={query().isFetching || !hasNextPage()}
-              onClick={() => setPage((current) => current + 1)}
+              disabled={query().isFetching || !table.getCanNextPage()}
+              onClick={() => table.nextPage()}
               size="icon-sm"
               variant="ghost"
             >

--- a/examples/start-solid-zaidan-example/src/components/auth/oauth-provider/oauth-clients.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/oauth-provider/oauth-clients.tsx
@@ -20,6 +20,7 @@ import {
   useSetOAuthClientDisabled,
   useUpdateOAuthClient
 } from "@better-auth-ui/solid/plugins/oauth-provider"
+import { createForm } from "@tanstack/solid-form"
 import {
   Check,
   Code2,
@@ -71,6 +72,15 @@ type ClientAction =
   | { kind: "delete"; client: ManagedOAuthClient }
   | { kind: "rotate"; client: ManagedOAuthClient }
 
+type OAuthClientFormValues = {
+  applicationType: "native" | "web"
+  clientName: string
+  clientUri: string
+  logoUri: string
+  redirectUris: string
+  scope: string
+}
+
 export type OAuthClientsProps = {
   manager: OAuthClientManager
   owner: OAuthClientOwner
@@ -87,6 +97,17 @@ const uniqueLines = (value: string) =>
         .filter(Boolean)
     )
   )
+
+const getOAuthClientFormValues = (
+  client?: ManagedOAuthClient
+): OAuthClientFormValues => ({
+  applicationType: client?.application_type === "native" ? "native" : "web",
+  clientName: client?.client_name ?? "",
+  clientUri: client?.client_uri ?? "",
+  logoUri: client?.logo_uri ?? "",
+  redirectUris: client?.redirect_uris.join("\n") ?? "",
+  scope: client?.scope ?? ""
+})
 
 export function OAuthClients(props: OAuthClientsProps) {
   const auth = useAuth()
@@ -115,42 +136,42 @@ export function OAuthClients(props: OAuthClientsProps) {
     onError: (error) =>
       toast.error(error instanceof Error ? error.message : String(error))
   })
+  const form = createForm(() => ({
+    defaultValues: getOAuthClientFormValues(),
+    onSubmit: async ({ value }) => {
+      const input: OAuthClientInput = {
+        client_name: value.clientName.trim(),
+        application_type: value.applicationType,
+        redirect_uris: uniqueLines(value.redirectUris),
+        client_uri: value.clientUri.trim() || undefined,
+        logo_uri: value.logoUri.trim() || undefined,
+        scope: value.scope.trim() || undefined
+      }
+      const editing = editingClient()
+
+      try {
+        if (editing) {
+          await updateClient.mutateAsync({
+            clientId: editing.client_id,
+            update: input
+          })
+          setEditorOpen(false)
+          return
+        }
+
+        const client = await createClient.mutateAsync(input)
+        setEditorOpen(false)
+        setSecret(client)
+      } catch {
+        // The mutation keeps its error state for the host application.
+      }
+    }
+  }))
 
   const openCreate = () => {
     setEditingClient(undefined)
+    form.reset(getOAuthClientFormValues())
     setEditorOpen(true)
-  }
-
-  const handleEditorSubmit = (event: SubmitEvent) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget as HTMLFormElement)
-
-    const input: OAuthClientInput = {
-      client_name: String(formData.get("clientName") ?? "").trim(),
-      application_type:
-        formData.get("applicationType") === "native" ? "native" : "web",
-      redirect_uris: uniqueLines(String(formData.get("redirectUris") ?? "")),
-      client_uri: String(formData.get("clientUri") ?? "").trim() || undefined,
-      logo_uri: String(formData.get("logoUri") ?? "").trim() || undefined,
-      scope: String(formData.get("scope") ?? "").trim() || undefined
-    }
-
-    const editing = editingClient()
-
-    if (editing) {
-      updateClient.mutate(
-        { clientId: editing.client_id, update: input },
-        { onSuccess: () => setEditorOpen(false) }
-      )
-      return
-    }
-
-    createClient.mutate(input, {
-      onSuccess: (client) => {
-        setEditorOpen(false)
-        setSecret(client)
-      }
-    })
   }
 
   const confirmAction = () => {
@@ -172,7 +193,6 @@ export function OAuthClients(props: OAuthClientsProps) {
     })
   }
 
-  const isSaving = () => createClient.isPending || updateClient.isPending
   const isConfirming = () => deleteClient.isPending || rotateSecret.isPending
 
   return (
@@ -264,6 +284,7 @@ export function OAuthClients(props: OAuthClientsProps) {
                         aria-label={oauthLocalization.editClient}
                         onClick={() => {
                           setEditingClient(client)
+                          form.reset(getOAuthClientFormValues(client))
                           setEditorOpen(true)
                         }}
                         size="icon-sm"
@@ -317,7 +338,13 @@ export function OAuthClients(props: OAuthClientsProps) {
 
       <Dialog onOpenChange={setEditorOpen} open={editorOpen()}>
         <DialogContent>
-          <form class="flex flex-col gap-6" onSubmit={handleEditorSubmit}>
+          <form
+            class="flex flex-col gap-6"
+            onSubmit={(event) => {
+              event.preventDefault()
+              void form.handleSubmit()
+            }}
+          >
             <DialogHeader>
               <DialogTitle>
                 {editingClient()
@@ -330,87 +357,136 @@ export function OAuthClients(props: OAuthClientsProps) {
             </DialogHeader>
 
             <div class="flex flex-col gap-4">
-              <Field>
-                <FieldLabel for="oauth-client-name">
-                  {oauthLocalization.clientName}
-                </FieldLabel>
-                <Input
-                  id="oauth-client-name"
-                  name="clientName"
-                  required
-                  value={editingClient()?.client_name ?? ""}
-                />
-              </Field>
+              <form.Field name="clientName">
+                {(field) => (
+                  <Field>
+                    <FieldLabel for="oauth-client-name">
+                      {oauthLocalization.clientName}
+                    </FieldLabel>
+                    <Input
+                      id="oauth-client-name"
+                      name={field().name}
+                      onBlur={field().handleBlur}
+                      onInput={(event) =>
+                        field().handleChange(event.currentTarget.value)
+                      }
+                      required
+                      value={field().state.value}
+                    />
+                  </Field>
+                )}
+              </form.Field>
 
-              <Field>
-                <FieldLabel for="oauth-application-type">
-                  {oauthLocalization.applicationType}
-                </FieldLabel>
-                <NativeSelect
-                  id="oauth-application-type"
-                  name="applicationType"
-                  value={editingClient()?.application_type ?? "web"}
-                >
-                  <option value="web">
-                    {oauthLocalization.webApplication}
-                  </option>
-                  <option value="native">
-                    {oauthLocalization.nativeApplication}
-                  </option>
-                </NativeSelect>
-              </Field>
+              <form.Field name="applicationType">
+                {(field) => (
+                  <Field>
+                    <FieldLabel for="oauth-application-type">
+                      {oauthLocalization.applicationType}
+                    </FieldLabel>
+                    <NativeSelect
+                      id="oauth-application-type"
+                      name={field().name}
+                      onChange={(event) =>
+                        field().handleChange(
+                          event.currentTarget.value as "native" | "web"
+                        )
+                      }
+                      value={field().state.value}
+                    >
+                      <option value="web">
+                        {oauthLocalization.webApplication}
+                      </option>
+                      <option value="native">
+                        {oauthLocalization.nativeApplication}
+                      </option>
+                    </NativeSelect>
+                  </Field>
+                )}
+              </form.Field>
 
-              <Field>
-                <FieldLabel for="oauth-redirect-uris">
-                  {oauthLocalization.redirectUrls}
-                </FieldLabel>
-                <Textarea
-                  id="oauth-redirect-uris"
-                  name="redirectUris"
-                  required
-                  rows={3}
-                  value={editingClient()?.redirect_uris.join("\n") ?? ""}
-                />
-                <FieldDescription>
-                  {oauthLocalization.redirectUrlsDescription}
-                </FieldDescription>
-              </Field>
+              <form.Field name="redirectUris">
+                {(field) => (
+                  <Field>
+                    <FieldLabel for="oauth-redirect-uris">
+                      {oauthLocalization.redirectUrls}
+                    </FieldLabel>
+                    <Textarea
+                      id="oauth-redirect-uris"
+                      name={field().name}
+                      onBlur={field().handleBlur}
+                      onInput={(event) =>
+                        field().handleChange(event.currentTarget.value)
+                      }
+                      required
+                      rows={3}
+                      value={field().state.value}
+                    />
+                    <FieldDescription>
+                      {oauthLocalization.redirectUrlsDescription}
+                    </FieldDescription>
+                  </Field>
+                )}
+              </form.Field>
 
-              <Field>
-                <FieldLabel for="oauth-client-uri">
-                  {oauthLocalization.applicationUrl}
-                </FieldLabel>
-                <Input
-                  id="oauth-client-uri"
-                  name="clientUri"
-                  type="url"
-                  value={editingClient()?.client_uri ?? ""}
-                />
-              </Field>
+              <form.Field name="clientUri">
+                {(field) => (
+                  <Field>
+                    <FieldLabel for="oauth-client-uri">
+                      {oauthLocalization.applicationUrl}
+                    </FieldLabel>
+                    <Input
+                      id="oauth-client-uri"
+                      name={field().name}
+                      onBlur={field().handleBlur}
+                      onInput={(event) =>
+                        field().handleChange(event.currentTarget.value)
+                      }
+                      type="url"
+                      value={field().state.value}
+                    />
+                  </Field>
+                )}
+              </form.Field>
 
-              <Field>
-                <FieldLabel for="oauth-logo-uri">
-                  {oauthLocalization.logoUrl}
-                </FieldLabel>
-                <Input
-                  id="oauth-logo-uri"
-                  name="logoUri"
-                  type="url"
-                  value={editingClient()?.logo_uri ?? ""}
-                />
-              </Field>
+              <form.Field name="logoUri">
+                {(field) => (
+                  <Field>
+                    <FieldLabel for="oauth-logo-uri">
+                      {oauthLocalization.logoUrl}
+                    </FieldLabel>
+                    <Input
+                      id="oauth-logo-uri"
+                      name={field().name}
+                      onBlur={field().handleBlur}
+                      onInput={(event) =>
+                        field().handleChange(event.currentTarget.value)
+                      }
+                      type="url"
+                      value={field().state.value}
+                    />
+                  </Field>
+                )}
+              </form.Field>
 
-              <Field>
-                <FieldLabel for="oauth-scopes">
-                  {oauthLocalization.scopes}
-                </FieldLabel>
-                <Input
-                  id="oauth-scopes"
-                  name="scope"
-                  placeholder="openid profile email"
-                  value={editingClient()?.scope ?? ""}
-                />
-              </Field>
+              <form.Field name="scope">
+                {(field) => (
+                  <Field>
+                    <FieldLabel for="oauth-scopes">
+                      {oauthLocalization.scopes}
+                    </FieldLabel>
+                    <Input
+                      id="oauth-scopes"
+                      name={field().name}
+                      onBlur={field().handleBlur}
+                      onInput={(event) =>
+                        field().handleChange(event.currentTarget.value)
+                      }
+                      placeholder="openid profile email"
+                      value={field().state.value}
+                    />
+                  </Field>
+                )}
+              </form.Field>
             </div>
 
             <DialogFooter>
@@ -421,14 +497,18 @@ export function OAuthClients(props: OAuthClientsProps) {
               >
                 {oauthLocalization.cancel}
               </Button>
-              <Button disabled={isSaving()} type="submit">
-                <Show when={isSaving()}>
-                  <Spinner data-icon="inline-start" />
-                </Show>
-                {editingClient()
-                  ? oauthLocalization.saveChanges
-                  : oauthLocalization.createClient}
-              </Button>
+              <form.Subscribe selector={(state) => state.isSubmitting}>
+                {(isSubmitting) => (
+                  <Button disabled={isSubmitting()} type="submit">
+                    <Show when={isSubmitting()}>
+                      <Spinner data-icon="inline-start" />
+                    </Show>
+                    {editingClient()
+                      ? oauthLocalization.saveChanges
+                      : oauthLocalization.createClient}
+                  </Button>
+                )}
+              </form.Subscribe>
             </DialogFooter>
           </form>
         </DialogContent>

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/edit-member-roles-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/edit-member-roles-dialog.tsx
@@ -6,8 +6,9 @@ import {
 } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import { useUpdateMemberRole } from "@better-auth-ui/solid/plugins/organization"
+import { createForm } from "@tanstack/solid-form"
 import { ShieldCheck } from "lucide-solid"
-import { createEffect, createSignal, For, Show } from "solid-js"
+import { createEffect, For, Show } from "solid-js"
 import { toast } from "solid-sonner"
 
 import { Button } from "@/components/ui/button"
@@ -68,36 +69,41 @@ const selectedMemberRoles = (
 export function EditMemberRolesDialog(props: EditMemberRolesDialogProps) {
   const auth = useAuth<OrganizationAuthClient>()
   const config = useAuthPlugin(organizationPlugin)
-  const [selectedRoles, setSelectedRoles] = createSignal(
-    selectedMemberRoles(
-      props.member.role,
-      config.allowMultipleRoles,
-      props.protectedRole
-    )
-  )
   const updateMemberRole = useUpdateMemberRole(auth.authClient, () => ({
     onSuccess: () => {
       toast.success(props.localization.memberRoleUpdated)
       props.onOpenChange(false)
     }
   }))
+  const form = createForm(() => ({
+    defaultValues: {
+      roles: selectedMemberRoles(
+        props.member.role,
+        config.allowMultipleRoles,
+        props.protectedRole
+      )
+    },
+    onSubmit: ({ value }) => {
+      if (value.roles.length === 0) return
+
+      updateMemberRole.mutate({
+        memberId: props.member.id,
+        organizationId: props.member.organizationId,
+        role: value.roles as UpdateMemberRoleParams["role"]
+      })
+    }
+  }))
 
   createEffect(() => {
     if (props.open)
-      setSelectedRoles(
-        selectedMemberRoles(
+      form.reset({
+        roles: selectedMemberRoles(
           props.member.role,
           config.allowMultipleRoles,
           props.protectedRole
         )
-      )
+      })
   })
-
-  const protectedRoleSelected = () =>
-    !config.allowMultipleRoles &&
-    props.protectedRoleRemovalDisabled &&
-    props.protectedRole !== undefined &&
-    selectedRoles().includes(props.protectedRole)
 
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
@@ -106,13 +112,7 @@ export function EditMemberRolesDialog(props: EditMemberRolesDialogProps) {
           class="flex flex-col gap-6"
           onSubmit={(event) => {
             event.preventDefault()
-            if (selectedRoles().length === 0) return
-
-            updateMemberRole.mutate({
-              memberId: props.member.id,
-              organizationId: props.member.organizationId,
-              role: selectedRoles() as UpdateMemberRoleParams["role"]
-            })
+            void form.handleSubmit()
           }}
         >
           <DialogHeader>
@@ -125,110 +125,129 @@ export function EditMemberRolesDialog(props: EditMemberRolesDialogProps) {
             </DialogDescription>
           </DialogHeader>
 
-          <Show
-            when={config.allowMultipleRoles}
-            fallback={
-              <RadioGroup
-                disabled={updateMemberRole.isPending}
-                onChange={(role) => setSelectedRoles([role])}
-                value={selectedRoles()[0] ?? ""}
-              >
-                <div class="flex flex-col gap-2">
-                  <For each={props.roles}>
-                    {([role, label]) => {
-                      const selected = () => selectedRoles().includes(role)
-                      const disabled = () =>
-                        (protectedRoleSelected() &&
-                          role !== props.protectedRole) ||
-                        (role === props.protectedRole &&
-                          selected() &&
-                          props.protectedRoleRemovalDisabled)
-                      const id = `member-${props.member.id}-role-${role}`
+          <form.Field name="roles">
+            {(field) => {
+              const selectedRoles = () => field().state.value
+              const protectedRoleSelected = () =>
+                !config.allowMultipleRoles &&
+                props.protectedRoleRemovalDisabled &&
+                props.protectedRole !== undefined &&
+                selectedRoles().includes(props.protectedRole)
 
-                      return (
-                        <FieldLabel for={id}>
-                          <Field
-                            data-disabled={disabled() || undefined}
-                            orientation="horizontal"
-                          >
-                            <FieldContent>
-                              <FieldTitle>{label}</FieldTitle>
-                            </FieldContent>
-                            <RadioGroupItem
-                              disabled={disabled()}
-                              id={id}
-                              value={role}
-                            />
-                          </Field>
-                        </FieldLabel>
-                      )
-                    }}
-                  </For>
-                </div>
-              </RadioGroup>
-            }
-          >
-            <div class="flex flex-col gap-2">
-              <For each={props.roles}>
-                {([role, label]) => {
-                  const checked = () => selectedRoles().includes(role)
-                  const disabled = () =>
-                    updateMemberRole.isPending ||
-                    (checked() && selectedRoles().length === 1) ||
-                    (role === props.protectedRole &&
-                      checked() &&
-                      props.protectedRoleRemovalDisabled)
-                  const id = `member-${props.member.id}-role-${role}`
-
-                  return (
-                    <FieldLabel for={id}>
-                      <Field
-                        data-disabled={disabled() || undefined}
-                        orientation="horizontal"
+              return (
+                <>
+                  <Show
+                    when={config.allowMultipleRoles}
+                    fallback={
+                      <RadioGroup
+                        disabled={updateMemberRole.isPending}
+                        onChange={(role) => field().handleChange([role])}
+                        value={selectedRoles()[0] ?? ""}
                       >
-                        <FieldContent>
-                          <FieldTitle>{label}</FieldTitle>
-                        </FieldContent>
-                        <Checkbox
-                          checked={checked()}
-                          disabled={disabled()}
-                          id={id}
-                          onChange={(selected) =>
-                            setSelectedRoles((current) =>
-                              selected
-                                ? current.includes(role)
-                                  ? current
-                                  : [...current, role]
-                                : current.filter((entry) => entry !== role)
-                            )
-                          }
-                        />
-                      </Field>
-                    </FieldLabel>
-                  )
-                }}
-              </For>
-            </div>
-          </Show>
+                        <div class="flex flex-col gap-2">
+                          <For each={props.roles}>
+                            {([role, label]) => {
+                              const selected = () =>
+                                selectedRoles().includes(role)
+                              const disabled = () =>
+                                (protectedRoleSelected() &&
+                                  role !== props.protectedRole) ||
+                                (role === props.protectedRole &&
+                                  selected() &&
+                                  props.protectedRoleRemovalDisabled)
+                              const id = `member-${props.member.id}-role-${role}`
 
-          <DialogFooter>
-            <Button
-              disabled={updateMemberRole.isPending}
-              onClick={() => props.onOpenChange(false)}
-              type="button"
-              variant="outline"
-            >
-              {auth.localization.settings.cancel}
-            </Button>
-            <Button
-              disabled={
-                updateMemberRole.isPending || selectedRoles().length === 0
-              }
-              type="submit"
-            >
-              {auth.localization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
+                              return (
+                                <FieldLabel for={id}>
+                                  <Field
+                                    data-disabled={disabled() || undefined}
+                                    orientation="horizontal"
+                                  >
+                                    <FieldContent>
+                                      <FieldTitle>{label}</FieldTitle>
+                                    </FieldContent>
+                                    <RadioGroupItem
+                                      disabled={disabled()}
+                                      id={id}
+                                      value={role}
+                                    />
+                                  </Field>
+                                </FieldLabel>
+                              )
+                            }}
+                          </For>
+                        </div>
+                      </RadioGroup>
+                    }
+                  >
+                    <div class="flex flex-col gap-2">
+                      <For each={props.roles}>
+                        {([role, label]) => {
+                          const checked = () => selectedRoles().includes(role)
+                          const disabled = () =>
+                            updateMemberRole.isPending ||
+                            (checked() && selectedRoles().length === 1) ||
+                            (role === props.protectedRole &&
+                              checked() &&
+                              props.protectedRoleRemovalDisabled)
+                          const id = `member-${props.member.id}-role-${role}`
+
+                          return (
+                            <FieldLabel for={id}>
+                              <Field
+                                data-disabled={disabled() || undefined}
+                                orientation="horizontal"
+                              >
+                                <FieldContent>
+                                  <FieldTitle>{label}</FieldTitle>
+                                </FieldContent>
+                                <Checkbox
+                                  checked={checked()}
+                                  disabled={disabled()}
+                                  id={id}
+                                  onChange={(selected) =>
+                                    field().handleChange(
+                                      selected
+                                        ? selectedRoles().includes(role)
+                                          ? selectedRoles()
+                                          : [...selectedRoles(), role]
+                                        : selectedRoles().filter(
+                                            (entry) => entry !== role
+                                          )
+                                    )
+                                  }
+                                />
+                              </Field>
+                            </FieldLabel>
+                          )
+                        }}
+                      </For>
+                    </div>
+                  </Show>
+
+                  <DialogFooter>
+                    <Button
+                      disabled={updateMemberRole.isPending}
+                      onClick={() => props.onOpenChange(false)}
+                      type="button"
+                      variant="outline"
+                    >
+                      {auth.localization.settings.cancel}
+                    </Button>
+                    <Button
+                      disabled={
+                        updateMemberRole.isPending ||
+                        selectedRoles().length === 0
+                      }
+                      type="submit"
+                    >
+                      {auth.localization.settings.saveChanges}
+                    </Button>
+                  </DialogFooter>
+                </>
+              )
+            }}
+          </form.Field>
         </form>
       </DialogContent>
     </Dialog>

--- a/examples/start-solid-zaidan-example/src/components/auth/reset-password.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/reset-password.tsx
@@ -3,6 +3,7 @@ import {
   isPasswordCompromisedError
 } from "@better-auth-ui/core"
 import { AuthLink, useAuth, useResetPassword } from "@better-auth-ui/solid"
+import { createForm } from "@tanstack/solid-form"
 import { Eye, EyeOff } from "lucide-solid"
 import { createSignal, Show } from "solid-js"
 import { Alert, AlertDescription } from "@/components/ui/alert"
@@ -26,9 +27,7 @@ const tokenFromLocation = () => {
 
 export function ResetPassword(props: ResetPasswordProps) {
   const auth = useAuth()
-  const [password, setPassword] = createSignal("")
   const [passwordError, setPasswordError] = createSignal<string>()
-  const [confirmPassword, setConfirmPassword] = createSignal("")
   const [confirmPasswordError, setConfirmPasswordError] = createSignal<string>()
   const [tokenError, setTokenError] = createSignal<string>()
   const [isPasswordVisible, setIsPasswordVisible] = createSignal(false)
@@ -43,24 +42,24 @@ export function ResetPassword(props: ResetPasswordProps) {
       }
     }
   }))
+  const form = createForm(() => ({
+    defaultValues: { confirmPassword: "", password: "" },
+    onSubmit: ({ value }) => {
+      const token = props.token ?? tokenFromLocation()
 
-  const submitPasswordReset = (event: SubmitEvent) => {
-    event.preventDefault()
-    const token = props.token ?? tokenFromLocation()
+      setTokenError(
+        token ? undefined : auth.localization.auth.invalidResetPasswordToken
+      )
+      setConfirmPasswordError(
+        value.password === value.confirmPassword
+          ? undefined
+          : auth.localization.auth.passwordsDoNotMatch
+      )
 
-    setTokenError(
-      token ? undefined : auth.localization.auth.invalidResetPasswordToken
-    )
-    setConfirmPasswordError(
-      password() === confirmPassword()
-        ? undefined
-        : auth.localization.auth.passwordsDoNotMatch
-    )
-
-    if (!token || password() !== confirmPassword()) return
-
-    resetPassword.mutate({ token, newPassword: password() })
-  }
+      if (!token || value.password !== value.confirmPassword) return
+      resetPassword.mutate({ token, newPassword: value.password })
+    }
+  }))
 
   return (
     <Card class={cn("w-full max-w-sm", props.class)}>
@@ -71,129 +70,149 @@ export function ResetPassword(props: ResetPasswordProps) {
       </CardHeader>
 
       <CardContent>
-        <form aria-label="Reset password" onSubmit={submitPasswordReset}>
+        <form
+          aria-label="Reset password"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void form.handleSubmit()
+          }}
+        >
           <div class="flex flex-col gap-6">
-            <Field data-invalid={Boolean(passwordError())}>
-              <FieldLabel for="reset-password-new">
-                {auth.localization.auth.newPassword}
-              </FieldLabel>
-              <div class="relative">
-                <Input
-                  aria-invalid={Boolean(passwordError())}
-                  autocomplete="new-password"
-                  class="pr-12"
-                  id="reset-password-new"
-                  maxLength={auth.emailAndPassword.maxPasswordLength}
-                  minLength={auth.emailAndPassword.minPasswordLength}
-                  name="password"
-                  onInput={(event) => {
-                    setPassword(event.currentTarget.value)
-                    setPasswordError(undefined)
-                    setConfirmPasswordError(undefined)
-                  }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    setPasswordError(event.currentTarget.validationMessage)
-                  }}
-                  placeholder={auth.localization.auth.newPasswordPlaceholder}
-                  required
-                  type={isPasswordVisible() ? "text" : "password"}
-                  value={password()}
-                />
+            <form.Field name="password">
+              {(field) => (
+                <Field data-invalid={Boolean(passwordError())}>
+                  <FieldLabel for="reset-password-new">
+                    {auth.localization.auth.newPassword}
+                  </FieldLabel>
+                  <div class="relative">
+                    <Input
+                      aria-invalid={Boolean(passwordError())}
+                      autocomplete="new-password"
+                      class="pr-12"
+                      id="reset-password-new"
+                      maxLength={auth.emailAndPassword.maxPasswordLength}
+                      minLength={auth.emailAndPassword.minPasswordLength}
+                      name={field().name}
+                      onBlur={field().handleBlur}
+                      onInput={(event) => {
+                        field().handleChange(event.currentTarget.value)
+                        setPasswordError(undefined)
+                        setConfirmPasswordError(undefined)
+                      }}
+                      onInvalid={(event) => {
+                        event.preventDefault()
+                        setPasswordError(event.currentTarget.validationMessage)
+                      }}
+                      placeholder={
+                        auth.localization.auth.newPasswordPlaceholder
+                      }
+                      required
+                      type={isPasswordVisible() ? "text" : "password"}
+                      value={field().state.value}
+                    />
 
-                <Button
-                  aria-label={
-                    isPasswordVisible()
-                      ? auth.localization.auth.hidePassword
-                      : auth.localization.auth.showPassword
-                  }
-                  class="absolute right-1 top-1/2 -translate-y-1/2"
-                  onClick={() => setIsPasswordVisible((visible) => !visible)}
-                  size="icon-sm"
-                  title={
-                    isPasswordVisible()
-                      ? auth.localization.auth.hidePassword
-                      : auth.localization.auth.showPassword
-                  }
-                  type="button"
-                  variant="ghost"
-                >
-                  {isPasswordVisible() ? (
-                    <EyeOff aria-hidden class="size-4" />
-                  ) : (
-                    <Eye aria-hidden class="size-4" />
-                  )}
-                </Button>
-              </div>
+                    <Button
+                      aria-label={
+                        isPasswordVisible()
+                          ? auth.localization.auth.hidePassword
+                          : auth.localization.auth.showPassword
+                      }
+                      class="absolute right-1 top-1/2 -translate-y-1/2"
+                      onClick={() =>
+                        setIsPasswordVisible((visible) => !visible)
+                      }
+                      size="icon-sm"
+                      title={
+                        isPasswordVisible()
+                          ? auth.localization.auth.hidePassword
+                          : auth.localization.auth.showPassword
+                      }
+                      type="button"
+                      variant="ghost"
+                    >
+                      {isPasswordVisible() ? (
+                        <EyeOff aria-hidden class="size-4" />
+                      ) : (
+                        <Eye aria-hidden class="size-4" />
+                      )}
+                    </Button>
+                  </div>
 
-              <Show when={passwordError()}>
-                {(message) => <FieldError>{message()}</FieldError>}
-              </Show>
+                  <Show when={passwordError()}>
+                    {(message) => <FieldError>{message()}</FieldError>}
+                  </Show>
 
-              <PasswordStrengthMeter password={password()} />
-            </Field>
-            <Field data-invalid={Boolean(confirmPasswordError())}>
-              <FieldLabel for="reset-password-confirm">
-                {auth.localization.auth.confirmPassword}
-              </FieldLabel>
-              <div class="relative">
-                <Input
-                  aria-invalid={Boolean(confirmPasswordError())}
-                  autocomplete="new-password"
-                  class="pr-12"
-                  id="reset-password-confirm"
-                  maxLength={auth.emailAndPassword.maxPasswordLength}
-                  minLength={auth.emailAndPassword.minPasswordLength}
-                  name="confirmPassword"
-                  onInput={(event) => {
-                    setConfirmPassword(event.currentTarget.value)
-                    setConfirmPasswordError(undefined)
-                  }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    setConfirmPasswordError(
-                      event.currentTarget.validationMessage
-                    )
-                  }}
-                  placeholder={
-                    auth.localization.auth.confirmPasswordPlaceholder
-                  }
-                  required
-                  type={isConfirmPasswordVisible() ? "text" : "password"}
-                  value={confirmPassword()}
-                />
+                  <PasswordStrengthMeter password={field().state.value} />
+                </Field>
+              )}
+            </form.Field>
+            <form.Field name="confirmPassword">
+              {(field) => (
+                <Field data-invalid={Boolean(confirmPasswordError())}>
+                  <FieldLabel for="reset-password-confirm">
+                    {auth.localization.auth.confirmPassword}
+                  </FieldLabel>
+                  <div class="relative">
+                    <Input
+                      aria-invalid={Boolean(confirmPasswordError())}
+                      autocomplete="new-password"
+                      class="pr-12"
+                      id="reset-password-confirm"
+                      maxLength={auth.emailAndPassword.maxPasswordLength}
+                      minLength={auth.emailAndPassword.minPasswordLength}
+                      name={field().name}
+                      onBlur={field().handleBlur}
+                      onInput={(event) => {
+                        field().handleChange(event.currentTarget.value)
+                        setConfirmPasswordError(undefined)
+                      }}
+                      onInvalid={(event) => {
+                        event.preventDefault()
+                        setConfirmPasswordError(
+                          event.currentTarget.validationMessage
+                        )
+                      }}
+                      placeholder={
+                        auth.localization.auth.confirmPasswordPlaceholder
+                      }
+                      required
+                      type={isConfirmPasswordVisible() ? "text" : "password"}
+                      value={field().state.value}
+                    />
 
-                <Button
-                  aria-label={
-                    isConfirmPasswordVisible()
-                      ? auth.localization.auth.hidePassword
-                      : auth.localization.auth.showPassword
-                  }
-                  class="absolute right-1 top-1/2 -translate-y-1/2"
-                  onClick={() =>
-                    setIsConfirmPasswordVisible((visible) => !visible)
-                  }
-                  size="icon-sm"
-                  title={
-                    isConfirmPasswordVisible()
-                      ? auth.localization.auth.hidePassword
-                      : auth.localization.auth.showPassword
-                  }
-                  type="button"
-                  variant="ghost"
-                >
-                  {isConfirmPasswordVisible() ? (
-                    <EyeOff aria-hidden class="size-4" />
-                  ) : (
-                    <Eye aria-hidden class="size-4" />
-                  )}
-                </Button>
-              </div>
+                    <Button
+                      aria-label={
+                        isConfirmPasswordVisible()
+                          ? auth.localization.auth.hidePassword
+                          : auth.localization.auth.showPassword
+                      }
+                      class="absolute right-1 top-1/2 -translate-y-1/2"
+                      onClick={() =>
+                        setIsConfirmPasswordVisible((visible) => !visible)
+                      }
+                      size="icon-sm"
+                      title={
+                        isConfirmPasswordVisible()
+                          ? auth.localization.auth.hidePassword
+                          : auth.localization.auth.showPassword
+                      }
+                      type="button"
+                      variant="ghost"
+                    >
+                      {isConfirmPasswordVisible() ? (
+                        <EyeOff aria-hidden class="size-4" />
+                      ) : (
+                        <Eye aria-hidden class="size-4" />
+                      )}
+                    </Button>
+                  </div>
 
-              <Show when={confirmPasswordError()}>
-                {(message) => <FieldError>{message()}</FieldError>}
-              </Show>
-            </Field>
+                  <Show when={confirmPasswordError()}>
+                    {(message) => <FieldError>{message()}</FieldError>}
+                  </Show>
+                </Field>
+              )}
+            </form.Field>
             <Button disabled={resetPassword.isPending} type="submit">
               {resetPassword.isPending
                 ? `${auth.localization.auth.resetPassword}…`

--- a/examples/start-solid-zaidan-example/src/components/auth/settings/security/change-password.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/settings/security/change-password.tsx
@@ -6,6 +6,7 @@ import {
   useRequestPasswordReset,
   useSession
 } from "@better-auth-ui/solid"
+import { createForm } from "@tanstack/solid-form"
 import type { BetterFetchError } from "better-auth/client"
 import { Eye, EyeOff } from "lucide-solid"
 import { createSignal, Show } from "solid-js"
@@ -55,9 +56,7 @@ export function ChangePasswordSettings(
   const requestPasswordReset = useRequestPasswordReset(auth.authClient)
   const changePassword = useChangePassword(auth.authClient, () => ({
     onError: (error: BetterFetchError) => {
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
+      form.reset()
 
       // The haveIBeenPwned plugin rejects on the password itself, so it
       // belongs against the field rather than in a toast.
@@ -72,15 +71,10 @@ export function ChangePasswordSettings(
       toast.error(error.error?.message || error.message)
     },
     onSuccess: () => {
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
+      form.reset()
       toast.success(auth.localization.settings.changePasswordSuccess)
     }
   }))
-  const [currentPassword, setCurrentPassword] = createSignal("")
-  const [newPassword, setNewPassword] = createSignal("")
-  const [confirmPassword, setConfirmPassword] = createSignal("")
   const [isCurrentPasswordVisible, setIsCurrentPasswordVisible] =
     createSignal(false)
   const [isNewPasswordVisible, setIsNewPasswordVisible] = createSignal(false)
@@ -97,12 +91,6 @@ export function ChangePasswordSettings(
     setFieldErrors((previous) => ({ ...previous, [field]: message }))
   }
 
-  const resetPasswordFields = () => {
-    setCurrentPassword("")
-    setNewPassword("")
-    setConfirmPassword("")
-  }
-
   const sendResetLink = () => {
     if (!session.data) return
 
@@ -116,21 +104,29 @@ export function ChangePasswordSettings(
     } as Parameters<typeof requestPasswordReset.mutate>[0])
   }
 
-  const submitChangePassword = (event: SubmitEvent) => {
-    event.preventDefault()
+  const form = createForm(() => ({
+    defaultValues: {
+      confirmPassword: "",
+      currentPassword: "",
+      newPassword: ""
+    },
+    onSubmit: ({ value }) => {
+      if (
+        props.confirmPassword &&
+        value.newPassword !== value.confirmPassword
+      ) {
+        form.reset()
+        toast.error(auth.localization.auth.passwordsDoNotMatch)
+        return
+      }
 
-    if (props.confirmPassword && newPassword() !== confirmPassword()) {
-      resetPasswordFields()
-      toast.error(auth.localization.auth.passwordsDoNotMatch)
-      return
+      changePassword.mutate({
+        currentPassword: value.currentPassword,
+        newPassword: value.newPassword,
+        revokeOtherSessions: true
+      } as Parameters<typeof changePassword.mutate>[0])
     }
-
-    changePassword.mutate({
-      currentPassword: currentPassword(),
-      newPassword: newPassword(),
-      revokeOtherSessions: true
-    } as Parameters<typeof changePassword.mutate>[0])
-  }
+  }))
 
   const isPasswordPending = () =>
     changePassword.isPending || requestPasswordReset.isPending
@@ -194,211 +190,232 @@ export function ChangePasswordSettings(
         {auth.localization.settings.changePassword}
       </h2>
 
-      <form onSubmit={submitChangePassword}>
+      <form
+        onSubmit={(event) => {
+          event.preventDefault()
+          void form.handleSubmit()
+        }}
+      >
         <Card>
           <CardContent class="flex flex-col gap-6">
-            <Field data-invalid={Boolean(fieldErrors().currentPassword)}>
-              <FieldLabel for="currentPassword">
-                {auth.localization.settings.currentPassword}
-              </FieldLabel>
-              <Show
-                fallback={<ChangePasswordSkeletonInput />}
-                when={session.data && !linkedAccounts.isPending}
-              >
-                <InputGroup>
-                  <InputGroupInput
-                    aria-invalid={!!fieldErrors().currentPassword}
-                    autocomplete="current-password"
-                    disabled={isPasswordPending()}
-                    id="currentPassword"
-                    name="currentPassword"
-                    onInput={(event) => {
-                      setCurrentPassword(event.currentTarget.value)
-                      setPasswordFieldError("currentPassword")
-                    }}
-                    onInvalid={(event) => {
-                      event.preventDefault()
-                      setPasswordFieldError(
-                        "currentPassword",
-                        event.currentTarget.validationMessage
-                      )
-                    }}
-                    placeholder={
-                      auth.localization.settings.currentPasswordPlaceholder
-                    }
-                    required
-                    type={isCurrentPasswordVisible() ? "text" : "password"}
-                    value={currentPassword()}
-                  />
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      aria-label={
-                        isCurrentPasswordVisible()
-                          ? auth.localization.auth.hidePassword
-                          : auth.localization.auth.showPassword
-                      }
-                      disabled={isPasswordPending()}
-                      onClick={() =>
-                        setIsCurrentPasswordVisible((visible) => !visible)
-                      }
-                      size="icon-sm"
-                      title={
-                        isCurrentPasswordVisible()
-                          ? auth.localization.auth.hidePassword
-                          : auth.localization.auth.showPassword
-                      }
-                    >
-                      <Show
-                        when={isCurrentPasswordVisible()}
-                        fallback={<Eye aria-hidden class="size-4" />}
-                      >
-                        <EyeOff aria-hidden class="size-4" />
-                      </Show>
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
-              </Show>
-              <Show when={fieldErrors().currentPassword}>
-                {(message) => <FieldError>{message()}</FieldError>}
-              </Show>
-            </Field>
+            <form.Field name="currentPassword">
+              {(field) => (
+                <Field data-invalid={Boolean(fieldErrors().currentPassword)}>
+                  <FieldLabel for="currentPassword">
+                    {auth.localization.settings.currentPassword}
+                  </FieldLabel>
+                  <Show
+                    fallback={<ChangePasswordSkeletonInput />}
+                    when={session.data && !linkedAccounts.isPending}
+                  >
+                    <InputGroup>
+                      <InputGroupInput
+                        aria-invalid={!!fieldErrors().currentPassword}
+                        autocomplete="current-password"
+                        disabled={isPasswordPending()}
+                        id="currentPassword"
+                        name={field().name}
+                        onInput={(event) => {
+                          field().handleChange(event.currentTarget.value)
+                          setPasswordFieldError("currentPassword")
+                        }}
+                        onInvalid={(event) => {
+                          event.preventDefault()
+                          setPasswordFieldError(
+                            "currentPassword",
+                            event.currentTarget.validationMessage
+                          )
+                        }}
+                        placeholder={
+                          auth.localization.settings.currentPasswordPlaceholder
+                        }
+                        required
+                        type={isCurrentPasswordVisible() ? "text" : "password"}
+                        value={field().state.value}
+                      />
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          aria-label={
+                            isCurrentPasswordVisible()
+                              ? auth.localization.auth.hidePassword
+                              : auth.localization.auth.showPassword
+                          }
+                          disabled={isPasswordPending()}
+                          onClick={() =>
+                            setIsCurrentPasswordVisible((visible) => !visible)
+                          }
+                          size="icon-sm"
+                          title={
+                            isCurrentPasswordVisible()
+                              ? auth.localization.auth.hidePassword
+                              : auth.localization.auth.showPassword
+                          }
+                        >
+                          <Show
+                            when={isCurrentPasswordVisible()}
+                            fallback={<Eye aria-hidden class="size-4" />}
+                          >
+                            <EyeOff aria-hidden class="size-4" />
+                          </Show>
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  </Show>
+                  <Show when={fieldErrors().currentPassword}>
+                    {(message) => <FieldError>{message()}</FieldError>}
+                  </Show>
+                </Field>
+              )}
+            </form.Field>
 
-            <Field data-invalid={Boolean(fieldErrors().newPassword)}>
-              <FieldLabel for="newPassword">
-                {auth.localization.auth.newPassword}
-              </FieldLabel>
-              <Show
-                fallback={<ChangePasswordSkeletonInput />}
-                when={session.data && !linkedAccounts.isPending}
-              >
-                <InputGroup>
-                  <InputGroupInput
-                    aria-invalid={!!fieldErrors().newPassword}
-                    autocomplete="new-password"
-                    disabled={isPasswordPending()}
-                    id="newPassword"
-                    maxLength={auth.emailAndPassword.maxPasswordLength}
-                    minLength={auth.emailAndPassword.minPasswordLength}
-                    name="newPassword"
-                    onInput={(event) => {
-                      setNewPassword(event.currentTarget.value)
-                      setPasswordFieldError("newPassword")
-                    }}
-                    onInvalid={(event) => {
-                      event.preventDefault()
-                      setPasswordFieldError(
-                        "newPassword",
-                        event.currentTarget.validationMessage
-                      )
-                    }}
-                    placeholder={auth.localization.auth.newPasswordPlaceholder}
-                    required
-                    type={isNewPasswordVisible() ? "text" : "password"}
-                    value={newPassword()}
-                  />
-                  <InputGroupAddon align="inline-end">
-                    <InputGroupButton
-                      aria-label={
-                        isNewPasswordVisible()
-                          ? auth.localization.auth.hidePassword
-                          : auth.localization.auth.showPassword
-                      }
-                      disabled={isPasswordPending()}
-                      onClick={() =>
-                        setIsNewPasswordVisible((visible) => !visible)
-                      }
-                      size="icon-sm"
-                      title={
-                        isNewPasswordVisible()
-                          ? auth.localization.auth.hidePassword
-                          : auth.localization.auth.showPassword
-                      }
-                      type="button"
-                    >
-                      {isNewPasswordVisible() ? (
-                        <EyeOff aria-hidden class="size-4" />
-                      ) : (
-                        <Eye aria-hidden class="size-4" />
-                      )}
-                    </InputGroupButton>
-                  </InputGroupAddon>
-                </InputGroup>
-              </Show>
-              <Show when={fieldErrors().newPassword}>
-                {(message) => <FieldError>{message()}</FieldError>}
-              </Show>
+            <form.Field name="newPassword">
+              {(field) => (
+                <Field data-invalid={Boolean(fieldErrors().newPassword)}>
+                  <FieldLabel for="newPassword">
+                    {auth.localization.auth.newPassword}
+                  </FieldLabel>
+                  <Show
+                    fallback={<ChangePasswordSkeletonInput />}
+                    when={session.data && !linkedAccounts.isPending}
+                  >
+                    <InputGroup>
+                      <InputGroupInput
+                        aria-invalid={!!fieldErrors().newPassword}
+                        autocomplete="new-password"
+                        disabled={isPasswordPending()}
+                        id="newPassword"
+                        maxLength={auth.emailAndPassword.maxPasswordLength}
+                        minLength={auth.emailAndPassword.minPasswordLength}
+                        name={field().name}
+                        onInput={(event) => {
+                          field().handleChange(event.currentTarget.value)
+                          setPasswordFieldError("newPassword")
+                        }}
+                        onInvalid={(event) => {
+                          event.preventDefault()
+                          setPasswordFieldError(
+                            "newPassword",
+                            event.currentTarget.validationMessage
+                          )
+                        }}
+                        placeholder={
+                          auth.localization.auth.newPasswordPlaceholder
+                        }
+                        required
+                        type={isNewPasswordVisible() ? "text" : "password"}
+                        value={field().state.value}
+                      />
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          aria-label={
+                            isNewPasswordVisible()
+                              ? auth.localization.auth.hidePassword
+                              : auth.localization.auth.showPassword
+                          }
+                          disabled={isPasswordPending()}
+                          onClick={() =>
+                            setIsNewPasswordVisible((visible) => !visible)
+                          }
+                          size="icon-sm"
+                          title={
+                            isNewPasswordVisible()
+                              ? auth.localization.auth.hidePassword
+                              : auth.localization.auth.showPassword
+                          }
+                          type="button"
+                        >
+                          {isNewPasswordVisible() ? (
+                            <EyeOff aria-hidden class="size-4" />
+                          ) : (
+                            <Eye aria-hidden class="size-4" />
+                          )}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  </Show>
+                  <Show when={fieldErrors().newPassword}>
+                    {(message) => <FieldError>{message()}</FieldError>}
+                  </Show>
 
-              <PasswordStrengthMeter password={newPassword()} />
-            </Field>
+                  <PasswordStrengthMeter password={field().state.value} />
+                </Field>
+              )}
+            </form.Field>
 
             <Show when={props.confirmPassword}>
-              <Field data-invalid={Boolean(fieldErrors().confirmPassword)}>
-                <FieldLabel for="confirmPassword">
-                  {auth.localization.auth.confirmPassword}
-                </FieldLabel>
-                <Show
-                  fallback={<ChangePasswordSkeletonInput />}
-                  when={session.data && !linkedAccounts.isPending}
-                >
-                  <InputGroup>
-                    <InputGroupInput
-                      aria-invalid={!!fieldErrors().confirmPassword}
-                      autocomplete="new-password"
-                      disabled={isPasswordPending()}
-                      id="confirmPassword"
-                      maxLength={auth.emailAndPassword.maxPasswordLength}
-                      minLength={auth.emailAndPassword.minPasswordLength}
-                      name="confirmPassword"
-                      onInput={(event) => {
-                        setConfirmPassword(event.currentTarget.value)
-                        setPasswordFieldError("confirmPassword")
-                      }}
-                      onInvalid={(event) => {
-                        event.preventDefault()
-                        setPasswordFieldError(
-                          "confirmPassword",
-                          event.currentTarget.validationMessage
-                        )
-                      }}
-                      placeholder={
-                        auth.localization.auth.confirmPasswordPlaceholder
-                      }
-                      required
-                      type={isConfirmPasswordVisible() ? "text" : "password"}
-                      value={confirmPassword()}
-                    />
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        aria-label={
-                          isConfirmPasswordVisible()
-                            ? auth.localization.auth.hidePassword
-                            : auth.localization.auth.showPassword
-                        }
-                        disabled={isPasswordPending()}
-                        onClick={() =>
-                          setIsConfirmPasswordVisible((visible) => !visible)
-                        }
-                        size="icon-sm"
-                        title={
-                          isConfirmPasswordVisible()
-                            ? auth.localization.auth.hidePassword
-                            : auth.localization.auth.showPassword
-                        }
-                        type="button"
-                      >
-                        {isConfirmPasswordVisible() ? (
-                          <EyeOff aria-hidden class="size-4" />
-                        ) : (
-                          <Eye aria-hidden class="size-4" />
-                        )}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                </Show>
-                <Show when={fieldErrors().confirmPassword}>
-                  {(message) => <FieldError>{message()}</FieldError>}
-                </Show>
-              </Field>
+              <form.Field name="confirmPassword">
+                {(field) => (
+                  <Field data-invalid={Boolean(fieldErrors().confirmPassword)}>
+                    <FieldLabel for="confirmPassword">
+                      {auth.localization.auth.confirmPassword}
+                    </FieldLabel>
+                    <Show
+                      fallback={<ChangePasswordSkeletonInput />}
+                      when={session.data && !linkedAccounts.isPending}
+                    >
+                      <InputGroup>
+                        <InputGroupInput
+                          aria-invalid={!!fieldErrors().confirmPassword}
+                          autocomplete="new-password"
+                          disabled={isPasswordPending()}
+                          id="confirmPassword"
+                          maxLength={auth.emailAndPassword.maxPasswordLength}
+                          minLength={auth.emailAndPassword.minPasswordLength}
+                          name={field().name}
+                          onInput={(event) => {
+                            field().handleChange(event.currentTarget.value)
+                            setPasswordFieldError("confirmPassword")
+                          }}
+                          onInvalid={(event) => {
+                            event.preventDefault()
+                            setPasswordFieldError(
+                              "confirmPassword",
+                              event.currentTarget.validationMessage
+                            )
+                          }}
+                          placeholder={
+                            auth.localization.auth.confirmPasswordPlaceholder
+                          }
+                          required
+                          type={
+                            isConfirmPasswordVisible() ? "text" : "password"
+                          }
+                          value={field().state.value}
+                        />
+                        <InputGroupAddon align="inline-end">
+                          <InputGroupButton
+                            aria-label={
+                              isConfirmPasswordVisible()
+                                ? auth.localization.auth.hidePassword
+                                : auth.localization.auth.showPassword
+                            }
+                            disabled={isPasswordPending()}
+                            onClick={() =>
+                              setIsConfirmPasswordVisible((visible) => !visible)
+                            }
+                            size="icon-sm"
+                            title={
+                              isConfirmPasswordVisible()
+                                ? auth.localization.auth.hidePassword
+                                : auth.localization.auth.showPassword
+                            }
+                            type="button"
+                          >
+                            {isConfirmPasswordVisible() ? (
+                              <EyeOff aria-hidden class="size-4" />
+                            ) : (
+                              <Eye aria-hidden class="size-4" />
+                            )}
+                          </InputGroupButton>
+                        </InputGroupAddon>
+                      </InputGroup>
+                    </Show>
+                    <Show when={fieldErrors().confirmPassword}>
+                      {(message) => <FieldError>{message()}</FieldError>}
+                    </Show>
+                  </Field>
+                )}
+              </form.Field>
             </Show>
           </CardContent>
 

--- a/examples/start-solid-zaidan-example/src/components/auth/sign-up.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/sign-up.tsx
@@ -12,6 +12,7 @@ import {
   useFetchOptions,
   useSignUpEmail
 } from "@better-auth-ui/solid"
+import { createForm } from "@tanstack/solid-form"
 import { useQueryClient } from "@tanstack/solid-query"
 import { Eye, EyeOff } from "lucide-solid"
 import { createSignal, For, Show } from "solid-js"
@@ -42,13 +43,9 @@ export function SignUp(props: SignUpProps) {
   const auth = useAuth()
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
   const queryClient = useQueryClient()
-  const [email, setEmail] = createSignal("")
   const [emailError, setEmailError] = createSignal<string>()
-  const [name, setName] = createSignal("")
   const [nameError, setNameError] = createSignal<string>()
-  const [password, setPassword] = createSignal("")
   const [passwordError, setPasswordError] = createSignal<string>()
-  const [confirmPassword, setConfirmPassword] = createSignal("")
   const [confirmPasswordError, setConfirmPasswordError] = createSignal<string>()
   const [isPasswordVisible, setIsPasswordVisible] = createSignal(false)
   const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
@@ -98,22 +95,40 @@ export function SignUp(props: SignUpProps) {
     auth.additionalFields?.filter(
       (field) => field.signUp && field.signUp !== "above"
     ) ?? []
+  let additionalFieldValues: Record<string, unknown> = {}
+  const form = createForm(() => ({
+    defaultValues: {
+      confirmPassword: "",
+      email: "",
+      name: "",
+      password: ""
+    },
+    onSubmit: ({ value }) => {
+      setConfirmPasswordError(undefined)
+
+      if (
+        auth.emailAndPassword.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
+        setConfirmPasswordError(auth.localization.auth.passwordsDoNotMatch)
+        return
+      }
+
+      signUp.mutate({
+        email: value.email,
+        fetchOptions: fetchOptions(),
+        name: auth.emailAndPassword.name ? value.name : "",
+        password: value.password,
+        ...additionalFieldValues
+      } as Parameters<typeof signUp.mutate>[0])
+    }
+  }))
 
   const submitSignUp = async (event: SubmitEvent) => {
     event.preventDefault()
 
-    setConfirmPasswordError(undefined)
-
-    if (
-      auth.emailAndPassword.confirmPassword &&
-      password() !== confirmPassword()
-    ) {
-      setConfirmPasswordError(auth.localization.auth.passwordsDoNotMatch)
-      return
-    }
-
     const formData = new FormData(event.currentTarget as HTMLFormElement)
-    const additionalFieldValues: Record<string, unknown> = {}
+    const values: Record<string, unknown> = {}
 
     for (const field of auth.additionalFields ?? []) {
       if (!field.signUp || field.readOnly) continue
@@ -133,17 +148,12 @@ export function SignUp(props: SignUpProps) {
       }
 
       if (value !== undefined) {
-        additionalFieldValues[field.name] = value
+        values[field.name] = value
       }
     }
 
-    signUp.mutate({
-      email: email(),
-      fetchOptions: fetchOptions(),
-      name: name(),
-      password: password(),
-      ...additionalFieldValues
-    } as Parameters<typeof signUp.mutate>[0])
+    additionalFieldValues = values
+    await form.handleSubmit()
   }
 
   return (
@@ -170,61 +180,69 @@ export function SignUp(props: SignUpProps) {
         <form aria-label="Sign up" onSubmit={submitSignUp}>
           <div class="flex flex-col gap-6">
             <Show when={auth.emailAndPassword.name}>
-              <Field>
-                <FieldLabel for="sign-up-name">
-                  {auth.localization.auth.name}
-                </FieldLabel>
-                <Input
-                  aria-invalid={Boolean(nameError())}
-                  autocomplete="name"
-                  id="sign-up-name"
-                  name="name"
-                  onInput={(event) => {
-                    setName(event.currentTarget.value)
-                    setNameError(undefined)
-                  }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    setNameError(event.currentTarget.validationMessage)
-                  }}
-                  placeholder={auth.localization.auth.namePlaceholder}
-                  required={auth.emailAndPassword.name}
-                  type="text"
-                  value={name()}
-                />
+              <form.Field name="name">
+                {(field) => (
+                  <Field>
+                    <FieldLabel for="sign-up-name">
+                      {auth.localization.auth.name}
+                    </FieldLabel>
+                    <Input
+                      aria-invalid={Boolean(nameError())}
+                      autocomplete="name"
+                      id="sign-up-name"
+                      name={field().name}
+                      onInput={(event) => {
+                        field().handleChange(event.currentTarget.value)
+                        setNameError(undefined)
+                      }}
+                      onInvalid={(event) => {
+                        event.preventDefault()
+                        setNameError(event.currentTarget.validationMessage)
+                      }}
+                      placeholder={auth.localization.auth.namePlaceholder}
+                      required={auth.emailAndPassword.name}
+                      type="text"
+                      value={field().state.value}
+                    />
 
-                <Show when={nameError()}>
-                  {(message) => <FieldError>{message()}</FieldError>}
-                </Show>
-              </Field>
+                    <Show when={nameError()}>
+                      {(message) => <FieldError>{message()}</FieldError>}
+                    </Show>
+                  </Field>
+                )}
+              </form.Field>
             </Show>
-            <Field>
-              <FieldLabel for="sign-up-email">
-                {auth.localization.auth.email}
-              </FieldLabel>
-              <Input
-                aria-invalid={Boolean(emailError())}
-                autocomplete="email"
-                id="sign-up-email"
-                name="email"
-                onInput={(event) => {
-                  setEmail(event.currentTarget.value)
-                  setEmailError(undefined)
-                }}
-                onInvalid={(event) => {
-                  event.preventDefault()
-                  setEmailError(event.currentTarget.validationMessage)
-                }}
-                placeholder={auth.localization.auth.emailPlaceholder}
-                required
-                type="email"
-                value={email()}
-              />
+            <form.Field name="email">
+              {(field) => (
+                <Field>
+                  <FieldLabel for="sign-up-email">
+                    {auth.localization.auth.email}
+                  </FieldLabel>
+                  <Input
+                    aria-invalid={Boolean(emailError())}
+                    autocomplete="email"
+                    id="sign-up-email"
+                    name={field().name}
+                    onInput={(event) => {
+                      field().handleChange(event.currentTarget.value)
+                      setEmailError(undefined)
+                    }}
+                    onInvalid={(event) => {
+                      event.preventDefault()
+                      setEmailError(event.currentTarget.validationMessage)
+                    }}
+                    placeholder={auth.localization.auth.emailPlaceholder}
+                    required
+                    type="email"
+                    value={field().state.value}
+                  />
 
-              <Show when={emailError()}>
-                {(message) => <FieldError>{message()}</FieldError>}
-              </Show>
-            </Field>
+                  <Show when={emailError()}>
+                    {(message) => <FieldError>{message()}</FieldError>}
+                  </Show>
+                </Field>
+              )}
+            </form.Field>
             <For each={signUpFieldsAbove()}>
               {(field) => (
                 <AdditionalField
@@ -235,128 +253,138 @@ export function SignUp(props: SignUpProps) {
                 />
               )}
             </For>
-            <Field>
-              <FieldLabel for="sign-up-password">
-                {auth.localization.auth.password}
-              </FieldLabel>
-              <div class="relative">
-                <Input
-                  aria-invalid={Boolean(passwordError())}
-                  autocomplete="new-password"
-                  class="pr-12"
-                  id="sign-up-password"
-                  maxLength={auth.emailAndPassword.maxPasswordLength}
-                  minLength={auth.emailAndPassword.minPasswordLength}
-                  name="password"
-                  onInput={(event) => {
-                    setPassword(event.currentTarget.value)
-                    setPasswordError(undefined)
-                    setConfirmPasswordError(undefined)
-                  }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    setPasswordError(event.currentTarget.validationMessage)
-                  }}
-                  placeholder={auth.localization.auth.passwordPlaceholder}
-                  required
-                  type={isPasswordVisible() ? "text" : "password"}
-                  value={password()}
-                />
+            <form.Field name="password">
+              {(field) => (
+                <Field>
+                  <FieldLabel for="sign-up-password">
+                    {auth.localization.auth.password}
+                  </FieldLabel>
+                  <div class="relative">
+                    <Input
+                      aria-invalid={Boolean(passwordError())}
+                      autocomplete="new-password"
+                      class="pr-12"
+                      id="sign-up-password"
+                      maxLength={auth.emailAndPassword.maxPasswordLength}
+                      minLength={auth.emailAndPassword.minPasswordLength}
+                      name={field().name}
+                      onInput={(event) => {
+                        field().handleChange(event.currentTarget.value)
+                        setPasswordError(undefined)
+                        setConfirmPasswordError(undefined)
+                      }}
+                      onInvalid={(event) => {
+                        event.preventDefault()
+                        setPasswordError(event.currentTarget.validationMessage)
+                      }}
+                      placeholder={auth.localization.auth.passwordPlaceholder}
+                      required
+                      type={isPasswordVisible() ? "text" : "password"}
+                      value={field().state.value}
+                    />
 
-                <Button
-                  aria-label={
-                    isPasswordVisible()
-                      ? auth.localization.auth.hidePassword
-                      : auth.localization.auth.showPassword
-                  }
-                  class="absolute right-1 top-1/2 -translate-y-1/2"
-                  onClick={() => setIsPasswordVisible((visible) => !visible)}
-                  size="icon-sm"
-                  title={
-                    isPasswordVisible()
-                      ? auth.localization.auth.hidePassword
-                      : auth.localization.auth.showPassword
-                  }
-                  type="button"
-                  variant="ghost"
-                >
-                  {isPasswordVisible() ? (
-                    <EyeOff aria-hidden class="size-4" />
-                  ) : (
-                    <Eye aria-hidden class="size-4" />
-                  )}
-                </Button>
-              </div>
+                    <Button
+                      aria-label={
+                        isPasswordVisible()
+                          ? auth.localization.auth.hidePassword
+                          : auth.localization.auth.showPassword
+                      }
+                      class="absolute right-1 top-1/2 -translate-y-1/2"
+                      onClick={() =>
+                        setIsPasswordVisible((visible) => !visible)
+                      }
+                      size="icon-sm"
+                      title={
+                        isPasswordVisible()
+                          ? auth.localization.auth.hidePassword
+                          : auth.localization.auth.showPassword
+                      }
+                      type="button"
+                      variant="ghost"
+                    >
+                      {isPasswordVisible() ? (
+                        <EyeOff aria-hidden class="size-4" />
+                      ) : (
+                        <Eye aria-hidden class="size-4" />
+                      )}
+                    </Button>
+                  </div>
 
-              <Show when={passwordError()}>
-                {(message) => <FieldError>{message()}</FieldError>}
-              </Show>
+                  <Show when={passwordError()}>
+                    {(message) => <FieldError>{message()}</FieldError>}
+                  </Show>
 
-              <PasswordStrengthMeter password={password()} />
-            </Field>
+                  <PasswordStrengthMeter password={field().state.value} />
+                </Field>
+              )}
+            </form.Field>
             <Show when={auth.emailAndPassword.confirmPassword}>
-              <Field>
-                <FieldLabel for="sign-up-confirm-password">
-                  {auth.localization.auth.confirmPassword}
-                </FieldLabel>
-                <div class="relative">
-                  <Input
-                    aria-invalid={Boolean(confirmPasswordError())}
-                    autocomplete="new-password"
-                    class="pr-12"
-                    id="sign-up-confirm-password"
-                    maxLength={auth.emailAndPassword.maxPasswordLength}
-                    minLength={auth.emailAndPassword.minPasswordLength}
-                    name="confirmPassword"
-                    onInput={(event) => {
-                      setConfirmPassword(event.currentTarget.value)
-                      setConfirmPasswordError(undefined)
-                    }}
-                    onInvalid={(event) => {
-                      event.preventDefault()
-                      setConfirmPasswordError(
-                        event.currentTarget.validationMessage
-                      )
-                    }}
-                    placeholder={
-                      auth.localization.auth.confirmPasswordPlaceholder
-                    }
-                    required
-                    type={isConfirmPasswordVisible() ? "text" : "password"}
-                    value={confirmPassword()}
-                  />
+              <form.Field name="confirmPassword">
+                {(field) => (
+                  <Field>
+                    <FieldLabel for="sign-up-confirm-password">
+                      {auth.localization.auth.confirmPassword}
+                    </FieldLabel>
+                    <div class="relative">
+                      <Input
+                        aria-invalid={Boolean(confirmPasswordError())}
+                        autocomplete="new-password"
+                        class="pr-12"
+                        id="sign-up-confirm-password"
+                        maxLength={auth.emailAndPassword.maxPasswordLength}
+                        minLength={auth.emailAndPassword.minPasswordLength}
+                        name={field().name}
+                        onInput={(event) => {
+                          field().handleChange(event.currentTarget.value)
+                          setConfirmPasswordError(undefined)
+                        }}
+                        onInvalid={(event) => {
+                          event.preventDefault()
+                          setConfirmPasswordError(
+                            event.currentTarget.validationMessage
+                          )
+                        }}
+                        placeholder={
+                          auth.localization.auth.confirmPasswordPlaceholder
+                        }
+                        required
+                        type={isConfirmPasswordVisible() ? "text" : "password"}
+                        value={field().state.value}
+                      />
 
-                  <Button
-                    aria-label={
-                      isConfirmPasswordVisible()
-                        ? auth.localization.auth.hidePassword
-                        : auth.localization.auth.showPassword
-                    }
-                    class="absolute right-1 top-1/2 -translate-y-1/2"
-                    onClick={() =>
-                      setIsConfirmPasswordVisible((visible) => !visible)
-                    }
-                    size="icon-sm"
-                    title={
-                      isConfirmPasswordVisible()
-                        ? auth.localization.auth.hidePassword
-                        : auth.localization.auth.showPassword
-                    }
-                    type="button"
-                    variant="ghost"
-                  >
-                    {isConfirmPasswordVisible() ? (
-                      <EyeOff aria-hidden class="size-4" />
-                    ) : (
-                      <Eye aria-hidden class="size-4" />
-                    )}
-                  </Button>
-                </div>
+                      <Button
+                        aria-label={
+                          isConfirmPasswordVisible()
+                            ? auth.localization.auth.hidePassword
+                            : auth.localization.auth.showPassword
+                        }
+                        class="absolute right-1 top-1/2 -translate-y-1/2"
+                        onClick={() =>
+                          setIsConfirmPasswordVisible((visible) => !visible)
+                        }
+                        size="icon-sm"
+                        title={
+                          isConfirmPasswordVisible()
+                            ? auth.localization.auth.hidePassword
+                            : auth.localization.auth.showPassword
+                        }
+                        type="button"
+                        variant="ghost"
+                      >
+                        {isConfirmPasswordVisible() ? (
+                          <EyeOff aria-hidden class="size-4" />
+                        ) : (
+                          <Eye aria-hidden class="size-4" />
+                        )}
+                      </Button>
+                    </div>
 
-                <Show when={confirmPasswordError()}>
-                  {(message) => <FieldError>{message()}</FieldError>}
-                </Show>
-              </Field>
+                    <Show when={confirmPasswordError()}>
+                      {(message) => <FieldError>{message()}</FieldError>}
+                    </Show>
+                  </Field>
+                )}
+              </form.Field>
             </Show>
             <For each={signUpFieldsBelow()}>
               {(field) => (

--- a/examples/start-solid-zaidan-example/src/components/auth/sign-up.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/sign-up.tsx
@@ -58,6 +58,8 @@ export function SignUp(props: SignUpProps) {
         setPasswordError(auth.localization.auth.passwordCompromised)
       }
 
+      form.setFieldValue("password", "")
+      form.setFieldValue("confirmPassword", "")
       resetFetchOptions()
     },
     onSuccess: (_data, variables) => {
@@ -111,6 +113,8 @@ export function SignUp(props: SignUpProps) {
         value.password !== value.confirmPassword
       ) {
         setConfirmPasswordError(auth.localization.auth.passwordsDoNotMatch)
+        form.setFieldValue("password", "")
+        form.setFieldValue("confirmPassword", "")
         return
       }
 

--- a/examples/start-solid-zaidan-example/src/components/auth/sso/organization-sso-providers.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/sso/organization-sso-providers.tsx
@@ -14,9 +14,10 @@ import {
   useSsoProviders,
   useUpdateSsoProvider
 } from "@better-auth-ui/solid/plugins/sso"
+import { createForm } from "@tanstack/solid-form"
 import type { BetterFetchError } from "better-auth/client"
 import { Pencil, Trash2 } from "lucide-solid"
-import { createMemo, createSignal, For, Show } from "solid-js"
+import { createEffect, createMemo, createSignal, For, on, Show } from "solid-js"
 import { toast } from "solid-sonner"
 
 import {
@@ -78,8 +79,27 @@ export type OrganizationSsoProvidersProps = {
 
 const providerSkeletonIds = ["solid-sso-provider-1", "solid-sso-provider-2"]
 
-const readString = (formData: FormData, name: string) =>
-  String(formData.get(name) ?? "").trim()
+type SsoProviderEditorValues = {
+  clientId: string
+  clientSecret: string
+  discoveryEndpoint: string
+  domain: string
+  entryPoint: string
+  identityProviderMetadata: string
+  issuer: string
+}
+
+const getSsoProviderEditorValues = (
+  provider?: SsoProvider
+): SsoProviderEditorValues => ({
+  clientId: "",
+  clientSecret: "",
+  discoveryEndpoint: provider?.oidcConfig?.discoveryEndpoint ?? "",
+  domain: provider?.domain ?? "",
+  entryPoint: provider?.samlConfig?.entryPoint ?? "",
+  identityProviderMetadata: "",
+  issuer: provider?.issuer ?? ""
+})
 
 const getErrorMessage = (error: Error | null) => {
   const authError = error as BetterFetchError | null
@@ -294,48 +314,54 @@ function EditSsoProviderDialog(props: {
     update.reset()
     props.onOpenChange(undefined)
   }
-  const submit = (event: SubmitEvent) => {
-    event.preventDefault()
-    if (!props.provider) return
-    const data = new FormData(event.currentTarget as HTMLFormElement)
-    const clientId = readString(data, "clientId")
-    const clientSecret = readString(data, "clientSecret")
-    const identityProviderMetadata = readString(
-      data,
-      "identityProviderMetadata"
-    )
-    const params = {
-      providerId: props.provider.providerId,
-      issuer: readString(data, "issuer"),
-      domain: readString(data, "domain"),
-      ...(props.provider.oidcConfig
-        ? {
-            oidcConfig: {
-              ...(clientId ? { clientId } : {}),
-              ...(clientSecret ? { clientSecret } : {}),
-              discoveryEndpoint:
-                readString(data, "discoveryEndpoint") || undefined
+  const form = createForm(() => ({
+    defaultValues: getSsoProviderEditorValues(props.provider),
+    onSubmit: async ({ value }) => {
+      const provider = props.provider
+      if (!provider) return
+      const clientId = value.clientId.trim()
+      const clientSecret = value.clientSecret.trim()
+      const identityProviderMetadata = value.identityProviderMetadata.trim()
+      const params = {
+        providerId: provider.providerId,
+        issuer: value.issuer.trim(),
+        domain: value.domain.trim(),
+        ...(provider.oidcConfig
+          ? {
+              oidcConfig: {
+                ...(clientId ? { clientId } : {}),
+                ...(clientSecret ? { clientSecret } : {}),
+                discoveryEndpoint: value.discoveryEndpoint.trim() || undefined
+              }
             }
-          }
-        : {}),
-      ...(props.provider.samlConfig
-        ? {
-            samlConfig: {
-              entryPoint: readString(data, "entryPoint"),
-              ...(identityProviderMetadata
-                ? { idpMetadata: { metadata: identityProviderMetadata } }
-                : {})
+          : {}),
+        ...(provider.samlConfig
+          ? {
+              samlConfig: {
+                entryPoint: value.entryPoint.trim(),
+                ...(identityProviderMetadata
+                  ? { idpMetadata: { metadata: identityProviderMetadata } }
+                  : {})
+              }
             }
-          }
-        : {})
-    } as UpdateSsoProviderParams
-    update.mutate(params, {
-      onSuccess: () => {
+          : {})
+      } as UpdateSsoProviderParams
+      try {
+        await update.mutateAsync(params)
         toast.success(localization.providerUpdated)
         close()
+      } catch {
+        // The mutation error is rendered below the fields.
       }
-    })
-  }
+    }
+  }))
+  createEffect(
+    on(
+      () => props.provider,
+      (provider) => form.reset(getSsoProviderEditorValues(provider)),
+      { defer: true }
+    )
+  )
 
   return (
     <Dialog
@@ -345,90 +371,146 @@ function EditSsoProviderDialog(props: {
       }}
     >
       <DialogContent class="max-h-[90vh] max-w-xl overflow-y-auto">
-        <form class="flex flex-col gap-4" onSubmit={submit}>
+        <form
+          class="flex flex-col gap-4"
+          onSubmit={(event) => {
+            event.preventDefault()
+            void form.handleSubmit()
+          }}
+        >
           <DialogHeader>
             <DialogTitle>{localization.editProvider}</DialogTitle>
             <DialogDescription>{props.provider?.providerId}</DialogDescription>
           </DialogHeader>
           <FieldGroup>
-            <Field>
-              <FieldLabel for="solid-sso-edit-domain">
-                {localization.domain}
-              </FieldLabel>
-              <Input
-                id="solid-sso-edit-domain"
-                name="domain"
-                required
-                value={props.provider?.domain ?? ""}
-              />
-            </Field>
-            <Field>
-              <FieldLabel for="solid-sso-edit-issuer">
-                {localization.issuer}
-              </FieldLabel>
-              <Input
-                id="solid-sso-edit-issuer"
-                name="issuer"
-                required
-                type="url"
-                value={props.provider?.issuer ?? ""}
-              />
-            </Field>
+            <form.Field name="domain">
+              {(field) => (
+                <Field>
+                  <FieldLabel for="solid-sso-edit-domain">
+                    {localization.domain}
+                  </FieldLabel>
+                  <Input
+                    id="solid-sso-edit-domain"
+                    name={field().name}
+                    onBlur={field().handleBlur}
+                    onInput={(event) =>
+                      field().handleChange(event.currentTarget.value)
+                    }
+                    required
+                    value={field().state.value}
+                  />
+                </Field>
+              )}
+            </form.Field>
+            <form.Field name="issuer">
+              {(field) => (
+                <Field>
+                  <FieldLabel for="solid-sso-edit-issuer">
+                    {localization.issuer}
+                  </FieldLabel>
+                  <Input
+                    id="solid-sso-edit-issuer"
+                    name={field().name}
+                    onBlur={field().handleBlur}
+                    onInput={(event) =>
+                      field().handleChange(event.currentTarget.value)
+                    }
+                    required
+                    type="url"
+                    value={field().state.value}
+                  />
+                </Field>
+              )}
+            </form.Field>
             <Show when={props.provider?.oidcConfig}>
               {(oidc) => (
                 <>
-                  <Field>
-                    <FieldLabel for="solid-sso-edit-discovery">
-                      {localization.discoveryEndpoint}
-                    </FieldLabel>
-                    <Input
-                      id="solid-sso-edit-discovery"
-                      name="discoveryEndpoint"
-                      type="url"
-                      value={oidc().discoveryEndpoint ?? ""}
-                    />
-                  </Field>
+                  <form.Field name="discoveryEndpoint">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel for="solid-sso-edit-discovery">
+                          {localization.discoveryEndpoint}
+                        </FieldLabel>
+                        <Input
+                          id="solid-sso-edit-discovery"
+                          name={field().name}
+                          onBlur={field().handleBlur}
+                          onInput={(event) =>
+                            field().handleChange(event.currentTarget.value)
+                          }
+                          type="url"
+                          value={field().state.value}
+                        />
+                      </Field>
+                    )}
+                  </form.Field>
                   <div class="grid gap-4 sm:grid-cols-2">
-                    <Field>
-                      <FieldLabel for="solid-sso-edit-client-id">
-                        {localization.clientId}
-                      </FieldLabel>
-                      <Input
-                        id="solid-sso-edit-client-id"
-                        name="clientId"
-                        placeholder={`••••${oidc().clientIdLastFour}`}
-                      />
-                    </Field>
-                    <Field>
-                      <FieldLabel for="solid-sso-edit-client-secret">
-                        {localization.clientSecret}
-                      </FieldLabel>
-                      <Input
-                        autocomplete="new-password"
-                        id="solid-sso-edit-client-secret"
-                        name="clientSecret"
-                        type="password"
-                      />
-                    </Field>
+                    <form.Field name="clientId">
+                      {(field) => (
+                        <Field>
+                          <FieldLabel for="solid-sso-edit-client-id">
+                            {localization.clientId}
+                          </FieldLabel>
+                          <Input
+                            id="solid-sso-edit-client-id"
+                            name={field().name}
+                            onBlur={field().handleBlur}
+                            onInput={(event) =>
+                              field().handleChange(event.currentTarget.value)
+                            }
+                            placeholder={`••••${oidc().clientIdLastFour}`}
+                            value={field().state.value}
+                          />
+                        </Field>
+                      )}
+                    </form.Field>
+                    <form.Field name="clientSecret">
+                      {(field) => (
+                        <Field>
+                          <FieldLabel for="solid-sso-edit-client-secret">
+                            {localization.clientSecret}
+                          </FieldLabel>
+                          <Input
+                            autocomplete="new-password"
+                            id="solid-sso-edit-client-secret"
+                            name={field().name}
+                            onBlur={field().handleBlur}
+                            onInput={(event) =>
+                              field().handleChange(event.currentTarget.value)
+                            }
+                            type="password"
+                            value={field().state.value}
+                          />
+                        </Field>
+                      )}
+                    </form.Field>
                   </div>
                 </>
               )}
             </Show>
             <Show when={props.provider?.samlConfig}>
-              {(saml) => (
-                <>
+              <form.Field name="entryPoint">
+                {(field) => (
                   <Field>
                     <FieldLabel for="solid-sso-edit-entry-point">
                       {localization.entryPoint}
                     </FieldLabel>
                     <Input
                       id="solid-sso-edit-entry-point"
-                      name="entryPoint"
+                      name={field().name}
+                      onBlur={field().handleBlur}
+                      onInput={(event) =>
+                        field().handleChange(event.currentTarget.value)
+                      }
                       required
                       type="url"
-                      value={saml().entryPoint}
+                      value={field().state.value}
                     />
                   </Field>
+                )}
+              </form.Field>
+              <form.Field name="identityProviderMetadata">
+                {(field) => (
                   <Field>
                     <FieldLabel for="solid-sso-edit-metadata">
                       {localization.identityProviderMetadata}
@@ -436,12 +518,17 @@ function EditSsoProviderDialog(props: {
                     <Textarea
                       class="font-mono text-xs"
                       id="solid-sso-edit-metadata"
-                      name="identityProviderMetadata"
+                      name={field().name}
+                      onBlur={field().handleBlur}
+                      onInput={(event) =>
+                        field().handleChange(event.currentTarget.value)
+                      }
                       rows={6}
+                      value={field().state.value}
                     />
                   </Field>
-                </>
-              )}
+                )}
+              </form.Field>
             </Show>
           </FieldGroup>
           <FieldError>{getErrorMessage(update.error)}</FieldError>
@@ -454,12 +541,16 @@ function EditSsoProviderDialog(props: {
             >
               {localization.cancel}
             </Button>
-            <Button disabled={update.isPending} type="submit">
-              <Show when={update.isPending}>
-                <Spinner />
-              </Show>
-              {localization.saveProvider}
-            </Button>
+            <form.Subscribe selector={(state) => state.isSubmitting}>
+              {(isSubmitting) => (
+                <Button disabled={isSubmitting()} type="submit">
+                  <Show when={isSubmitting()}>
+                    <Spinner />
+                  </Show>
+                  {localization.saveProvider}
+                </Button>
+              )}
+            </form.Subscribe>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/examples/start-solid-zaidan-example/tests/auth-route.test.ts
+++ b/examples/start-solid-zaidan-example/tests/auth-route.test.ts
@@ -1586,7 +1586,8 @@ describe("Solid auth route component selection", () => {
     expect(signUp).toContain("<AdditionalField")
     expect(signUp).toContain("if (!field.signUp || field.readOnly) continue")
     expect(signUp).toContain("await field.validate(value)")
-    expect(signUp).toContain("additionalFieldValues[field.name] = value")
+    expect(signUp).toContain("values[field.name] = value")
+    expect(signUp).toContain("additionalFieldValues = values")
     expect(signUp).toContain("...additionalFieldValues")
 
     expect(userProfile).toContain("parseAdditionalFieldValue")
@@ -2163,7 +2164,8 @@ describe("Solid auth route component selection", () => {
     expect(changePassword).toContain("resetLinkSentTo")
     expect(changePassword).toContain("OpenEmailButton")
     expect(changePassword).toContain("const changePassword = useChangePassword")
-    expect(changePassword).toContain("submitChangePassword")
+    expect(changePassword).toContain("createForm(() => ({")
+    expect(changePassword).toContain("onSubmit: ({ value }) =>")
     expect(changePassword).toContain("passwordsDoNotMatch")
     expect(changePassword).toContain("changePassword.mutate({")
     expect(changePassword).toContain("currentPassword,")
@@ -3582,7 +3584,7 @@ describe("Solid auth route component selection", () => {
     expect(editMemberRolesDialog).toContain("updateMemberRole.mutate")
     expect(editMemberRolesDialog).toContain("memberId: props.member.id")
     expect(editMemberRolesDialog).toContain(
-      'selectedRoles() as UpdateMemberRoleParams["role"]'
+      'value.roles as UpdateMemberRoleParams["role"]'
     )
     expect(editMemberRolesDialog).toContain("parseMemberRoles")
     expect(organizationMemberRow).toContain("key !== config.creatorRole")

--- a/examples/start-solid-zaidan-example/tests/registry.test.ts
+++ b/examples/start-solid-zaidan-example/tests/registry.test.ts
@@ -1304,7 +1304,7 @@ describe("Solid registry isolation", () => {
     expect(forgotPassword).toContain("auth.viewPaths.auth.signIn")
 
     expect(resetPassword).toContain(
-      "placeholder={auth.localization.auth.newPasswordPlaceholder}"
+      "auth.localization.auth.newPasswordPlaceholder"
     )
     expect(resetPassword).toContain(
       "auth.localization.auth.confirmPasswordPlaceholder"
@@ -1599,9 +1599,7 @@ describe("Solid registry isolation", () => {
     expect(signUp).toContain('import { Eye, EyeOff } from "lucide-solid"')
     expect(signUp).toContain('type={isPasswordVisible() ? "text" : "password"}')
     expect(signUp).toContain('type="button"')
-    expect(signUp).toContain(
-      "onClick={() => setIsPasswordVisible((visible) => !visible)}"
-    )
+    expect(signUp).toContain("setIsPasswordVisible((visible) => !visible)")
     expect(signUp).toContain(
       "setIsConfirmPasswordVisible((visible) => !visible)"
     )
@@ -1626,7 +1624,7 @@ describe("Solid registry isolation", () => {
     )
     expect(resetPassword).toContain('type="button"')
     expect(resetPassword).toContain(
-      "onClick={() => setIsPasswordVisible((visible) => !visible)}"
+      "setIsPasswordVisible((visible) => !visible)"
     )
     expect(resetPassword).toContain(
       "setIsConfirmPasswordVisible((visible) => !visible)"

--- a/packages/heroui/src/components/auth/admin/admin-users.tsx
+++ b/packages/heroui/src/components/auth/admin/admin-users.tsx
@@ -57,6 +57,7 @@ import {
   Tabs,
   TextField
 } from "@heroui/react"
+import { useForm } from "@tanstack/react-form"
 import { keepPreviousData } from "@tanstack/react-query"
 import {
   type ColumnFiltersState,
@@ -589,19 +590,46 @@ function CreateUserDialog({
   const config = useAuthPlugin(adminPlugin)
   const createUser = useCreateAdminUser(authClient)
   const canSetRole = useAdminPermission(authClient, { user: ["set-role"] })
-  const [emailVerified, setEmailVerified] = useState(false)
   const [formError, setFormError] = useState<string>()
-  const [roles, setRoles] = useState([config.defaultRole])
+  const additionalFieldValuesRef = useRef<
+    Record<string, AdditionalFieldValue | null>
+  >({})
+  const form = useForm({
+    defaultValues: {
+      email: "",
+      emailVerified: false,
+      name: "",
+      password: "",
+      roles: [config.defaultRole]
+    },
+    onSubmit: ({ value }) => {
+      createUser.mutate(
+        {
+          data: {
+            ...additionalFieldValuesRef.current,
+            emailVerified: value.emailVerified
+          },
+          email: value.email,
+          name: value.name,
+          password: value.password,
+          ...(canSetRole.data?.success
+            ? { role: asAdminRoles(value.roles) }
+            : {})
+        },
+        { onSuccess: close }
+      )
+    }
+  })
 
   useEffect(() => {
-    if (!config.allowMultipleRoles) setRoles((current) => current.slice(0, 1))
-  }, [config.allowMultipleRoles])
+    if (!config.allowMultipleRoles)
+      form.setFieldValue("roles", (current) => current.slice(0, 1))
+  }, [config.allowMultipleRoles, form.setFieldValue])
 
   const close = () => {
     createUser.reset()
-    setEmailVerified(false)
+    form.reset()
     setFormError(undefined)
-    setRoles([config.defaultRole])
     onOpenChange(false)
   }
   const submit = async (event: FormEvent<HTMLFormElement>) => {
@@ -618,16 +646,8 @@ function CreateUserDialog({
       return
     }
     setFormError(undefined)
-    createUser.mutate(
-      {
-        data: { ...additionalFieldValues, emailVerified },
-        email: String(data.get("email")),
-        name: String(data.get("name")),
-        password: String(data.get("password")),
-        ...(canSetRole.data?.success ? { role: asAdminRoles(roles) } : {})
-      },
-      { onSuccess: close }
-    )
+    additionalFieldValuesRef.current = additionalFieldValues
+    await form.handleSubmit()
   }
 
   return (
@@ -652,63 +672,109 @@ function CreateUserDialog({
                 {config.localization.usersDescription}
               </p>
               <div className="mt-4 flex flex-col gap-4">
-                <TextField isRequired name="name">
-                  <Label>{config.localization.name}</Label>
-                  <Input autoFocus variant="secondary" />
-                  <FieldError />
-                </TextField>
-                <TextField isRequired name="email" type="email">
-                  <Label>{config.localization.email}</Label>
-                  <Input autoComplete="off" variant="secondary" />
-                  <FieldError />
-                </TextField>
-                <TextField isRequired name="password" type="password">
-                  <Label>{config.localization.password}</Label>
-                  <Input autoComplete="new-password" variant="secondary" />
-                  <FieldError />
-                </TextField>
+                <form.Field name="name">
+                  {(field) => (
+                    <TextField
+                      isRequired
+                      name={field.name}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                    >
+                      <Label>{config.localization.name}</Label>
+                      <Input autoFocus variant="secondary" />
+                      <FieldError />
+                    </TextField>
+                  )}
+                </form.Field>
+                <form.Field name="email">
+                  {(field) => (
+                    <TextField
+                      isRequired
+                      name={field.name}
+                      type="email"
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                    >
+                      <Label>{config.localization.email}</Label>
+                      <Input autoComplete="off" variant="secondary" />
+                      <FieldError />
+                    </TextField>
+                  )}
+                </form.Field>
+                <form.Field name="password">
+                  {(field) => (
+                    <TextField
+                      isRequired
+                      name={field.name}
+                      type="password"
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                    >
+                      <Label>{config.localization.password}</Label>
+                      <Input autoComplete="new-password" variant="secondary" />
+                      <FieldError />
+                    </TextField>
+                  )}
+                </form.Field>
                 {canSetRole.isPending ? (
                   <Skeleton className="h-10 w-full" />
                 ) : canSetRole.data?.success ? (
-                  <Select
-                    fullWidth
-                    selectionMode={
-                      config.allowMultipleRoles ? "multiple" : "single"
-                    }
-                    value={roles}
-                    variant="secondary"
-                    onChange={(keys) => {
-                      const next = [...(keys as Iterable<string>)]
-                      if (next.length)
-                        setRoles(
-                          config.allowMultipleRoles ? next : next.slice(0, 1)
-                        )
-                    }}
-                  >
-                    <Label>{config.localization.role}</Label>
-                    <Select.Trigger>
-                      <Select.Value />
-                      <Select.Indicator />
-                    </Select.Trigger>
-                    <Select.Popover>
-                      <ListBox
+                  <form.Field name="roles">
+                    {(field) => (
+                      <Select
+                        fullWidth
                         selectionMode={
                           config.allowMultipleRoles ? "multiple" : "single"
                         }
+                        value={field.state.value}
+                        variant="secondary"
+                        onChange={(keys) => {
+                          const next = [...(keys as Iterable<string>)]
+                          if (next.length)
+                            field.handleChange(
+                              config.allowMultipleRoles
+                                ? next
+                                : next.slice(0, 1)
+                            )
+                        }}
                       >
-                        {config.roles.map((role) => (
-                          <ListBox.Item id={role} key={role} textValue={role}>
-                            {role}
-                            <ListBox.ItemIndicator />
-                          </ListBox.Item>
-                        ))}
-                      </ListBox>
-                    </Select.Popover>
-                  </Select>
+                        <Label>{config.localization.role}</Label>
+                        <Select.Trigger>
+                          <Select.Value />
+                          <Select.Indicator />
+                        </Select.Trigger>
+                        <Select.Popover>
+                          <ListBox
+                            selectionMode={
+                              config.allowMultipleRoles ? "multiple" : "single"
+                            }
+                          >
+                            {config.roles.map((role) => (
+                              <ListBox.Item
+                                id={role}
+                                key={role}
+                                textValue={role}
+                              >
+                                {role}
+                                <ListBox.ItemIndicator />
+                              </ListBox.Item>
+                            ))}
+                          </ListBox>
+                        </Select.Popover>
+                      </Select>
+                    )}
+                  </form.Field>
                 ) : null}
-                <Switch isSelected={emailVerified} onChange={setEmailVerified}>
-                  {config.localization.emailVerified}
-                </Switch>
+                <form.Field name="emailVerified">
+                  {(field) => (
+                    <Switch
+                      isSelected={field.state.value}
+                      onChange={field.handleChange}
+                    >
+                      {config.localization.emailVerified}
+                    </Switch>
+                  )}
+                </form.Field>
                 {additionalFields?.map((field) => (
                   <AdditionalField
                     field={field}
@@ -819,10 +885,6 @@ function UserDrawer({
     { session: ["revoke"] },
     { enabled: Boolean(userId) }
   )
-  const [name, setName] = useState("")
-  const [email, setEmail] = useState("")
-  const [emailVerified, setEmailVerified] = useState(false)
-  const [roles, setRoles] = useState([config.defaultRole])
   const [banReason, setBanReason] = useState("")
   const [banDuration, setBanDuration] = useState("")
   const banDurationSeconds = getBanDurationSeconds(banDuration)
@@ -850,24 +912,74 @@ function UserDrawer({
   const revokeSession = useRevokeAdminUserSession(authClient, userId)
   const revokeSessions = useRevokeAdminUserSessions(authClient, userId)
 
+  const profileAdditionalFieldValuesRef = useRef<
+    Record<string, AdditionalFieldValue | null>
+  >({})
+  const profileForm = useForm({
+    defaultValues: {
+      email: "",
+      emailVerified: false,
+      name: "",
+      roles: [config.defaultRole]
+    },
+    onSubmit: async ({ value }) => {
+      if (!detail) return
+
+      const mutations: Promise<unknown>[] = []
+      if (canUpdate.data?.success) {
+        mutations.push(
+          updateUser.mutateAsync({
+            userId: detail.id,
+            data: {
+              ...profileAdditionalFieldValuesRef.current,
+              name: value.name.trim(),
+              ...(canSetEmail.data?.success
+                ? {
+                    email: value.email.trim(),
+                    emailVerified: value.emailVerified
+                  }
+                : {})
+            }
+          })
+        )
+      }
+      if (canSetRole.data?.success && !isSelf) {
+        mutations.push(
+          setRoleMutation.mutateAsync({
+            userId: detail.id,
+            role: asAdminRoles(value.roles)
+          })
+        )
+      }
+
+      try {
+        await Promise.all(mutations)
+        onOpenChange(false)
+      } catch {
+        // Mutation errors are rendered next to the form.
+      }
+    }
+  })
+
   useEffect(() => {
-    setName(detail?.name ?? "")
-    setEmail(detail?.email ?? "")
-    setEmailVerified(detail?.emailVerified ?? false)
-    setRoles(
-      parseAdminRoles(
+    profileForm.reset({
+      email: detail?.email ?? "",
+      emailVerified: detail?.emailVerified ?? false,
+      name: detail?.name ?? "",
+      roles: parseAdminRoles(
         detail?.role,
         config.defaultRole,
         config.allowMultipleRoles
       )
-    )
+    })
   }, [
     config.allowMultipleRoles,
     config.defaultRole,
     detail?.email,
     detail?.emailVerified,
     detail?.name,
-    detail?.role
+    detail?.role,
+    profileForm.reset
   ])
 
   useEffect(() => {
@@ -952,7 +1064,6 @@ function UserDrawer({
     event.preventDefault()
     if (!detail) return
 
-    const mutations: Promise<unknown>[] = []
     if (canUpdate.data?.success) {
       const formData = new FormData(event.currentTarget)
       let additionalFieldValues: Record<string, AdditionalFieldValue | null>
@@ -966,34 +1077,10 @@ function UserDrawer({
         return
       }
       setProfileError(undefined)
-      mutations.push(
-        updateUser.mutateAsync({
-          userId: detail.id,
-          data: {
-            ...additionalFieldValues,
-            name: name.trim(),
-            ...(canSetEmail.data?.success
-              ? { email: email.trim(), emailVerified }
-              : {})
-          }
-        })
-      )
-    }
-    if (canSetRole.data?.success && !isSelf) {
-      mutations.push(
-        setRoleMutation.mutateAsync({
-          userId: detail.id,
-          role: asAdminRoles(roles)
-        })
-      )
+      profileAdditionalFieldValuesRef.current = additionalFieldValues
     }
 
-    try {
-      await Promise.all(mutations)
-      onOpenChange(false)
-    } catch {
-      // Mutation errors are rendered next to the form.
-    }
+    await profileForm.handleSubmit()
   }
 
   return (
@@ -1104,85 +1191,105 @@ function UserDrawer({
                             {config.localization.profileAndAccess}
                           </h3>
                           <div className="grid gap-5 md:grid-cols-2">
-                            <TextField
-                              isDisabled={!canUpdate.data?.success}
-                              isRequired
-                              value={name}
-                              onChange={setName}
-                            >
-                              <Label>{config.localization.name}</Label>
-                              <Input variant="secondary" />
-                            </TextField>
-                            <TextField
-                              isDisabled={
-                                !canUpdate.data?.success ||
-                                !canSetEmail.data?.success
-                              }
-                              isRequired
-                              type="email"
-                              value={email}
-                              onChange={setEmail}
-                            >
-                              <Label>{config.localization.email}</Label>
-                              <Input variant="secondary" />
-                              <FieldError />
-                            </TextField>
-                            <Switch
-                              isDisabled={
-                                !canUpdate.data?.success ||
-                                !canSetEmail.data?.success
-                              }
-                              isSelected={emailVerified}
-                              onChange={setEmailVerified}
-                            >
-                              {config.localization.emailVerified}
-                            </Switch>
-                            <Select
-                              fullWidth
-                              isDisabled={isSelf || !canSetRole.data?.success}
-                              selectionMode={
-                                config.allowMultipleRoles
-                                  ? "multiple"
-                                  : "single"
-                              }
-                              value={roles}
-                              variant="secondary"
-                              onChange={(keys) => {
-                                const next = [...(keys as Iterable<string>)]
-                                if (next.length)
-                                  setRoles(
-                                    config.allowMultipleRoles
-                                      ? next
-                                      : next.slice(0, 1)
-                                  )
-                              }}
-                            >
-                              <Label>{config.localization.role}</Label>
-                              <Select.Trigger>
-                                <Select.Value />
-                                <Select.Indicator />
-                              </Select.Trigger>
-                              <Select.Popover>
-                                <ListBox
+                            <profileForm.Field name="name">
+                              {(field) => (
+                                <TextField
+                                  isDisabled={!canUpdate.data?.success}
+                                  isRequired
+                                  name={field.name}
+                                  value={field.state.value}
+                                  onChange={field.handleChange}
+                                >
+                                  <Label>{config.localization.name}</Label>
+                                  <Input variant="secondary" />
+                                </TextField>
+                              )}
+                            </profileForm.Field>
+                            <profileForm.Field name="email">
+                              {(field) => (
+                                <TextField
+                                  isDisabled={
+                                    !canUpdate.data?.success ||
+                                    !canSetEmail.data?.success
+                                  }
+                                  isRequired
+                                  name={field.name}
+                                  type="email"
+                                  value={field.state.value}
+                                  onChange={field.handleChange}
+                                >
+                                  <Label>{config.localization.email}</Label>
+                                  <Input variant="secondary" />
+                                  <FieldError />
+                                </TextField>
+                              )}
+                            </profileForm.Field>
+                            <profileForm.Field name="emailVerified">
+                              {(field) => (
+                                <Switch
+                                  isDisabled={
+                                    !canUpdate.data?.success ||
+                                    !canSetEmail.data?.success
+                                  }
+                                  isSelected={field.state.value}
+                                  onChange={field.handleChange}
+                                >
+                                  {config.localization.emailVerified}
+                                </Switch>
+                              )}
+                            </profileForm.Field>
+                            <profileForm.Field name="roles">
+                              {(field) => (
+                                <Select
+                                  fullWidth
+                                  isDisabled={
+                                    isSelf || !canSetRole.data?.success
+                                  }
                                   selectionMode={
                                     config.allowMultipleRoles
                                       ? "multiple"
                                       : "single"
                                   }
+                                  value={field.state.value}
+                                  variant="secondary"
+                                  onChange={(keys) => {
+                                    const next = [...(keys as Iterable<string>)]
+                                    if (next.length)
+                                      field.handleChange(
+                                        config.allowMultipleRoles
+                                          ? next
+                                          : next.slice(0, 1)
+                                      )
+                                  }}
                                 >
-                                  {config.roles.map((item) => (
-                                    <ListBox.Item
-                                      id={item}
-                                      key={item}
-                                      textValue={item}
+                                  <Label>{config.localization.role}</Label>
+                                  <Select.Trigger>
+                                    <Select.Value />
+                                    <Select.Indicator />
+                                  </Select.Trigger>
+                                  <Select.Popover>
+                                    <ListBox
+                                      selectionMode={
+                                        config.allowMultipleRoles
+                                          ? "multiple"
+                                          : "single"
+                                      }
                                     >
-                                      {item}
-                                      <ListBox.ItemIndicator />
-                                    </ListBox.Item>
-                                  ))}
-                                </ListBox>
-                              </Select.Popover>
-                            </Select>
+                                      {config.roles.map((item) => (
+                                        <ListBox.Item
+                                          id={item}
+                                          key={item}
+                                          textValue={item}
+                                        >
+                                          {item}
+                                          <ListBox.ItemIndicator />
+                                        </ListBox.Item>
+                                      ))}
+                                    </ListBox>
+                                  </Select.Popover>
+                                </Select>
+                              )}
+                            </profileForm.Field>
                             {additionalFields?.map((field) => {
                               const value = (
                                 detail as unknown as Record<string, unknown>
@@ -1351,22 +1458,32 @@ function UserDrawer({
                         >
                           {config.localization.cancel}
                         </Button>
-                        <Button
-                          isDisabled={
-                            !name.trim() ||
-                            !email.trim() ||
-                            canUpdate.isPending ||
-                            canSetRole.isPending ||
-                            (!canUpdate.data?.success &&
-                              (!canSetRole.data?.success || isSelf))
-                          }
-                          isPending={
-                            updateUser.isPending || setRoleMutation.isPending
-                          }
-                          type="submit"
+                        <profileForm.Subscribe
+                          selector={(state) => [
+                            state.values.name,
+                            state.values.email
+                          ]}
                         >
-                          {config.localization.saveChanges}
-                        </Button>
+                          {([name, email]) => (
+                            <Button
+                              isDisabled={
+                                !name.trim() ||
+                                !email.trim() ||
+                                canUpdate.isPending ||
+                                canSetRole.isPending ||
+                                (!canUpdate.data?.success &&
+                                  (!canSetRole.data?.success || isSelf))
+                              }
+                              isPending={
+                                updateUser.isPending ||
+                                setRoleMutation.isPending
+                              }
+                              type="submit"
+                            >
+                              {config.localization.saveChanges}
+                            </Button>
+                          )}
+                        </profileForm.Subscribe>
                       </div>
                     </Form>
                   </Tabs.Panel>

--- a/packages/heroui/src/components/auth/api-key/api-keys.tsx
+++ b/packages/heroui/src/components/auth/api-key/api-keys.tsx
@@ -1,4 +1,7 @@
-import type { ApiKeyAuthClient } from "@better-auth-ui/core/plugins/api-key"
+import type {
+  ApiKeyAuthClient,
+  ListedApiKey
+} from "@better-auth-ui/core/plugins/api-key"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useListApiKeys } from "@better-auth-ui/react/plugins/api-key"
 import {
@@ -10,6 +13,16 @@ import {
   ListBox,
   Select
 } from "@heroui/react"
+import {
+  createTableHook,
+  functionalUpdate,
+  type PaginationState,
+  rowPaginationFeature,
+  rowSortingFeature,
+  type SortingState,
+  tableFeatures,
+  type Updater
+} from "@tanstack/react-table"
 import { useState } from "react"
 
 import { apiKeyPlugin } from "../../../lib/auth/api-key-plugin"
@@ -17,6 +30,20 @@ import { ApiKey } from "./api-key"
 import { ApiKeySkeleton } from "./api-key-skeleton"
 import { ApiKeysEmpty } from "./api-keys-empty"
 import { CreateApiKeyDialog } from "./create-api-key-dialog"
+
+const { createAppColumnHelper, useAppTable: useApiKeyTable } = createTableHook({
+  enableMultiSort: false,
+  enableSortingRemoval: false,
+  sortDescFirst: false,
+  features: tableFeatures({ rowPaginationFeature, rowSortingFeature })
+})
+
+const apiKeyColumnHelper = createAppColumnHelper<ListedApiKey>()
+const apiKeyColumns = apiKeyColumnHelper.columns([
+  apiKeyColumnHelper.accessor("createdAt", { id: "createdAt" }),
+  apiKeyColumnHelper.accessor("name", { id: "name" })
+])
+const EMPTY_API_KEYS: ListedApiKey[] = []
 
 export type ApiKeysProps = {
   className?: string
@@ -45,17 +72,25 @@ export function ApiKeys({
   const { authClient } = useAuth()
   const { localization: apiKeyLocalization, pageSize } =
     useAuthPlugin(apiKeyPlugin)
-  const [page, setPage] = useState(0)
-  const [sort, setSort] = useState("createdAt:desc")
-  const [sortBy, sortDirection] = sort.split(":") as [string, "asc" | "desc"]
+  const [pagination, setPaginationState] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const [sorting, setSortingState] = useState<SortingState>([
+    { id: "createdAt", desc: true }
+  ])
+  const primarySort = sorting[0]
+  const sortBy = primarySort?.id === "name" ? "name" : "createdAt"
+  const sortDirection = primarySort?.desc ? "desc" : "asc"
+  const sort = `${sortBy}:${sortDirection}`
 
   const { data: listData, isPending: isListPending } = useListApiKeys(
     authClient as ApiKeyAuthClient,
     {
       enabled: !isPendingProp,
       query: {
-        limit: pageSize,
-        offset: page * pageSize,
+        limit: pagination.pageSize,
+        offset: pagination.pageIndex * pagination.pageSize,
         sortBy,
         sortDirection,
         ...(organizationId ? { organizationId, configId: "organization" } : {})
@@ -64,6 +99,22 @@ export function ApiKeys({
   )
 
   const isPending = isPendingProp || isListPending
+  const setPagination = (updater: Updater<PaginationState>) =>
+    setPaginationState((current) => functionalUpdate(updater, current))
+  const setSorting = (updater: Updater<SortingState>) => {
+    setSortingState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const table = useApiKeyTable({
+    columns: apiKeyColumns,
+    data: listData?.apiKeys ?? EMPTY_API_KEYS,
+    getRowId: (apiKey) => apiKey.id,
+    manualPagination: true,
+    manualSorting: true,
+    state: { pagination, sorting },
+    onPaginationChange: setPagination,
+    onSortingChange: setSorting
+  })
 
   const [createOpen, setCreateOpen] = useState(false)
 
@@ -89,8 +140,8 @@ export function ApiKeys({
         aria-label={apiKeyLocalization.sortBy}
         value={sort}
         onChange={(value) => {
-          setSort(String(value))
-          setPage(0)
+          const [id, direction] = String(value).split(":")
+          table.setSorting([{ id, desc: direction === "desc" }])
         }}
       >
         <Label>{apiKeyLocalization.sortBy}</Label>
@@ -126,14 +177,14 @@ export function ApiKeys({
               hideCreate={hideCreate}
             />
           ) : (
-            listData?.apiKeys.map((key, index) => (
-              <div key={key.id}>
+            table.getRowModel().rows.map((row, index) => (
+              <div key={row.id}>
                 {index > 0 && (
                   <div className="border-b border-dashed -mx-4 my-4" />
                 )}
 
                 <ApiKey
-                  apiKey={key}
+                  apiKey={row.original}
                   hideDelete={hideDelete}
                   hideUpdate={hideUpdate}
                   organizationId={organizationId}
@@ -143,21 +194,22 @@ export function ApiKeys({
           )}
         </Card.Content>
       </Card>
-      {(page > 0 || (listData?.apiKeys.length ?? 0) === pageSize) && (
+      {(pagination.pageIndex > 0 ||
+        (listData?.apiKeys.length ?? 0) === pagination.pageSize) && (
         <div className="flex justify-end gap-2">
           <Button
             size="sm"
             variant="outline"
-            isDisabled={page === 0}
-            onPress={() => setPage((value) => Math.max(0, value - 1))}
+            isDisabled={!table.getCanPreviousPage()}
+            onPress={() => table.previousPage()}
           >
             {apiKeyLocalization.previousPage}
           </Button>
           <Button
             size="sm"
             variant="outline"
-            isDisabled={(listData?.apiKeys.length ?? 0) < pageSize}
-            onPress={() => setPage((value) => value + 1)}
+            isDisabled={(listData?.apiKeys.length ?? 0) < pagination.pageSize}
+            onPress={() => table.nextPage()}
           >
             {apiKeyLocalization.nextPage}
           </Button>

--- a/packages/heroui/src/components/auth/dash/activity.tsx
+++ b/packages/heroui/src/components/auth/dash/activity.tsx
@@ -45,11 +45,37 @@ import {
   Spinner
 } from "@heroui/react"
 import { keepPreviousData } from "@tanstack/react-query"
+import {
+  type ColumnFiltersState,
+  columnFilteringFeature,
+  createTableHook,
+  functionalUpdate,
+  globalFilteringFeature,
+  type PaginationState,
+  rowPaginationFeature,
+  tableFeatures,
+  type Updater
+} from "@tanstack/react-table"
 import { useDeferredValue, useMemo, useState } from "react"
 import { dashPlugin } from "../../../lib/auth/dash-plugin"
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
 
 type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
+
+const { createAppColumnHelper, useAppTable: useActivityTable } =
+  createTableHook({
+    features: tableFeatures({
+      columnFilteringFeature,
+      globalFilteringFeature,
+      rowPaginationFeature
+    })
+  })
+
+const activityColumnHelper = createAppColumnHelper<DashAuditLog>()
+const activityColumns = activityColumnHelper.columns([
+  activityColumnHelper.accessor("eventType", { id: "eventType" })
+])
+const EMPTY_EVENTS: DashAuditLog[] = []
 
 type ActivityFeedProps = {
   access: ActivityAccess
@@ -205,20 +231,28 @@ function ActivityFeed({
 }: ActivityFeedProps) {
   const { authClient, locale } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
-  const [page, setPage] = useState(0)
-  const [eventType, setEventType] = useState("all")
-  const [identifier, setIdentifier] = useState("")
-  const deferredIdentifier = useDeferredValue(identifier.trim())
+  const [pagination, setPaginationState] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const [columnFilters, setColumnFiltersState] = useState<ColumnFiltersState>(
+    []
+  )
+  const [globalFilter, setGlobalFilterState] = useState("")
+  const eventType = String(
+    columnFilters.find((filter) => filter.id === "eventType")?.value ?? "all"
+  )
+  const deferredIdentifier = useDeferredValue(globalFilter.trim())
   const eventOptions = useMemo(
     () => Object.entries(localization.eventLabels),
     [localization.eventLabels]
   )
   const numberFormatter = new Intl.NumberFormat(locale.languageTag)
-  const offset = page * pageSize
+  const offset = pagination.pageIndex * pagination.pageSize
   const params = {
     eventType: eventType === "all" ? undefined : eventType,
     identifier: deferredIdentifier || undefined,
-    limit: pageSize,
+    limit: pagination.pageSize,
     offset,
     organizationId
   }
@@ -240,7 +274,7 @@ function ActivityFeed({
       params: {
         eventType: params.eventType,
         identifier: params.identifier,
-        limit: pageSize,
+        limit: pagination.pageSize,
         offset
       }
     }
@@ -254,7 +288,28 @@ function ActivityFeed({
   const { data, error, isFetching, isPending } = query
   const showPending = !ready || isPending
   const pageEnd = offset + (data?.events.length ?? 0)
-  const hasNextPage = pageEnd < (data?.total ?? 0)
+  const setPagination = (updater: Updater<PaginationState>) =>
+    setPaginationState((current) => functionalUpdate(updater, current))
+  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
+    setColumnFiltersState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const setGlobalFilter = (updater: Updater<string>) => {
+    setGlobalFilterState((current) => functionalUpdate(updater, current))
+    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
+  }
+  const table = useActivityTable({
+    columns: activityColumns,
+    data: data?.events ?? EMPTY_EVENTS,
+    getRowId: getDashEventKey,
+    manualFiltering: true,
+    manualPagination: true,
+    rowCount: data?.total ?? 0,
+    state: { columnFilters, globalFilter, pagination },
+    onColumnFiltersChange: setColumnFilters,
+    onGlobalFilterChange: setGlobalFilter,
+    onPaginationChange: setPagination
+  })
 
   return (
     <div className={cn("flex flex-col gap-3", className)}>
@@ -285,8 +340,12 @@ function ActivityFeed({
         <Select
           value={eventType}
           onChange={(value) => {
-            setEventType(String(value))
-            setPage(0)
+            const nextEventType = String(value)
+            table
+              .getColumn("eventType")
+              ?.setFilterValue(
+                nextEventType === "all" ? undefined : nextEventType
+              )
           }}
         >
           <Label>{localization.eventType}</Label>
@@ -307,10 +366,9 @@ function ActivityFeed({
         </Select>
         <SearchField
           aria-label={localization.identifier}
-          value={identifier}
+          value={globalFilter}
           onChange={(value) => {
-            setIdentifier(value)
-            setPage(0)
+            table.setGlobalFilter(value)
           }}
         >
           <Label>{localization.identifier}</Label>
@@ -355,8 +413,8 @@ function ActivityFeed({
             </div>
           ) : data?.events.length ? (
             <ul>
-              {data.events.map((event) => (
-                <ActivityRow key={getDashEventKey(event)} event={event} />
+              {table.getRowModel().rows.map((row) => (
+                <ActivityRow key={row.id} event={row.original} />
               ))}
             </ul>
           ) : (
@@ -392,8 +450,8 @@ function ActivityFeed({
                 aria-label={localization.previousPage}
                 size="sm"
                 variant="ghost"
-                isDisabled={isFetching || page === 0}
-                onPress={() => setPage((current) => Math.max(0, current - 1))}
+                isDisabled={isFetching || !table.getCanPreviousPage()}
+                onPress={() => table.previousPage()}
               >
                 <ChevronLeft />
               </Button>
@@ -402,8 +460,8 @@ function ActivityFeed({
                 aria-label={localization.nextPage}
                 size="sm"
                 variant="ghost"
-                isDisabled={isFetching || !hasNextPage}
-                onPress={() => setPage((current) => current + 1)}
+                isDisabled={isFetching || !table.getCanNextPage()}
+                onPress={() => table.nextPage()}
               >
                 <ChevronRight />
               </Button>

--- a/packages/heroui/src/components/auth/oauth-provider/oauth-clients.tsx
+++ b/packages/heroui/src/components/auth/oauth-provider/oauth-clients.tsx
@@ -51,13 +51,23 @@ import {
   TextField,
   toast
 } from "@heroui/react"
-import { type SyntheticEvent, useMemo, useState } from "react"
+import { useForm } from "@tanstack/react-form"
+import { useMemo, useState } from "react"
 
 import { oauthProviderPlugin } from "../../../lib/auth/oauth-provider-plugin"
 
 type ClientAction =
   | { kind: "delete"; client: ManagedOAuthClient }
   | { kind: "rotate"; client: ManagedOAuthClient }
+
+type OAuthClientFormValues = {
+  applicationType: "native" | "web"
+  clientName: string
+  clientUri: string
+  logoUri: string
+  redirectUris: string
+  scope: string
+}
 
 export type OAuthClientsProps = {
   manager: OAuthClientManager
@@ -76,6 +86,17 @@ const lines = (value: string) =>
         .filter(Boolean)
     )
   )
+
+const getOAuthClientFormValues = (
+  client?: ManagedOAuthClient
+): OAuthClientFormValues => ({
+  applicationType: client?.application_type === "native" ? "native" : "web",
+  clientName: client?.client_name ?? "",
+  clientUri: client?.client_uri ?? "",
+  logoUri: client?.logo_uri ?? "",
+  redirectUris: client?.redirect_uris.join("\n") ?? "",
+  scope: client?.scope ?? ""
+})
 
 export function OAuthClients({
   manager,
@@ -100,44 +121,47 @@ export function OAuthClients({
     onError: (error) =>
       toast.danger(error instanceof Error ? error.message : String(error))
   })
+  const form = useForm({
+    defaultValues: getOAuthClientFormValues(),
+    onSubmit: async ({ value }) => {
+      const input: OAuthClientInput = {
+        client_name: value.clientName.trim(),
+        application_type: value.applicationType,
+        redirect_uris: lines(value.redirectUris),
+        client_uri: value.clientUri.trim() || undefined,
+        logo_uri: value.logoUri.trim() || undefined,
+        scope: value.scope.trim() || undefined
+      }
+
+      try {
+        if (editingClient) {
+          await updateClient.mutateAsync({
+            clientId: editingClient.client_id,
+            update: input
+          })
+          setEditorOpen(false)
+          return
+        }
+
+        const client = await createClient.mutateAsync(input)
+        setEditorOpen(false)
+        setSecret(client)
+      } catch {
+        // The mutation keeps its error state for the host application.
+      }
+    }
+  })
 
   const openCreate = () => {
     setEditingClient(undefined)
+    form.reset(getOAuthClientFormValues())
     setEditorOpen(true)
   }
 
   const openEdit = (client: ManagedOAuthClient) => {
     setEditingClient(client)
+    form.reset(getOAuthClientFormValues(client))
     setEditorOpen(true)
-  }
-
-  const handleEditorSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    const input: OAuthClientInput = {
-      client_name: String(formData.get("clientName") ?? "").trim(),
-      application_type:
-        formData.get("applicationType") === "native" ? "native" : "web",
-      redirect_uris: lines(String(formData.get("redirectUris") ?? "")),
-      client_uri: String(formData.get("clientUri") ?? "").trim() || undefined,
-      logo_uri: String(formData.get("logoUri") ?? "").trim() || undefined,
-      scope: String(formData.get("scope") ?? "").trim() || undefined
-    }
-
-    if (editingClient) {
-      updateClient.mutate(
-        { clientId: editingClient.client_id, update: input },
-        { onSuccess: () => setEditorOpen(false) }
-      )
-      return
-    }
-
-    createClient.mutate(input, {
-      onSuccess: (client) => {
-        setEditorOpen(false)
-        setSecret(client)
-      }
-    })
   }
 
   const confirmAction = () => {
@@ -303,7 +327,12 @@ export function OAuthClients({
       <Modal.Backdrop isOpen={editorOpen} onOpenChange={setEditorOpen}>
         <Modal.Container>
           <Modal.Dialog>
-            <Form onSubmit={handleEditorSubmit}>
+            <Form
+              onSubmit={(event) => {
+                event.preventDefault()
+                void form.handleSubmit()
+              }}
+            >
               <Modal.CloseTrigger />
               <Modal.Header>
                 <Modal.Icon>
@@ -316,85 +345,110 @@ export function OAuthClients({
                 </Modal.Heading>
               </Modal.Header>
               <Modal.Body className="flex flex-col gap-4 overflow-visible">
-                <TextField
-                  name="clientName"
-                  defaultValue={editingClient?.client_name ?? ""}
-                  isRequired
-                >
-                  <Label>{oauthLocalization.clientName}</Label>
-                  <Input autoFocus variant="secondary" />
-                  <FieldError />
-                </TextField>
-                <Select
-                  name="applicationType"
-                  defaultValue={editingClient?.application_type ?? "web"}
-                  variant="secondary"
-                >
-                  <Label>{oauthLocalization.applicationType}</Label>
-                  <Select.Trigger>
-                    <Select.Value />
-                    <Select.Indicator />
-                  </Select.Trigger>
-                  <Select.Popover>
-                    <ListBox>
-                      <ListBox.Item id="web">
-                        {oauthLocalization.webApplication}
-                      </ListBox.Item>
-                      <ListBox.Item id="native">
-                        {oauthLocalization.nativeApplication}
-                      </ListBox.Item>
-                    </ListBox>
-                  </Select.Popover>
-                </Select>
-                <TextField
-                  name="redirectUris"
-                  defaultValue={editingClient?.redirect_uris.join("\n") ?? ""}
-                  isRequired
-                >
-                  <Label>{oauthLocalization.redirectUrls}</Label>
-                  <TextArea rows={3} variant="secondary" />
-                  <p className="text-muted text-xs">
-                    {oauthLocalization.redirectUrlsDescription}
-                  </p>
-                  <FieldError />
-                </TextField>
-                <TextField
-                  name="clientUri"
-                  defaultValue={editingClient?.client_uri ?? ""}
-                >
-                  <Label>{oauthLocalization.applicationUrl}</Label>
-                  <Input type="url" variant="secondary" />
-                </TextField>
-                <TextField
-                  name="logoUri"
-                  defaultValue={editingClient?.logo_uri ?? ""}
-                >
-                  <Label>{oauthLocalization.logoUrl}</Label>
-                  <Input type="url" variant="secondary" />
-                </TextField>
-                <TextField
-                  name="scope"
-                  defaultValue={editingClient?.scope ?? ""}
-                >
-                  <Label>{oauthLocalization.scopes}</Label>
-                  <Input
-                    placeholder="openid profile email"
-                    variant="secondary"
-                  />
-                </TextField>
+                <form.Field name="clientName">
+                  {(field) => (
+                    <TextField
+                      isRequired
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={field.handleChange}
+                      value={field.state.value}
+                    >
+                      <Label>{oauthLocalization.clientName}</Label>
+                      <Input autoFocus variant="secondary" />
+                      <FieldError />
+                    </TextField>
+                  )}
+                </form.Field>
+                <form.Field name="applicationType">
+                  {(field) => (
+                    <Select
+                      name={field.name}
+                      onChange={(value) =>
+                        field.handleChange(String(value) as "native" | "web")
+                      }
+                      value={field.state.value}
+                      variant="secondary"
+                    >
+                      <Label>{oauthLocalization.applicationType}</Label>
+                      <Select.Trigger>
+                        <Select.Value />
+                        <Select.Indicator />
+                      </Select.Trigger>
+                      <Select.Popover>
+                        <ListBox>
+                          <ListBox.Item id="web">
+                            {oauthLocalization.webApplication}
+                          </ListBox.Item>
+                          <ListBox.Item id="native">
+                            {oauthLocalization.nativeApplication}
+                          </ListBox.Item>
+                        </ListBox>
+                      </Select.Popover>
+                    </Select>
+                  )}
+                </form.Field>
+                <form.Field name="redirectUris">
+                  {(field) => (
+                    <TextField
+                      isRequired
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={field.handleChange}
+                      value={field.state.value}
+                    >
+                      <Label>{oauthLocalization.redirectUrls}</Label>
+                      <TextArea rows={3} variant="secondary" />
+                      <p className="text-muted text-xs">
+                        {oauthLocalization.redirectUrlsDescription}
+                      </p>
+                      <FieldError />
+                    </TextField>
+                  )}
+                </form.Field>
+                {(
+                  [
+                    ["clientUri", oauthLocalization.applicationUrl, "url"],
+                    ["logoUri", oauthLocalization.logoUrl, "url"],
+                    ["scope", oauthLocalization.scopes, "text"]
+                  ] as const
+                ).map(([name, label, type]) => (
+                  <form.Field key={name} name={name}>
+                    {(field) => (
+                      <TextField
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={field.handleChange}
+                        value={field.state.value}
+                      >
+                        <Label>{label}</Label>
+                        <Input
+                          placeholder={
+                            name === "scope"
+                              ? "openid profile email"
+                              : undefined
+                          }
+                          type={type}
+                          variant="secondary"
+                        />
+                      </TextField>
+                    )}
+                  </form.Field>
+                ))}
               </Modal.Body>
               <Modal.Footer>
                 <Button variant="ghost" onPress={() => setEditorOpen(false)}>
                   {oauthLocalization.cancel}
                 </Button>
-                <Button
-                  type="submit"
-                  isPending={createClient.isPending || updateClient.isPending}
-                >
-                  {editingClient
-                    ? oauthLocalization.saveChanges
-                    : oauthLocalization.createClient}
-                </Button>
+                <form.Subscribe selector={(state) => state.isSubmitting}>
+                  {(isSubmitting) => (
+                    <Button type="submit" isPending={isSubmitting}>
+                      {editingClient
+                        ? oauthLocalization.saveChanges
+                        : oauthLocalization.createClient}
+                    </Button>
+                  )}
+                </form.Subscribe>
               </Modal.Footer>
             </Form>
           </Modal.Dialog>

--- a/packages/heroui/src/components/auth/organization/edit-member-roles-dialog.tsx
+++ b/packages/heroui/src/components/auth/organization/edit-member-roles-dialog.tsx
@@ -15,7 +15,8 @@ import {
   Spinner,
   toast
 } from "@heroui/react"
-import { type FormEvent, useEffect, useState } from "react"
+import { useForm } from "@tanstack/react-form"
+import { useEffect } from "react"
 
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
 
@@ -61,9 +62,6 @@ export function EditMemberRolesDialog({
   const { authClient, localization } = useAuth()
   const { allowMultipleRoles, localization: organizationLocalization } =
     useAuthPlugin(organizationPlugin)
-  const [selectedRoles, setSelectedRoles] = useState(() =>
-    selectedMemberRoles(member.role, allowMultipleRoles, protectedRole)
-  )
   const updateMemberRole = useUpdateMemberRole(
     authClient as OrganizationAuthClient,
     {
@@ -73,36 +71,42 @@ export function EditMemberRolesDialog({
       }
     }
   )
+  const form = useForm({
+    defaultValues: {
+      roles: selectedMemberRoles(member.role, allowMultipleRoles, protectedRole)
+    },
+    onSubmit: ({ value }) => {
+      if (value.roles.length === 0) return
+
+      updateMemberRole.mutate({
+        memberId: member.id,
+        organizationId,
+        role: value.roles
+      })
+    }
+  })
 
   useEffect(() => {
     if (isOpen)
-      setSelectedRoles(
-        selectedMemberRoles(member.role, allowMultipleRoles, protectedRole)
-      )
-  }, [allowMultipleRoles, isOpen, member.role, protectedRole])
-
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (selectedRoles.length === 0) return
-
-    updateMemberRole.mutate({
-      memberId: member.id,
-      organizationId,
-      role: selectedRoles
-    })
-  }
-
-  const protectedRoleSelected =
-    !allowMultipleRoles &&
-    protectedRoleRemovalDisabled &&
-    protectedRole !== undefined &&
-    selectedRoles.includes(protectedRole)
+      form.reset({
+        roles: selectedMemberRoles(
+          member.role,
+          allowMultipleRoles,
+          protectedRole
+        )
+      })
+  }, [allowMultipleRoles, form.reset, isOpen, member.role, protectedRole])
 
   return (
     <AlertDialog.Backdrop isOpen={isOpen} onOpenChange={onOpenChange}>
       <AlertDialog.Container>
         <AlertDialog.Dialog>
-          <Form onSubmit={submit}>
+          <Form
+            onSubmit={(event) => {
+              event.preventDefault()
+              void form.handleSubmit()
+            }}
+          >
             <AlertDialog.CloseTrigger />
             <AlertDialog.Header>
               <AlertDialog.Heading className="flex items-center gap-2">
@@ -114,83 +118,97 @@ export function EditMemberRolesDialog({
               <p className="text-muted text-sm">
                 {organizationLocalization.changeMemberRoleDescription}
               </p>
-              {allowMultipleRoles ? (
-                <fieldset className="flex flex-col gap-2">
-                  <legend className="sr-only">
-                    {organizationLocalization.changeMemberRole}
-                  </legend>
-                  {roles.map(([role, label]) => {
-                    const selected = selectedRoles.includes(role)
-                    const disabled =
-                      updateMemberRole.isPending ||
-                      (selected && selectedRoles.length === 1) ||
-                      (role === protectedRole &&
-                        selected &&
-                        protectedRoleRemovalDisabled)
+              <form.Subscribe selector={(state) => state.values.roles}>
+                {(selectedRoles) => {
+                  const protectedRoleSelected =
+                    !allowMultipleRoles &&
+                    protectedRoleRemovalDisabled &&
+                    protectedRole !== undefined &&
+                    selectedRoles.includes(protectedRole)
 
-                    return (
-                      <Checkbox
-                        className="w-full rounded-lg border p-3"
-                        isDisabled={disabled}
-                        isSelected={selected}
-                        key={role}
-                        onChange={(checked) =>
-                          setSelectedRoles((current) =>
-                            checked
-                              ? current.includes(role)
-                                ? current
-                                : [...current, role]
-                              : current.filter((entry) => entry !== role)
+                  return allowMultipleRoles ? (
+                    <fieldset className="flex flex-col gap-2">
+                      <legend className="sr-only">
+                        {organizationLocalization.changeMemberRole}
+                      </legend>
+                      {roles.map(([role, label]) => {
+                        const selected = selectedRoles.includes(role)
+                        const disabled =
+                          updateMemberRole.isPending ||
+                          (selected && selectedRoles.length === 1) ||
+                          (role === protectedRole &&
+                            selected &&
+                            protectedRoleRemovalDisabled)
+
+                        return (
+                          <Checkbox
+                            className="w-full rounded-lg border p-3"
+                            isDisabled={disabled}
+                            isSelected={selected}
+                            key={role}
+                            onChange={(checked) =>
+                              form.setFieldValue("roles", (current) =>
+                                checked
+                                  ? current.includes(role)
+                                    ? current
+                                    : [...current, role]
+                                  : current.filter((entry) => entry !== role)
+                              )
+                            }
+                            variant="secondary"
+                          >
+                            <Checkbox.Content className="w-full">
+                              <Checkbox.Control>
+                                <Checkbox.Indicator />
+                              </Checkbox.Control>
+                              <span className="font-medium text-sm">
+                                {label}
+                              </span>
+                            </Checkbox.Content>
+                          </Checkbox>
+                        )
+                      })}
+                    </fieldset>
+                  ) : (
+                    <RadioGroup
+                      aria-label={organizationLocalization.changeMemberRole}
+                      isDisabled={updateMemberRole.isPending}
+                      onChange={(role) => form.setFieldValue("roles", [role])}
+                      value={selectedRoles[0] ?? ""}
+                      variant="secondary"
+                    >
+                      <div className="flex flex-col gap-2">
+                        {roles.map(([role, label]) => {
+                          const selected = selectedRoles.includes(role)
+                          const disabled =
+                            (protectedRoleSelected && role !== protectedRole) ||
+                            (role === protectedRole &&
+                              selected &&
+                              protectedRoleRemovalDisabled)
+
+                          return (
+                            <Radio
+                              className="w-full rounded-lg border p-3"
+                              isDisabled={disabled}
+                              key={role}
+                              value={role}
+                            >
+                              <Radio.Content className="w-full">
+                                <Radio.Control>
+                                  <Radio.Indicator />
+                                </Radio.Control>
+                                <span className="font-medium text-sm">
+                                  {label}
+                                </span>
+                              </Radio.Content>
+                            </Radio>
                           )
-                        }
-                        variant="secondary"
-                      >
-                        <Checkbox.Content className="w-full">
-                          <Checkbox.Control>
-                            <Checkbox.Indicator />
-                          </Checkbox.Control>
-                          <span className="font-medium text-sm">{label}</span>
-                        </Checkbox.Content>
-                      </Checkbox>
-                    )
-                  })}
-                </fieldset>
-              ) : (
-                <RadioGroup
-                  aria-label={organizationLocalization.changeMemberRole}
-                  isDisabled={updateMemberRole.isPending}
-                  onChange={(role) => setSelectedRoles([role])}
-                  value={selectedRoles[0] ?? ""}
-                  variant="secondary"
-                >
-                  <div className="flex flex-col gap-2">
-                    {roles.map(([role, label]) => {
-                      const selected = selectedRoles.includes(role)
-                      const disabled =
-                        (protectedRoleSelected && role !== protectedRole) ||
-                        (role === protectedRole &&
-                          selected &&
-                          protectedRoleRemovalDisabled)
-
-                      return (
-                        <Radio
-                          className="w-full rounded-lg border p-3"
-                          isDisabled={disabled}
-                          key={role}
-                          value={role}
-                        >
-                          <Radio.Content className="w-full">
-                            <Radio.Control>
-                              <Radio.Indicator />
-                            </Radio.Control>
-                            <span className="font-medium text-sm">{label}</span>
-                          </Radio.Content>
-                        </Radio>
-                      )
-                    })}
-                  </div>
-                </RadioGroup>
-              )}
+                        })}
+                      </div>
+                    </RadioGroup>
+                  )
+                }}
+              </form.Subscribe>
             </AlertDialog.Body>
             <AlertDialog.Footer>
               <Button
@@ -200,18 +218,22 @@ export function EditMemberRolesDialog({
               >
                 {localization.settings.cancel}
               </Button>
-              <Button
-                isDisabled={
-                  updateMemberRole.isPending || selectedRoles.length === 0
-                }
-                isPending={updateMemberRole.isPending}
-                type="submit"
-              >
-                {updateMemberRole.isPending && (
-                  <Spinner color="current" size="sm" />
+              <form.Subscribe selector={(state) => state.values.roles.length}>
+                {(selectedRoleCount) => (
+                  <Button
+                    isDisabled={
+                      updateMemberRole.isPending || selectedRoleCount === 0
+                    }
+                    isPending={updateMemberRole.isPending}
+                    type="submit"
+                  >
+                    {updateMemberRole.isPending && (
+                      <Spinner color="current" size="sm" />
+                    )}
+                    {localization.settings.saveChanges}
+                  </Button>
                 )}
-                {localization.settings.saveChanges}
-              </Button>
+              </form.Subscribe>
             </AlertDialog.Footer>
           </Form>
         </AlertDialog.Dialog>

--- a/packages/heroui/src/components/auth/reset-password.tsx
+++ b/packages/heroui/src/components/auth/reset-password.tsx
@@ -19,7 +19,8 @@ import {
   TextField,
   toast
 } from "@heroui/react"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useForm } from "@tanstack/react-form"
+import { useEffect, useState } from "react"
 import { PasswordStrengthMeter } from "./password-strength-meter"
 
 export type ResetPasswordProps = {
@@ -59,7 +60,6 @@ export function ResetPassword({ className, variant }: ResetPasswordProps) {
     }
   })
 
-  const [password, setPassword] = useState("")
   const [isCompromised, setIsCompromised] = useState(false)
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
   const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
@@ -75,29 +75,29 @@ export function ResetPassword({ className, variant }: ResetPasswordProps) {
     }
   }, [localization.auth.invalidResetPasswordToken, navigate, signInURL])
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
+  const form = useForm({
+    defaultValues: { confirmPassword: "", password: "" },
+    onSubmit: ({ value }) => {
+      const searchParams = new URLSearchParams(window.location.search)
+      const token = searchParams.get("token") as string
 
-    const searchParams = new URLSearchParams(window.location.search)
-    const token = searchParams.get("token") as string
+      if (!token) {
+        toast.danger(localization.auth.invalidResetPasswordToken)
+        navigate({ to: signInURL })
+        return
+      }
 
-    if (!token) {
-      toast.danger(localization.auth.invalidResetPasswordToken)
-      navigate({ to: signInURL })
-      return
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
+        toast.danger(localization.auth.passwordsDoNotMatch)
+        return
+      }
+
+      resetPassword({ token, newPassword: value.password })
     }
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-    const confirmPassword = formData.get("confirmPassword") as string
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      toast.danger(localization.auth.passwordsDoNotMatch)
-      return
-    }
-
-    resetPassword({ token, newPassword: password })
-  }
+  })
 
   return (
     <Card
@@ -111,128 +111,153 @@ export function ResetPassword({ className, variant }: ResetPasswordProps) {
       </Card.Header>
 
       <Card.Content className="gap-4">
-        <Form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          <TextField
-            minLength={emailAndPassword?.minPasswordLength}
-            maxLength={emailAndPassword?.maxPasswordLength}
-            name="password"
-            autoComplete="new-password"
-            value={password}
-            onChange={(value) => {
-              setPassword(value)
-              setIsCompromised(false)
-            }}
-            isInvalid={isCompromised || undefined}
-            isDisabled={isPending}
-            validate={(value) => {
-              if (!value) return localization.auth.fieldRequired
-              const min = emailAndPassword?.minPasswordLength
-              const max = emailAndPassword?.maxPasswordLength
-              if (min && value.length < min)
-                return localization.auth.tooShort.replace(
-                  "{{min}}",
-                  String(min)
-                )
-              if (max && value.length > max)
-                return localization.auth.tooLong.replace("{{max}}", String(max))
-            }}
-          >
-            <Label>{localization.auth.password}</Label>
+        <Form
+          onSubmit={(event) => {
+            event.preventDefault()
+            void form.handleSubmit()
+          }}
+          className="flex flex-col gap-4"
+        >
+          <form.Field name="password">
+            {(field) => (
+              <TextField
+                minLength={emailAndPassword?.minPasswordLength}
+                maxLength={emailAndPassword?.maxPasswordLength}
+                name={field.name}
+                autoComplete="new-password"
+                value={field.state.value}
+                onBlur={field.handleBlur}
+                onChange={(value) => {
+                  field.handleChange(value)
+                  setIsCompromised(false)
+                }}
+                isInvalid={isCompromised || undefined}
+                isDisabled={isPending}
+                validate={(value) => {
+                  if (!value) return localization.auth.fieldRequired
+                  const min = emailAndPassword?.minPasswordLength
+                  const max = emailAndPassword?.maxPasswordLength
+                  if (min && value.length < min)
+                    return localization.auth.tooShort.replace(
+                      "{{min}}",
+                      String(min)
+                    )
+                  if (max && value.length > max)
+                    return localization.auth.tooLong.replace(
+                      "{{max}}",
+                      String(max)
+                    )
+                }}
+              >
+                <Label>{localization.auth.password}</Label>
 
-            <InputGroup
-              variant={variant === "transparent" ? "primary" : "secondary"}
-            >
-              <InputGroup.Input
-                name="password"
-                placeholder={localization.auth.newPasswordPlaceholder}
-                type={isPasswordVisible ? "text" : "password"}
-                required
-              />
-
-              <InputGroup.Suffix className="px-0">
-                <Button
-                  isIconOnly
-                  aria-label={
-                    isPasswordVisible
-                      ? localization.auth.hidePassword
-                      : localization.auth.showPassword
-                  }
-                  size="sm"
-                  variant="ghost"
-                  onPress={() => setIsPasswordVisible(!isPasswordVisible)}
-                  isDisabled={isPending}
+                <InputGroup
+                  variant={variant === "transparent" ? "primary" : "secondary"}
                 >
-                  {isPasswordVisible ? <EyeSlash /> : <Eye />}
-                </Button>
-              </InputGroup.Suffix>
-            </InputGroup>
+                  <InputGroup.Input
+                    name="password"
+                    placeholder={localization.auth.newPasswordPlaceholder}
+                    type={isPasswordVisible ? "text" : "password"}
+                    required
+                  />
 
-            {isCompromised ? (
-              <FieldError>{localization.auth.passwordCompromised}</FieldError>
-            ) : (
-              <FieldError />
+                  <InputGroup.Suffix className="px-0">
+                    <Button
+                      isIconOnly
+                      aria-label={
+                        isPasswordVisible
+                          ? localization.auth.hidePassword
+                          : localization.auth.showPassword
+                      }
+                      size="sm"
+                      variant="ghost"
+                      onPress={() => setIsPasswordVisible(!isPasswordVisible)}
+                      isDisabled={isPending}
+                    >
+                      {isPasswordVisible ? <EyeSlash /> : <Eye />}
+                    </Button>
+                  </InputGroup.Suffix>
+                </InputGroup>
+
+                {isCompromised ? (
+                  <FieldError>
+                    {localization.auth.passwordCompromised}
+                  </FieldError>
+                ) : (
+                  <FieldError />
+                )}
+
+                <PasswordStrengthMeter password={field.state.value} />
+              </TextField>
             )}
-
-            <PasswordStrengthMeter password={password} />
-          </TextField>
+          </form.Field>
 
           {emailAndPassword?.confirmPassword && (
-            <TextField
-              minLength={emailAndPassword?.minPasswordLength}
-              maxLength={emailAndPassword?.maxPasswordLength}
-              name="confirmPassword"
-              autoComplete="new-password"
-              isDisabled={isPending}
-              validate={(value) => {
-                if (!value) return localization.auth.fieldRequired
-                const min = emailAndPassword?.minPasswordLength
-                const max = emailAndPassword?.maxPasswordLength
-                if (min && value.length < min)
-                  return localization.auth.tooShort.replace(
-                    "{{min}}",
-                    String(min)
-                  )
-                if (max && value.length > max)
-                  return localization.auth.tooLong.replace(
-                    "{{max}}",
-                    String(max)
-                  )
-              }}
-            >
-              <Label>{localization.auth.confirmPassword}</Label>
+            <form.Field name="confirmPassword">
+              {(field) => (
+                <TextField
+                  minLength={emailAndPassword?.minPasswordLength}
+                  maxLength={emailAndPassword?.maxPasswordLength}
+                  name={field.name}
+                  autoComplete="new-password"
+                  isDisabled={isPending}
+                  onBlur={field.handleBlur}
+                  onChange={field.handleChange}
+                  value={field.state.value}
+                  validate={(value) => {
+                    if (!value) return localization.auth.fieldRequired
+                    const min = emailAndPassword?.minPasswordLength
+                    const max = emailAndPassword?.maxPasswordLength
+                    if (min && value.length < min)
+                      return localization.auth.tooShort.replace(
+                        "{{min}}",
+                        String(min)
+                      )
+                    if (max && value.length > max)
+                      return localization.auth.tooLong.replace(
+                        "{{max}}",
+                        String(max)
+                      )
+                  }}
+                >
+                  <Label>{localization.auth.confirmPassword}</Label>
 
-              <InputGroup
-                variant={variant === "transparent" ? "primary" : "secondary"}
-              >
-                <InputGroup.Input
-                  placeholder={localization.auth.confirmPasswordPlaceholder}
-                  type={isConfirmPasswordVisible ? "text" : "password"}
-                  required
-                  name="confirmPassword"
-                />
-
-                <InputGroup.Suffix className="px-0">
-                  <Button
-                    isIconOnly
-                    aria-label={
-                      isConfirmPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
+                  <InputGroup
+                    variant={
+                      variant === "transparent" ? "primary" : "secondary"
                     }
-                    size="sm"
-                    variant="ghost"
-                    onPress={() =>
-                      setIsConfirmPasswordVisible(!isConfirmPasswordVisible)
-                    }
-                    isDisabled={isPending}
                   >
-                    {isConfirmPasswordVisible ? <EyeSlash /> : <Eye />}
-                  </Button>
-                </InputGroup.Suffix>
-              </InputGroup>
+                    <InputGroup.Input
+                      placeholder={localization.auth.confirmPasswordPlaceholder}
+                      type={isConfirmPasswordVisible ? "text" : "password"}
+                      required
+                      name="confirmPassword"
+                    />
 
-              <FieldError />
-            </TextField>
+                    <InputGroup.Suffix className="px-0">
+                      <Button
+                        isIconOnly
+                        aria-label={
+                          isConfirmPasswordVisible
+                            ? localization.auth.hidePassword
+                            : localization.auth.showPassword
+                        }
+                        size="sm"
+                        variant="ghost"
+                        onPress={() =>
+                          setIsConfirmPasswordVisible(!isConfirmPasswordVisible)
+                        }
+                        isDisabled={isPending}
+                      >
+                        {isConfirmPasswordVisible ? <EyeSlash /> : <Eye />}
+                      </Button>
+                    </InputGroup.Suffix>
+                  </InputGroup>
+
+                  <FieldError />
+                </TextField>
+              )}
+            </form.Field>
           )}
 
           <div className="flex flex-col gap-3">

--- a/packages/heroui/src/components/auth/settings/security/change-password.tsx
+++ b/packages/heroui/src/components/auth/settings/security/change-password.tsx
@@ -23,7 +23,8 @@ import {
   TextField,
   toast
 } from "@heroui/react"
-import { type SyntheticEvent, useState } from "react"
+import { useForm } from "@tanstack/react-form"
+import { useState } from "react"
 
 import { OpenEmailButton } from "../../open-email-button"
 import { PasswordStrengthMeter } from "../../password-strength-meter"
@@ -175,10 +176,7 @@ function ChangePasswordForm({
   session: ReturnType<typeof useSession>["data"]
 } & Omit<CardProps, "children">) {
   const { authClient } = useAuth()
-  const [currentPassword, setCurrentPassword] = useState("")
-  const [newPassword, setNewPassword] = useState("")
   const [isCompromised, setIsCompromised] = useState(false)
-  const [confirmPassword, setConfirmPassword] = useState("")
   const [isCurrentPasswordVisible, setIsCurrentPasswordVisible] =
     useState(false)
 
@@ -188,14 +186,10 @@ function ChangePasswordForm({
       // belongs against the field rather than in a toast.
       setIsCompromised(isPasswordCompromisedError(error))
 
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
+      form.reset()
     },
     onSuccess: () => {
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
+      form.reset()
       toast.success(localization.settings.changePasswordSuccess)
     }
   })
@@ -204,23 +198,29 @@ function ChangePasswordForm({
   const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
     useState(false)
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useForm({
+    defaultValues: {
+      confirmPassword: "",
+      currentPassword: "",
+      newPassword: ""
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.newPassword !== value.confirmPassword
+      ) {
+        form.reset()
+        toast.danger(localization.auth.passwordsDoNotMatch)
+        return
+      }
 
-    if (emailAndPassword?.confirmPassword && newPassword !== confirmPassword) {
-      setCurrentPassword("")
-      setNewPassword("")
-      setConfirmPassword("")
-      toast.danger(localization.auth.passwordsDoNotMatch)
-      return
+      changePassword({
+        currentPassword: value.currentPassword,
+        newPassword: value.newPassword,
+        revokeOtherSessions: true
+      })
     }
-
-    changePassword({
-      currentPassword,
-      newPassword,
-      revokeOtherSessions: true
-    })
-  }
+  })
 
   return (
     <div>
@@ -230,178 +230,202 @@ function ChangePasswordForm({
 
       <Card className={cn("p-4 gap-4", className)} variant={variant} {...props}>
         <Card.Content>
-          <Form onSubmit={handleSubmit}>
+          <Form
+            onSubmit={(event) => {
+              event.preventDefault()
+              void form.handleSubmit()
+            }}
+          >
             <Fieldset className="w-full gap-4">
               <Fieldset.Group>
-                <TextField
-                  name="currentPassword"
-                  isDisabled={isPending || !session}
-                  defaultValue=""
-                  value={currentPassword}
-                  onChange={setCurrentPassword}
-                >
-                  <Label>{localization.settings.currentPassword}</Label>
+                <form.Field name="currentPassword">
+                  {(field) => (
+                    <TextField
+                      name={field.name}
+                      isDisabled={isPending || !session}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                    >
+                      <Label>{localization.settings.currentPassword}</Label>
 
-                  <InputGroup
-                    className={cn(!session && "hidden")}
-                    variant={
-                      variant === "transparent" ? "primary" : "secondary"
-                    }
-                  >
-                    <InputGroup.Input
-                      autoComplete="current-password"
-                      name="currentPassword"
-                      placeholder={
-                        localization.settings.currentPasswordPlaceholder
-                      }
-                      required
-                      type={isCurrentPasswordVisible ? "text" : "password"}
-                    />
-
-                    <InputGroup.Suffix className="px-0">
-                      <Button
-                        isIconOnly
-                        aria-label={
-                          isCurrentPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
+                      <InputGroup
+                        className={cn(!session && "hidden")}
+                        variant={
+                          variant === "transparent" ? "primary" : "secondary"
                         }
-                        size="sm"
-                        variant="ghost"
-                        onPress={() =>
-                          setIsCurrentPasswordVisible(!isCurrentPasswordVisible)
-                        }
-                        isDisabled={isPending}
                       >
-                        {isCurrentPasswordVisible ? <EyeSlash /> : <Eye />}
-                      </Button>
-                    </InputGroup.Suffix>
-                  </InputGroup>
+                        <InputGroup.Input
+                          autoComplete="current-password"
+                          name="currentPassword"
+                          placeholder={
+                            localization.settings.currentPasswordPlaceholder
+                          }
+                          required
+                          type={isCurrentPasswordVisible ? "text" : "password"}
+                        />
 
-                  {!session && (
-                    <Skeleton className="h-10 md:h-9 w-full rounded-xl" />
+                        <InputGroup.Suffix className="px-0">
+                          <Button
+                            isIconOnly
+                            aria-label={
+                              isCurrentPasswordVisible
+                                ? localization.auth.hidePassword
+                                : localization.auth.showPassword
+                            }
+                            size="sm"
+                            variant="ghost"
+                            onPress={() =>
+                              setIsCurrentPasswordVisible(
+                                !isCurrentPasswordVisible
+                              )
+                            }
+                            isDisabled={isPending}
+                          >
+                            {isCurrentPasswordVisible ? <EyeSlash /> : <Eye />}
+                          </Button>
+                        </InputGroup.Suffix>
+                      </InputGroup>
+
+                      {!session && (
+                        <Skeleton className="h-10 md:h-9 w-full rounded-xl" />
+                      )}
+
+                      <FieldError />
+                    </TextField>
                   )}
+                </form.Field>
 
-                  <FieldError />
-                </TextField>
+                <form.Field name="newPassword">
+                  {(field) => (
+                    <TextField
+                      minLength={emailAndPassword?.minPasswordLength}
+                      maxLength={emailAndPassword?.maxPasswordLength}
+                      isDisabled={isPending || !session}
+                      value={field.state.value}
+                      onChange={(value) => {
+                        field.handleChange(value)
+                        setIsCompromised(false)
+                      }}
+                      isInvalid={isCompromised || undefined}
+                    >
+                      <Label>{localization.auth.newPassword}</Label>
 
-                <TextField
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  isDisabled={isPending || !session}
-                  value={newPassword}
-                  onChange={(value) => {
-                    setNewPassword(value)
-                    setIsCompromised(false)
-                  }}
-                  isInvalid={isCompromised || undefined}
-                >
-                  <Label>{localization.auth.newPassword}</Label>
-
-                  <InputGroup
-                    className={cn(!session && "hidden")}
-                    variant={
-                      variant === "transparent" ? "primary" : "secondary"
-                    }
-                  >
-                    <InputGroup.Input
-                      name="newPassword"
-                      type={isNewPasswordVisible ? "text" : "password"}
-                      autoComplete="new-password"
-                      placeholder={localization.auth.newPasswordPlaceholder}
-                      required
-                    />
-
-                    <InputGroup.Suffix className="px-0">
-                      <Button
-                        isIconOnly
-                        aria-label={
-                          isNewPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
+                      <InputGroup
+                        className={cn(!session && "hidden")}
+                        variant={
+                          variant === "transparent" ? "primary" : "secondary"
                         }
-                        size="sm"
-                        variant="ghost"
-                        onPress={() =>
-                          setIsNewPasswordVisible(!isNewPasswordVisible)
-                        }
-                        isDisabled={isPending}
                       >
-                        {isNewPasswordVisible ? <EyeSlash /> : <Eye />}
-                      </Button>
-                    </InputGroup.Suffix>
-                  </InputGroup>
+                        <InputGroup.Input
+                          name="newPassword"
+                          type={isNewPasswordVisible ? "text" : "password"}
+                          autoComplete="new-password"
+                          placeholder={localization.auth.newPasswordPlaceholder}
+                          required
+                        />
 
-                  {!session && (
-                    <Skeleton className="h-10 md:h-9 w-full rounded-xl" />
+                        <InputGroup.Suffix className="px-0">
+                          <Button
+                            isIconOnly
+                            aria-label={
+                              isNewPasswordVisible
+                                ? localization.auth.hidePassword
+                                : localization.auth.showPassword
+                            }
+                            size="sm"
+                            variant="ghost"
+                            onPress={() =>
+                              setIsNewPasswordVisible(!isNewPasswordVisible)
+                            }
+                            isDisabled={isPending}
+                          >
+                            {isNewPasswordVisible ? <EyeSlash /> : <Eye />}
+                          </Button>
+                        </InputGroup.Suffix>
+                      </InputGroup>
+
+                      {!session && (
+                        <Skeleton className="h-10 md:h-9 w-full rounded-xl" />
+                      )}
+
+                      {isCompromised ? (
+                        <FieldError>
+                          {localization.auth.passwordCompromised}
+                        </FieldError>
+                      ) : (
+                        <FieldError />
+                      )}
+
+                      <PasswordStrengthMeter password={field.state.value} />
+                    </TextField>
                   )}
-
-                  {isCompromised ? (
-                    <FieldError>
-                      {localization.auth.passwordCompromised}
-                    </FieldError>
-                  ) : (
-                    <FieldError />
-                  )}
-
-                  <PasswordStrengthMeter password={newPassword} />
-                </TextField>
+                </form.Field>
 
                 {emailAndPassword?.confirmPassword && (
-                  <TextField
-                    minLength={emailAndPassword?.minPasswordLength}
-                    maxLength={emailAndPassword?.maxPasswordLength}
-                    isDisabled={isPending || !session}
-                    isRequired
-                    value={confirmPassword}
-                    onChange={setConfirmPassword}
-                  >
-                    <Label>{localization.auth.confirmPassword}</Label>
+                  <form.Field name="confirmPassword">
+                    {(field) => (
+                      <TextField
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        isDisabled={isPending || !session}
+                        isRequired
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                      >
+                        <Label>{localization.auth.confirmPassword}</Label>
 
-                    <InputGroup
-                      className={cn(!session && "hidden")}
-                      variant={
-                        variant === "transparent" ? "primary" : "secondary"
-                      }
-                    >
-                      <InputGroup.Input
-                        name="confirmPassword"
-                        type={isConfirmPasswordVisible ? "text" : "password"}
-                        autoComplete="new-password"
-                        placeholder={
-                          localization.auth.confirmPasswordPlaceholder
-                        }
-                        required
-                      />
-
-                      <InputGroup.Suffix className="px-0">
-                        <Button
-                          isIconOnly
-                          aria-label={
-                            isConfirmPasswordVisible
-                              ? localization.auth.hidePassword
-                              : localization.auth.showPassword
+                        <InputGroup
+                          className={cn(!session && "hidden")}
+                          variant={
+                            variant === "transparent" ? "primary" : "secondary"
                           }
-                          size="sm"
-                          variant="ghost"
-                          onPress={() =>
-                            setIsConfirmPasswordVisible(
-                              !isConfirmPasswordVisible
-                            )
-                          }
-                          isDisabled={isPending}
                         >
-                          {isConfirmPasswordVisible ? <EyeSlash /> : <Eye />}
-                        </Button>
-                      </InputGroup.Suffix>
-                    </InputGroup>
+                          <InputGroup.Input
+                            name="confirmPassword"
+                            type={
+                              isConfirmPasswordVisible ? "text" : "password"
+                            }
+                            autoComplete="new-password"
+                            placeholder={
+                              localization.auth.confirmPasswordPlaceholder
+                            }
+                            required
+                          />
 
-                    {!session && (
-                      <Skeleton className="h-10 md:h-9 w-full rounded-xl" />
+                          <InputGroup.Suffix className="px-0">
+                            <Button
+                              isIconOnly
+                              aria-label={
+                                isConfirmPasswordVisible
+                                  ? localization.auth.hidePassword
+                                  : localization.auth.showPassword
+                              }
+                              size="sm"
+                              variant="ghost"
+                              onPress={() =>
+                                setIsConfirmPasswordVisible(
+                                  !isConfirmPasswordVisible
+                                )
+                              }
+                              isDisabled={isPending}
+                            >
+                              {isConfirmPasswordVisible ? (
+                                <EyeSlash />
+                              ) : (
+                                <Eye />
+                              )}
+                            </Button>
+                          </InputGroup.Suffix>
+                        </InputGroup>
+
+                        {!session && (
+                          <Skeleton className="h-10 md:h-9 w-full rounded-xl" />
+                        )}
+
+                        <FieldError />
+                      </TextField>
                     )}
-
-                    <FieldError />
-                  </TextField>
+                  </form.Field>
                 )}
               </Fieldset.Group>
 

--- a/packages/heroui/src/components/auth/sign-up.tsx
+++ b/packages/heroui/src/components/auth/sign-up.tsx
@@ -27,8 +27,9 @@ import {
   TextField,
   toast
 } from "@heroui/react"
+import { useForm } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
+import { type FormEvent, useRef, useState } from "react"
 import { AdditionalField } from "./additional-field"
 import { FieldSeparator } from "./field-separator"
 import { PasswordStrengthMeter } from "./password-strength-meter"
@@ -80,10 +81,7 @@ export function SignUp({
 
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
 
-  const [password, setPassword] = useState("")
-
   const [isCompromised, setIsCompromised] = useState(false)
-  const [confirmPassword, setConfirmPassword] = useState("")
 
   const { mutate: signUpEmail, isPending: signUpEmailPending } = useSignUpEmail(
     authClient,
@@ -93,8 +91,7 @@ export function SignUp({
         // it belongs against the field rather than in a toast.
         setIsCompromised(isPasswordCompromisedError(error))
 
-        setPassword("")
-        setConfirmPassword("")
+        form.reset()
         resetFetchOptions()
       },
       onSuccess: (_data, { email }) => {
@@ -130,21 +127,38 @@ export function SignUp({
   const Captcha = plugins.find(
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
+  const additionalFieldValuesRef = useRef<Record<string, unknown>>({})
+  const form = useForm({
+    defaultValues: {
+      confirmPassword: "",
+      email: "",
+      name: "",
+      password: ""
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
+        toast.danger(localization.auth.passwordsDoNotMatch)
+        form.reset()
+        return
+      }
 
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    // `emailAndPassword.name === false` hides the name field and submits "".
-    const name = (formData.get("name") as string | null) ?? ""
-    const email = formData.get("email") as string
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      toast.danger(localization.auth.passwordsDoNotMatch)
-      setPassword("")
-      setConfirmPassword("")
-      return
+      signUpEmail({
+        name: emailAndPassword?.name === false ? "" : value.name,
+        email: value.email,
+        password: value.password,
+        ...additionalFieldValuesRef.current,
+        fetchOptions
+      })
     }
+  })
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const formData = new FormData(event.currentTarget)
 
     const additionalFieldValues: Record<string, unknown> = {}
 
@@ -169,13 +183,8 @@ export function SignUp({
       }
     }
 
-    signUpEmail({
-      name,
-      email,
-      password,
-      ...additionalFieldValues,
-      fetchOptions
-    })
+    additionalFieldValuesRef.current = additionalFieldValues
+    await form.handleSubmit()
   }
 
   const showSeparator = emailAndPassword?.enabled && !!socialProviders?.length
@@ -208,48 +217,64 @@ export function SignUp({
         {emailAndPassword?.enabled && (
           <Form onSubmit={handleSubmit} className="flex flex-col gap-4">
             {emailAndPassword.name !== false && (
-              <TextField
-                name="name"
-                type="text"
-                autoComplete="name"
-                isDisabled={isPending}
-                validate={(value) => {
-                  if (!value) return localization.auth.fieldRequired
-                }}
-              >
-                <Label>{localization.auth.name}</Label>
+              <form.Field name="name">
+                {(field) => (
+                  <TextField
+                    name={field.name}
+                    type="text"
+                    autoComplete="name"
+                    isDisabled={isPending}
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                    validate={(value) => {
+                      if (!value) return localization.auth.fieldRequired
+                    }}
+                  >
+                    <Label>{localization.auth.name}</Label>
 
-                <Input
-                  placeholder={localization.auth.namePlaceholder}
-                  required
-                  variant={variant === "transparent" ? "primary" : "secondary"}
-                />
+                    <Input
+                      placeholder={localization.auth.namePlaceholder}
+                      required
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
+                      }
+                    />
 
-                <FieldError />
-              </TextField>
+                    <FieldError />
+                  </TextField>
+                )}
+              </form.Field>
             )}
 
-            <TextField
-              name="email"
-              type="email"
-              autoComplete="email"
-              isDisabled={isPending}
-              validate={(value) => {
-                if (!value) return localization.auth.fieldRequired
-                if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
-                  return localization.auth.invalidEmail
-              }}
-            >
-              <Label>{localization.auth.email}</Label>
+            <form.Field name="email">
+              {(field) => (
+                <TextField
+                  name={field.name}
+                  type="email"
+                  autoComplete="email"
+                  isDisabled={isPending}
+                  value={field.state.value}
+                  onChange={field.handleChange}
+                  validate={(value) => {
+                    if (!value) return localization.auth.fieldRequired
+                    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
+                      return localization.auth.invalidEmail
+                  }}
+                >
+                  <Label>{localization.auth.email}</Label>
 
-              <Input
-                placeholder={localization.auth.emailPlaceholder}
-                required
-                variant={variant === "transparent" ? "primary" : "secondary"}
-              />
+                  <Input
+                    placeholder={localization.auth.emailPlaceholder}
+                    required
+                    variant={
+                      variant === "transparent" ? "primary" : "secondary"
+                    }
+                  />
 
-              <FieldError />
-            </TextField>
+                  <FieldError />
+                </TextField>
+              )}
+            </form.Field>
 
             {additionalFields?.map(
               (field) =>
@@ -265,132 +290,150 @@ export function SignUp({
                 )
             )}
 
-            <TextField
-              minLength={emailAndPassword?.minPasswordLength}
-              maxLength={emailAndPassword?.maxPasswordLength}
-              name="password"
-              autoComplete="new-password"
-              isDisabled={isPending}
-              value={password}
-              onChange={(value) => {
-                setPassword(value)
-                setIsCompromised(false)
-              }}
-              isInvalid={isCompromised || undefined}
-              validate={(value) => {
-                if (!value) return localization.auth.fieldRequired
-                const min = emailAndPassword?.minPasswordLength
-                const max = emailAndPassword?.maxPasswordLength
-                if (min && value.length < min)
-                  return localization.auth.tooShort.replace(
-                    "{{min}}",
-                    String(min)
-                  )
-                if (max && value.length > max)
-                  return localization.auth.tooLong.replace(
-                    "{{max}}",
-                    String(max)
-                  )
-              }}
-            >
-              <Label>{localization.auth.password}</Label>
+            <form.Field name="password">
+              {(field) => (
+                <TextField
+                  minLength={emailAndPassword?.minPasswordLength}
+                  maxLength={emailAndPassword?.maxPasswordLength}
+                  name={field.name}
+                  autoComplete="new-password"
+                  isDisabled={isPending}
+                  value={field.state.value}
+                  onChange={(value) => {
+                    field.handleChange(value)
+                    setIsCompromised(false)
+                  }}
+                  isInvalid={isCompromised || undefined}
+                  validate={(value) => {
+                    if (!value) return localization.auth.fieldRequired
+                    const min = emailAndPassword?.minPasswordLength
+                    const max = emailAndPassword?.maxPasswordLength
+                    if (min && value.length < min)
+                      return localization.auth.tooShort.replace(
+                        "{{min}}",
+                        String(min)
+                      )
+                    if (max && value.length > max)
+                      return localization.auth.tooLong.replace(
+                        "{{max}}",
+                        String(max)
+                      )
+                  }}
+                >
+                  <Label>{localization.auth.password}</Label>
 
-              <InputGroup
-                variant={variant === "transparent" ? "primary" : "secondary"}
-              >
-                <InputGroup.Input
-                  placeholder={localization.auth.passwordPlaceholder}
-                  type={isPasswordVisible ? "text" : "password"}
-                  name="password"
-                  required
-                />
-
-                <InputGroup.Suffix className="px-0">
-                  <Button
-                    isIconOnly
-                    aria-label={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
+                  <InputGroup
+                    variant={
+                      variant === "transparent" ? "primary" : "secondary"
                     }
-                    size="sm"
-                    variant="ghost"
-                    onPress={() => setIsPasswordVisible(!isPasswordVisible)}
-                    isDisabled={isPending}
                   >
-                    {isPasswordVisible ? <EyeSlash /> : <Eye />}
-                  </Button>
-                </InputGroup.Suffix>
-              </InputGroup>
+                    <InputGroup.Input
+                      placeholder={localization.auth.passwordPlaceholder}
+                      type={isPasswordVisible ? "text" : "password"}
+                      name="password"
+                      required
+                    />
 
-              {isCompromised ? (
-                <FieldError>{localization.auth.passwordCompromised}</FieldError>
-              ) : (
-                <FieldError />
+                    <InputGroup.Suffix className="px-0">
+                      <Button
+                        isIconOnly
+                        aria-label={
+                          isPasswordVisible
+                            ? localization.auth.hidePassword
+                            : localization.auth.showPassword
+                        }
+                        size="sm"
+                        variant="ghost"
+                        onPress={() => setIsPasswordVisible(!isPasswordVisible)}
+                        isDisabled={isPending}
+                      >
+                        {isPasswordVisible ? <EyeSlash /> : <Eye />}
+                      </Button>
+                    </InputGroup.Suffix>
+                  </InputGroup>
+
+                  {isCompromised ? (
+                    <FieldError>
+                      {localization.auth.passwordCompromised}
+                    </FieldError>
+                  ) : (
+                    <FieldError />
+                  )}
+
+                  <PasswordStrengthMeter password={field.state.value} />
+                </TextField>
               )}
-
-              <PasswordStrengthMeter password={password} />
-            </TextField>
+            </form.Field>
 
             {emailAndPassword?.confirmPassword && (
-              <TextField
-                minLength={emailAndPassword?.minPasswordLength}
-                maxLength={emailAndPassword?.maxPasswordLength}
-                name="confirmPassword"
-                autoComplete="new-password"
-                isDisabled={isPending}
-                value={confirmPassword}
-                onChange={setConfirmPassword}
-                validate={(value) => {
-                  if (!value) return localization.auth.fieldRequired
-                  const min = emailAndPassword?.minPasswordLength
-                  const max = emailAndPassword?.maxPasswordLength
-                  if (min && value.length < min)
-                    return localization.auth.tooShort.replace(
-                      "{{min}}",
-                      String(min)
-                    )
-                  if (max && value.length > max)
-                    return localization.auth.tooLong.replace(
-                      "{{max}}",
-                      String(max)
-                    )
-                }}
-              >
-                <Label>{localization.auth.confirmPassword}</Label>
+              <form.Field name="confirmPassword">
+                {(field) => (
+                  <TextField
+                    minLength={emailAndPassword?.minPasswordLength}
+                    maxLength={emailAndPassword?.maxPasswordLength}
+                    name={field.name}
+                    autoComplete="new-password"
+                    isDisabled={isPending}
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                    validate={(value) => {
+                      if (!value) return localization.auth.fieldRequired
+                      const min = emailAndPassword?.minPasswordLength
+                      const max = emailAndPassword?.maxPasswordLength
+                      if (min && value.length < min)
+                        return localization.auth.tooShort.replace(
+                          "{{min}}",
+                          String(min)
+                        )
+                      if (max && value.length > max)
+                        return localization.auth.tooLong.replace(
+                          "{{max}}",
+                          String(max)
+                        )
+                    }}
+                  >
+                    <Label>{localization.auth.confirmPassword}</Label>
 
-                <InputGroup
-                  variant={variant === "transparent" ? "primary" : "secondary"}
-                >
-                  <InputGroup.Input
-                    name="confirmPassword"
-                    placeholder={localization.auth.confirmPasswordPlaceholder}
-                    type={isConfirmPasswordVisible ? "text" : "password"}
-                    required
-                  />
-
-                  <InputGroup.Suffix className="px-0">
-                    <Button
-                      isIconOnly
-                      aria-label={
-                        isConfirmPasswordVisible
-                          ? localization.auth.hidePassword
-                          : localization.auth.showPassword
+                    <InputGroup
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
                       }
-                      size="sm"
-                      variant="ghost"
-                      onPress={() =>
-                        setIsConfirmPasswordVisible(!isConfirmPasswordVisible)
-                      }
-                      isDisabled={isPending}
                     >
-                      {isConfirmPasswordVisible ? <EyeSlash /> : <Eye />}
-                    </Button>
-                  </InputGroup.Suffix>
-                </InputGroup>
+                      <InputGroup.Input
+                        name="confirmPassword"
+                        placeholder={
+                          localization.auth.confirmPasswordPlaceholder
+                        }
+                        type={isConfirmPasswordVisible ? "text" : "password"}
+                        required
+                      />
 
-                <FieldError />
-              </TextField>
+                      <InputGroup.Suffix className="px-0">
+                        <Button
+                          isIconOnly
+                          aria-label={
+                            isConfirmPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          size="sm"
+                          variant="ghost"
+                          onPress={() =>
+                            setIsConfirmPasswordVisible(
+                              !isConfirmPasswordVisible
+                            )
+                          }
+                          isDisabled={isPending}
+                        >
+                          {isConfirmPasswordVisible ? <EyeSlash /> : <Eye />}
+                        </Button>
+                      </InputGroup.Suffix>
+                    </InputGroup>
+
+                    <FieldError />
+                  </TextField>
+                )}
+              </form.Field>
             )}
 
             {additionalFields?.map(

--- a/packages/heroui/src/components/auth/sign-up.tsx
+++ b/packages/heroui/src/components/auth/sign-up.tsx
@@ -91,7 +91,8 @@ export function SignUp({
         // it belongs against the field rather than in a toast.
         setIsCompromised(isPasswordCompromisedError(error))
 
-        form.reset()
+        form.setFieldValue("password", "")
+        form.setFieldValue("confirmPassword", "")
         resetFetchOptions()
       },
       onSuccess: (_data, { email }) => {
@@ -141,7 +142,8 @@ export function SignUp({
         value.password !== value.confirmPassword
       ) {
         toast.danger(localization.auth.passwordsDoNotMatch)
-        form.reset()
+        form.setFieldValue("password", "")
+        form.setFieldValue("confirmPassword", "")
         return
       }
 

--- a/packages/heroui/src/components/auth/sso/organization-sso-providers.tsx
+++ b/packages/heroui/src/components/auth/sso/organization-sso-providers.tsx
@@ -34,8 +34,9 @@ import {
   TextField,
   toast
 } from "@heroui/react"
+import { useForm } from "@tanstack/react-form"
 import type { BetterFetchError } from "better-auth/client"
-import { type FormEvent, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
 import { ssoPlugin } from "../../../lib/auth/sso-plugin"
@@ -49,8 +50,27 @@ export type OrganizationSsoProvidersProps = {
 
 const providerSkeletonIds = ["sso-provider-1", "sso-provider-2"]
 
-const readString = (formData: FormData, name: string) =>
-  String(formData.get(name) ?? "").trim()
+type SsoProviderEditorValues = {
+  clientId: string
+  clientSecret: string
+  discoveryEndpoint: string
+  domain: string
+  entryPoint: string
+  identityProviderMetadata: string
+  issuer: string
+}
+
+const getSsoProviderEditorValues = (
+  provider?: SsoProvider
+): SsoProviderEditorValues => ({
+  clientId: "",
+  clientSecret: "",
+  discoveryEndpoint: provider?.oidcConfig?.discoveryEndpoint ?? "",
+  domain: provider?.domain ?? "",
+  entryPoint: provider?.samlConfig?.entryPoint ?? "",
+  identityProviderMetadata: "",
+  issuer: provider?.issuer ?? ""
+})
 
 const getErrorMessage = (error: Error | null) => {
   const authError = error as BetterFetchError | null
@@ -213,7 +233,11 @@ export function OrganizationSsoProviders({
         )}
       </Card.Content>
 
-      <EditSsoProviderDialog provider={editing} onOpenChange={setEditing} />
+      <EditSsoProviderDialog
+        key={editing?.providerId ?? "closed"}
+        provider={editing}
+        onOpenChange={setEditing}
+      />
       <DeleteSsoProviderDialog provider={deleting} onOpenChange={setDeleting} />
       <AlertDialog.Backdrop
         isOpen={Boolean(verifying)}
@@ -257,49 +281,47 @@ function EditSsoProviderDialog({
     update.reset()
     onOpenChange(undefined)
   }
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!provider) return
-    const data = new FormData(event.currentTarget)
-    const clientId = readString(data, "clientId")
-    const clientSecret = readString(data, "clientSecret")
-    const identityProviderMetadata = readString(
-      data,
-      "identityProviderMetadata"
-    )
-    const params = {
-      providerId: provider.providerId,
-      issuer: readString(data, "issuer"),
-      domain: readString(data, "domain"),
-      ...(provider.oidcConfig
-        ? {
-            oidcConfig: {
-              ...(clientId ? { clientId } : {}),
-              ...(clientSecret ? { clientSecret } : {}),
-              discoveryEndpoint:
-                readString(data, "discoveryEndpoint") || undefined
+  const form = useForm({
+    defaultValues: getSsoProviderEditorValues(provider),
+    onSubmit: async ({ value }) => {
+      if (!provider) return
+      const clientId = value.clientId.trim()
+      const clientSecret = value.clientSecret.trim()
+      const identityProviderMetadata = value.identityProviderMetadata.trim()
+      const params = {
+        providerId: provider.providerId,
+        issuer: value.issuer.trim(),
+        domain: value.domain.trim(),
+        ...(provider.oidcConfig
+          ? {
+              oidcConfig: {
+                ...(clientId ? { clientId } : {}),
+                ...(clientSecret ? { clientSecret } : {}),
+                discoveryEndpoint: value.discoveryEndpoint.trim() || undefined
+              }
             }
-          }
-        : {}),
-      ...(provider.samlConfig
-        ? {
-            samlConfig: {
-              entryPoint: readString(data, "entryPoint"),
-              ...(identityProviderMetadata
-                ? { idpMetadata: { metadata: identityProviderMetadata } }
-                : {})
+          : {}),
+        ...(provider.samlConfig
+          ? {
+              samlConfig: {
+                entryPoint: value.entryPoint.trim(),
+                ...(identityProviderMetadata
+                  ? { idpMetadata: { metadata: identityProviderMetadata } }
+                  : {})
+              }
             }
-          }
-        : {})
-    } as UpdateSsoProviderParams
+          : {})
+      } as UpdateSsoProviderParams
 
-    update.mutate(params, {
-      onSuccess: () => {
+      try {
+        await update.mutateAsync(params)
         toast.success(localization.providerUpdated)
         close()
+      } catch {
+        // The mutation error is rendered below the fields.
       }
-    })
-  }
+    }
+  })
 
   return (
     <AlertDialog.Backdrop
@@ -310,7 +332,12 @@ function EditSsoProviderDialog({
     >
       <AlertDialog.Container>
         <AlertDialog.Dialog className="max-w-xl">
-          <Form onSubmit={submit}>
+          <Form
+            onSubmit={(event) => {
+              event.preventDefault()
+              void form.handleSubmit()
+            }}
+          >
             <AlertDialog.CloseTrigger />
             <AlertDialog.Header>
               <AlertDialog.Heading>
@@ -318,64 +345,110 @@ function EditSsoProviderDialog({
               </AlertDialog.Heading>
             </AlertDialog.Header>
             <AlertDialog.Body className="flex flex-col gap-4 overflow-visible">
-              <TextField
-                defaultValue={provider?.domain}
-                isRequired
-                name="domain"
-              >
-                <Label>{localization.domain}</Label>
-                <Input variant="secondary" />
-                <FieldError />
-              </TextField>
-              <TextField
-                defaultValue={provider?.issuer}
-                isRequired
-                name="issuer"
-              >
-                <Label>{localization.issuer}</Label>
-                <Input type="url" variant="secondary" />
-                <FieldError />
-              </TextField>
+              {(
+                [
+                  ["domain", localization.domain, "text"],
+                  ["issuer", localization.issuer, "url"]
+                ] as const
+              ).map(([name, label, type]) => (
+                <form.Field key={name} name={name}>
+                  {(field) => (
+                    <TextField
+                      isRequired
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={field.handleChange}
+                      value={field.state.value}
+                    >
+                      <Label>{label}</Label>
+                      <Input type={type} variant="secondary" />
+                      <FieldError />
+                    </TextField>
+                  )}
+                </form.Field>
+              ))}
               {provider?.oidcConfig ? (
                 <>
-                  <TextField name="discoveryEndpoint">
-                    <Label>{localization.discoveryEndpoint}</Label>
-                    <Input
-                      defaultValue={provider.oidcConfig.discoveryEndpoint}
-                      type="url"
-                      variant="secondary"
-                    />
-                  </TextField>
+                  <form.Field name="discoveryEndpoint">
+                    {(field) => (
+                      <TextField
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={field.handleChange}
+                        value={field.state.value}
+                      >
+                        <Label>{localization.discoveryEndpoint}</Label>
+                        <Input type="url" variant="secondary" />
+                      </TextField>
+                    )}
+                  </form.Field>
                   <div className="grid gap-4 sm:grid-cols-2">
-                    <TextField name="clientId">
-                      <Label>{localization.clientId}</Label>
-                      <Input
-                        placeholder={`••••${provider.oidcConfig.clientIdLastFour}`}
-                        variant="secondary"
-                      />
-                    </TextField>
-                    <TextField name="clientSecret" type="password">
-                      <Label>{localization.clientSecret}</Label>
-                      <Input autoComplete="new-password" variant="secondary" />
-                    </TextField>
+                    <form.Field name="clientId">
+                      {(field) => (
+                        <TextField
+                          name={field.name}
+                          onBlur={field.handleBlur}
+                          onChange={field.handleChange}
+                          value={field.state.value}
+                        >
+                          <Label>{localization.clientId}</Label>
+                          <Input
+                            placeholder={`••••${provider.oidcConfig?.clientIdLastFour}`}
+                            variant="secondary"
+                          />
+                        </TextField>
+                      )}
+                    </form.Field>
+                    <form.Field name="clientSecret">
+                      {(field) => (
+                        <TextField
+                          name={field.name}
+                          onBlur={field.handleBlur}
+                          onChange={field.handleChange}
+                          type="password"
+                          value={field.state.value}
+                        >
+                          <Label>{localization.clientSecret}</Label>
+                          <Input
+                            autoComplete="new-password"
+                            variant="secondary"
+                          />
+                        </TextField>
+                      )}
+                    </form.Field>
                   </div>
                 </>
               ) : null}
               {provider?.samlConfig ? (
                 <>
-                  <TextField isRequired name="entryPoint">
-                    <Label>{localization.entryPoint}</Label>
-                    <Input
-                      defaultValue={provider.samlConfig.entryPoint}
-                      type="url"
-                      variant="secondary"
-                    />
-                    <FieldError />
-                  </TextField>
-                  <TextField name="identityProviderMetadata">
-                    <Label>{localization.identityProviderMetadata}</Label>
-                    <TextArea className="font-mono text-xs" rows={6} />
-                  </TextField>
+                  <form.Field name="entryPoint">
+                    {(field) => (
+                      <TextField
+                        isRequired
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={field.handleChange}
+                        value={field.state.value}
+                      >
+                        <Label>{localization.entryPoint}</Label>
+                        <Input type="url" variant="secondary" />
+                        <FieldError />
+                      </TextField>
+                    )}
+                  </form.Field>
+                  <form.Field name="identityProviderMetadata">
+                    {(field) => (
+                      <TextField
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={field.handleChange}
+                        value={field.state.value}
+                      >
+                        <Label>{localization.identityProviderMetadata}</Label>
+                        <TextArea className="font-mono text-xs" rows={6} />
+                      </TextField>
+                    )}
+                  </form.Field>
                 </>
               ) : null}
               {update.error ? (
@@ -390,9 +463,13 @@ function EditSsoProviderDialog({
               >
                 {localization.cancel}
               </Button>
-              <Button isPending={update.isPending} type="submit">
-                {localization.saveProvider}
-              </Button>
+              <form.Subscribe selector={(state) => state.isSubmitting}>
+                {(isSubmitting) => (
+                  <Button isPending={isSubmitting} type="submit">
+                    {localization.saveProvider}
+                  </Button>
+                )}
+              </form.Subscribe>
             </AlertDialog.Footer>
           </Form>
         </AlertDialog.Dialog>

--- a/packages/heroui/tests/sign-up.test.tsx
+++ b/packages/heroui/tests/sign-up.test.tsx
@@ -6,10 +6,12 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { AuthProvider } from "../src/components/auth/auth-provider"
 import { SignUp } from "../src/components/auth/sign-up"
 
-function createMockAuthClient() {
+function createMockAuthClient(
+  signUpEmail = vi.fn(async () => ({ data: {}, error: null }))
+) {
   return {
     signUp: {
-      email: vi.fn(async () => ({ data: {}, error: null }))
+      email: signUpEmail
     },
     useSession: () => ({ data: null, isPending: false, error: null })
   } as unknown as Parameters<typeof AuthProvider>[0]["authClient"]
@@ -100,6 +102,62 @@ describe("<SignUp />", () => {
         to: `/auth/verify-email?redirectTo=${encodeURIComponent(redirectTo)}`
       })
     })
+  })
+
+  it("clears only password fields after validation and request errors", async () => {
+    const user = userEvent.setup()
+    const signUpEmail = vi.fn(async () => {
+      throw { code: "PASSWORD_COMPROMISED" }
+    })
+
+    render(
+      <AuthProvider
+        authClient={createMockAuthClient(signUpEmail)}
+        emailAndPassword={{ confirmPassword: true }}
+        navigate={() => {}}
+        queryClient={
+          new QueryClient({
+            defaultOptions: {
+              queries: { retry: false },
+              mutations: { retry: false }
+            }
+          })
+        }
+      >
+        <SignUp />
+      </AuthProvider>
+    )
+
+    const name = screen.getByLabelText("Name")
+    const email = screen.getByLabelText("Email")
+    const password = screen.getByLabelText("Password")
+    const confirmPassword = screen.getByLabelText("Confirm password")
+
+    await user.type(name, "Ada Lovelace")
+    await user.type(email, "ada@example.com")
+    await user.type(password, "correct horse battery")
+    await user.type(confirmPassword, "different horse battery")
+    await user.click(screen.getByRole("button", { name: "Sign Up" }))
+
+    await waitFor(() => {
+      expect(password).toHaveValue("")
+      expect(confirmPassword).toHaveValue("")
+    })
+    expect(name).toHaveValue("Ada Lovelace")
+    expect(email).toHaveValue("ada@example.com")
+    expect(signUpEmail).not.toHaveBeenCalled()
+
+    await user.type(password, "compromised password")
+    await user.type(confirmPassword, "compromised password")
+    await user.click(screen.getByRole("button", { name: "Sign Up" }))
+
+    await waitFor(() => expect(signUpEmail).toHaveBeenCalledOnce())
+    await waitFor(() => {
+      expect(password).toHaveValue("")
+      expect(confirmPassword).toHaveValue("")
+    })
+    expect(name).toHaveValue("Ada Lovelace")
+    expect(email).toHaveValue("ada@example.com")
   })
 
   it("labels optional additional fields without marking required fields", () => {


### PR DESCRIPTION
## Summary

- move API key and activity list state to TanStack Table
- move SSO, OAuth client, admin create/profile, organization role, sign-up, reset-password, and change-password state to TanStack Form
- keep React, Solid, shadcn/ui, Base UI, HeroUI, Zaidan, docs, and example consumers in sync
- preserve the existing UI, permissions, validation, loading, and mutation behavior

## Validation

- `bun run registry:build`
- `bun nx run-many -t typecheck`
- `bun nx run-many -t lint`
- `bun nx run start-solid-zaidan-example:test -- tests/auth-route.test.ts --run --reporter=dot` (64 passed)
- targeted Solid registry auth-form and password-feedback assertions

The full `bun nx run-many -t test` still reports failures outside this diff: the core passkey metadata expectation and HeroUI organization-role table selection both fail in files unchanged from `main`, while documentation tests also report existing link/content assertions and one timeout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized authentication, user-management, OAuth, SSO, password, and role-editing forms with clearer validation, submission feedback, error handling, and resets.
  * Improved create and edit dialogs to preserve entered values when switching records or providers.
  * Enhanced API key and activity views with consistent sorting, filtering, pagination, and navigation.
* **Tests**
  * Updated example coverage for revised form submission and field-handling behavior.
  * Added coverage confirming password fields clear after validation or security errors while other entries remain intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->