### PR TITLE
refactor(forms): register additional fields with TanStack Form

### DIFF
--- a/apps/docs/src/components/auth/additional-field.tsx
+++ b/apps/docs/src/components/auth/additional-field.tsx
@@ -2,6 +2,8 @@
 
 import {
   type AdditionalField as AdditionalFieldConfig,
+  type AdditionalFieldFormValue,
+  getFormFieldErrors,
   resolveInputType
 } from "@better-auth-ui/core"
 import { useAuth, useCopyToClipboard } from "@better-auth-ui/react"
@@ -54,9 +56,19 @@ import { cn } from "@/lib/utils"
 export type AdditionalFieldProps = {
   name: string
   field: AdditionalFieldConfig
+  value: AdditionalFieldFormValue
+  onBlur: () => void
+  onChange: (value: AdditionalFieldFormValue) => void
+  isInvalid?: boolean
+  errors?: unknown[]
   isPending?: boolean
   /** Complete suffix appended to labels for fields that are not required. */
   optionalLabel?: string
+}
+
+function valueToString(value: AdditionalFieldFormValue) {
+  if (value == null) return ""
+  return value instanceof Date ? value.toISOString() : String(value)
 }
 
 /** Convert a `defaultValue` into a `Date` for the calendar. */
@@ -124,6 +136,11 @@ function CopyButton({
 export function AdditionalField({
   name,
   field: configuredField,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
   isPending,
   optionalLabel
 }: AdditionalFieldProps) {
@@ -140,6 +157,7 @@ export function AdditionalField({
         }
       : configuredField
   const inputType = resolveInputType(field)
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
   if (field.render) {
     const FieldRenderer = field.render as ComponentType<AdditionalFieldProps>
@@ -147,6 +165,11 @@ export function AdditionalField({
       <FieldRenderer
         name={name}
         field={field}
+        value={value}
+        onBlur={onBlur}
+        onChange={onChange}
+        isInvalid={isInvalid}
+        errors={errors}
         isPending={isPending}
         optionalLabel={optionalLabel}
       />
@@ -155,38 +178,29 @@ export function AdditionalField({
 
   if (inputType === "hidden") {
     return (
-      <input
-        type="hidden"
-        name={name}
-        value={
-          field.defaultValue == null
-            ? ""
-            : field.defaultValue instanceof Date
-              ? field.defaultValue.toISOString()
-              : String(field.defaultValue)
-        }
-      />
+      <input type="hidden" name={name} value={valueToString(value)} readOnly />
     )
   }
 
   if (inputType === "textarea") {
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <Textarea
           id={name}
           name={name}
-          defaultValue={
-            field.defaultValue == null ? undefined : String(field.defaultValue)
-          }
+          value={valueToString(value)}
+          onBlur={onBlur}
+          onChange={(event) => onChange(event.target.value || null)}
           placeholder={field.placeholder}
           required={field.required}
           readOnly={field.readOnly}
           disabled={isPending}
+          aria-invalid={isInvalid}
         />
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
@@ -195,7 +209,7 @@ export function AdditionalField({
     const maxFractionDigits = field.formatOptions?.maximumFractionDigits
 
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <Input
@@ -209,81 +223,101 @@ export function AdditionalField({
             field.step ??
             (maxFractionDigits ? 1 / 10 ** maxFractionDigits : undefined)
           }
-          defaultValue={
-            field.defaultValue == null
-              ? undefined
-              : typeof field.defaultValue === "number"
-                ? field.defaultValue
-                : String(field.defaultValue)
+          value={typeof value === "number" ? value : ""}
+          onBlur={onBlur}
+          onChange={(event) =>
+            onChange(
+              event.target.value === "" ? null : event.target.valueAsNumber
+            )
           }
           placeholder={field.placeholder}
           required={field.required}
           readOnly={field.readOnly}
           disabled={isPending}
+          aria-invalid={isInvalid}
         />
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "slider") {
-    return <SliderField name={name} field={field} isPending={isPending} />
+    return (
+      <SliderField
+        name={name}
+        field={field}
+        value={value}
+        onBlur={onBlur}
+        onChange={onChange}
+        isInvalid={isInvalid}
+        errors={errors}
+        isPending={isPending}
+      />
+    )
   }
 
   if (inputType === "switch") {
     return (
-      <Field orientation="horizontal">
+      <Field data-invalid={isInvalid} orientation="horizontal">
         <Switch
           id={name}
           name={name}
-          defaultChecked={
-            field.defaultValue === true || field.defaultValue === "true"
-          }
+          checked={value === true}
+          onBlur={onBlur}
+          onCheckedChange={onChange}
           disabled={isPending || field.readOnly}
+          aria-invalid={isInvalid}
         />
 
         <FieldContent>
           <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
         </FieldContent>
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "checkbox") {
     return (
-      <Field orientation="horizontal">
+      <Field data-invalid={isInvalid} orientation="horizontal">
         <Checkbox
           id={name}
           name={name}
-          defaultChecked={
-            field.defaultValue === true || field.defaultValue === "true"
-          }
+          checked={value === true}
+          onBlur={onBlur}
+          onCheckedChange={(checked) => onChange(checked === true)}
           required={field.required}
           disabled={isPending || field.readOnly}
+          aria-invalid={isInvalid}
         />
 
         <FieldContent>
           <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
         </FieldContent>
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "select") {
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <Select
           name={name}
-          defaultValue={
-            field.defaultValue != null ? String(field.defaultValue) : undefined
-          }
+          value={valueToString(value) || undefined}
+          onValueChange={(nextValue) => onChange(nextValue)}
           required={field.required}
           disabled={isPending || field.readOnly}
         >
-          <SelectTrigger id={name} className="w-full">
+          <SelectTrigger
+            id={name}
+            className="w-full"
+            onBlur={onBlur}
+            aria-invalid={isInvalid}
+          >
             <SelectValue placeholder={field.placeholder} />
           </SelectTrigger>
 
@@ -296,26 +330,34 @@ export function AdditionalField({
           </SelectContent>
         </Select>
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "combobox") {
+    const selectedOption = field.options?.find(
+      (option) => option.value === valueToString(value)
+    )
+
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <Combobox
           items={field.options ?? []}
           name={name}
-          defaultValue={
-            field.defaultValue != null ? String(field.defaultValue) : undefined
-          }
+          value={selectedOption ?? null}
+          onValueChange={(option) => onChange(option?.value ?? null)}
           required={field.required}
           disabled={isPending || field.readOnly}
         >
-          <ComboboxInput placeholder={field.placeholder} id={name} />
+          <ComboboxInput
+            placeholder={field.placeholder}
+            id={name}
+            onBlur={onBlur}
+            aria-invalid={isInvalid}
+          />
 
           <ComboboxContent>
             <ComboboxEmpty>No items found.</ComboboxEmpty>
@@ -330,20 +372,52 @@ export function AdditionalField({
           </ComboboxContent>
         </Combobox>
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "date" || inputType === "datetime") {
-    return <DateInput name={name} field={field} isPending={isPending} />
+    return (
+      <DateInput
+        name={name}
+        field={field}
+        value={value}
+        onBlur={onBlur}
+        onChange={onChange}
+        isInvalid={isInvalid}
+        errors={errors}
+        isPending={isPending}
+      />
+    )
   }
 
-  return <InputField name={name} field={field} isPending={isPending} />
+  return (
+    <InputField
+      name={name}
+      field={field}
+      value={value}
+      onBlur={onBlur}
+      onChange={onChange}
+      isInvalid={isInvalid}
+      errors={errors}
+      isPending={isPending}
+    />
+  )
 }
 
-function InputField({ name, field, isPending }: AdditionalFieldProps) {
+function InputField({
+  name,
+  field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
+  isPending
+}: AdditionalFieldProps) {
   const inputRef = useRef<HTMLInputElement>(null)
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
   const hasPrefix = field.prefix != null
   const hasSuffix = field.suffix != null || field.copyable
@@ -360,7 +434,7 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
 
   if (hasPrefix || hasSuffix) {
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <InputGroup>
@@ -377,15 +451,14 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
             type={nativeInputType}
             inputMode={nativeInputMode}
             step={nativeStep}
-            defaultValue={
-              field.defaultValue == null
-                ? undefined
-                : String(field.defaultValue)
-            }
+            value={valueToString(value)}
+            onBlur={onBlur}
+            onChange={(event) => onChange(event.target.value || null)}
             placeholder={field.placeholder}
             required={field.required}
             readOnly={field.readOnly}
             disabled={isPending}
+            aria-invalid={isInvalid}
           />
 
           {field.copyable ? (
@@ -404,13 +477,13 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
           )}
         </InputGroup>
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   return (
-    <Field>
+    <Field data-invalid={isInvalid}>
       <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
       <Input
@@ -419,16 +492,17 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
         type={nativeInputType}
         inputMode={nativeInputMode}
         step={nativeStep}
-        defaultValue={
-          field.defaultValue == null ? undefined : String(field.defaultValue)
-        }
+        value={valueToString(value)}
+        onBlur={onBlur}
+        onChange={(event) => onChange(event.target.value || null)}
         placeholder={field.placeholder}
         required={field.required}
         readOnly={field.readOnly}
         disabled={isPending}
+        aria-invalid={isInvalid}
       />
 
-      <FieldError />
+      <FieldError errors={fieldErrors} />
     </Field>
   )
 }
@@ -438,44 +512,51 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
  * it next to the label and control the state to keep the displayed value in
  * sync. The selected value is submitted via the underlying Radix `name` prop.
  */
-function SliderField({ name, field, isPending }: AdditionalFieldProps) {
+function SliderField({
+  name,
+  field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
+  isPending
+}: AdditionalFieldProps) {
   const maxFractionDigits = field.formatOptions?.maximumFractionDigits
   const min = field.min ?? 0
   const max = field.max ?? 100
   const step =
     field.step ?? (maxFractionDigits ? 1 / 10 ** maxFractionDigits : 1)
-  const initial =
-    typeof field.defaultValue === "number"
-      ? field.defaultValue
-      : field.defaultValue != null && !Number.isNaN(Number(field.defaultValue))
-        ? Number(field.defaultValue)
-        : min
-
-  const [value, setValue] = useState<number>(initial)
+  const numericValue = typeof value === "number" ? value : min
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
   const formatter = new Intl.NumberFormat(undefined, field.formatOptions)
 
   return (
-    <Field>
+    <Field data-invalid={isInvalid}>
       <div className="flex items-center justify-between gap-2">
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
         <span className="text-sm text-muted-foreground tabular-nums">
-          {formatter.format(value)}
+          {formatter.format(numericValue)}
         </span>
       </div>
 
       <Slider
         id={name}
         name={name}
-        value={[value]}
-        onValueChange={(v) => setValue((Array.isArray(v) ? v[0] : v) ?? min)}
+        value={[numericValue]}
+        onBlur={onBlur}
+        onValueChange={(nextValue) =>
+          onChange((Array.isArray(nextValue) ? nextValue[0] : nextValue) ?? min)
+        }
         min={min}
         max={max}
         step={step}
         disabled={isPending || field.readOnly}
+        aria-invalid={isInvalid}
       />
 
-      <FieldError />
+      <FieldError errors={fieldErrors} />
     </Field>
   )
 }
@@ -485,68 +566,42 @@ function SliderField({ name, field, isPending }: AdditionalFieldProps) {
  * (optionally) `<input type="time">` for the time. Submits the combined ISO
  * value via a hidden `<input>` so it shows up in `FormData`.
  */
-function DateInput({ name, field, isPending }: AdditionalFieldProps) {
+function DateInput({
+  name,
+  field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
+  isPending
+}: AdditionalFieldProps) {
   const { localization } = useAuth()
   const inputType = resolveInputType(field)
   const isDateTime = inputType === "datetime"
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
-  const [date, setDate] = useState<Date | undefined>(toDate(field.defaultValue))
+  const date = toDate(value)
   const [time, setTime] = useState<string>(
     isDateTime && date ? formatTime(date) : ""
   )
   const [open, setOpen] = useState(false)
-  const [error, setError] = useState<string>()
 
   // Compose the hidden form value: ISO date for "date", ISO datetime for
   // "datetime" (date + time).
-  let formValue = ""
-  if (date) {
-    if (isDateTime && time && time.trim() !== "") {
-      const [h = "0", m = "0", s = "0"] = time.split(":")
-      const combined = new Date(date)
-      combined.setHours(Number(h), Number(m), Number(s), 0)
-      formValue = combined.toISOString()
-    } else {
-      // Anchor to local midnight then serialize as ISO so the downstream
-      // `parseAdditionalFieldValue` parses the same calendar day regardless
-      // of timezone (a bare "YYYY-MM-DD" would be parsed as UTC midnight).
-      // Datetime fields with a blank time also fall through here, defaulting
-      // the time to local midnight since the parsed value is always a `Date`.
-      const localMidnight = new Date(date)
-      localMidnight.setHours(0, 0, 0, 0)
-      formValue = localMidnight.toISOString()
-    }
-  }
-
   return (
-    <Field data-invalid={!!error}>
+    <Field data-invalid={isInvalid}>
       <FieldLabel htmlFor={`${name}-date`}>{field.label}</FieldLabel>
 
       <div className="relative flex gap-2">
-        {/* Visually-hidden input so required constraint validation fires on submit.
-            onInvalid suppresses the native browser balloon and routes the message
-            through the styled <FieldError> below — matching the pattern used by
-            the Name / Email / Password fields in the sign-up form. */}
-        <input
-          aria-label={typeof field.label === "string" ? field.label : name}
-          type="text"
-          name={name}
-          value={formValue}
-          onChange={() => {}}
-          required={field.required}
-          tabIndex={-1}
-          className="sr-only"
-          onInvalid={(e) => {
-            e.preventDefault()
-            setError((e.target as HTMLInputElement).validationMessage)
-          }}
-        />
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger
             type="button"
             id={`${name}-date`}
             data-empty={!date}
-            aria-invalid={!!error}
+            aria-invalid={isInvalid}
+            aria-required={field.required}
+            onBlur={onBlur}
             disabled={isPending || field.readOnly}
             className={cn(
               buttonVariants({ variant: "outline" }),
@@ -566,8 +621,24 @@ function DateInput({ name, field, isPending }: AdditionalFieldProps) {
               defaultMonth={date}
               captionLayout="dropdown"
               onSelect={(value) => {
-                setDate(value)
-                if (value) setError(undefined)
+                if (!value) {
+                  onChange(null)
+                } else {
+                  const nextValue = new Date(value)
+                  if (isDateTime && time.trim()) {
+                    const [hours = "0", minutes = "0", seconds = "0"] =
+                      time.split(":")
+                    nextValue.setHours(
+                      Number(hours),
+                      Number(minutes),
+                      Number(seconds),
+                      0
+                    )
+                  } else {
+                    nextValue.setHours(0, 0, 0, 0)
+                  }
+                  onChange(nextValue)
+                }
                 if (!isDateTime) setOpen(false)
               }}
             />
@@ -585,7 +656,21 @@ function DateInput({ name, field, isPending }: AdditionalFieldProps) {
               id={`${name}-time`}
               step="1"
               value={time}
-              onChange={(e) => setTime(e.target.value)}
+              onChange={(event) => {
+                const nextTime = event.target.value
+                setTime(nextTime)
+                if (!date) return
+                const nextValue = new Date(date)
+                const [hours = "0", minutes = "0", seconds = "0"] =
+                  nextTime.split(":")
+                nextValue.setHours(
+                  Number(hours),
+                  Number(minutes),
+                  Number(seconds),
+                  0
+                )
+                onChange(nextValue)
+              }}
               disabled={isPending || field.readOnly}
               className="appearance-none bg-background [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
             />
@@ -593,7 +678,7 @@ function DateInput({ name, field, isPending }: AdditionalFieldProps) {
         )}
       </div>
 
-      <FieldError>{error}</FieldError>
+      <FieldError errors={fieldErrors} />
     </Field>
   )
 }

--- a/apps/docs/src/components/auth/admin/admin-users.tsx
+++ b/apps/docs/src/components/auth/admin/admin-users.tsx
@@ -1,9 +1,10 @@
 "use client"
 
 import {
-  type AdditionalFieldValue,
-  getClampedTablePageIndex,
-  parseAdditionalFieldValues
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  getClampedTablePageIndex
 } from "@better-auth-ui/core"
 import {
   type AdminAuthClient,
@@ -55,10 +56,8 @@ import {
   useDeferredValue,
   useEffect,
   useMemo,
-  useRef,
   useState
 } from "react"
-import { AdditionalField } from "@/components/auth/additional-field"
 import { UserAvatar } from "@/components/auth/user/user-avatar"
 import {
   AlertDialog,
@@ -123,7 +122,7 @@ import {
 } from "@/components/ui/table"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { adminPlugin } from "@/lib/auth/admin-plugin"
-import { useAuthForm } from "../auth-form"
+import { getAuthAdditionalFieldValidators, useAuthForm } from "../auth-form"
 
 import { createAdminColumnHelper, useAdminTable } from "./admin-table"
 
@@ -691,18 +690,16 @@ function CreateUserDialog({
   const auth = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
   const { data: session } = useSession(auth.authClient)
-  const [formError, setFormError] = useState<string>()
   const createUser = useMutation(
     createAdminUserOptions(auth.authClient, session?.user.id)
   )
   const canSetRole = useAdminPermission(auth.authClient, {
     user: ["set-role"]
   })
-  const additionalFieldValuesRef = useRef<
-    Record<string, AdditionalFieldValue | null>
-  >({})
+  const additionalFields = auth.additionalFields ?? []
   const form = useAuthForm({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(additionalFields),
       email: "",
       emailVerified: false,
       name: "",
@@ -714,7 +711,10 @@ function CreateUserDialog({
         await createUser.mutateAsync(
           {
             data: {
-              ...additionalFieldValuesRef.current,
+              ...getAdditionalFieldSubmitValues(
+                additionalFields,
+                value.additionalFields
+              ),
               emailVerified: value.emailVerified
             },
             email: value.email,
@@ -739,24 +739,8 @@ function CreateUserDialog({
 
   const close = () => {
     form.reset()
-    setFormError(undefined)
     createUser.reset()
     onOpenChange(false)
-  }
-  const prepareSubmit = async (formElement: HTMLFormElement) => {
-    const data = new FormData(formElement)
-    let additionalFieldValues: Record<string, AdditionalFieldValue | null>
-    try {
-      additionalFieldValues = await parseAdditionalFieldValues(
-        auth.additionalFields ?? [],
-        data
-      )
-    } catch (error) {
-      setFormError(error instanceof Error ? error.message : String(error))
-      return false
-    }
-    setFormError(undefined)
-    additionalFieldValuesRef.current = additionalFieldValues
   }
 
   return (
@@ -766,10 +750,7 @@ function CreateUserDialog({
     >
       <DialogContent>
         <form.AppForm>
-          <form.AuthFormRoot
-            className="flex flex-col gap-4"
-            prepareSubmit={prepareSubmit}
-          >
+          <form.AuthFormRoot className="flex flex-col gap-4">
             <DialogHeader>
               <DialogTitle>{config.localization.createUser}</DialogTitle>
               <DialogDescription>
@@ -910,18 +891,25 @@ function CreateUserDialog({
                   </Field>
                 )}
               </form.Field>
-              {auth.additionalFields?.map((field) => (
-                <AdditionalField
-                  field={field}
-                  isPending={createUser.isPending}
-                  key={field.name}
-                  name={field.name}
-                />
+              {additionalFields.map((configuredField) => (
+                <form.AppField
+                  key={configuredField.name}
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    auth.localization.auth.fieldRequired
+                  )}
+                >
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      isPending={createUser.isPending}
+                    />
+                  )}
+                </form.AppField>
               ))}
             </FieldGroup>
-            <FieldError>
-              {formError ?? getAdminErrorMessage(createUser.error)}
-            </FieldError>
+            <FieldError>{getAdminErrorMessage(createUser.error)}</FieldError>
             <DialogFooter>
               <Button onClick={close} type="button" variant="outline">
                 {config.localization.cancel}
@@ -1030,21 +1018,13 @@ function UserInspector({
   const [banReason, setBanReason] = useState("")
   const [banDuration, setBanDuration] = useState("")
   const banDurationSeconds = getBanDurationSeconds(banDuration)
-  const [profileError, setProfileError] = useState<string>()
   const [passwordOpen, setPasswordOpen] = useState(false)
   const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
-  const profileUserId = useRef(user?.id)
   const isSelf = user?.id === actor?.user.id
 
   const updateUser = useMutation(
     updateAdminUserOptions(auth.authClient, actor?.user.id)
   )
-
-  useEffect(() => {
-    if (profileUserId.current === user?.id) return
-    profileUserId.current = user?.id
-    setProfileError(undefined)
-  }, [user?.id])
 
   useEffect(() => {
     if (user?.id) updateUser.reset()
@@ -1073,11 +1053,17 @@ function UserInspector({
   const revokeSessions = useMutation(
     revokeAdminUserSessionsOptions(auth.authClient, actor?.user.id, userId)
   )
-  const profileAdditionalFieldValuesRef = useRef<
-    Record<string, AdditionalFieldValue | null>
-  >({})
+  const configuredUserFields = useMemo(
+    () =>
+      fieldsWithModelValues(
+        auth.additionalFields ?? [],
+        user ? (user as unknown as Record<string, unknown>) : {}
+      ),
+    [auth.additionalFields, user]
+  )
   const profileForm = useAuthForm({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredUserFields),
       email: "",
       emailVerified: false,
       name: "",
@@ -1092,7 +1078,10 @@ function UserInspector({
           updateUser.mutateAsync({
             userId: user.id,
             data: {
-              ...profileAdditionalFieldValuesRef.current,
+              ...getAdditionalFieldSubmitValues(
+                configuredUserFields,
+                value.additionalFields
+              ),
               name: value.name.trim(),
               ...(canSetEmail.data?.success
                 ? {
@@ -1124,6 +1113,7 @@ function UserInspector({
 
   useEffect(() => {
     profileForm.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredUserFields),
       email: user?.email ?? "",
       emailVerified: user?.emailVerified ?? false,
       name: user?.name ?? "",
@@ -1136,6 +1126,7 @@ function UserInspector({
   }, [
     config.allowMultipleRoles,
     config.defaultRole,
+    configuredUserFields,
     profileForm.reset,
     user?.email,
     user?.emailVerified,
@@ -1215,26 +1206,6 @@ function UserInspector({
         : dangerousAction === "revokeAll"
           ? config.localization.revokeAllSessions
           : config.localization.impersonateUser
-
-  const prepareSaveUser = async (formElement: HTMLFormElement) => {
-    if (!user) return false
-
-    if (canUpdate.data?.success) {
-      const formData = new FormData(formElement)
-      let additionalFieldValues: Record<string, AdditionalFieldValue | null>
-      try {
-        additionalFieldValues = await parseAdditionalFieldValues(
-          auth.additionalFields ?? [],
-          formData
-        )
-      } catch (error) {
-        setProfileError(error instanceof Error ? error.message : String(error))
-        return false
-      }
-      setProfileError(undefined)
-      profileAdditionalFieldValuesRef.current = additionalFieldValues
-    }
-  }
 
   return (
     <>
@@ -1330,10 +1301,7 @@ function UserInspector({
               </TabsList>
               <TabsContent className="min-h-0 overflow-hidden" value="overview">
                 <profileForm.AppForm>
-                  <profileForm.AuthFormRoot
-                    className="grid h-full grid-rows-[minmax(0,1fr)_auto]"
-                    prepareSubmit={prepareSaveUser}
-                  >
+                  <profileForm.AuthFormRoot className="grid h-full grid-rows-[minmax(0,1fr)_auto]">
                     <div className="overflow-y-auto">
                       <section className="flex flex-col gap-5 p-6">
                         <h3 className="font-medium">
@@ -1479,30 +1447,29 @@ function UserInspector({
                               }
                             </profileForm.Field>
                           </FieldSet>
-                          {auth.additionalFields?.map((field) => {
-                            const value = (
-                              user as unknown as Record<string, unknown>
-                            )[field.name]
-                            return (
-                              <AdditionalField
-                                field={{
-                                  ...field,
-                                  defaultValue:
-                                    value as AdditionalFieldValue | null
-                                }}
-                                isPending={
-                                  updateUser.isPending ||
-                                  !canUpdate.data?.success
-                                }
-                                key={`${user.id}-${field.name}-${String(value ?? "")}`}
-                                name={field.name}
-                              />
-                            )
-                          })}
+                          {configuredUserFields.map((configuredField) => (
+                            <profileForm.AppField
+                              key={configuredField.name}
+                              name={`additionalFields.${configuredField.name}`}
+                              validators={getAuthAdditionalFieldValidators(
+                                configuredField,
+                                auth.localization.auth.fieldRequired
+                              )}
+                            >
+                              {(field) => (
+                                <field.AuthFormAdditionalField
+                                  field={configuredField}
+                                  isPending={
+                                    updateUser.isPending ||
+                                    !canUpdate.data?.success
+                                  }
+                                />
+                              )}
+                            </profileForm.AppField>
+                          ))}
                         </FieldGroup>
                         <FieldError>
-                          {profileError ??
-                            getAdminErrorMessage(updateUser.error) ??
+                          {getAdminErrorMessage(updateUser.error) ??
                             getAdminErrorMessage(setRoleMutation.error)}
                         </FieldError>
                       </section>

--- a/apps/docs/src/components/auth/auth-form.tsx
+++ b/apps/docs/src/components/auth/auth-form.tsx
@@ -1,12 +1,19 @@
 "use client"
 
-import { getFormFieldErrors } from "@better-auth-ui/core"
+import {
+  type AdditionalField as AdditionalFieldConfig,
+  type AdditionalFieldFormValue,
+  getFormFieldErrors,
+  validateAdditionalFieldRequired,
+  validateAdditionalFieldValue
+} from "@better-auth-ui/core"
 import { createFormHook, createFormHookContexts } from "@tanstack/react-form"
-import type { ComponentProps, FormEvent } from "react"
+import { type ComponentProps, type FormEvent, useRef } from "react"
 
 import { Button } from "@/components/ui/button"
 import { FieldError } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
+import { AdditionalField, type AdditionalFieldProps } from "./additional-field"
 
 const { fieldContext, formContext, useFieldContext, useFormContext } =
   createFormHookContexts()
@@ -33,24 +40,30 @@ function AuthFormFieldError() {
 }
 
 type AuthFormRootProps = Omit<ComponentProps<"form">, "onSubmit"> & {
-  prepareSubmit?: (
-    form: HTMLFormElement
-  ) => boolean | undefined | Promise<boolean | undefined>
+  onBeforeSubmit?: () => void
 }
 
 function AuthFormRoot({
   children,
-  prepareSubmit,
+  onBeforeSubmit,
   ...props
 }: AuthFormRootProps) {
   const form = useFormContext()
+  const submittingRef = useRef(false)
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
+    if (submittingRef.current || form.state.isSubmitting) return
+
     const formElement = event.currentTarget
-    if ((await prepareSubmit?.(formElement)) === false) return
-    await form.handleSubmit()
-    if (!form.state.isValid) focusFirstInvalidAuthFormControl(formElement)
+    onBeforeSubmit?.()
+    submittingRef.current = true
+    try {
+      await form.handleSubmit()
+      if (!form.state.isValid) focusFirstInvalidAuthFormControl(formElement)
+    } finally {
+      submittingRef.current = false
+    }
   }
 
   return (
@@ -91,8 +104,32 @@ function AuthFormSubmitButton({
   )
 }
 
+type AuthFormAdditionalFieldProps = Omit<
+  AdditionalFieldProps,
+  "errors" | "isInvalid" | "name" | "onBlur" | "onChange" | "value"
+>
+
+function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
+  const field = useFieldContext<AdditionalFieldFormValue>()
+  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+
+  return (
+    <AdditionalField
+      {...props}
+      errors={
+        isInvalid ? getFormFieldErrors(field.state.meta.errors) : undefined
+      }
+      isInvalid={isInvalid}
+      name={field.name}
+      onBlur={field.handleBlur}
+      onChange={field.handleChange}
+      value={field.state.value}
+    />
+  )
+}
+
 export const { useAppForm: useAuthForm } = createFormHook({
-  fieldComponents: { AuthFormFieldError },
+  fieldComponents: { AuthFormAdditionalField, AuthFormFieldError },
   fieldContext,
   formComponents: { AuthFormRoot, AuthFormSubmitButton },
   formContext
@@ -106,4 +143,18 @@ export function isAuthFormFieldInvalid({
   isValid: boolean
 }) {
   return isTouched && !isValid
+}
+
+export function getAuthAdditionalFieldValidators(
+  field: AdditionalFieldConfig,
+  requiredMessage: string
+) {
+  return {
+    onChange: ({ value }: { value: AdditionalFieldFormValue }) =>
+      validateAdditionalFieldRequired(field, value, requiredMessage),
+    onChangeAsync: field.validate
+      ? ({ value }: { value: AdditionalFieldFormValue }) =>
+          validateAdditionalFieldValue(field, value)
+      : undefined
+  }
 }

--- a/apps/docs/src/components/auth/organization/create-organization-dialog.tsx
+++ b/apps/docs/src/components/auth/organization/create-organization-dialog.tsx
@@ -1,13 +1,16 @@
 "use client"
 
-import { parseAdditionalFieldValue } from "@better-auth-ui/core"
+import {
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useCreateOrganization } from "@better-auth-ui/react/plugins/organization"
 import { Briefcase } from "lucide-react"
-import { type SyntheticEvent, useEffect, useRef, useState } from "react"
-import { toast } from "sonner"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useEffect, useRef, useState } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -17,11 +20,14 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 import { SlugField, sanitizeSlug } from "./slug-field"
 
 /** Props for the `CreateOrganizationDialog` component. */
@@ -44,150 +50,153 @@ export function CreateOrganizationDialog({
   } = useAuthPlugin(organizationPlugin)
   const hideSlug = hideSlugProp ?? pluginHideSlug ?? false
 
-  const [name, setName] = useState("")
-  const [slug, setSlug] = useState("")
   const [slugEdited, setSlugEdited] = useState(false)
-  const [nameError, setNameError] = useState<string>()
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const submissionLocked = useRef(false)
+  const submissionGeneration = useRef(0)
+  const submissionAttemptGeneration = useRef(0)
 
-  const { mutate: createOrganization, isPending: isCreating } =
-    useCreateOrganization(authClient, {
-      onSuccess: () => onOpenChange(false),
-      onSettled: () => {
-        submissionLocked.current = false
-        setIsSubmitting(false)
-      }
-    })
+  const { mutateAsync: createOrganization } = useCreateOrganization(authClient)
 
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    if (submissionLocked.current) return
-
-    submissionLocked.current = true
-    setIsSubmitting(true)
-    const formData = new FormData(e.currentTarget)
-    const additionalValues: Record<string, unknown> = {}
-    try {
-      for (const field of additionalFields) {
-        const value = parseAdditionalFieldValue(
-          field,
-          formData.get(field.name) as string | null
-        )
-        await field.validate?.(value)
-        if (value !== undefined) additionalValues[field.name] = value
-      }
-    } catch (error) {
-      submissionLocked.current = false
-      setIsSubmitting(false)
-      toast.error(error instanceof Error ? error.message : String(error))
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(additionalFields),
+      name: "",
+      slug: ""
+    },
+    onSubmit: async ({ value }) => {
+      const generation = submissionAttemptGeneration.current
+      if (generation !== submissionGeneration.current) return
+      await createOrganization({
+        ...getAdditionalFieldSubmitValues(
+          additionalFields,
+          value.additionalFields
+        ),
+        name: value.name,
+        slug: hideSlug ? undefined : value.slug
+      })
+      if (generation === submissionGeneration.current) onOpenChange(false)
     }
-    createOrganization({
-      ...additionalValues,
-      name,
-      slug: hideSlug ? undefined : slug
-    })
-  }
-
-  const isPending = isCreating || isSubmitting
+  })
 
   useEffect(() => {
     if (!open) {
-      setSlug("")
-      setName("")
+      submissionGeneration.current += 1
+      form.reset()
       setSlugEdited(false)
-      setNameError(undefined)
     }
-  }, [open])
-
-  useEffect(() => {
-    if (slugEdited) return
-    setSlug(sanitizeSlug(name))
-  }, [name, slugEdited])
+  }, [form, open])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Briefcase />
-              {organizationLocalization.createOrganization}
-            </DialogTitle>
+        <form.AppForm>
+          <form.AuthFormRoot
+            className="flex flex-col gap-6"
+            onBeforeSubmit={() => {
+              submissionAttemptGeneration.current = submissionGeneration.current
+            }}
+          >
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Briefcase />
+                {organizationLocalization.createOrganization}
+              </DialogTitle>
 
-            <DialogDescription>
-              {organizationLocalization.organizationsDescription}
-            </DialogDescription>
-          </DialogHeader>
+              <DialogDescription>
+                {organizationLocalization.organizationsDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <div className="flex flex-col gap-4">
-            <Field data-invalid={!!nameError}>
-              <FieldLabel htmlFor="create-organization-name">
-                {organizationLocalization.name}
-              </FieldLabel>
-
-              <Input
-                id="create-organization-name"
+            <div className="flex flex-col gap-4">
+              <form.AppField
                 name="name"
-                autoFocus
-                required
-                placeholder={organizationLocalization.namePlaceholder}
-                value={name}
-                onChange={(e) => {
-                  setName(e.target.value)
-                  setNameError(undefined)
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired,
+                      trim: true
+                    })
                 }}
-                onInvalid={(e) => {
-                  e.preventDefault()
-                  setNameError(localization.auth.fieldRequired)
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="create-organization-name">
+                        {organizationLocalization.name}
+                      </FieldLabel>
+
+                      <Input
+                        id="create-organization-name"
+                        name={field.name}
+                        autoFocus
+                        placeholder={organizationLocalization.namePlaceholder}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => {
+                          const value = event.target.value
+                          field.handleChange(value)
+                          if (!slugEdited) {
+                            form.setFieldValue("slug", sanitizeSlug(value))
+                          }
+                        }}
+                        aria-invalid={isInvalid}
+                      />
+
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
                 }}
-                aria-invalid={!!nameError}
-                disabled={isPending}
-              />
+              </form.AppField>
 
-              <FieldError>{nameError}</FieldError>
-            </Field>
+              {!hideSlug && (
+                <form.AppField name="slug">
+                  {(field) => (
+                    <SlugField
+                      id="create-organization-slug"
+                      value={field.state.value}
+                      onChange={(value) => {
+                        field.handleChange(value)
+                        setSlugEdited(true)
+                      }}
+                    />
+                  )}
+                </form.AppField>
+              )}
 
-            {!hideSlug && (
-              <SlugField
-                id="create-organization-slug"
-                value={slug}
-                onChange={(value) => {
-                  setSlug(value)
-                  setSlugEdited(true)
-                }}
-                disabled={isPending}
-              />
-            )}
+              {additionalFields.map((configuredField) => (
+                <form.AppField
+                  key={configuredField.name}
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    localization.auth.fieldRequired
+                  )}
+                >
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      optionalLabel={localization.settings.optional}
+                    />
+                  )}
+                </form.AppField>
+              ))}
+            </div>
 
-            {additionalFields.map((field) => (
-              <AdditionalField
-                key={field.name}
-                field={field}
-                isPending={isPending}
-                name={field.name}
-                optionalLabel={localization.settings.optional}
-              />
-            ))}
-          </div>
+            <DialogFooter>
+              <DialogClose
+                className={buttonVariants({ variant: "outline" })}
+                type="button"
+              >
+                {localization.settings.cancel}
+              </DialogClose>
 
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              disabled={isPending}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Spinner />}
-
-              {organizationLocalization.createOrganization}
-            </Button>
-          </DialogFooter>
-        </form>
+              <form.AuthFormSubmitButton>
+                {organizationLocalization.createOrganization}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/apps/docs/src/components/auth/organization/invite-member-dialog.tsx
+++ b/apps/docs/src/components/auth/organization/invite-member-dialog.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { parseAdditionalFieldValues } from "@better-auth-ui/core"
+import {
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateEmailAddress
+} from "@better-auth-ui/core"
 import {
   mergeOrganizationRoleLabels,
   type OrganizationAuthClient,
@@ -17,16 +21,9 @@ import {
   useListTeams
 } from "@better-auth-ui/react/plugins/organization"
 import { ChevronDown, UserPlus } from "lucide-react"
-import {
-  type SyntheticEvent,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from "react"
+import { useEffect, useMemo, useRef } from "react"
 import { toast } from "sonner"
-import { AdditionalField } from "@/components/auth/additional-field"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -42,7 +39,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import {
   Select,
@@ -52,9 +49,13 @@ import {
   SelectTrigger,
   SelectValue
 } from "@/components/ui/select"
-import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 
 /** Props for the `InviteMemberDialog` component. */
 export type InviteMemberDialogProps = {
@@ -107,38 +108,10 @@ export function InviteMemberDialog({
     [dynamicRoles.data, roles]
   )
 
-  const [selectedRoles, setSelectedRoles] = useState(() => {
-    const fallback = pickDefaultRole(Object.keys(assignableRoles))
-    return fallback ? [fallback] : []
-  })
-  const [teamId, setTeamId] = useState("")
-  const [emailError, setEmailError] = useState<string>()
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const activeOrganizationId = activeOrganization?.id
   const previousOrganizationId = useRef(activeOrganizationId)
 
-  useEffect(() => {
-    setSelectedRoles((current) => {
-      const keys = Object.keys(assignableRoles)
-      const kept = current.filter((entry) => keys.includes(entry))
-
-      if (kept.length > 0) return allowMultipleRoles ? kept : kept.slice(0, 1)
-
-      const fallback = pickDefaultRole(keys)
-      return fallback ? [fallback] : []
-    })
-  }, [allowMultipleRoles, assignableRoles])
-
-  useEffect(() => {
-    const organizationChanged =
-      previousOrganizationId.current !== activeOrganizationId
-
-    if (open || organizationChanged) setTeamId("")
-    if (!open) setEmailError(undefined)
-    previousOrganizationId.current = activeOrganizationId
-  }, [open, activeOrganizationId])
-
-  const { mutate: inviteMember, isPending: isInviting } = useInviteMember(
+  const { mutateAsync: inviteMember, isPending: isInviting } = useInviteMember(
     authClient as OrganizationTeamsAuthClient,
     {
       onSuccess: () => {
@@ -148,249 +121,322 @@ export function InviteMemberDialog({
     }
   )
 
-  const isRoleValid = selectedRoles.length > 0
-
-  const roleSummary = selectedRoles
-    .map((entry) => assignableRoles[entry] ?? entry)
-    .join(", ")
-
-  const toggleRole = (role: string) => {
-    setSelectedRoles((current) =>
-      current.includes(role)
-        ? current.filter((entry) => entry !== role)
-        : [...current, role]
-    )
-  }
-
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (
-      !activeOrganizationId ||
-      !canInvite.data?.success ||
-      !isRoleValid ||
-      atInvitationLimit
-    )
-      return
-
-    const formData = new FormData(e.currentTarget)
-    const invitationEmail = (formData.get("email") as string).trim()
-    const invitationRoles = [...selectedRoles] as Parameters<
-      typeof inviteMember
-    >[0]["role"]
-    const selectedTeamId = teams.data?.some((team) => team.id === teamId)
-      ? teamId
-      : undefined
-
-    setIsSubmitting(true)
-    let invitationValues: Record<string, unknown>
-    try {
-      invitationValues = await parseAdditionalFieldValues(
-        invitationFields,
-        formData
-      )
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      setIsSubmitting(false)
-      return
-    }
-
-    inviteMember(
-      {
-        ...invitationValues,
-        email: invitationEmail,
-        organizationId: activeOrganizationId,
-        role: invitationRoles,
-        teamId: selectedTeamId
-      },
-      { onSettled: () => setIsSubmitting(false) }
-    )
-  }
-
   const atInvitationLimit =
     invitationLimit !== undefined &&
     (invitations.data?.filter((invitation) => invitation.status === "pending")
       .length ?? 0) >= invitationLimit
 
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(invitationFields),
+      email: "",
+      roles: [] as string[],
+      teamId: ""
+    },
+    onSubmit: async ({ value }) => {
+      if (
+        !activeOrganizationId ||
+        !canInvite.data?.success ||
+        value.roles.length === 0 ||
+        atInvitationLimit
+      )
+        return
+
+      const teamId = teams.data?.some((team) => team.id === value.teamId)
+        ? value.teamId
+        : undefined
+
+      try {
+        await inviteMember({
+          ...getAdditionalFieldSubmitValues(
+            invitationFields,
+            value.additionalFields
+          ),
+          email: value.email.trim(),
+          organizationId: activeOrganizationId,
+          role: value.roles as Parameters<typeof inviteMember>[0]["role"],
+          teamId
+        })
+      } catch {
+        // The mutation reports the error through its configured handler.
+      }
+    }
+  })
+
+  useEffect(() => {
+    const keys = Object.keys(assignableRoles)
+    const current = form.getFieldValue("roles")
+    const kept = current.filter((entry) => keys.includes(entry))
+    const roles =
+      kept.length > 0
+        ? allowMultipleRoles
+          ? kept
+          : kept.slice(0, 1)
+        : (() => {
+            const fallback = pickDefaultRole(keys)
+            return fallback ? [fallback] : []
+          })()
+
+    form.setFieldValue("roles", roles)
+  }, [allowMultipleRoles, assignableRoles, form])
+
+  useEffect(() => {
+    const organizationChanged =
+      previousOrganizationId.current !== activeOrganizationId
+
+    if (open || organizationChanged) {
+      const fallback = pickDefaultRole(Object.keys(assignableRoles))
+      form.reset({
+        additionalFields: getAdditionalFieldDefaultValues(invitationFields),
+        email: "",
+        roles: fallback ? [fallback] : [],
+        teamId: ""
+      })
+    }
+    previousOrganizationId.current = activeOrganizationId
+  }, [activeOrganizationId, assignableRoles, form, invitationFields, open])
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <UserPlus />
-              {organizationLocalization.inviteMember}
-            </DialogTitle>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <UserPlus />
+                {organizationLocalization.inviteMember}
+              </DialogTitle>
 
-            <DialogDescription>
-              {organizationLocalization.inviteMemberDescription}
-            </DialogDescription>
-          </DialogHeader>
+              <DialogDescription>
+                {organizationLocalization.inviteMemberDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <div className="flex flex-col gap-4">
-            <Field data-invalid={!!emailError}>
-              <FieldLabel htmlFor="invite-member-email">
-                {localization.auth.email}
-              </FieldLabel>
-
-              <Input
-                id="invite-member-email"
+            <div className="flex flex-col gap-4">
+              <form.AppField
                 name="email"
-                type="email"
-                autoFocus
-                required
-                placeholder={localization.auth.email}
-                disabled={isInviting}
-                onChange={() => setEmailError(undefined)}
-                onInvalid={(e) => {
-                  e.preventDefault()
-                  const el = e.target as HTMLInputElement
-                  const msg = el.validity.valueMissing
-                    ? localization.auth.fieldRequired
-                    : localization.auth.invalidEmail
-                  setEmailError(msg)
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
                 }}
-                aria-invalid={!!emailError}
-              />
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
-              <FieldError>{emailError}</FieldError>
-            </Field>
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="invite-member-email">
+                        {localization.auth.email}
+                      </FieldLabel>
+                      <Input
+                        id="invite-member-email"
+                        name={field.name}
+                        type="email"
+                        autoFocus
+                        placeholder={localization.auth.email}
+                        disabled={isInviting}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        aria-invalid={isInvalid}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
 
-            <Field>
-              <FieldLabel htmlFor="invite-member-role">
-                {organizationLocalization.role}
-              </FieldLabel>
+              <form.AppField
+                name="roles"
+                validators={{
+                  onChange: ({ value }) =>
+                    value.length > 0
+                      ? undefined
+                      : localization.auth.fieldRequired
+                }}
+              >
+                {(field) => {
+                  const selectedRoles = field.state.value
+                  const roleSummary = selectedRoles
+                    .map((entry) => assignableRoles[entry] ?? entry)
+                    .join(", ")
+                  const toggleRole = (role: string) =>
+                    field.handleChange(
+                      selectedRoles.includes(role)
+                        ? selectedRoles.filter((entry) => entry !== role)
+                        : [...selectedRoles, role]
+                    )
 
-              {allowMultipleRoles ? (
-                <DropdownMenu>
-                  <DropdownMenuTrigger
-                    id="invite-member-role"
-                    disabled={isInviting}
-                    className={cn(
-                      buttonVariants({ variant: "outline" }),
-                      "w-full justify-between font-normal"
-                    )}
-                  >
-                    <span
-                      className={cn(!roleSummary && "text-muted-foreground")}
+                  return (
+                    <Field
+                      data-invalid={isAuthFormFieldInvalid(field.state.meta)}
                     >
-                      {roleSummary || organizationLocalization.selectRoles}
-                    </span>
-                    <ChevronDown className="opacity-50" />
-                  </DropdownMenuTrigger>
+                      <FieldLabel htmlFor="invite-member-role">
+                        {organizationLocalization.role}
+                      </FieldLabel>
+                      {allowMultipleRoles ? (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger
+                            id="invite-member-role"
+                            disabled={isInviting}
+                            className={cn(
+                              buttonVariants({ variant: "outline" }),
+                              "w-full justify-between font-normal"
+                            )}
+                          >
+                            <span
+                              className={cn(
+                                !roleSummary && "text-muted-foreground"
+                              )}
+                            >
+                              {roleSummary ||
+                                organizationLocalization.selectRoles}
+                            </span>
+                            <ChevronDown className="opacity-50" />
+                          </DropdownMenuTrigger>
 
-                  <DropdownMenuContent
-                    align="start"
-                    className="w-(--radix-dropdown-menu-trigger-width)"
-                  >
-                    {Object.entries(assignableRoles).map(([key, label]) => {
-                      const checked = selectedRoles.includes(key)
+                          <DropdownMenuContent
+                            align="start"
+                            className="w-(--radix-dropdown-menu-trigger-width)"
+                          >
+                            {Object.entries(assignableRoles).map(
+                              ([key, label]) => {
+                                const checked = selectedRoles.includes(key)
 
-                      return (
-                        <DropdownMenuCheckboxItem
-                          key={key}
-                          checked={checked}
-                          disabled={checked && selectedRoles.length === 1}
-                          onSelect={(event) => {
-                            event.preventDefault()
-                            toggleRole(key)
-                          }}
+                                return (
+                                  <DropdownMenuCheckboxItem
+                                    key={key}
+                                    checked={checked}
+                                    disabled={
+                                      checked && selectedRoles.length === 1
+                                    }
+                                    onSelect={(event) => {
+                                      event.preventDefault()
+                                      toggleRole(key)
+                                    }}
+                                  >
+                                    {label}
+                                  </DropdownMenuCheckboxItem>
+                                )
+                              }
+                            )}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      ) : (
+                        <Select
+                          disabled={isInviting}
+                          onValueChange={(role) => field.handleChange([role])}
+                          value={selectedRoles[0] ?? ""}
                         >
-                          {label}
-                        </DropdownMenuCheckboxItem>
-                      )
-                    })}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              ) : (
-                <Select
-                  disabled={isInviting}
-                  onValueChange={(role) => setSelectedRoles([role])}
-                  value={selectedRoles[0] ?? ""}
-                >
-                  <SelectTrigger id="invite-member-role" className="w-full">
-                    <SelectValue
-                      placeholder={organizationLocalization.selectRoles}
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      {Object.entries(assignableRoles).map(([key, label]) => (
-                        <SelectItem key={key} value={key}>
-                          {label}
-                        </SelectItem>
-                      ))}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
+                          <SelectTrigger
+                            id="invite-member-role"
+                            className="w-full"
+                          >
+                            <SelectValue
+                              placeholder={organizationLocalization.selectRoles}
+                            />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              {Object.entries(assignableRoles).map(
+                                ([key, label]) => (
+                                  <SelectItem key={key} value={key}>
+                                    {label}
+                                  </SelectItem>
+                                )
+                              )}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      )}
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+
+              {teamsEnabled && (
+                <form.AppField name="teamId">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="invite-member-team">
+                        {organizationLocalization.team}
+                      </FieldLabel>
+                      <Select
+                        value={field.state.value}
+                        onValueChange={(value) =>
+                          field.handleChange(value ?? "")
+                        }
+                        disabled={isInviting}
+                      >
+                        <SelectTrigger
+                          id="invite-member-team"
+                          className="w-full"
+                        >
+                          <SelectValue
+                            placeholder={organizationLocalization.selectTeam}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {teams.data?.map((team) => (
+                            <SelectItem key={team.id} value={team.id}>
+                              {team.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </Field>
+                  )}
+                </form.AppField>
               )}
 
-              <FieldError />
-            </Field>
-
-            {teamsEnabled && (
-              <Field>
-                <FieldLabel htmlFor="invite-member-team">
-                  {organizationLocalization.team}
-                </FieldLabel>
-                <Select
-                  value={teamId}
-                  onValueChange={(value) => setTeamId(value ?? "")}
-                  disabled={isInviting}
+              {invitationFields.map((configuredField) => (
+                <form.AppField
+                  key={configuredField.name}
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    localization.auth.fieldRequired
+                  )}
                 >
-                  <SelectTrigger id="invite-member-team" className="w-full">
-                    <SelectValue
-                      placeholder={organizationLocalization.selectTeam}
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      isPending={isInviting}
+                      optionalLabel={localization.settings.optional}
                     />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {teams.data?.map((team) => (
-                      <SelectItem key={team.id} value={team.id}>
-                        {team.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </Field>
-            )}
+                  )}
+                </form.AppField>
+              ))}
+            </div>
 
-            {invitationFields.map((field) => (
-              <AdditionalField
-                key={field.name}
-                field={field}
-                name={field.name}
-                isPending={isInviting || isSubmitting}
-                optionalLabel={localization.settings.optional}
-              />
-            ))}
-          </div>
+            <DialogFooter>
+              <DialogClose
+                className={buttonVariants({ variant: "outline" })}
+                disabled={isInviting}
+                type="button"
+              >
+                {localization.settings.cancel}
+              </DialogClose>
 
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              disabled={isInviting || isSubmitting}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-
-            <Button
-              type="submit"
-              disabled={
-                isInviting ||
-                isSubmitting ||
-                !isRoleValid ||
-                atInvitationLimit ||
-                canInvite.isPending ||
-                !canInvite.data?.success
-              }
-            >
-              {(isInviting || isSubmitting) && <Spinner />}
-
-              {organizationLocalization.inviteMember}
-            </Button>
-          </DialogFooter>
-        </form>
+              <form.AuthFormSubmitButton
+                disabled={
+                  isInviting ||
+                  atInvitationLimit ||
+                  canInvite.isPending ||
+                  !canInvite.data?.success
+                }
+              >
+                {organizationLocalization.inviteMember}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/apps/docs/src/components/auth/organization/organization-profile.tsx
+++ b/apps/docs/src/components/auth/organization/organization-profile.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { parseAdditionalFieldValue } from "@better-auth-ui/core"
+import {
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
@@ -8,18 +13,20 @@ import {
   useHasPermission,
   useUpdateOrganization
 } from "@better-auth-ui/react/plugins/organization"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 import { ChangeOrganizationLogo } from "./change-organization-logo"
 import { SlugField } from "./slug-field"
 
@@ -48,44 +55,46 @@ export function OrganizationProfile({
     permissions: { organization: ["update"] }
   })
 
-  const [slug, setSlug] = useState(activeOrganization?.slug ?? "")
-
-  useEffect(() => {
-    setSlug(activeOrganization?.slug ?? "")
-  }, [activeOrganization?.slug])
-
-  const { mutate: commitOrganizationUpdate, isPending } = useUpdateOrganization(
-    authClient,
-    {
+  const { mutateAsync: commitOrganizationUpdate, isPending } =
+    useUpdateOrganization(authClient, {
       onSuccess: () =>
         toast.success(organizationLocalization.organizationUpdatedSuccess)
-    }
-  )
-
-  async function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    if (!activeOrganization || !canUpdate.data?.success) return
-    const formData = new FormData(e.currentTarget)
-    const name = formData.get("name") as string
-    const additionalValues: Record<string, unknown> = {}
-    try {
-      for (const field of additionalFields) {
-        const value = parseAdditionalFieldValue(
-          field,
-          formData.get(field.name) as string | null
-        )
-        await field.validate?.(value)
-        if (value !== undefined) additionalValues[field.name] = value
-      }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      return
-    }
-
-    commitOrganizationUpdate({
-      data: { ...additionalValues, name, ...(!hideSlug && { slug }) }
     })
-  }
+
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(additionalFields),
+      name: "",
+      slug: ""
+    },
+    onSubmit: async ({ value }) => {
+      if (!activeOrganization || !canUpdate.data?.success) return
+      await commitOrganizationUpdate({
+        data: {
+          ...getAdditionalFieldSubmitValues(
+            additionalFields,
+            value.additionalFields
+          ),
+          name: value.name,
+          ...(!hideSlug && { slug: value.slug })
+        }
+      })
+    }
+  })
+
+  useEffect(() => {
+    if (!activeOrganization) return
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(
+        fieldsWithModelValues(
+          additionalFields,
+          activeOrganization as Record<string, unknown>
+        )
+      ),
+      name: activeOrganization.name,
+      slug: activeOrganization.slug
+    })
+  }, [activeOrganization, additionalFields, form])
 
   const nameInputId = `${activeOrganization?.id ?? "org"}-name`
   const slugInputId = `${activeOrganization?.id ?? "org"}-slug`
@@ -100,76 +109,104 @@ export function OrganizationProfile({
 
       <Card className={className}>
         <CardContent>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <ChangeOrganizationLogo />
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-4">
+              <ChangeOrganizationLogo />
 
-            <Field>
-              <FieldLabel htmlFor={nameInputId}>
-                {organizationLocalization.name}
-              </FieldLabel>
-
-              {activeOrganization ? (
-                <Input
-                  key={activeOrganization.id}
-                  id={nameInputId}
-                  name="name"
-                  defaultValue={activeOrganization.name}
-                  autoComplete="organization"
-                  placeholder={organizationLocalization.namePlaceholder}
-                  disabled={formDisabled}
-                />
-              ) : (
-                <Skeleton className="h-8 w-full rounded-md" />
-              )}
-
-              <FieldError />
-            </Field>
-
-            {!hideSlug &&
-              (activeOrganization ? (
-                <SlugField
-                  id={slugInputId}
-                  value={slug}
-                  onChange={setSlug}
-                  currentSlug={activeOrganization.slug}
-                  disabled={formDisabled}
-                />
-              ) : (
-                <Field>
-                  <FieldLabel>{organizationLocalization.slug}</FieldLabel>
-                  <Skeleton className="h-8 w-full rounded-md" />
-                </Field>
-              ))}
-
-            {activeOrganization &&
-              additionalFields.map((field) => (
-                <AdditionalField
-                  key={field.name}
-                  field={{
-                    ...field,
-                    defaultValue: (
-                      activeOrganization as Record<string, unknown>
-                    )[field.name] as never
-                  }}
-                  isPending={formDisabled}
-                  name={field.name}
-                  optionalLabel={localization.settings.optional}
-                />
-              ))}
-
-            {(canUpdate.isPending || canUpdate.data?.success) && (
-              <Button
-                type="submit"
-                disabled={formDisabled || !activeOrganization}
-                size="sm"
-                className="mt-1 w-fit"
+              <form.AppField
+                name="name"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
               >
-                {isPending && <Spinner />}
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
-                {localization.settings.saveChanges}
-              </Button>
-            )}
-          </form>
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor={nameInputId}>
+                        {organizationLocalization.name}
+                      </FieldLabel>
+
+                      {activeOrganization ? (
+                        <Input
+                          id={nameInputId}
+                          name={field.name}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          autoComplete="organization"
+                          placeholder={organizationLocalization.namePlaceholder}
+                          disabled={formDisabled}
+                          aria-invalid={isInvalid}
+                        />
+                      ) : (
+                        <Skeleton className="h-8 w-full rounded-md" />
+                      )}
+
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+
+              {!hideSlug &&
+                (activeOrganization ? (
+                  <form.AppField name="slug">
+                    {(field) => (
+                      <SlugField
+                        id={slugInputId}
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        currentSlug={activeOrganization.slug}
+                        disabled={formDisabled}
+                      />
+                    )}
+                  </form.AppField>
+                ) : (
+                  <Field>
+                    <FieldLabel>{organizationLocalization.slug}</FieldLabel>
+                    <Skeleton className="h-8 w-full rounded-md" />
+                  </Field>
+                ))}
+
+              {activeOrganization &&
+                additionalFields.map((configuredField) => (
+                  <form.AppField
+                    key={configuredField.name}
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={formDisabled}
+                        optionalLabel={localization.settings.optional}
+                      />
+                    )}
+                  </form.AppField>
+                ))}
+
+              {(canUpdate.isPending || canUpdate.data?.success) && (
+                <form.AuthFormSubmitButton
+                  disabled={formDisabled || !activeOrganization}
+                  size="sm"
+                  className="mt-1 w-fit"
+                >
+                  {localization.settings.saveChanges}
+                </form.AuthFormSubmitButton>
+              )}
+            </form.AuthFormRoot>
+          </form.AppForm>
         </CardContent>
       </Card>
     </div>

--- a/apps/docs/src/components/auth/organization/organization-roles.tsx
+++ b/apps/docs/src/components/auth/organization/organization-roles.tsx
@@ -3,7 +3,9 @@
 import {
   type AdditionalFields,
   fieldsWithModelValues,
-  parseAdditionalFieldValues
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type { OrganizationRolesAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
@@ -16,7 +18,7 @@ import {
   useUpdateRole
 } from "@better-auth-ui/react/plugins/organization"
 import { Filter, Pencil, Plus, Search, Trash2, X } from "lucide-react"
-import { type FormEvent, useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -67,7 +69,11 @@ import {
 } from "@/components/ui/table"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 import { OrganizationSortableTableHead } from "./organization-sortable-table-head"
 import {
   createOrganizationColumnHelper,
@@ -620,9 +626,6 @@ function RoleDialog({
   const { authClient, localization: authLocalization } =
     useAuth<OrganizationRolesAuthClient>()
   const { localization } = useAuthPlugin(organizationPlugin)
-  const [name, setName] = useState("")
-  const [permission, setPermission] = useState<Record<string, string[]>>({})
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const createRole = useCreateRole(authClient, organizationId, {
     onSuccess: () => {
       toast.success(localization.roleCreated)
@@ -636,154 +639,207 @@ function RoleDialog({
     }
   })
 
-  useEffect(() => {
-    if (!open) return
-    setName(role?.role ?? "")
-    setPermission(role?.permission ?? {})
-  }, [open, role])
+  const configuredRoleFields = useMemo(
+    () => fieldsWithModelValues(roleFields, role ?? {}),
+    [role, roleFields]
+  )
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredRoleFields),
+      name: role?.role ?? "",
+      permission: role?.permission ?? ({} as Record<string, string[]>)
+    },
+    onSubmit: async ({ value }) => {
+      const roleName = value.name.trim()
+      if (!roleName) return
 
-  async function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    const roleName = name.trim()
-    if (!roleName) return
+      try {
+        if (
+          Object.values(value.permission).some((actions) => actions.length > 0)
+        ) {
+          const access = await authClient.organization.hasPermission({
+            organizationId,
+            permissions: value.permission as Parameters<
+              OrganizationRolesAuthClient["organization"]["hasPermission"]
+            >[0]["permissions"]
+          })
 
-    setIsSubmitting(true)
-    try {
-      if (Object.values(permission).some((actions) => actions.length > 0)) {
-        const access = await authClient.organization.hasPermission({
-          organizationId,
-          permissions: permission as Parameters<
-            OrganizationRolesAuthClient["organization"]["hasPermission"]
-          >[0]["permissions"]
-        })
-
-        if (access.error || !access.data?.success) {
-          toast.error(localization.permissionsLimitedDescription)
-          setIsSubmitting(false)
-          return
+          if (access.error || !access.data?.success) {
+            toast.error(localization.permissionsLimitedDescription)
+            return
+          }
         }
-      }
 
-      const additionalFields = await parseAdditionalFieldValues(
-        roleFields,
-        new FormData(event.currentTarget)
-      )
-      if (role) {
-        updateRole.mutate(
-          {
+        const additionalFields = getAdditionalFieldSubmitValues(
+          configuredRoleFields,
+          value.additionalFields
+        )
+        if (role) {
+          await updateRole.mutateAsync({
             organizationId,
             roleId: role.id,
-            data: { ...additionalFields, roleName, permission }
-          },
-          { onSettled: () => setIsSubmitting(false) }
-        )
-      } else {
-        createRole.mutate(
-          {
+            data: {
+              ...additionalFields,
+              roleName,
+              permission: value.permission
+            }
+          })
+        } else {
+          await createRole.mutateAsync({
             organizationId,
             role: roleName,
-            permission,
+            permission: value.permission,
             additionalFields
-          },
-          { onSettled: () => setIsSubmitting(false) }
-        )
+          })
+        }
+      } catch {
+        // The mutation reports the error through its configured handler.
       }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      setIsSubmitting(false)
     }
-  }
+  })
 
-  const pending = createRole.isPending || updateRole.isPending || isSubmitting
+  useEffect(() => {
+    if (!open) return
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredRoleFields),
+      name: role?.role ?? "",
+      permission: role?.permission ?? {}
+    })
+  }, [configuredRoleFields, form, open, role?.permission, role?.role])
+
+  const pending = createRole.isPending || updateRole.isPending
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
-        <form className="flex flex-col gap-6" onSubmit={submit}>
-          <DialogHeader>
-            <DialogTitle>
-              {role ? localization.editRole : localization.createRole}
-            </DialogTitle>
-            <DialogDescription>
-              {localization.rolesDescription}
-            </DialogDescription>
-          </DialogHeader>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle>
+                {role ? localization.editRole : localization.createRole}
+              </DialogTitle>
+              <DialogDescription>
+                {localization.rolesDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <Field>
-            <FieldLabel htmlFor="organization-role-name">
-              {localization.roleName}
-            </FieldLabel>
-            <Input
-              id="organization-role-name"
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              placeholder={localization.roleNamePlaceholder}
-              disabled={pending}
-              required
-            />
-          </Field>
-
-          {fieldsWithModelValues(roleFields, role ?? {}).map((field) => (
-            <AdditionalField
-              key={field.name}
-              field={field}
-              name={field.name}
-              isPending={pending}
-              optionalLabel={authLocalization.settings.optional}
-            />
-          ))}
-
-          <fieldset className="flex flex-col gap-4">
-            <legend className="text-sm font-medium">
-              {localization.permissions}
-            </legend>
-            {Object.entries(registry).map(([resource, definition]) => (
-              <div className="flex flex-col gap-2" key={resource}>
-                <p className="text-sm font-medium">
-                  {definition.label ?? resource}
-                </p>
-                <div className="grid gap-3 sm:grid-cols-2">
-                  {Object.entries(definition.actions).map(([action, label]) => (
-                    <RolePermissionCheckbox
-                      action={action}
-                      checked={permission[resource]?.includes(action) ?? false}
-                      key={action}
-                      label={label}
-                      onCheckedChange={(selected) =>
-                        setPermission((current) => ({
-                          ...current,
-                          [resource]: selected
-                            ? [...(current[resource] ?? []), action]
-                            : (current[resource] ?? []).filter(
-                                (entry) => entry !== action
-                              )
-                        }))
-                      }
-                      organizationId={organizationId}
-                      pending={pending}
-                      resource={resource}
-                    />
-                  ))}
-                </div>
-              </div>
-            ))}
-          </fieldset>
-
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={pending}
-              onClick={() => onOpenChange(false)}
+            <form.AppField
+              name="name"
+              validators={{
+                onChange: ({ value }) =>
+                  validateStringLength(value, {
+                    requiredMessage: authLocalization.auth.fieldRequired,
+                    trim: true
+                  })
+              }}
             >
-              {authLocalization.settings.cancel}
-            </Button>
-            <Button type="submit" disabled={pending || !name.trim()}>
-              {pending && <Spinner />}
-              {authLocalization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
-        </form>
+              {(field) => {
+                const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                return (
+                  <Field data-invalid={isInvalid}>
+                    <FieldLabel htmlFor="organization-role-name">
+                      {localization.roleName}
+                    </FieldLabel>
+                    <Input
+                      aria-invalid={isInvalid}
+                      disabled={pending}
+                      id="organization-role-name"
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      placeholder={localization.roleNamePlaceholder}
+                      value={field.state.value}
+                    />
+                    <field.AuthFormFieldError />
+                  </Field>
+                )
+              }}
+            </form.AppField>
+
+            {configuredRoleFields.map((configuredField) => (
+              <form.AppField
+                key={configuredField.name}
+                name={`additionalFields.${configuredField.name}`}
+                validators={getAuthAdditionalFieldValidators(
+                  configuredField,
+                  authLocalization.auth.fieldRequired
+                )}
+              >
+                {(field) => (
+                  <field.AuthFormAdditionalField
+                    field={configuredField}
+                    isPending={pending}
+                    optionalLabel={authLocalization.settings.optional}
+                  />
+                )}
+              </form.AppField>
+            ))}
+
+            <form.AppField name="permission">
+              {(field) => (
+                <fieldset className="flex flex-col gap-4">
+                  <legend className="text-sm font-medium">
+                    {localization.permissions}
+                  </legend>
+                  {Object.entries(registry).map(([resource, definition]) => (
+                    <div className="flex flex-col gap-2" key={resource}>
+                      <p className="text-sm font-medium">
+                        {definition.label ?? resource}
+                      </p>
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        {Object.entries(definition.actions).map(
+                          ([action, label]) => (
+                            <RolePermissionCheckbox
+                              action={action}
+                              checked={
+                                field.state.value[resource]?.includes(action) ??
+                                false
+                              }
+                              key={action}
+                              label={label}
+                              onCheckedChange={(selected) =>
+                                field.handleChange({
+                                  ...field.state.value,
+                                  [resource]: selected
+                                    ? [
+                                        ...(field.state.value[resource] ?? []),
+                                        action
+                                      ]
+                                    : (
+                                        field.state.value[resource] ?? []
+                                      ).filter((entry) => entry !== action)
+                                })
+                              }
+                              organizationId={organizationId}
+                              pending={pending}
+                              resource={resource}
+                            />
+                          )
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </fieldset>
+              )}
+            </form.AppField>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={pending}
+                onClick={() => onOpenChange(false)}
+              >
+                {authLocalization.settings.cancel}
+              </Button>
+              <form.AuthFormSubmitButton disabled={pending}>
+                {authLocalization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/apps/docs/src/components/auth/organization/organization-teams.tsx
+++ b/apps/docs/src/components/auth/organization/organization-teams.tsx
@@ -3,7 +3,9 @@
 import {
   type AdditionalFields,
   fieldsWithModelValues,
-  parseAdditionalFieldValues
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type { OrganizationTeamsAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
@@ -28,7 +30,7 @@ import {
   UserRoundMinus,
   Users
 } from "lucide-react"
-import { type FormEvent, useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 import {
   AlertDialog,
@@ -63,7 +65,11 @@ import {
 } from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 
 type Team = { id: string; name: string; [key: string]: unknown }
 
@@ -230,8 +236,6 @@ function TeamDialog({
     organizationId,
     permissions: { member: ["delete"] }
   })
-  const [name, setName] = useState("")
-  const [isSubmittingFields, setIsSubmittingFields] = useState(false)
   const [userId, setUserId] = useState("")
   const createTeam = useCreateTeam(authClient, {
     onSuccess: () => {
@@ -266,276 +270,309 @@ function TeamDialog({
     ? localization.activeTeamRemovalDisabled
     : localization.lastTeamRemovalDisabled
 
+  const configuredTeamFields = useMemo(
+    () => fieldsWithModelValues(teamFields, team ?? {}),
+    [team, teamFields]
+  )
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredTeamFields),
+      name: team?.name ?? ""
+    },
+    onSubmit: async ({ value }) => {
+      const name = value.name.trim()
+      if (!name || !organizationId || (!team && teamLimitReached)) return
+      if (team && !canUpdate.data?.success) return
+
+      const data = {
+        ...getAdditionalFieldSubmitValues(
+          configuredTeamFields,
+          value.additionalFields
+        ),
+        name,
+        organizationId
+      }
+
+      try {
+        if (team) await updateTeam.mutateAsync({ teamId: team.id, data })
+        else await createTeam.mutateAsync(data)
+      } catch {
+        // The mutation reports the error through its configured handler.
+      }
+    }
+  })
+
   useEffect(() => {
     if (!open) return
-    setName(team?.name ?? "")
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredTeamFields),
+      name: team?.name ?? ""
+    })
     setUserId("")
-  }, [open, team])
+  }, [configuredTeamFields, form, open, team?.name])
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const trimmedName = name.trim()
-    if (!trimmedName || !organizationId || (!team && teamLimitReached)) return
-    if (team && !canUpdate.data?.success) return
-
-    setIsSubmittingFields(true)
-    try {
-      const values = await parseAdditionalFieldValues(
-        teamFields,
-        new FormData(event.currentTarget)
-      )
-      if (team) {
-        updateTeam.mutate(
-          {
-            teamId: team.id,
-            data: { ...values, name: trimmedName, organizationId }
-          },
-          { onSettled: () => setIsSubmittingFields(false) }
-        )
-      } else {
-        createTeam.mutate(
-          { ...values, name: trimmedName, organizationId },
-          { onSettled: () => setIsSubmittingFields(false) }
-        )
-      }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      setIsSubmittingFields(false)
-    }
-  }
-
-  const pending =
-    createTeam.isPending || updateTeam.isPending || isSubmittingFields
+  const pending = createTeam.isPending || updateTeam.isPending
   const canEdit = !team || canUpdate.data?.success === true
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
-        <form className="flex flex-col gap-6" onSubmit={handleSubmit}>
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Users />
-              {team ? localization.renameTeam : localization.createTeam}
-            </DialogTitle>
-            <DialogDescription>
-              {localization.teamsDescription}
-            </DialogDescription>
-          </DialogHeader>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Users />
+                {team ? localization.renameTeam : localization.createTeam}
+              </DialogTitle>
+              <DialogDescription>
+                {localization.teamsDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <div className="flex flex-col gap-4">
-            <Field>
-              <FieldLabel htmlFor="organization-team-name">
-                {localization.name}
-              </FieldLabel>
-              <Input
-                autoFocus
-                disabled={pending || !canEdit}
-                id="organization-team-name"
-                onChange={(event) => setName(event.target.value)}
-                required
-                value={name}
-              />
-            </Field>
-
-            {fieldsWithModelValues(teamFields, team ?? {}).map((field) => (
-              <AdditionalField
-                field={field}
-                isPending={pending || !canEdit}
-                key={field.name}
-                name={field.name}
-                optionalLabel={authLocalization.settings.optional}
-              />
-            ))}
-          </div>
-
-          {team && canListMembers && (
-            <div className="flex flex-col gap-4 border-t pt-5">
-              <div>
-                <h3 className="text-sm font-medium">
-                  {localization.teamMembers}
-                </h3>
-                <p className="text-sm text-muted-foreground">
-                  {localization.addTeamMember}
-                </p>
-              </div>
-
-              {(canAddMember.isPending || canAddMember.data?.success) && (
-                <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-end">
-                  <Field className="flex-1">
-                    <FieldLabel>{localization.addTeamMember}</FieldLabel>
-                    <Select
-                      disabled={canAddMember.isPending || memberLimitReached}
-                      onValueChange={(value) => setUserId(value ?? "")}
-                      value={userId}
-                    >
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder={localization.selectMember} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {organizationMembers
-                          .filter((member) => !memberIds.has(member.userId))
-                          .map((member) => (
-                            <SelectItem
-                              key={member.userId}
-                              value={member.userId}
-                            >
-                              {member.user.name || member.user.email}
-                            </SelectItem>
-                          ))}
-                      </SelectContent>
-                    </Select>
-                  </Field>
-                  <Button
-                    disabled={
-                      canAddMember.isPending ||
-                      !userId ||
-                      addMember.isPending ||
-                      memberLimitReached
-                    }
-                    onClick={() => {
-                      if (!canAddMember.data?.success || !userId) return
-                      addMember.mutate({
-                        teamId: team.id,
-                        userId,
-                        organizationId
-                      })
-                    }}
-                    type="button"
-                  >
-                    <UserPlus data-icon="inline-start" />
-                    {localization.addTeamMember}
-                  </Button>
-                </div>
-              )}
-
-              {canAddMember.data?.success && memberLimitReached && (
-                <p className="text-sm text-destructive" role="alert">
-                  {localization.teamMemberLimitReached}
-                </p>
-              )}
-
-              <div className="flex flex-col gap-2">
-                {teamMembers.isPending && <Spinner />}
-                {teamMembers.data?.map((teamMember) => {
-                  const member = organizationMembers.find(
-                    (candidate) => candidate.userId === teamMember.userId
-                  )
+            <div className="flex flex-col gap-4">
+              <form.AppField
+                name="name"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: authLocalization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
                   return (
-                    <div
-                      className="flex items-center justify-between gap-3 rounded-md border px-3 py-2"
-                      key={teamMember.id}
-                    >
-                      <span className="truncate text-sm">
-                        {member?.user.name ||
-                          member?.user.email ||
-                          teamMember.userId}
-                      </span>
-                      {(canRemoveMember.isPending ||
-                        canRemoveMember.data?.success) && (
-                        <Button
-                          aria-label={localization.removeTeamMember}
-                          disabled={
-                            canRemoveMember.isPending || removeMember.isPending
-                          }
-                          onClick={() => {
-                            if (!canRemoveMember.data?.success) return
-                            removeMember.mutate({
-                              teamId: team.id,
-                              userId: teamMember.userId,
-                              organizationId
-                            })
-                          }}
-                          size="icon-sm"
-                          type="button"
-                          variant="ghost"
-                        >
-                          <UserRoundMinus />
-                        </Button>
-                      )}
-                    </div>
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="organization-team-name">
+                        {localization.name}
+                      </FieldLabel>
+                      <Input
+                        aria-invalid={isInvalid}
+                        autoFocus
+                        disabled={pending || !canEdit}
+                        id="organization-team-name"
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        value={field.state.value}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
                   )
-                })}
-              </div>
+                }}
+              </form.AppField>
+
+              {configuredTeamFields.map((configuredField) => (
+                <form.AppField
+                  key={configuredField.name}
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    authLocalization.auth.fieldRequired
+                  )}
+                >
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      isPending={pending || !canEdit}
+                      optionalLabel={authLocalization.settings.optional}
+                    />
+                  )}
+                </form.AppField>
+              ))}
             </div>
-          )}
 
-          {team && !canRemoveTeam && canDelete.data?.success && (
-            <p className="text-sm text-muted-foreground">
-              {teamRemovalDisabledReason}
-            </p>
-          )}
+            {team && canListMembers && (
+              <div className="flex flex-col gap-4 border-t pt-5">
+                <div>
+                  <h3 className="text-sm font-medium">
+                    {localization.teamMembers}
+                  </h3>
+                  <p className="text-sm text-muted-foreground">
+                    {localization.addTeamMember}
+                  </p>
+                </div>
 
-          <DialogFooter className="sm:justify-between">
-            {team && (canDelete.isPending || canDelete.data?.success) && (
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button
-                    disabled={
-                      canDelete.isPending ||
-                      removeTeam.isPending ||
-                      !canRemoveTeam
-                    }
-                    type="button"
-                    variant="destructive"
-                  >
-                    <Trash2 data-icon="inline-start" />
-                    {localization.deleteTeam}
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>
-                      {localization.deleteTeam}
-                    </AlertDialogTitle>
-                    <AlertDialogDescription>
-                      {localization.deleteTeamDescription}
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>
-                      {authLocalization.settings.cancel}
-                    </AlertDialogCancel>
-                    <AlertDialogAction
-                      className={buttonVariants({ variant: "destructive" })}
-                      onClick={() =>
-                        removeTeam.mutate({
+                {(canAddMember.isPending || canAddMember.data?.success) && (
+                  <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-end">
+                    <Field className="flex-1">
+                      <FieldLabel>{localization.addTeamMember}</FieldLabel>
+                      <Select
+                        disabled={canAddMember.isPending || memberLimitReached}
+                        onValueChange={(value) => setUserId(value ?? "")}
+                        value={userId}
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue
+                            placeholder={localization.selectMember}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {organizationMembers
+                            .filter((member) => !memberIds.has(member.userId))
+                            .map((member) => (
+                              <SelectItem
+                                key={member.userId}
+                                value={member.userId}
+                              >
+                                {member.user.name || member.user.email}
+                              </SelectItem>
+                            ))}
+                        </SelectContent>
+                      </Select>
+                    </Field>
+                    <Button
+                      disabled={
+                        canAddMember.isPending ||
+                        !userId ||
+                        addMember.isPending ||
+                        memberLimitReached
+                      }
+                      onClick={() => {
+                        if (!canAddMember.data?.success || !userId) return
+                        addMember.mutate({
                           teamId: team.id,
+                          userId,
                           organizationId
                         })
+                      }}
+                      type="button"
+                    >
+                      <UserPlus data-icon="inline-start" />
+                      {localization.addTeamMember}
+                    </Button>
+                  </div>
+                )}
+
+                {canAddMember.data?.success && memberLimitReached && (
+                  <p className="text-sm text-destructive" role="alert">
+                    {localization.teamMemberLimitReached}
+                  </p>
+                )}
+
+                <div className="flex flex-col gap-2">
+                  {teamMembers.isPending && <Spinner />}
+                  {teamMembers.data?.map((teamMember) => {
+                    const member = organizationMembers.find(
+                      (candidate) => candidate.userId === teamMember.userId
+                    )
+                    return (
+                      <div
+                        className="flex items-center justify-between gap-3 rounded-md border px-3 py-2"
+                        key={teamMember.id}
+                      >
+                        <span className="truncate text-sm">
+                          {member?.user.name ||
+                            member?.user.email ||
+                            teamMember.userId}
+                        </span>
+                        {(canRemoveMember.isPending ||
+                          canRemoveMember.data?.success) && (
+                          <Button
+                            aria-label={localization.removeTeamMember}
+                            disabled={
+                              canRemoveMember.isPending ||
+                              removeMember.isPending
+                            }
+                            onClick={() => {
+                              if (!canRemoveMember.data?.success) return
+                              removeMember.mutate({
+                                teamId: team.id,
+                                userId: teamMember.userId,
+                                organizationId
+                              })
+                            }}
+                            size="icon-sm"
+                            type="button"
+                            variant="ghost"
+                          >
+                            <UserRoundMinus />
+                          </Button>
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+
+            {team && !canRemoveTeam && canDelete.data?.success && (
+              <p className="text-sm text-muted-foreground">
+                {teamRemovalDisabledReason}
+              </p>
+            )}
+
+            <DialogFooter className="sm:justify-between">
+              {team && (canDelete.isPending || canDelete.data?.success) && (
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      disabled={
+                        canDelete.isPending ||
+                        removeTeam.isPending ||
+                        !canRemoveTeam
                       }
+                      type="button"
+                      variant="destructive"
                     >
                       <Trash2 data-icon="inline-start" />
                       {localization.deleteTeam}
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-            )}
-
-            <div className="flex flex-col-reverse gap-2 sm:flex-row">
-              <DialogClose
-                className={buttonVariants({ variant: "outline" })}
-                disabled={pending}
-                type="button"
-              >
-                {authLocalization.settings.cancel}
-              </DialogClose>
-              {canEdit && (
-                <Button
-                  disabled={
-                    pending || !name.trim() || (teamLimitReached && !team)
-                  }
-                  type="submit"
-                >
-                  {pending && <Spinner />}
-                  {team
-                    ? authLocalization.settings.saveChanges
-                    : localization.createTeam}
-                </Button>
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>
+                        {localization.deleteTeam}
+                      </AlertDialogTitle>
+                      <AlertDialogDescription>
+                        {localization.deleteTeamDescription}
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>
+                        {authLocalization.settings.cancel}
+                      </AlertDialogCancel>
+                      <AlertDialogAction
+                        className={buttonVariants({ variant: "destructive" })}
+                        onClick={() =>
+                          removeTeam.mutate({
+                            teamId: team.id,
+                            organizationId
+                          })
+                        }
+                      >
+                        <Trash2 data-icon="inline-start" />
+                        {localization.deleteTeam}
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
               )}
-            </div>
-          </DialogFooter>
-        </form>
+
+              <div className="flex flex-col-reverse gap-2 sm:flex-row">
+                <DialogClose
+                  className={buttonVariants({ variant: "outline" })}
+                  disabled={pending}
+                  type="button"
+                >
+                  {authLocalization.settings.cancel}
+                </DialogClose>
+                {canEdit && (
+                  <form.AuthFormSubmitButton
+                    disabled={pending || (teamLimitReached && !team)}
+                  >
+                    {team
+                      ? authLocalization.settings.saveChanges
+                      : localization.createTeam}
+                  </form.AuthFormSubmitButton>
+                )}
+              </div>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/apps/docs/src/components/auth/settings/account/user-profile.tsx
+++ b/apps/docs/src/components/auth/settings/account/user-profile.tsx
@@ -1,22 +1,26 @@
 "use client"
 
 import {
-  type AdditionalFieldValue,
-  parseAdditionalFieldValue
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type { UsernameAuthClient } from "@better-auth-ui/core/plugins/username"
 import { useAuth, useSession, useUpdateUser } from "@better-auth-ui/react"
-import { type SyntheticEvent, useState } from "react"
+import { useEffect, useMemo } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Spinner } from "@/components/ui/spinner"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "../../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../../auth-form"
 import { ChangeAvatar } from "./change-avatar"
 
 export type UserProfileProps = {
@@ -34,49 +38,39 @@ export function UserProfile({ className }: UserProfileProps) {
     useAuth<UsernameAuthClient>()
   const { data: session } = useSession(authClient)
 
-  const { mutate: updateUser, isPending } = useUpdateUser(authClient, {
+  const { mutateAsync: updateUser, isPending } = useUpdateUser(authClient, {
     onSuccess: () => toast.success(localization.settings.profileUpdatedSuccess)
   })
 
-  const [fieldErrors, setFieldErrors] = useState<{
-    name?: string
-  }>({})
-
-  async function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const name = formData.get("name") as string
-
-    const additionalFieldValues: Record<string, unknown> = {}
-
-    for (const field of additionalFields ?? []) {
-      if (field.profile === false || field.readOnly) continue
-      const value = parseAdditionalFieldValue(
-        field,
-        formData.get(field.name) as string | null
-      )
-
-      if (field.validate) {
-        try {
-          await field.validate(value)
-        } catch (error) {
-          toast.error(error instanceof Error ? error.message : String(error))
-          return
-        }
-      }
-
-      // `null` = explicit clear (forward to backend); `undefined` = omitted.
-      if (value !== undefined) {
-        additionalFieldValues[field.name] = value
-      }
+  const profileFields = useMemo(
+    () => additionalFields?.filter((field) => field.profile !== false) ?? [],
+    [additionalFields]
+  )
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(profileFields),
+      name: ""
+    },
+    onSubmit: async ({ value }) => {
+      await updateUser({
+        name: value.name,
+        ...getAdditionalFieldSubmitValues(profileFields, value.additionalFields)
+      })
     }
+  })
 
-    updateUser({
-      name,
-      ...additionalFieldValues
+  useEffect(() => {
+    if (!session) return
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(
+        fieldsWithModelValues(
+          profileFields,
+          session.user as Record<string, unknown>
+        )
+      ),
+      name: session.user.name
     })
-  }
+  }, [form, profileFields, session])
 
   return (
     <div>
@@ -84,101 +78,101 @@ export function UserProfile({ className }: UserProfileProps) {
         {localization.settings.userProfile}
       </h2>
 
-      <form onSubmit={handleSubmit}>
-        <Card className={cn(className)}>
-          <CardContent className="flex flex-col gap-6">
-            <ChangeAvatar />
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card className={cn(className)}>
+            <CardContent className="flex flex-col gap-6">
+              <ChangeAvatar />
 
-            <Field data-invalid={!!fieldErrors.name}>
-              <FieldLabel htmlFor="name">{localization.auth.name}</FieldLabel>
+              <form.AppField
+                name="name"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
-              {session ? (
-                <Input
-                  key={session?.user.name}
-                  id="name"
-                  name="name"
-                  autoComplete="name"
-                  defaultValue={session?.user.name}
-                  placeholder={localization.auth.name}
-                  disabled={isPending}
-                  required
-                  onChange={() => {
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      name: undefined
-                    }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="name">
+                        {localization.auth.name}
+                      </FieldLabel>
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      name: (e.target as HTMLInputElement).validationMessage
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.name}
-                />
-              ) : (
-                <Skeleton>
-                  <Input className="invisible" />
-                </Skeleton>
-              )}
+                      {session ? (
+                        <Input
+                          id="name"
+                          name={field.name}
+                          autoComplete="name"
+                          placeholder={localization.auth.name}
+                          disabled={isPending}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          aria-invalid={isInvalid}
+                        />
+                      ) : (
+                        <Skeleton>
+                          <Input className="invisible" />
+                        </Skeleton>
+                      )}
 
-              <FieldError>{fieldErrors.name}</FieldError>
-            </Field>
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
 
-            {additionalFields?.map((field) => {
-              if (field.profile === false) return null
+              {profileFields.map((configuredField) => {
+                if (!session) {
+                  if (configuredField.inputType === "hidden") {
+                    return null
+                  }
 
-              if (!session) {
-                if (field.inputType === "hidden") {
-                  return null
+                  return (
+                    <Skeleton key={configuredField.name}>
+                      <Input className="invisible" />
+                    </Skeleton>
+                  )
                 }
 
                 return (
-                  <Skeleton key={field.name}>
-                    <Input className="invisible" />
-                  </Skeleton>
+                  <form.AppField
+                    key={configuredField.name}
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={isPending}
+                      />
+                    )}
+                  </form.AppField>
                 )
-              }
+              })}
+            </CardContent>
 
-              const value = (session.user as Record<string, unknown>)[
-                field.name
-              ]
-
-              // Re-mount when the session value loads so the field's
-              // uncontrolled `defaultValue` reflects the latest data.
-              const key = `${field.name}:${
-                value instanceof Date
-                  ? value.toISOString()
-                  : String(value ?? "")
-              }`
-
-              return (
-                <AdditionalField
-                  key={key}
-                  name={field.name}
-                  field={{
-                    ...field,
-                    // `defaultValue` is sign-up-only; on the profile we
-                    // always seed from the session.
-                    defaultValue: value as AdditionalFieldValue | null
-                  }}
-                  isPending={isPending}
-                />
-              )
-            })}
-          </CardContent>
-
-          <CardFooter>
-            <Button type="submit" size="sm" disabled={isPending || !session}>
-              {isPending && <Spinner />}
-
-              {localization.settings.saveChanges}
-            </Button>
-          </CardFooter>
-        </Card>
-      </form>
+            <CardFooter>
+              <form.AuthFormSubmitButton
+                size="sm"
+                disabled={isPending || !session}
+              >
+                {localization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/apps/docs/src/components/auth/sign-up.tsx
+++ b/apps/docs/src/components/auth/sign-up.tsx
@@ -2,9 +2,10 @@
 
 import {
   authMutationKeys,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
   getAuthLinkURL,
   isPasswordCompromisedError,
-  parseAdditionalFieldValue,
   validateEmailAddress,
   validateMatchingValue,
   validateStringLength
@@ -17,8 +18,7 @@ import {
 } from "@better-auth-ui/react"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { useRef, useState } from "react"
-import { toast } from "sonner"
+import { useMemo, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Field,
@@ -36,8 +36,11 @@ import {
   InputGroupInput
 } from "@/components/ui/input-group"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "./additional-field"
-import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "./auth-form"
 import { PasswordStrengthMeter } from "./password-strength-meter"
 import { ProviderButtons, type SocialLayout } from "./provider-buttons"
 
@@ -136,9 +139,13 @@ export function SignUp({
     useState(false)
 
   const [isCompromised, setIsCompromised] = useState(false)
-  const additionalFieldValuesRef = useRef<Record<string, unknown>>({})
+  const signUpFields = useMemo(
+    () => additionalFields?.filter((field) => field.signUp) ?? [],
+    [additionalFields]
+  )
   const form = useAuthForm({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(signUpFields),
       confirmPassword: "",
       email: "",
       name: "",
@@ -150,7 +157,10 @@ export function SignUp({
           name: emailAndPassword?.name === false ? "" : value.name,
           email: value.email.trim(),
           password: value.password,
-          ...additionalFieldValuesRef.current,
+          ...getAdditionalFieldSubmitValues(
+            signUpFields,
+            value.additionalFields
+          ),
           fetchOptions
         })
       } catch {
@@ -158,35 +168,6 @@ export function SignUp({
       }
     }
   })
-
-  const prepareSubmit = async (formElement: HTMLFormElement) => {
-    const formData = new FormData(formElement)
-
-    const additionalFieldValues: Record<string, unknown> = {}
-
-    for (const field of additionalFields ?? []) {
-      if (!field.signUp || field.readOnly) continue
-      const value = parseAdditionalFieldValue(
-        field,
-        formData.get(field.name) as string | null
-      )
-
-      if (field.validate) {
-        try {
-          await field.validate(value)
-        } catch (error) {
-          toast.error(error instanceof Error ? error.message : String(error))
-          return false
-        }
-      }
-
-      if (value !== undefined) {
-        additionalFieldValues[field.name] = value
-      }
-    }
-
-    additionalFieldValuesRef.current = additionalFieldValues
-  }
 
   const showSeparator =
     emailAndPassword?.enabled && socialProviders && socialProviders.length > 0
@@ -218,7 +199,7 @@ export function SignUp({
 
           {emailAndPassword?.enabled && (
             <form.AppForm>
-              <form.AuthFormRoot prepareSubmit={prepareSubmit}>
+              <form.AuthFormRoot>
                 <FieldGroup>
                   {emailAndPassword.name !== false && (
                     <form.AppField
@@ -306,16 +287,25 @@ export function SignUp({
                     }}
                   </form.AppField>
 
-                  {additionalFields?.map(
-                    (field) =>
-                      field.signUp === "above" && (
-                        <AdditionalField
-                          key={field.name}
-                          name={field.name}
-                          field={field}
-                          isPending={isPending}
-                          optionalLabel={localization.auth.optional}
-                        />
+                  {signUpFields.map(
+                    (configuredField) =>
+                      configuredField.signUp === "above" && (
+                        <form.AppField
+                          key={configuredField.name}
+                          name={`additionalFields.${configuredField.name}`}
+                          validators={getAuthAdditionalFieldValidators(
+                            configuredField,
+                            localization.auth.fieldRequired
+                          )}
+                        >
+                          {(field) => (
+                            <field.AuthFormAdditionalField
+                              field={configuredField}
+                              isPending={isPending}
+                              optionalLabel={localization.auth.optional}
+                            />
+                          )}
+                        </form.AppField>
                       )
                   )}
 
@@ -503,17 +493,25 @@ export function SignUp({
                     </form.AppField>
                   )}
 
-                  {additionalFields?.map(
-                    (field) =>
-                      field.signUp &&
-                      field.signUp !== "above" && (
-                        <AdditionalField
-                          key={field.name}
-                          name={field.name}
-                          field={field}
-                          isPending={isPending}
-                          optionalLabel={localization.auth.optional}
-                        />
+                  {signUpFields.map(
+                    (configuredField) =>
+                      configuredField.signUp !== "above" && (
+                        <form.AppField
+                          key={configuredField.name}
+                          name={`additionalFields.${configuredField.name}`}
+                          validators={getAuthAdditionalFieldValidators(
+                            configuredField,
+                            localization.auth.fieldRequired
+                          )}
+                        >
+                          {(field) => (
+                            <field.AuthFormAdditionalField
+                              field={configuredField}
+                              isPending={isPending}
+                              optionalLabel={localization.auth.optional}
+                            />
+                          )}
+                        </form.AppField>
                       )
                   )}
 

--- a/apps/docs/src/components/auth/username/username-field.tsx
+++ b/apps/docs/src/components/auth/username/username-field.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getFormFieldErrors } from "@better-auth-ui/core"
 import type { UsernameAuthClient } from "@better-auth-ui/core/plugins/username"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useIsUsernameAvailable } from "@better-auth-ui/react/plugins/username"
@@ -25,6 +26,11 @@ import { usernamePlugin } from "@/lib/auth/username-plugin"
 export function UsernameField({
   name,
   field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
   isPending
 }: AdditionalFieldProps) {
   const { authClient, localization: authLocalization } =
@@ -38,8 +44,9 @@ export function UsernameField({
   } = useAuthPlugin(usernamePlugin)
 
   const currentUsername = String(field.defaultValue ?? "")
-  const [value, setValue] = useState(currentUsername)
-  const [error, setError] = useState<string>()
+  const username = typeof value === "string" ? value : ""
+  const [nativeError, setNativeError] = useState<string>()
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
   const {
     mutate: requestAvailability,
@@ -64,8 +71,8 @@ export function UsernameField({
   )
 
   function handleChange(next: string) {
-    setValue(next)
-    setError(undefined)
+    onChange(next || null)
+    setNativeError(undefined)
     resetAvailability()
 
     if (checkAvailability) {
@@ -74,10 +81,12 @@ export function UsernameField({
   }
 
   const isCheckingAvailability =
-    !!checkAvailability && !!value.trim() && value.trim() !== currentUsername
+    !!checkAvailability &&
+    !!username.trim() &&
+    username.trim() !== currentUsername
 
   return (
-    <Field data-invalid={!!error}>
+    <Field data-invalid={isInvalid || !!nativeError}>
       <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
       <InputGroup>
@@ -97,7 +106,8 @@ export function UsernameField({
           disabled={isPending}
           required={field.required}
           readOnly={field.readOnly}
-          value={value}
+          value={username}
+          onBlur={onBlur}
           onChange={(e) => handleChange(e.target.value)}
           onInvalid={(e) => {
             e.preventDefault()
@@ -113,9 +123,9 @@ export function UsernameField({
                     "{{max}}",
                     String(maxUsernameLength)
                   )
-            setError(msg)
+            setNativeError(msg)
           }}
-          aria-invalid={!!error}
+          aria-invalid={isInvalid || !!nativeError}
           placeholder={field.placeholder}
         />
 
@@ -141,7 +151,7 @@ export function UsernameField({
         )}
       </InputGroup>
 
-      <FieldError>{error}</FieldError>
+      <FieldError errors={fieldErrors}>{nativeError}</FieldError>
     </Field>
   )
 }

--- a/examples/next-shadcn-example/src/components/auth/additional-field.tsx
+++ b/examples/next-shadcn-example/src/components/auth/additional-field.tsx
@@ -2,6 +2,8 @@
 
 import {
   type AdditionalField as AdditionalFieldConfig,
+  type AdditionalFieldFormValue,
+  getFormFieldErrors,
   resolveInputType
 } from "@better-auth-ui/core"
 import { useAuth, useCopyToClipboard } from "@better-auth-ui/react"
@@ -54,9 +56,19 @@ import { cn } from "@/lib/utils"
 export type AdditionalFieldProps = {
   name: string
   field: AdditionalFieldConfig
+  value: AdditionalFieldFormValue
+  onBlur: () => void
+  onChange: (value: AdditionalFieldFormValue) => void
+  isInvalid?: boolean
+  errors?: unknown[]
   isPending?: boolean
   /** Complete suffix appended to labels for fields that are not required. */
   optionalLabel?: string
+}
+
+function valueToString(value: AdditionalFieldFormValue) {
+  if (value == null) return ""
+  return value instanceof Date ? value.toISOString() : String(value)
 }
 
 /** Convert a `defaultValue` into a `Date` for the calendar. */
@@ -124,6 +136,11 @@ function CopyButton({
 export function AdditionalField({
   name,
   field: configuredField,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
   isPending,
   optionalLabel
 }: AdditionalFieldProps) {
@@ -140,6 +157,7 @@ export function AdditionalField({
         }
       : configuredField
   const inputType = resolveInputType(field)
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
   if (field.render) {
     const FieldRenderer = field.render as ComponentType<AdditionalFieldProps>
@@ -147,6 +165,11 @@ export function AdditionalField({
       <FieldRenderer
         name={name}
         field={field}
+        value={value}
+        onBlur={onBlur}
+        onChange={onChange}
+        isInvalid={isInvalid}
+        errors={errors}
         isPending={isPending}
         optionalLabel={optionalLabel}
       />
@@ -155,38 +178,29 @@ export function AdditionalField({
 
   if (inputType === "hidden") {
     return (
-      <input
-        type="hidden"
-        name={name}
-        value={
-          field.defaultValue == null
-            ? ""
-            : field.defaultValue instanceof Date
-              ? field.defaultValue.toISOString()
-              : String(field.defaultValue)
-        }
-      />
+      <input type="hidden" name={name} value={valueToString(value)} readOnly />
     )
   }
 
   if (inputType === "textarea") {
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <Textarea
           id={name}
           name={name}
-          defaultValue={
-            field.defaultValue == null ? undefined : String(field.defaultValue)
-          }
+          value={valueToString(value)}
+          onBlur={onBlur}
+          onChange={(event) => onChange(event.target.value || null)}
           placeholder={field.placeholder}
           required={field.required}
           readOnly={field.readOnly}
           disabled={isPending}
+          aria-invalid={isInvalid}
         />
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
@@ -195,7 +209,7 @@ export function AdditionalField({
     const maxFractionDigits = field.formatOptions?.maximumFractionDigits
 
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <Input
@@ -209,81 +223,101 @@ export function AdditionalField({
             field.step ??
             (maxFractionDigits ? 1 / 10 ** maxFractionDigits : undefined)
           }
-          defaultValue={
-            field.defaultValue == null
-              ? undefined
-              : typeof field.defaultValue === "number"
-                ? field.defaultValue
-                : String(field.defaultValue)
+          value={typeof value === "number" ? value : ""}
+          onBlur={onBlur}
+          onChange={(event) =>
+            onChange(
+              event.target.value === "" ? null : event.target.valueAsNumber
+            )
           }
           placeholder={field.placeholder}
           required={field.required}
           readOnly={field.readOnly}
           disabled={isPending}
+          aria-invalid={isInvalid}
         />
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "slider") {
-    return <SliderField name={name} field={field} isPending={isPending} />
+    return (
+      <SliderField
+        name={name}
+        field={field}
+        value={value}
+        onBlur={onBlur}
+        onChange={onChange}
+        isInvalid={isInvalid}
+        errors={errors}
+        isPending={isPending}
+      />
+    )
   }
 
   if (inputType === "switch") {
     return (
-      <Field orientation="horizontal">
+      <Field data-invalid={isInvalid} orientation="horizontal">
         <Switch
           id={name}
           name={name}
-          defaultChecked={
-            field.defaultValue === true || field.defaultValue === "true"
-          }
+          checked={value === true}
+          onBlur={onBlur}
+          onCheckedChange={onChange}
           disabled={isPending || field.readOnly}
+          aria-invalid={isInvalid}
         />
 
         <FieldContent>
           <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
         </FieldContent>
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "checkbox") {
     return (
-      <Field orientation="horizontal">
+      <Field data-invalid={isInvalid} orientation="horizontal">
         <Checkbox
           id={name}
           name={name}
-          defaultChecked={
-            field.defaultValue === true || field.defaultValue === "true"
-          }
+          checked={value === true}
+          onBlur={onBlur}
+          onCheckedChange={(checked) => onChange(checked === true)}
           required={field.required}
           disabled={isPending || field.readOnly}
+          aria-invalid={isInvalid}
         />
 
         <FieldContent>
           <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
         </FieldContent>
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "select") {
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <Select
           name={name}
-          defaultValue={
-            field.defaultValue != null ? String(field.defaultValue) : undefined
-          }
+          value={valueToString(value) || undefined}
+          onValueChange={(nextValue) => onChange(nextValue)}
           required={field.required}
           disabled={isPending || field.readOnly}
         >
-          <SelectTrigger id={name} className="w-full">
+          <SelectTrigger
+            id={name}
+            className="w-full"
+            onBlur={onBlur}
+            aria-invalid={isInvalid}
+          >
             <SelectValue placeholder={field.placeholder} />
           </SelectTrigger>
 
@@ -296,26 +330,34 @@ export function AdditionalField({
           </SelectContent>
         </Select>
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "combobox") {
+    const selectedOption = field.options?.find(
+      (option) => option.value === valueToString(value)
+    )
+
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <Combobox
           items={field.options ?? []}
           name={name}
-          defaultValue={
-            field.defaultValue != null ? String(field.defaultValue) : undefined
-          }
+          value={selectedOption ?? null}
+          onValueChange={(option) => onChange(option?.value ?? null)}
           required={field.required}
           disabled={isPending || field.readOnly}
         >
-          <ComboboxInput placeholder={field.placeholder} id={name} />
+          <ComboboxInput
+            placeholder={field.placeholder}
+            id={name}
+            onBlur={onBlur}
+            aria-invalid={isInvalid}
+          />
 
           <ComboboxContent>
             <ComboboxEmpty>No items found.</ComboboxEmpty>
@@ -330,20 +372,52 @@ export function AdditionalField({
           </ComboboxContent>
         </Combobox>
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "date" || inputType === "datetime") {
-    return <DateInput name={name} field={field} isPending={isPending} />
+    return (
+      <DateInput
+        name={name}
+        field={field}
+        value={value}
+        onBlur={onBlur}
+        onChange={onChange}
+        isInvalid={isInvalid}
+        errors={errors}
+        isPending={isPending}
+      />
+    )
   }
 
-  return <InputField name={name} field={field} isPending={isPending} />
+  return (
+    <InputField
+      name={name}
+      field={field}
+      value={value}
+      onBlur={onBlur}
+      onChange={onChange}
+      isInvalid={isInvalid}
+      errors={errors}
+      isPending={isPending}
+    />
+  )
 }
 
-function InputField({ name, field, isPending }: AdditionalFieldProps) {
+function InputField({
+  name,
+  field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
+  isPending
+}: AdditionalFieldProps) {
   const inputRef = useRef<HTMLInputElement>(null)
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
   const hasPrefix = field.prefix != null
   const hasSuffix = field.suffix != null || field.copyable
@@ -360,7 +434,7 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
 
   if (hasPrefix || hasSuffix) {
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <InputGroup>
@@ -377,15 +451,14 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
             type={nativeInputType}
             inputMode={nativeInputMode}
             step={nativeStep}
-            defaultValue={
-              field.defaultValue == null
-                ? undefined
-                : String(field.defaultValue)
-            }
+            value={valueToString(value)}
+            onBlur={onBlur}
+            onChange={(event) => onChange(event.target.value || null)}
             placeholder={field.placeholder}
             required={field.required}
             readOnly={field.readOnly}
             disabled={isPending}
+            aria-invalid={isInvalid}
           />
 
           {field.copyable ? (
@@ -404,13 +477,13 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
           )}
         </InputGroup>
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   return (
-    <Field>
+    <Field data-invalid={isInvalid}>
       <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
       <Input
@@ -419,16 +492,17 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
         type={nativeInputType}
         inputMode={nativeInputMode}
         step={nativeStep}
-        defaultValue={
-          field.defaultValue == null ? undefined : String(field.defaultValue)
-        }
+        value={valueToString(value)}
+        onBlur={onBlur}
+        onChange={(event) => onChange(event.target.value || null)}
         placeholder={field.placeholder}
         required={field.required}
         readOnly={field.readOnly}
         disabled={isPending}
+        aria-invalid={isInvalid}
       />
 
-      <FieldError />
+      <FieldError errors={fieldErrors} />
     </Field>
   )
 }
@@ -438,44 +512,51 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
  * it next to the label and control the state to keep the displayed value in
  * sync. The selected value is submitted via the underlying Radix `name` prop.
  */
-function SliderField({ name, field, isPending }: AdditionalFieldProps) {
+function SliderField({
+  name,
+  field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
+  isPending
+}: AdditionalFieldProps) {
   const maxFractionDigits = field.formatOptions?.maximumFractionDigits
   const min = field.min ?? 0
   const max = field.max ?? 100
   const step =
     field.step ?? (maxFractionDigits ? 1 / 10 ** maxFractionDigits : 1)
-  const initial =
-    typeof field.defaultValue === "number"
-      ? field.defaultValue
-      : field.defaultValue != null && !Number.isNaN(Number(field.defaultValue))
-        ? Number(field.defaultValue)
-        : min
-
-  const [value, setValue] = useState<number>(initial)
+  const numericValue = typeof value === "number" ? value : min
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
   const formatter = new Intl.NumberFormat(undefined, field.formatOptions)
 
   return (
-    <Field>
+    <Field data-invalid={isInvalid}>
       <div className="flex items-center justify-between gap-2">
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
         <span className="text-sm text-muted-foreground tabular-nums">
-          {formatter.format(value)}
+          {formatter.format(numericValue)}
         </span>
       </div>
 
       <Slider
         id={name}
         name={name}
-        value={[value]}
-        onValueChange={(v) => setValue((Array.isArray(v) ? v[0] : v) ?? min)}
+        value={[numericValue]}
+        onBlur={onBlur}
+        onValueChange={(nextValue) =>
+          onChange((Array.isArray(nextValue) ? nextValue[0] : nextValue) ?? min)
+        }
         min={min}
         max={max}
         step={step}
         disabled={isPending || field.readOnly}
+        aria-invalid={isInvalid}
       />
 
-      <FieldError />
+      <FieldError errors={fieldErrors} />
     </Field>
   )
 }
@@ -485,68 +566,42 @@ function SliderField({ name, field, isPending }: AdditionalFieldProps) {
  * (optionally) `<input type="time">` for the time. Submits the combined ISO
  * value via a hidden `<input>` so it shows up in `FormData`.
  */
-function DateInput({ name, field, isPending }: AdditionalFieldProps) {
+function DateInput({
+  name,
+  field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
+  isPending
+}: AdditionalFieldProps) {
   const { localization } = useAuth()
   const inputType = resolveInputType(field)
   const isDateTime = inputType === "datetime"
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
-  const [date, setDate] = useState<Date | undefined>(toDate(field.defaultValue))
+  const date = toDate(value)
   const [time, setTime] = useState<string>(
     isDateTime && date ? formatTime(date) : ""
   )
   const [open, setOpen] = useState(false)
-  const [error, setError] = useState<string>()
 
   // Compose the hidden form value: ISO date for "date", ISO datetime for
   // "datetime" (date + time).
-  let formValue = ""
-  if (date) {
-    if (isDateTime && time && time.trim() !== "") {
-      const [h = "0", m = "0", s = "0"] = time.split(":")
-      const combined = new Date(date)
-      combined.setHours(Number(h), Number(m), Number(s), 0)
-      formValue = combined.toISOString()
-    } else {
-      // Anchor to local midnight then serialize as ISO so the downstream
-      // `parseAdditionalFieldValue` parses the same calendar day regardless
-      // of timezone (a bare "YYYY-MM-DD" would be parsed as UTC midnight).
-      // Datetime fields with a blank time also fall through here, defaulting
-      // the time to local midnight since the parsed value is always a `Date`.
-      const localMidnight = new Date(date)
-      localMidnight.setHours(0, 0, 0, 0)
-      formValue = localMidnight.toISOString()
-    }
-  }
-
   return (
-    <Field data-invalid={!!error}>
+    <Field data-invalid={isInvalid}>
       <FieldLabel htmlFor={`${name}-date`}>{field.label}</FieldLabel>
 
       <div className="relative flex gap-2">
-        {/* Visually-hidden input so required constraint validation fires on submit.
-            onInvalid suppresses the native browser balloon and routes the message
-            through the styled <FieldError> below — matching the pattern used by
-            the Name / Email / Password fields in the sign-up form. */}
-        <input
-          aria-label={typeof field.label === "string" ? field.label : name}
-          type="text"
-          name={name}
-          value={formValue}
-          onChange={() => {}}
-          required={field.required}
-          tabIndex={-1}
-          className="sr-only"
-          onInvalid={(e) => {
-            e.preventDefault()
-            setError((e.target as HTMLInputElement).validationMessage)
-          }}
-        />
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger
             type="button"
             id={`${name}-date`}
             data-empty={!date}
-            aria-invalid={!!error}
+            aria-invalid={isInvalid}
+            aria-required={field.required}
+            onBlur={onBlur}
             disabled={isPending || field.readOnly}
             className={cn(
               buttonVariants({ variant: "outline" }),
@@ -566,8 +621,24 @@ function DateInput({ name, field, isPending }: AdditionalFieldProps) {
               defaultMonth={date}
               captionLayout="dropdown"
               onSelect={(value) => {
-                setDate(value)
-                if (value) setError(undefined)
+                if (!value) {
+                  onChange(null)
+                } else {
+                  const nextValue = new Date(value)
+                  if (isDateTime && time.trim()) {
+                    const [hours = "0", minutes = "0", seconds = "0"] =
+                      time.split(":")
+                    nextValue.setHours(
+                      Number(hours),
+                      Number(minutes),
+                      Number(seconds),
+                      0
+                    )
+                  } else {
+                    nextValue.setHours(0, 0, 0, 0)
+                  }
+                  onChange(nextValue)
+                }
                 if (!isDateTime) setOpen(false)
               }}
             />
@@ -585,7 +656,21 @@ function DateInput({ name, field, isPending }: AdditionalFieldProps) {
               id={`${name}-time`}
               step="1"
               value={time}
-              onChange={(e) => setTime(e.target.value)}
+              onChange={(event) => {
+                const nextTime = event.target.value
+                setTime(nextTime)
+                if (!date) return
+                const nextValue = new Date(date)
+                const [hours = "0", minutes = "0", seconds = "0"] =
+                  nextTime.split(":")
+                nextValue.setHours(
+                  Number(hours),
+                  Number(minutes),
+                  Number(seconds),
+                  0
+                )
+                onChange(nextValue)
+              }}
               disabled={isPending || field.readOnly}
               className="appearance-none bg-background [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
             />
@@ -593,7 +678,7 @@ function DateInput({ name, field, isPending }: AdditionalFieldProps) {
         )}
       </div>
 
-      <FieldError>{error}</FieldError>
+      <FieldError errors={fieldErrors} />
     </Field>
   )
 }

--- a/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -1,9 +1,10 @@
 "use client"
 
 import {
-  type AdditionalFieldValue,
-  getClampedTablePageIndex,
-  parseAdditionalFieldValues
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  getClampedTablePageIndex
 } from "@better-auth-ui/core"
 import {
   type AdminAuthClient,
@@ -55,10 +56,8 @@ import {
   useDeferredValue,
   useEffect,
   useMemo,
-  useRef,
   useState
 } from "react"
-import { AdditionalField } from "@/components/auth/additional-field"
 import { UserAvatar } from "@/components/auth/user/user-avatar"
 import {
   AlertDialog,
@@ -123,7 +122,7 @@ import {
 } from "@/components/ui/table"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { adminPlugin } from "@/lib/auth/admin-plugin"
-import { useAuthForm } from "../auth-form"
+import { getAuthAdditionalFieldValidators, useAuthForm } from "../auth-form"
 
 import { createAdminColumnHelper, useAdminTable } from "./admin-table"
 
@@ -691,18 +690,16 @@ function CreateUserDialog({
   const auth = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
   const { data: session } = useSession(auth.authClient)
-  const [formError, setFormError] = useState<string>()
   const createUser = useMutation(
     createAdminUserOptions(auth.authClient, session?.user.id)
   )
   const canSetRole = useAdminPermission(auth.authClient, {
     user: ["set-role"]
   })
-  const additionalFieldValuesRef = useRef<
-    Record<string, AdditionalFieldValue | null>
-  >({})
+  const additionalFields = auth.additionalFields ?? []
   const form = useAuthForm({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(additionalFields),
       email: "",
       emailVerified: false,
       name: "",
@@ -714,7 +711,10 @@ function CreateUserDialog({
         await createUser.mutateAsync(
           {
             data: {
-              ...additionalFieldValuesRef.current,
+              ...getAdditionalFieldSubmitValues(
+                additionalFields,
+                value.additionalFields
+              ),
               emailVerified: value.emailVerified
             },
             email: value.email,
@@ -739,24 +739,8 @@ function CreateUserDialog({
 
   const close = () => {
     form.reset()
-    setFormError(undefined)
     createUser.reset()
     onOpenChange(false)
-  }
-  const prepareSubmit = async (formElement: HTMLFormElement) => {
-    const data = new FormData(formElement)
-    let additionalFieldValues: Record<string, AdditionalFieldValue | null>
-    try {
-      additionalFieldValues = await parseAdditionalFieldValues(
-        auth.additionalFields ?? [],
-        data
-      )
-    } catch (error) {
-      setFormError(error instanceof Error ? error.message : String(error))
-      return false
-    }
-    setFormError(undefined)
-    additionalFieldValuesRef.current = additionalFieldValues
   }
 
   return (
@@ -766,10 +750,7 @@ function CreateUserDialog({
     >
       <DialogContent>
         <form.AppForm>
-          <form.AuthFormRoot
-            className="flex flex-col gap-4"
-            prepareSubmit={prepareSubmit}
-          >
+          <form.AuthFormRoot className="flex flex-col gap-4">
             <DialogHeader>
               <DialogTitle>{config.localization.createUser}</DialogTitle>
               <DialogDescription>
@@ -910,18 +891,25 @@ function CreateUserDialog({
                   </Field>
                 )}
               </form.Field>
-              {auth.additionalFields?.map((field) => (
-                <AdditionalField
-                  field={field}
-                  isPending={createUser.isPending}
-                  key={field.name}
-                  name={field.name}
-                />
+              {additionalFields.map((configuredField) => (
+                <form.AppField
+                  key={configuredField.name}
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    auth.localization.auth.fieldRequired
+                  )}
+                >
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      isPending={createUser.isPending}
+                    />
+                  )}
+                </form.AppField>
               ))}
             </FieldGroup>
-            <FieldError>
-              {formError ?? getAdminErrorMessage(createUser.error)}
-            </FieldError>
+            <FieldError>{getAdminErrorMessage(createUser.error)}</FieldError>
             <DialogFooter>
               <Button onClick={close} type="button" variant="outline">
                 {config.localization.cancel}
@@ -1030,21 +1018,13 @@ function UserInspector({
   const [banReason, setBanReason] = useState("")
   const [banDuration, setBanDuration] = useState("")
   const banDurationSeconds = getBanDurationSeconds(banDuration)
-  const [profileError, setProfileError] = useState<string>()
   const [passwordOpen, setPasswordOpen] = useState(false)
   const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
-  const profileUserId = useRef(user?.id)
   const isSelf = user?.id === actor?.user.id
 
   const updateUser = useMutation(
     updateAdminUserOptions(auth.authClient, actor?.user.id)
   )
-
-  useEffect(() => {
-    if (profileUserId.current === user?.id) return
-    profileUserId.current = user?.id
-    setProfileError(undefined)
-  }, [user?.id])
 
   useEffect(() => {
     if (user?.id) updateUser.reset()
@@ -1073,11 +1053,17 @@ function UserInspector({
   const revokeSessions = useMutation(
     revokeAdminUserSessionsOptions(auth.authClient, actor?.user.id, userId)
   )
-  const profileAdditionalFieldValuesRef = useRef<
-    Record<string, AdditionalFieldValue | null>
-  >({})
+  const configuredUserFields = useMemo(
+    () =>
+      fieldsWithModelValues(
+        auth.additionalFields ?? [],
+        user ? (user as unknown as Record<string, unknown>) : {}
+      ),
+    [auth.additionalFields, user]
+  )
   const profileForm = useAuthForm({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredUserFields),
       email: "",
       emailVerified: false,
       name: "",
@@ -1092,7 +1078,10 @@ function UserInspector({
           updateUser.mutateAsync({
             userId: user.id,
             data: {
-              ...profileAdditionalFieldValuesRef.current,
+              ...getAdditionalFieldSubmitValues(
+                configuredUserFields,
+                value.additionalFields
+              ),
               name: value.name.trim(),
               ...(canSetEmail.data?.success
                 ? {
@@ -1124,6 +1113,7 @@ function UserInspector({
 
   useEffect(() => {
     profileForm.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredUserFields),
       email: user?.email ?? "",
       emailVerified: user?.emailVerified ?? false,
       name: user?.name ?? "",
@@ -1136,6 +1126,7 @@ function UserInspector({
   }, [
     config.allowMultipleRoles,
     config.defaultRole,
+    configuredUserFields,
     profileForm.reset,
     user?.email,
     user?.emailVerified,
@@ -1215,26 +1206,6 @@ function UserInspector({
         : dangerousAction === "revokeAll"
           ? config.localization.revokeAllSessions
           : config.localization.impersonateUser
-
-  const prepareSaveUser = async (formElement: HTMLFormElement) => {
-    if (!user) return false
-
-    if (canUpdate.data?.success) {
-      const formData = new FormData(formElement)
-      let additionalFieldValues: Record<string, AdditionalFieldValue | null>
-      try {
-        additionalFieldValues = await parseAdditionalFieldValues(
-          auth.additionalFields ?? [],
-          formData
-        )
-      } catch (error) {
-        setProfileError(error instanceof Error ? error.message : String(error))
-        return false
-      }
-      setProfileError(undefined)
-      profileAdditionalFieldValuesRef.current = additionalFieldValues
-    }
-  }
 
   return (
     <>
@@ -1330,10 +1301,7 @@ function UserInspector({
               </TabsList>
               <TabsContent className="min-h-0 overflow-hidden" value="overview">
                 <profileForm.AppForm>
-                  <profileForm.AuthFormRoot
-                    className="grid h-full grid-rows-[minmax(0,1fr)_auto]"
-                    prepareSubmit={prepareSaveUser}
-                  >
+                  <profileForm.AuthFormRoot className="grid h-full grid-rows-[minmax(0,1fr)_auto]">
                     <div className="overflow-y-auto">
                       <section className="flex flex-col gap-5 p-6">
                         <h3 className="font-medium">
@@ -1479,30 +1447,29 @@ function UserInspector({
                               }
                             </profileForm.Field>
                           </FieldSet>
-                          {auth.additionalFields?.map((field) => {
-                            const value = (
-                              user as unknown as Record<string, unknown>
-                            )[field.name]
-                            return (
-                              <AdditionalField
-                                field={{
-                                  ...field,
-                                  defaultValue:
-                                    value as AdditionalFieldValue | null
-                                }}
-                                isPending={
-                                  updateUser.isPending ||
-                                  !canUpdate.data?.success
-                                }
-                                key={`${user.id}-${field.name}-${String(value ?? "")}`}
-                                name={field.name}
-                              />
-                            )
-                          })}
+                          {configuredUserFields.map((configuredField) => (
+                            <profileForm.AppField
+                              key={configuredField.name}
+                              name={`additionalFields.${configuredField.name}`}
+                              validators={getAuthAdditionalFieldValidators(
+                                configuredField,
+                                auth.localization.auth.fieldRequired
+                              )}
+                            >
+                              {(field) => (
+                                <field.AuthFormAdditionalField
+                                  field={configuredField}
+                                  isPending={
+                                    updateUser.isPending ||
+                                    !canUpdate.data?.success
+                                  }
+                                />
+                              )}
+                            </profileForm.AppField>
+                          ))}
                         </FieldGroup>
                         <FieldError>
-                          {profileError ??
-                            getAdminErrorMessage(updateUser.error) ??
+                          {getAdminErrorMessage(updateUser.error) ??
                             getAdminErrorMessage(setRoleMutation.error)}
                         </FieldError>
                       </section>

--- a/examples/next-shadcn-example/src/components/auth/auth-form.tsx
+++ b/examples/next-shadcn-example/src/components/auth/auth-form.tsx
@@ -1,23 +1,22 @@
 "use client"
 
-import { getFormFieldErrors } from "@better-auth-ui/core"
-import { createFormHook, createFormHookContexts } from "@tanstack/react-form"
 import {
-  type ComponentProps,
-  createContext,
-  type FormEvent,
-  useContext,
-  useRef,
-  useState
-} from "react"
+  type AdditionalField as AdditionalFieldConfig,
+  type AdditionalFieldFormValue,
+  getFormFieldErrors,
+  validateAdditionalFieldRequired,
+  validateAdditionalFieldValue
+} from "@better-auth-ui/core"
+import { createFormHook, createFormHookContexts } from "@tanstack/react-form"
+import { type ComponentProps, type FormEvent, useRef } from "react"
 
 import { Button } from "@/components/ui/button"
 import { FieldError } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
+import { AdditionalField, type AdditionalFieldProps } from "./additional-field"
 
 const { fieldContext, formContext, useFieldContext, useFormContext } =
   createFormHookContexts()
-const AuthFormPreparationContext = createContext(false)
 
 export function focusFirstInvalidAuthFormControl(form: HTMLFormElement) {
   requestAnimationFrame(() => {
@@ -41,53 +40,42 @@ function AuthFormFieldError() {
 }
 
 type AuthFormRootProps = Omit<ComponentProps<"form">, "onSubmit"> & {
-  prepareSubmit?: (
-    form: HTMLFormElement
-  ) => boolean | undefined | Promise<boolean | undefined>
+  onBeforeSubmit?: () => void
 }
 
 function AuthFormRoot({
   children,
-  prepareSubmit,
+  onBeforeSubmit,
   ...props
 }: AuthFormRootProps) {
   const form = useFormContext()
-  const preparingRef = useRef(false)
-  const [isPreparing, setIsPreparing] = useState(false)
+  const submittingRef = useRef(false)
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    if (preparingRef.current || form.state.isSubmitting) return
+    if (submittingRef.current || form.state.isSubmitting) return
 
     const formElement = event.currentTarget
-    preparingRef.current = true
-    setIsPreparing(true)
-
-    let shouldSubmit = true
+    onBeforeSubmit?.()
+    submittingRef.current = true
     try {
-      shouldSubmit = (await prepareSubmit?.(formElement)) !== false
+      await form.handleSubmit()
+      if (!form.state.isValid) focusFirstInvalidAuthFormControl(formElement)
     } finally {
-      preparingRef.current = false
-      setIsPreparing(false)
+      submittingRef.current = false
     }
-
-    if (!shouldSubmit) return
-    await form.handleSubmit()
-    if (!form.state.isValid) focusFirstInvalidAuthFormControl(formElement)
   }
 
   return (
-    <AuthFormPreparationContext.Provider value={isPreparing}>
-      <form
-        {...props}
-        onInvalid={(event) =>
-          focusFirstInvalidAuthFormControl(event.currentTarget)
-        }
-        onSubmit={submit}
-      >
-        {children}
-      </form>
-    </AuthFormPreparationContext.Provider>
+    <form
+      {...props}
+      onInvalid={(event) =>
+        focusFirstInvalidAuthFormControl(event.currentTarget)
+      }
+      onSubmit={submit}
+    >
+      {children}
+    </form>
   )
 }
 
@@ -97,7 +85,6 @@ function AuthFormSubmitButton({
   ...props
 }: ComponentProps<typeof Button>) {
   const form = useFormContext()
-  const isPreparing = useContext(AuthFormPreparationContext)
 
   return (
     <form.Subscribe
@@ -106,10 +93,10 @@ function AuthFormSubmitButton({
       {([canSubmit, isSubmitting]) => (
         <Button
           {...props}
-          disabled={disabled || isPreparing || !canSubmit || isSubmitting}
+          disabled={disabled || !canSubmit || isSubmitting}
           type="submit"
         >
-          {isPreparing || isSubmitting ? <Spinner /> : null}
+          {isSubmitting ? <Spinner /> : null}
           {children}
         </Button>
       )}
@@ -117,8 +104,32 @@ function AuthFormSubmitButton({
   )
 }
 
+type AuthFormAdditionalFieldProps = Omit<
+  AdditionalFieldProps,
+  "errors" | "isInvalid" | "name" | "onBlur" | "onChange" | "value"
+>
+
+function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
+  const field = useFieldContext<AdditionalFieldFormValue>()
+  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+
+  return (
+    <AdditionalField
+      {...props}
+      errors={
+        isInvalid ? getFormFieldErrors(field.state.meta.errors) : undefined
+      }
+      isInvalid={isInvalid}
+      name={field.name}
+      onBlur={field.handleBlur}
+      onChange={field.handleChange}
+      value={field.state.value}
+    />
+  )
+}
+
 export const { useAppForm: useAuthForm } = createFormHook({
-  fieldComponents: { AuthFormFieldError },
+  fieldComponents: { AuthFormAdditionalField, AuthFormFieldError },
   fieldContext,
   formComponents: { AuthFormRoot, AuthFormSubmitButton },
   formContext
@@ -132,4 +143,18 @@ export function isAuthFormFieldInvalid({
   isValid: boolean
 }) {
   return isTouched && !isValid
+}
+
+export function getAuthAdditionalFieldValidators(
+  field: AdditionalFieldConfig,
+  requiredMessage: string
+) {
+  return {
+    onChange: ({ value }: { value: AdditionalFieldFormValue }) =>
+      validateAdditionalFieldRequired(field, value, requiredMessage),
+    onChangeAsync: field.validate
+      ? ({ value }: { value: AdditionalFieldFormValue }) =>
+          validateAdditionalFieldValue(field, value)
+      : undefined
+  }
 }

--- a/examples/next-shadcn-example/src/components/auth/organization/create-organization-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/create-organization-dialog.tsx
@@ -1,13 +1,16 @@
 "use client"
 
-import { parseAdditionalFieldValue } from "@better-auth-ui/core"
+import {
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useCreateOrganization } from "@better-auth-ui/react/plugins/organization"
 import { Briefcase } from "lucide-react"
-import { type SyntheticEvent, useEffect, useRef, useState } from "react"
-import { toast } from "sonner"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useEffect, useRef, useState } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -17,11 +20,14 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 import { SlugField, sanitizeSlug } from "./slug-field"
 
 /** Props for the `CreateOrganizationDialog` component. */
@@ -44,150 +50,153 @@ export function CreateOrganizationDialog({
   } = useAuthPlugin(organizationPlugin)
   const hideSlug = hideSlugProp ?? pluginHideSlug ?? false
 
-  const [name, setName] = useState("")
-  const [slug, setSlug] = useState("")
   const [slugEdited, setSlugEdited] = useState(false)
-  const [nameError, setNameError] = useState<string>()
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const submissionLocked = useRef(false)
+  const submissionGeneration = useRef(0)
+  const submissionAttemptGeneration = useRef(0)
 
-  const { mutate: createOrganization, isPending: isCreating } =
-    useCreateOrganization(authClient, {
-      onSuccess: () => onOpenChange(false),
-      onSettled: () => {
-        submissionLocked.current = false
-        setIsSubmitting(false)
-      }
-    })
+  const { mutateAsync: createOrganization } = useCreateOrganization(authClient)
 
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    if (submissionLocked.current) return
-
-    submissionLocked.current = true
-    setIsSubmitting(true)
-    const formData = new FormData(e.currentTarget)
-    const additionalValues: Record<string, unknown> = {}
-    try {
-      for (const field of additionalFields) {
-        const value = parseAdditionalFieldValue(
-          field,
-          formData.get(field.name) as string | null
-        )
-        await field.validate?.(value)
-        if (value !== undefined) additionalValues[field.name] = value
-      }
-    } catch (error) {
-      submissionLocked.current = false
-      setIsSubmitting(false)
-      toast.error(error instanceof Error ? error.message : String(error))
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(additionalFields),
+      name: "",
+      slug: ""
+    },
+    onSubmit: async ({ value }) => {
+      const generation = submissionAttemptGeneration.current
+      if (generation !== submissionGeneration.current) return
+      await createOrganization({
+        ...getAdditionalFieldSubmitValues(
+          additionalFields,
+          value.additionalFields
+        ),
+        name: value.name,
+        slug: hideSlug ? undefined : value.slug
+      })
+      if (generation === submissionGeneration.current) onOpenChange(false)
     }
-    createOrganization({
-      ...additionalValues,
-      name,
-      slug: hideSlug ? undefined : slug
-    })
-  }
-
-  const isPending = isCreating || isSubmitting
+  })
 
   useEffect(() => {
     if (!open) {
-      setSlug("")
-      setName("")
+      submissionGeneration.current += 1
+      form.reset()
       setSlugEdited(false)
-      setNameError(undefined)
     }
-  }, [open])
-
-  useEffect(() => {
-    if (slugEdited) return
-    setSlug(sanitizeSlug(name))
-  }, [name, slugEdited])
+  }, [form, open])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Briefcase />
-              {organizationLocalization.createOrganization}
-            </DialogTitle>
+        <form.AppForm>
+          <form.AuthFormRoot
+            className="flex flex-col gap-6"
+            onBeforeSubmit={() => {
+              submissionAttemptGeneration.current = submissionGeneration.current
+            }}
+          >
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Briefcase />
+                {organizationLocalization.createOrganization}
+              </DialogTitle>
 
-            <DialogDescription>
-              {organizationLocalization.organizationsDescription}
-            </DialogDescription>
-          </DialogHeader>
+              <DialogDescription>
+                {organizationLocalization.organizationsDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <div className="flex flex-col gap-4">
-            <Field data-invalid={!!nameError}>
-              <FieldLabel htmlFor="create-organization-name">
-                {organizationLocalization.name}
-              </FieldLabel>
-
-              <Input
-                id="create-organization-name"
+            <div className="flex flex-col gap-4">
+              <form.AppField
                 name="name"
-                autoFocus
-                required
-                placeholder={organizationLocalization.namePlaceholder}
-                value={name}
-                onChange={(e) => {
-                  setName(e.target.value)
-                  setNameError(undefined)
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired,
+                      trim: true
+                    })
                 }}
-                onInvalid={(e) => {
-                  e.preventDefault()
-                  setNameError(localization.auth.fieldRequired)
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="create-organization-name">
+                        {organizationLocalization.name}
+                      </FieldLabel>
+
+                      <Input
+                        id="create-organization-name"
+                        name={field.name}
+                        autoFocus
+                        placeholder={organizationLocalization.namePlaceholder}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => {
+                          const value = event.target.value
+                          field.handleChange(value)
+                          if (!slugEdited) {
+                            form.setFieldValue("slug", sanitizeSlug(value))
+                          }
+                        }}
+                        aria-invalid={isInvalid}
+                      />
+
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
                 }}
-                aria-invalid={!!nameError}
-                disabled={isPending}
-              />
+              </form.AppField>
 
-              <FieldError>{nameError}</FieldError>
-            </Field>
+              {!hideSlug && (
+                <form.AppField name="slug">
+                  {(field) => (
+                    <SlugField
+                      id="create-organization-slug"
+                      value={field.state.value}
+                      onChange={(value) => {
+                        field.handleChange(value)
+                        setSlugEdited(true)
+                      }}
+                    />
+                  )}
+                </form.AppField>
+              )}
 
-            {!hideSlug && (
-              <SlugField
-                id="create-organization-slug"
-                value={slug}
-                onChange={(value) => {
-                  setSlug(value)
-                  setSlugEdited(true)
-                }}
-                disabled={isPending}
-              />
-            )}
+              {additionalFields.map((configuredField) => (
+                <form.AppField
+                  key={configuredField.name}
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    localization.auth.fieldRequired
+                  )}
+                >
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      optionalLabel={localization.settings.optional}
+                    />
+                  )}
+                </form.AppField>
+              ))}
+            </div>
 
-            {additionalFields.map((field) => (
-              <AdditionalField
-                key={field.name}
-                field={field}
-                isPending={isPending}
-                name={field.name}
-                optionalLabel={localization.settings.optional}
-              />
-            ))}
-          </div>
+            <DialogFooter>
+              <DialogClose
+                className={buttonVariants({ variant: "outline" })}
+                type="button"
+              >
+                {localization.settings.cancel}
+              </DialogClose>
 
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              disabled={isPending}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Spinner />}
-
-              {organizationLocalization.createOrganization}
-            </Button>
-          </DialogFooter>
-        </form>
+              <form.AuthFormSubmitButton>
+                {organizationLocalization.createOrganization}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/next-shadcn-example/src/components/auth/organization/invite-member-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/invite-member-dialog.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { parseAdditionalFieldValues } from "@better-auth-ui/core"
+import {
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateEmailAddress
+} from "@better-auth-ui/core"
 import {
   mergeOrganizationRoleLabels,
   type OrganizationAuthClient,
@@ -17,16 +21,9 @@ import {
   useListTeams
 } from "@better-auth-ui/react/plugins/organization"
 import { ChevronDown, UserPlus } from "lucide-react"
-import {
-  type SyntheticEvent,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from "react"
+import { useEffect, useMemo, useRef } from "react"
 import { toast } from "sonner"
-import { AdditionalField } from "@/components/auth/additional-field"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -42,7 +39,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import {
   Select,
@@ -52,9 +49,13 @@ import {
   SelectTrigger,
   SelectValue
 } from "@/components/ui/select"
-import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 
 /** Props for the `InviteMemberDialog` component. */
 export type InviteMemberDialogProps = {
@@ -107,38 +108,10 @@ export function InviteMemberDialog({
     [dynamicRoles.data, roles]
   )
 
-  const [selectedRoles, setSelectedRoles] = useState(() => {
-    const fallback = pickDefaultRole(Object.keys(assignableRoles))
-    return fallback ? [fallback] : []
-  })
-  const [teamId, setTeamId] = useState("")
-  const [emailError, setEmailError] = useState<string>()
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const activeOrganizationId = activeOrganization?.id
   const previousOrganizationId = useRef(activeOrganizationId)
 
-  useEffect(() => {
-    setSelectedRoles((current) => {
-      const keys = Object.keys(assignableRoles)
-      const kept = current.filter((entry) => keys.includes(entry))
-
-      if (kept.length > 0) return allowMultipleRoles ? kept : kept.slice(0, 1)
-
-      const fallback = pickDefaultRole(keys)
-      return fallback ? [fallback] : []
-    })
-  }, [allowMultipleRoles, assignableRoles])
-
-  useEffect(() => {
-    const organizationChanged =
-      previousOrganizationId.current !== activeOrganizationId
-
-    if (open || organizationChanged) setTeamId("")
-    if (!open) setEmailError(undefined)
-    previousOrganizationId.current = activeOrganizationId
-  }, [open, activeOrganizationId])
-
-  const { mutate: inviteMember, isPending: isInviting } = useInviteMember(
+  const { mutateAsync: inviteMember, isPending: isInviting } = useInviteMember(
     authClient as OrganizationTeamsAuthClient,
     {
       onSuccess: () => {
@@ -148,249 +121,322 @@ export function InviteMemberDialog({
     }
   )
 
-  const isRoleValid = selectedRoles.length > 0
-
-  const roleSummary = selectedRoles
-    .map((entry) => assignableRoles[entry] ?? entry)
-    .join(", ")
-
-  const toggleRole = (role: string) => {
-    setSelectedRoles((current) =>
-      current.includes(role)
-        ? current.filter((entry) => entry !== role)
-        : [...current, role]
-    )
-  }
-
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (
-      !activeOrganizationId ||
-      !canInvite.data?.success ||
-      !isRoleValid ||
-      atInvitationLimit
-    )
-      return
-
-    const formData = new FormData(e.currentTarget)
-    const invitationEmail = (formData.get("email") as string).trim()
-    const invitationRoles = [...selectedRoles] as Parameters<
-      typeof inviteMember
-    >[0]["role"]
-    const selectedTeamId = teams.data?.some((team) => team.id === teamId)
-      ? teamId
-      : undefined
-
-    setIsSubmitting(true)
-    let invitationValues: Record<string, unknown>
-    try {
-      invitationValues = await parseAdditionalFieldValues(
-        invitationFields,
-        formData
-      )
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      setIsSubmitting(false)
-      return
-    }
-
-    inviteMember(
-      {
-        ...invitationValues,
-        email: invitationEmail,
-        organizationId: activeOrganizationId,
-        role: invitationRoles,
-        teamId: selectedTeamId
-      },
-      { onSettled: () => setIsSubmitting(false) }
-    )
-  }
-
   const atInvitationLimit =
     invitationLimit !== undefined &&
     (invitations.data?.filter((invitation) => invitation.status === "pending")
       .length ?? 0) >= invitationLimit
 
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(invitationFields),
+      email: "",
+      roles: [] as string[],
+      teamId: ""
+    },
+    onSubmit: async ({ value }) => {
+      if (
+        !activeOrganizationId ||
+        !canInvite.data?.success ||
+        value.roles.length === 0 ||
+        atInvitationLimit
+      )
+        return
+
+      const teamId = teams.data?.some((team) => team.id === value.teamId)
+        ? value.teamId
+        : undefined
+
+      try {
+        await inviteMember({
+          ...getAdditionalFieldSubmitValues(
+            invitationFields,
+            value.additionalFields
+          ),
+          email: value.email.trim(),
+          organizationId: activeOrganizationId,
+          role: value.roles as Parameters<typeof inviteMember>[0]["role"],
+          teamId
+        })
+      } catch {
+        // The mutation reports the error through its configured handler.
+      }
+    }
+  })
+
+  useEffect(() => {
+    const keys = Object.keys(assignableRoles)
+    const current = form.getFieldValue("roles")
+    const kept = current.filter((entry) => keys.includes(entry))
+    const roles =
+      kept.length > 0
+        ? allowMultipleRoles
+          ? kept
+          : kept.slice(0, 1)
+        : (() => {
+            const fallback = pickDefaultRole(keys)
+            return fallback ? [fallback] : []
+          })()
+
+    form.setFieldValue("roles", roles)
+  }, [allowMultipleRoles, assignableRoles, form])
+
+  useEffect(() => {
+    const organizationChanged =
+      previousOrganizationId.current !== activeOrganizationId
+
+    if (open || organizationChanged) {
+      const fallback = pickDefaultRole(Object.keys(assignableRoles))
+      form.reset({
+        additionalFields: getAdditionalFieldDefaultValues(invitationFields),
+        email: "",
+        roles: fallback ? [fallback] : [],
+        teamId: ""
+      })
+    }
+    previousOrganizationId.current = activeOrganizationId
+  }, [activeOrganizationId, assignableRoles, form, invitationFields, open])
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <UserPlus />
-              {organizationLocalization.inviteMember}
-            </DialogTitle>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <UserPlus />
+                {organizationLocalization.inviteMember}
+              </DialogTitle>
 
-            <DialogDescription>
-              {organizationLocalization.inviteMemberDescription}
-            </DialogDescription>
-          </DialogHeader>
+              <DialogDescription>
+                {organizationLocalization.inviteMemberDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <div className="flex flex-col gap-4">
-            <Field data-invalid={!!emailError}>
-              <FieldLabel htmlFor="invite-member-email">
-                {localization.auth.email}
-              </FieldLabel>
-
-              <Input
-                id="invite-member-email"
+            <div className="flex flex-col gap-4">
+              <form.AppField
                 name="email"
-                type="email"
-                autoFocus
-                required
-                placeholder={localization.auth.email}
-                disabled={isInviting}
-                onChange={() => setEmailError(undefined)}
-                onInvalid={(e) => {
-                  e.preventDefault()
-                  const el = e.target as HTMLInputElement
-                  const msg = el.validity.valueMissing
-                    ? localization.auth.fieldRequired
-                    : localization.auth.invalidEmail
-                  setEmailError(msg)
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
                 }}
-                aria-invalid={!!emailError}
-              />
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
-              <FieldError>{emailError}</FieldError>
-            </Field>
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="invite-member-email">
+                        {localization.auth.email}
+                      </FieldLabel>
+                      <Input
+                        id="invite-member-email"
+                        name={field.name}
+                        type="email"
+                        autoFocus
+                        placeholder={localization.auth.email}
+                        disabled={isInviting}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        aria-invalid={isInvalid}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
 
-            <Field>
-              <FieldLabel htmlFor="invite-member-role">
-                {organizationLocalization.role}
-              </FieldLabel>
+              <form.AppField
+                name="roles"
+                validators={{
+                  onChange: ({ value }) =>
+                    value.length > 0
+                      ? undefined
+                      : localization.auth.fieldRequired
+                }}
+              >
+                {(field) => {
+                  const selectedRoles = field.state.value
+                  const roleSummary = selectedRoles
+                    .map((entry) => assignableRoles[entry] ?? entry)
+                    .join(", ")
+                  const toggleRole = (role: string) =>
+                    field.handleChange(
+                      selectedRoles.includes(role)
+                        ? selectedRoles.filter((entry) => entry !== role)
+                        : [...selectedRoles, role]
+                    )
 
-              {allowMultipleRoles ? (
-                <DropdownMenu>
-                  <DropdownMenuTrigger
-                    id="invite-member-role"
-                    disabled={isInviting}
-                    className={cn(
-                      buttonVariants({ variant: "outline" }),
-                      "w-full justify-between font-normal"
-                    )}
-                  >
-                    <span
-                      className={cn(!roleSummary && "text-muted-foreground")}
+                  return (
+                    <Field
+                      data-invalid={isAuthFormFieldInvalid(field.state.meta)}
                     >
-                      {roleSummary || organizationLocalization.selectRoles}
-                    </span>
-                    <ChevronDown className="opacity-50" />
-                  </DropdownMenuTrigger>
+                      <FieldLabel htmlFor="invite-member-role">
+                        {organizationLocalization.role}
+                      </FieldLabel>
+                      {allowMultipleRoles ? (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger
+                            id="invite-member-role"
+                            disabled={isInviting}
+                            className={cn(
+                              buttonVariants({ variant: "outline" }),
+                              "w-full justify-between font-normal"
+                            )}
+                          >
+                            <span
+                              className={cn(
+                                !roleSummary && "text-muted-foreground"
+                              )}
+                            >
+                              {roleSummary ||
+                                organizationLocalization.selectRoles}
+                            </span>
+                            <ChevronDown className="opacity-50" />
+                          </DropdownMenuTrigger>
 
-                  <DropdownMenuContent
-                    align="start"
-                    className="w-(--radix-dropdown-menu-trigger-width)"
-                  >
-                    {Object.entries(assignableRoles).map(([key, label]) => {
-                      const checked = selectedRoles.includes(key)
+                          <DropdownMenuContent
+                            align="start"
+                            className="w-(--radix-dropdown-menu-trigger-width)"
+                          >
+                            {Object.entries(assignableRoles).map(
+                              ([key, label]) => {
+                                const checked = selectedRoles.includes(key)
 
-                      return (
-                        <DropdownMenuCheckboxItem
-                          key={key}
-                          checked={checked}
-                          disabled={checked && selectedRoles.length === 1}
-                          onSelect={(event) => {
-                            event.preventDefault()
-                            toggleRole(key)
-                          }}
+                                return (
+                                  <DropdownMenuCheckboxItem
+                                    key={key}
+                                    checked={checked}
+                                    disabled={
+                                      checked && selectedRoles.length === 1
+                                    }
+                                    onSelect={(event) => {
+                                      event.preventDefault()
+                                      toggleRole(key)
+                                    }}
+                                  >
+                                    {label}
+                                  </DropdownMenuCheckboxItem>
+                                )
+                              }
+                            )}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      ) : (
+                        <Select
+                          disabled={isInviting}
+                          onValueChange={(role) => field.handleChange([role])}
+                          value={selectedRoles[0] ?? ""}
                         >
-                          {label}
-                        </DropdownMenuCheckboxItem>
-                      )
-                    })}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              ) : (
-                <Select
-                  disabled={isInviting}
-                  onValueChange={(role) => setSelectedRoles([role])}
-                  value={selectedRoles[0] ?? ""}
-                >
-                  <SelectTrigger id="invite-member-role" className="w-full">
-                    <SelectValue
-                      placeholder={organizationLocalization.selectRoles}
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      {Object.entries(assignableRoles).map(([key, label]) => (
-                        <SelectItem key={key} value={key}>
-                          {label}
-                        </SelectItem>
-                      ))}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
+                          <SelectTrigger
+                            id="invite-member-role"
+                            className="w-full"
+                          >
+                            <SelectValue
+                              placeholder={organizationLocalization.selectRoles}
+                            />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              {Object.entries(assignableRoles).map(
+                                ([key, label]) => (
+                                  <SelectItem key={key} value={key}>
+                                    {label}
+                                  </SelectItem>
+                                )
+                              )}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      )}
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+
+              {teamsEnabled && (
+                <form.AppField name="teamId">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="invite-member-team">
+                        {organizationLocalization.team}
+                      </FieldLabel>
+                      <Select
+                        value={field.state.value}
+                        onValueChange={(value) =>
+                          field.handleChange(value ?? "")
+                        }
+                        disabled={isInviting}
+                      >
+                        <SelectTrigger
+                          id="invite-member-team"
+                          className="w-full"
+                        >
+                          <SelectValue
+                            placeholder={organizationLocalization.selectTeam}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {teams.data?.map((team) => (
+                            <SelectItem key={team.id} value={team.id}>
+                              {team.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </Field>
+                  )}
+                </form.AppField>
               )}
 
-              <FieldError />
-            </Field>
-
-            {teamsEnabled && (
-              <Field>
-                <FieldLabel htmlFor="invite-member-team">
-                  {organizationLocalization.team}
-                </FieldLabel>
-                <Select
-                  value={teamId}
-                  onValueChange={(value) => setTeamId(value ?? "")}
-                  disabled={isInviting}
+              {invitationFields.map((configuredField) => (
+                <form.AppField
+                  key={configuredField.name}
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    localization.auth.fieldRequired
+                  )}
                 >
-                  <SelectTrigger id="invite-member-team" className="w-full">
-                    <SelectValue
-                      placeholder={organizationLocalization.selectTeam}
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      isPending={isInviting}
+                      optionalLabel={localization.settings.optional}
                     />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {teams.data?.map((team) => (
-                      <SelectItem key={team.id} value={team.id}>
-                        {team.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </Field>
-            )}
+                  )}
+                </form.AppField>
+              ))}
+            </div>
 
-            {invitationFields.map((field) => (
-              <AdditionalField
-                key={field.name}
-                field={field}
-                name={field.name}
-                isPending={isInviting || isSubmitting}
-                optionalLabel={localization.settings.optional}
-              />
-            ))}
-          </div>
+            <DialogFooter>
+              <DialogClose
+                className={buttonVariants({ variant: "outline" })}
+                disabled={isInviting}
+                type="button"
+              >
+                {localization.settings.cancel}
+              </DialogClose>
 
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              disabled={isInviting || isSubmitting}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-
-            <Button
-              type="submit"
-              disabled={
-                isInviting ||
-                isSubmitting ||
-                !isRoleValid ||
-                atInvitationLimit ||
-                canInvite.isPending ||
-                !canInvite.data?.success
-              }
-            >
-              {(isInviting || isSubmitting) && <Spinner />}
-
-              {organizationLocalization.inviteMember}
-            </Button>
-          </DialogFooter>
-        </form>
+              <form.AuthFormSubmitButton
+                disabled={
+                  isInviting ||
+                  atInvitationLimit ||
+                  canInvite.isPending ||
+                  !canInvite.data?.success
+                }
+              >
+                {organizationLocalization.inviteMember}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-profile.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-profile.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { parseAdditionalFieldValue } from "@better-auth-ui/core"
+import {
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
@@ -8,18 +13,20 @@ import {
   useHasPermission,
   useUpdateOrganization
 } from "@better-auth-ui/react/plugins/organization"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 import { ChangeOrganizationLogo } from "./change-organization-logo"
 import { SlugField } from "./slug-field"
 
@@ -48,44 +55,46 @@ export function OrganizationProfile({
     permissions: { organization: ["update"] }
   })
 
-  const [slug, setSlug] = useState(activeOrganization?.slug ?? "")
-
-  useEffect(() => {
-    setSlug(activeOrganization?.slug ?? "")
-  }, [activeOrganization?.slug])
-
-  const { mutate: commitOrganizationUpdate, isPending } = useUpdateOrganization(
-    authClient,
-    {
+  const { mutateAsync: commitOrganizationUpdate, isPending } =
+    useUpdateOrganization(authClient, {
       onSuccess: () =>
         toast.success(organizationLocalization.organizationUpdatedSuccess)
-    }
-  )
-
-  async function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    if (!activeOrganization || !canUpdate.data?.success) return
-    const formData = new FormData(e.currentTarget)
-    const name = formData.get("name") as string
-    const additionalValues: Record<string, unknown> = {}
-    try {
-      for (const field of additionalFields) {
-        const value = parseAdditionalFieldValue(
-          field,
-          formData.get(field.name) as string | null
-        )
-        await field.validate?.(value)
-        if (value !== undefined) additionalValues[field.name] = value
-      }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      return
-    }
-
-    commitOrganizationUpdate({
-      data: { ...additionalValues, name, ...(!hideSlug && { slug }) }
     })
-  }
+
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(additionalFields),
+      name: "",
+      slug: ""
+    },
+    onSubmit: async ({ value }) => {
+      if (!activeOrganization || !canUpdate.data?.success) return
+      await commitOrganizationUpdate({
+        data: {
+          ...getAdditionalFieldSubmitValues(
+            additionalFields,
+            value.additionalFields
+          ),
+          name: value.name,
+          ...(!hideSlug && { slug: value.slug })
+        }
+      })
+    }
+  })
+
+  useEffect(() => {
+    if (!activeOrganization) return
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(
+        fieldsWithModelValues(
+          additionalFields,
+          activeOrganization as Record<string, unknown>
+        )
+      ),
+      name: activeOrganization.name,
+      slug: activeOrganization.slug
+    })
+  }, [activeOrganization, additionalFields, form])
 
   const nameInputId = `${activeOrganization?.id ?? "org"}-name`
   const slugInputId = `${activeOrganization?.id ?? "org"}-slug`
@@ -100,76 +109,104 @@ export function OrganizationProfile({
 
       <Card className={className}>
         <CardContent>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <ChangeOrganizationLogo />
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-4">
+              <ChangeOrganizationLogo />
 
-            <Field>
-              <FieldLabel htmlFor={nameInputId}>
-                {organizationLocalization.name}
-              </FieldLabel>
-
-              {activeOrganization ? (
-                <Input
-                  key={activeOrganization.id}
-                  id={nameInputId}
-                  name="name"
-                  defaultValue={activeOrganization.name}
-                  autoComplete="organization"
-                  placeholder={organizationLocalization.namePlaceholder}
-                  disabled={formDisabled}
-                />
-              ) : (
-                <Skeleton className="h-8 w-full rounded-md" />
-              )}
-
-              <FieldError />
-            </Field>
-
-            {!hideSlug &&
-              (activeOrganization ? (
-                <SlugField
-                  id={slugInputId}
-                  value={slug}
-                  onChange={setSlug}
-                  currentSlug={activeOrganization.slug}
-                  disabled={formDisabled}
-                />
-              ) : (
-                <Field>
-                  <FieldLabel>{organizationLocalization.slug}</FieldLabel>
-                  <Skeleton className="h-8 w-full rounded-md" />
-                </Field>
-              ))}
-
-            {activeOrganization &&
-              additionalFields.map((field) => (
-                <AdditionalField
-                  key={field.name}
-                  field={{
-                    ...field,
-                    defaultValue: (
-                      activeOrganization as Record<string, unknown>
-                    )[field.name] as never
-                  }}
-                  isPending={formDisabled}
-                  name={field.name}
-                  optionalLabel={localization.settings.optional}
-                />
-              ))}
-
-            {(canUpdate.isPending || canUpdate.data?.success) && (
-              <Button
-                type="submit"
-                disabled={formDisabled || !activeOrganization}
-                size="sm"
-                className="mt-1 w-fit"
+              <form.AppField
+                name="name"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
               >
-                {isPending && <Spinner />}
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
-                {localization.settings.saveChanges}
-              </Button>
-            )}
-          </form>
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor={nameInputId}>
+                        {organizationLocalization.name}
+                      </FieldLabel>
+
+                      {activeOrganization ? (
+                        <Input
+                          id={nameInputId}
+                          name={field.name}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          autoComplete="organization"
+                          placeholder={organizationLocalization.namePlaceholder}
+                          disabled={formDisabled}
+                          aria-invalid={isInvalid}
+                        />
+                      ) : (
+                        <Skeleton className="h-8 w-full rounded-md" />
+                      )}
+
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+
+              {!hideSlug &&
+                (activeOrganization ? (
+                  <form.AppField name="slug">
+                    {(field) => (
+                      <SlugField
+                        id={slugInputId}
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        currentSlug={activeOrganization.slug}
+                        disabled={formDisabled}
+                      />
+                    )}
+                  </form.AppField>
+                ) : (
+                  <Field>
+                    <FieldLabel>{organizationLocalization.slug}</FieldLabel>
+                    <Skeleton className="h-8 w-full rounded-md" />
+                  </Field>
+                ))}
+
+              {activeOrganization &&
+                additionalFields.map((configuredField) => (
+                  <form.AppField
+                    key={configuredField.name}
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={formDisabled}
+                        optionalLabel={localization.settings.optional}
+                      />
+                    )}
+                  </form.AppField>
+                ))}
+
+              {(canUpdate.isPending || canUpdate.data?.success) && (
+                <form.AuthFormSubmitButton
+                  disabled={formDisabled || !activeOrganization}
+                  size="sm"
+                  className="mt-1 w-fit"
+                >
+                  {localization.settings.saveChanges}
+                </form.AuthFormSubmitButton>
+              )}
+            </form.AuthFormRoot>
+          </form.AppForm>
         </CardContent>
       </Card>
     </div>

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-roles.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-roles.tsx
@@ -3,7 +3,9 @@
 import {
   type AdditionalFields,
   fieldsWithModelValues,
-  parseAdditionalFieldValues
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type { OrganizationRolesAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
@@ -16,7 +18,7 @@ import {
   useUpdateRole
 } from "@better-auth-ui/react/plugins/organization"
 import { Filter, Pencil, Plus, Search, Trash2, X } from "lucide-react"
-import { type FormEvent, useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -67,7 +69,11 @@ import {
 } from "@/components/ui/table"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 import { OrganizationSortableTableHead } from "./organization-sortable-table-head"
 import {
   createOrganizationColumnHelper,
@@ -620,9 +626,6 @@ function RoleDialog({
   const { authClient, localization: authLocalization } =
     useAuth<OrganizationRolesAuthClient>()
   const { localization } = useAuthPlugin(organizationPlugin)
-  const [name, setName] = useState("")
-  const [permission, setPermission] = useState<Record<string, string[]>>({})
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const createRole = useCreateRole(authClient, organizationId, {
     onSuccess: () => {
       toast.success(localization.roleCreated)
@@ -636,154 +639,207 @@ function RoleDialog({
     }
   })
 
-  useEffect(() => {
-    if (!open) return
-    setName(role?.role ?? "")
-    setPermission(role?.permission ?? {})
-  }, [open, role])
+  const configuredRoleFields = useMemo(
+    () => fieldsWithModelValues(roleFields, role ?? {}),
+    [role, roleFields]
+  )
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredRoleFields),
+      name: role?.role ?? "",
+      permission: role?.permission ?? ({} as Record<string, string[]>)
+    },
+    onSubmit: async ({ value }) => {
+      const roleName = value.name.trim()
+      if (!roleName) return
 
-  async function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    const roleName = name.trim()
-    if (!roleName) return
+      try {
+        if (
+          Object.values(value.permission).some((actions) => actions.length > 0)
+        ) {
+          const access = await authClient.organization.hasPermission({
+            organizationId,
+            permissions: value.permission as Parameters<
+              OrganizationRolesAuthClient["organization"]["hasPermission"]
+            >[0]["permissions"]
+          })
 
-    setIsSubmitting(true)
-    try {
-      if (Object.values(permission).some((actions) => actions.length > 0)) {
-        const access = await authClient.organization.hasPermission({
-          organizationId,
-          permissions: permission as Parameters<
-            OrganizationRolesAuthClient["organization"]["hasPermission"]
-          >[0]["permissions"]
-        })
-
-        if (access.error || !access.data?.success) {
-          toast.error(localization.permissionsLimitedDescription)
-          setIsSubmitting(false)
-          return
+          if (access.error || !access.data?.success) {
+            toast.error(localization.permissionsLimitedDescription)
+            return
+          }
         }
-      }
 
-      const additionalFields = await parseAdditionalFieldValues(
-        roleFields,
-        new FormData(event.currentTarget)
-      )
-      if (role) {
-        updateRole.mutate(
-          {
+        const additionalFields = getAdditionalFieldSubmitValues(
+          configuredRoleFields,
+          value.additionalFields
+        )
+        if (role) {
+          await updateRole.mutateAsync({
             organizationId,
             roleId: role.id,
-            data: { ...additionalFields, roleName, permission }
-          },
-          { onSettled: () => setIsSubmitting(false) }
-        )
-      } else {
-        createRole.mutate(
-          {
+            data: {
+              ...additionalFields,
+              roleName,
+              permission: value.permission
+            }
+          })
+        } else {
+          await createRole.mutateAsync({
             organizationId,
             role: roleName,
-            permission,
+            permission: value.permission,
             additionalFields
-          },
-          { onSettled: () => setIsSubmitting(false) }
-        )
+          })
+        }
+      } catch {
+        // The mutation reports the error through its configured handler.
       }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      setIsSubmitting(false)
     }
-  }
+  })
 
-  const pending = createRole.isPending || updateRole.isPending || isSubmitting
+  useEffect(() => {
+    if (!open) return
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredRoleFields),
+      name: role?.role ?? "",
+      permission: role?.permission ?? {}
+    })
+  }, [configuredRoleFields, form, open, role?.permission, role?.role])
+
+  const pending = createRole.isPending || updateRole.isPending
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
-        <form className="flex flex-col gap-6" onSubmit={submit}>
-          <DialogHeader>
-            <DialogTitle>
-              {role ? localization.editRole : localization.createRole}
-            </DialogTitle>
-            <DialogDescription>
-              {localization.rolesDescription}
-            </DialogDescription>
-          </DialogHeader>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle>
+                {role ? localization.editRole : localization.createRole}
+              </DialogTitle>
+              <DialogDescription>
+                {localization.rolesDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <Field>
-            <FieldLabel htmlFor="organization-role-name">
-              {localization.roleName}
-            </FieldLabel>
-            <Input
-              id="organization-role-name"
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              placeholder={localization.roleNamePlaceholder}
-              disabled={pending}
-              required
-            />
-          </Field>
-
-          {fieldsWithModelValues(roleFields, role ?? {}).map((field) => (
-            <AdditionalField
-              key={field.name}
-              field={field}
-              name={field.name}
-              isPending={pending}
-              optionalLabel={authLocalization.settings.optional}
-            />
-          ))}
-
-          <fieldset className="flex flex-col gap-4">
-            <legend className="text-sm font-medium">
-              {localization.permissions}
-            </legend>
-            {Object.entries(registry).map(([resource, definition]) => (
-              <div className="flex flex-col gap-2" key={resource}>
-                <p className="text-sm font-medium">
-                  {definition.label ?? resource}
-                </p>
-                <div className="grid gap-3 sm:grid-cols-2">
-                  {Object.entries(definition.actions).map(([action, label]) => (
-                    <RolePermissionCheckbox
-                      action={action}
-                      checked={permission[resource]?.includes(action) ?? false}
-                      key={action}
-                      label={label}
-                      onCheckedChange={(selected) =>
-                        setPermission((current) => ({
-                          ...current,
-                          [resource]: selected
-                            ? [...(current[resource] ?? []), action]
-                            : (current[resource] ?? []).filter(
-                                (entry) => entry !== action
-                              )
-                        }))
-                      }
-                      organizationId={organizationId}
-                      pending={pending}
-                      resource={resource}
-                    />
-                  ))}
-                </div>
-              </div>
-            ))}
-          </fieldset>
-
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={pending}
-              onClick={() => onOpenChange(false)}
+            <form.AppField
+              name="name"
+              validators={{
+                onChange: ({ value }) =>
+                  validateStringLength(value, {
+                    requiredMessage: authLocalization.auth.fieldRequired,
+                    trim: true
+                  })
+              }}
             >
-              {authLocalization.settings.cancel}
-            </Button>
-            <Button type="submit" disabled={pending || !name.trim()}>
-              {pending && <Spinner />}
-              {authLocalization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
-        </form>
+              {(field) => {
+                const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                return (
+                  <Field data-invalid={isInvalid}>
+                    <FieldLabel htmlFor="organization-role-name">
+                      {localization.roleName}
+                    </FieldLabel>
+                    <Input
+                      aria-invalid={isInvalid}
+                      disabled={pending}
+                      id="organization-role-name"
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      placeholder={localization.roleNamePlaceholder}
+                      value={field.state.value}
+                    />
+                    <field.AuthFormFieldError />
+                  </Field>
+                )
+              }}
+            </form.AppField>
+
+            {configuredRoleFields.map((configuredField) => (
+              <form.AppField
+                key={configuredField.name}
+                name={`additionalFields.${configuredField.name}`}
+                validators={getAuthAdditionalFieldValidators(
+                  configuredField,
+                  authLocalization.auth.fieldRequired
+                )}
+              >
+                {(field) => (
+                  <field.AuthFormAdditionalField
+                    field={configuredField}
+                    isPending={pending}
+                    optionalLabel={authLocalization.settings.optional}
+                  />
+                )}
+              </form.AppField>
+            ))}
+
+            <form.AppField name="permission">
+              {(field) => (
+                <fieldset className="flex flex-col gap-4">
+                  <legend className="text-sm font-medium">
+                    {localization.permissions}
+                  </legend>
+                  {Object.entries(registry).map(([resource, definition]) => (
+                    <div className="flex flex-col gap-2" key={resource}>
+                      <p className="text-sm font-medium">
+                        {definition.label ?? resource}
+                      </p>
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        {Object.entries(definition.actions).map(
+                          ([action, label]) => (
+                            <RolePermissionCheckbox
+                              action={action}
+                              checked={
+                                field.state.value[resource]?.includes(action) ??
+                                false
+                              }
+                              key={action}
+                              label={label}
+                              onCheckedChange={(selected) =>
+                                field.handleChange({
+                                  ...field.state.value,
+                                  [resource]: selected
+                                    ? [
+                                        ...(field.state.value[resource] ?? []),
+                                        action
+                                      ]
+                                    : (
+                                        field.state.value[resource] ?? []
+                                      ).filter((entry) => entry !== action)
+                                })
+                              }
+                              organizationId={organizationId}
+                              pending={pending}
+                              resource={resource}
+                            />
+                          )
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </fieldset>
+              )}
+            </form.AppField>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={pending}
+                onClick={() => onOpenChange(false)}
+              >
+                {authLocalization.settings.cancel}
+              </Button>
+              <form.AuthFormSubmitButton disabled={pending}>
+                {authLocalization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-teams.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-teams.tsx
@@ -3,7 +3,9 @@
 import {
   type AdditionalFields,
   fieldsWithModelValues,
-  parseAdditionalFieldValues
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type { OrganizationTeamsAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
@@ -28,7 +30,7 @@ import {
   UserRoundMinus,
   Users
 } from "lucide-react"
-import { type FormEvent, useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 import {
   AlertDialog,
@@ -63,7 +65,11 @@ import {
 } from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 
 type Team = { id: string; name: string; [key: string]: unknown }
 
@@ -230,8 +236,6 @@ function TeamDialog({
     organizationId,
     permissions: { member: ["delete"] }
   })
-  const [name, setName] = useState("")
-  const [isSubmittingFields, setIsSubmittingFields] = useState(false)
   const [userId, setUserId] = useState("")
   const createTeam = useCreateTeam(authClient, {
     onSuccess: () => {
@@ -266,276 +270,309 @@ function TeamDialog({
     ? localization.activeTeamRemovalDisabled
     : localization.lastTeamRemovalDisabled
 
+  const configuredTeamFields = useMemo(
+    () => fieldsWithModelValues(teamFields, team ?? {}),
+    [team, teamFields]
+  )
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredTeamFields),
+      name: team?.name ?? ""
+    },
+    onSubmit: async ({ value }) => {
+      const name = value.name.trim()
+      if (!name || !organizationId || (!team && teamLimitReached)) return
+      if (team && !canUpdate.data?.success) return
+
+      const data = {
+        ...getAdditionalFieldSubmitValues(
+          configuredTeamFields,
+          value.additionalFields
+        ),
+        name,
+        organizationId
+      }
+
+      try {
+        if (team) await updateTeam.mutateAsync({ teamId: team.id, data })
+        else await createTeam.mutateAsync(data)
+      } catch {
+        // The mutation reports the error through its configured handler.
+      }
+    }
+  })
+
   useEffect(() => {
     if (!open) return
-    setName(team?.name ?? "")
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredTeamFields),
+      name: team?.name ?? ""
+    })
     setUserId("")
-  }, [open, team])
+  }, [configuredTeamFields, form, open, team?.name])
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const trimmedName = name.trim()
-    if (!trimmedName || !organizationId || (!team && teamLimitReached)) return
-    if (team && !canUpdate.data?.success) return
-
-    setIsSubmittingFields(true)
-    try {
-      const values = await parseAdditionalFieldValues(
-        teamFields,
-        new FormData(event.currentTarget)
-      )
-      if (team) {
-        updateTeam.mutate(
-          {
-            teamId: team.id,
-            data: { ...values, name: trimmedName, organizationId }
-          },
-          { onSettled: () => setIsSubmittingFields(false) }
-        )
-      } else {
-        createTeam.mutate(
-          { ...values, name: trimmedName, organizationId },
-          { onSettled: () => setIsSubmittingFields(false) }
-        )
-      }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      setIsSubmittingFields(false)
-    }
-  }
-
-  const pending =
-    createTeam.isPending || updateTeam.isPending || isSubmittingFields
+  const pending = createTeam.isPending || updateTeam.isPending
   const canEdit = !team || canUpdate.data?.success === true
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
-        <form className="flex flex-col gap-6" onSubmit={handleSubmit}>
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Users />
-              {team ? localization.renameTeam : localization.createTeam}
-            </DialogTitle>
-            <DialogDescription>
-              {localization.teamsDescription}
-            </DialogDescription>
-          </DialogHeader>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Users />
+                {team ? localization.renameTeam : localization.createTeam}
+              </DialogTitle>
+              <DialogDescription>
+                {localization.teamsDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <div className="flex flex-col gap-4">
-            <Field>
-              <FieldLabel htmlFor="organization-team-name">
-                {localization.name}
-              </FieldLabel>
-              <Input
-                autoFocus
-                disabled={pending || !canEdit}
-                id="organization-team-name"
-                onChange={(event) => setName(event.target.value)}
-                required
-                value={name}
-              />
-            </Field>
-
-            {fieldsWithModelValues(teamFields, team ?? {}).map((field) => (
-              <AdditionalField
-                field={field}
-                isPending={pending || !canEdit}
-                key={field.name}
-                name={field.name}
-                optionalLabel={authLocalization.settings.optional}
-              />
-            ))}
-          </div>
-
-          {team && canListMembers && (
-            <div className="flex flex-col gap-4 border-t pt-5">
-              <div>
-                <h3 className="text-sm font-medium">
-                  {localization.teamMembers}
-                </h3>
-                <p className="text-sm text-muted-foreground">
-                  {localization.addTeamMember}
-                </p>
-              </div>
-
-              {(canAddMember.isPending || canAddMember.data?.success) && (
-                <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-end">
-                  <Field className="flex-1">
-                    <FieldLabel>{localization.addTeamMember}</FieldLabel>
-                    <Select
-                      disabled={canAddMember.isPending || memberLimitReached}
-                      onValueChange={(value) => setUserId(value ?? "")}
-                      value={userId}
-                    >
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder={localization.selectMember} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {organizationMembers
-                          .filter((member) => !memberIds.has(member.userId))
-                          .map((member) => (
-                            <SelectItem
-                              key={member.userId}
-                              value={member.userId}
-                            >
-                              {member.user.name || member.user.email}
-                            </SelectItem>
-                          ))}
-                      </SelectContent>
-                    </Select>
-                  </Field>
-                  <Button
-                    disabled={
-                      canAddMember.isPending ||
-                      !userId ||
-                      addMember.isPending ||
-                      memberLimitReached
-                    }
-                    onClick={() => {
-                      if (!canAddMember.data?.success || !userId) return
-                      addMember.mutate({
-                        teamId: team.id,
-                        userId,
-                        organizationId
-                      })
-                    }}
-                    type="button"
-                  >
-                    <UserPlus data-icon="inline-start" />
-                    {localization.addTeamMember}
-                  </Button>
-                </div>
-              )}
-
-              {canAddMember.data?.success && memberLimitReached && (
-                <p className="text-sm text-destructive" role="alert">
-                  {localization.teamMemberLimitReached}
-                </p>
-              )}
-
-              <div className="flex flex-col gap-2">
-                {teamMembers.isPending && <Spinner />}
-                {teamMembers.data?.map((teamMember) => {
-                  const member = organizationMembers.find(
-                    (candidate) => candidate.userId === teamMember.userId
-                  )
+            <div className="flex flex-col gap-4">
+              <form.AppField
+                name="name"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: authLocalization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
                   return (
-                    <div
-                      className="flex items-center justify-between gap-3 rounded-md border px-3 py-2"
-                      key={teamMember.id}
-                    >
-                      <span className="truncate text-sm">
-                        {member?.user.name ||
-                          member?.user.email ||
-                          teamMember.userId}
-                      </span>
-                      {(canRemoveMember.isPending ||
-                        canRemoveMember.data?.success) && (
-                        <Button
-                          aria-label={localization.removeTeamMember}
-                          disabled={
-                            canRemoveMember.isPending || removeMember.isPending
-                          }
-                          onClick={() => {
-                            if (!canRemoveMember.data?.success) return
-                            removeMember.mutate({
-                              teamId: team.id,
-                              userId: teamMember.userId,
-                              organizationId
-                            })
-                          }}
-                          size="icon-sm"
-                          type="button"
-                          variant="ghost"
-                        >
-                          <UserRoundMinus />
-                        </Button>
-                      )}
-                    </div>
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="organization-team-name">
+                        {localization.name}
+                      </FieldLabel>
+                      <Input
+                        aria-invalid={isInvalid}
+                        autoFocus
+                        disabled={pending || !canEdit}
+                        id="organization-team-name"
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        value={field.state.value}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
                   )
-                })}
-              </div>
+                }}
+              </form.AppField>
+
+              {configuredTeamFields.map((configuredField) => (
+                <form.AppField
+                  key={configuredField.name}
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    authLocalization.auth.fieldRequired
+                  )}
+                >
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      isPending={pending || !canEdit}
+                      optionalLabel={authLocalization.settings.optional}
+                    />
+                  )}
+                </form.AppField>
+              ))}
             </div>
-          )}
 
-          {team && !canRemoveTeam && canDelete.data?.success && (
-            <p className="text-sm text-muted-foreground">
-              {teamRemovalDisabledReason}
-            </p>
-          )}
+            {team && canListMembers && (
+              <div className="flex flex-col gap-4 border-t pt-5">
+                <div>
+                  <h3 className="text-sm font-medium">
+                    {localization.teamMembers}
+                  </h3>
+                  <p className="text-sm text-muted-foreground">
+                    {localization.addTeamMember}
+                  </p>
+                </div>
 
-          <DialogFooter className="sm:justify-between">
-            {team && (canDelete.isPending || canDelete.data?.success) && (
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button
-                    disabled={
-                      canDelete.isPending ||
-                      removeTeam.isPending ||
-                      !canRemoveTeam
-                    }
-                    type="button"
-                    variant="destructive"
-                  >
-                    <Trash2 data-icon="inline-start" />
-                    {localization.deleteTeam}
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>
-                      {localization.deleteTeam}
-                    </AlertDialogTitle>
-                    <AlertDialogDescription>
-                      {localization.deleteTeamDescription}
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>
-                      {authLocalization.settings.cancel}
-                    </AlertDialogCancel>
-                    <AlertDialogAction
-                      className={buttonVariants({ variant: "destructive" })}
-                      onClick={() =>
-                        removeTeam.mutate({
+                {(canAddMember.isPending || canAddMember.data?.success) && (
+                  <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-end">
+                    <Field className="flex-1">
+                      <FieldLabel>{localization.addTeamMember}</FieldLabel>
+                      <Select
+                        disabled={canAddMember.isPending || memberLimitReached}
+                        onValueChange={(value) => setUserId(value ?? "")}
+                        value={userId}
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue
+                            placeholder={localization.selectMember}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {organizationMembers
+                            .filter((member) => !memberIds.has(member.userId))
+                            .map((member) => (
+                              <SelectItem
+                                key={member.userId}
+                                value={member.userId}
+                              >
+                                {member.user.name || member.user.email}
+                              </SelectItem>
+                            ))}
+                        </SelectContent>
+                      </Select>
+                    </Field>
+                    <Button
+                      disabled={
+                        canAddMember.isPending ||
+                        !userId ||
+                        addMember.isPending ||
+                        memberLimitReached
+                      }
+                      onClick={() => {
+                        if (!canAddMember.data?.success || !userId) return
+                        addMember.mutate({
                           teamId: team.id,
+                          userId,
                           organizationId
                         })
+                      }}
+                      type="button"
+                    >
+                      <UserPlus data-icon="inline-start" />
+                      {localization.addTeamMember}
+                    </Button>
+                  </div>
+                )}
+
+                {canAddMember.data?.success && memberLimitReached && (
+                  <p className="text-sm text-destructive" role="alert">
+                    {localization.teamMemberLimitReached}
+                  </p>
+                )}
+
+                <div className="flex flex-col gap-2">
+                  {teamMembers.isPending && <Spinner />}
+                  {teamMembers.data?.map((teamMember) => {
+                    const member = organizationMembers.find(
+                      (candidate) => candidate.userId === teamMember.userId
+                    )
+                    return (
+                      <div
+                        className="flex items-center justify-between gap-3 rounded-md border px-3 py-2"
+                        key={teamMember.id}
+                      >
+                        <span className="truncate text-sm">
+                          {member?.user.name ||
+                            member?.user.email ||
+                            teamMember.userId}
+                        </span>
+                        {(canRemoveMember.isPending ||
+                          canRemoveMember.data?.success) && (
+                          <Button
+                            aria-label={localization.removeTeamMember}
+                            disabled={
+                              canRemoveMember.isPending ||
+                              removeMember.isPending
+                            }
+                            onClick={() => {
+                              if (!canRemoveMember.data?.success) return
+                              removeMember.mutate({
+                                teamId: team.id,
+                                userId: teamMember.userId,
+                                organizationId
+                              })
+                            }}
+                            size="icon-sm"
+                            type="button"
+                            variant="ghost"
+                          >
+                            <UserRoundMinus />
+                          </Button>
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+
+            {team && !canRemoveTeam && canDelete.data?.success && (
+              <p className="text-sm text-muted-foreground">
+                {teamRemovalDisabledReason}
+              </p>
+            )}
+
+            <DialogFooter className="sm:justify-between">
+              {team && (canDelete.isPending || canDelete.data?.success) && (
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      disabled={
+                        canDelete.isPending ||
+                        removeTeam.isPending ||
+                        !canRemoveTeam
                       }
+                      type="button"
+                      variant="destructive"
                     >
                       <Trash2 data-icon="inline-start" />
                       {localization.deleteTeam}
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-            )}
-
-            <div className="flex flex-col-reverse gap-2 sm:flex-row">
-              <DialogClose
-                className={buttonVariants({ variant: "outline" })}
-                disabled={pending}
-                type="button"
-              >
-                {authLocalization.settings.cancel}
-              </DialogClose>
-              {canEdit && (
-                <Button
-                  disabled={
-                    pending || !name.trim() || (teamLimitReached && !team)
-                  }
-                  type="submit"
-                >
-                  {pending && <Spinner />}
-                  {team
-                    ? authLocalization.settings.saveChanges
-                    : localization.createTeam}
-                </Button>
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>
+                        {localization.deleteTeam}
+                      </AlertDialogTitle>
+                      <AlertDialogDescription>
+                        {localization.deleteTeamDescription}
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>
+                        {authLocalization.settings.cancel}
+                      </AlertDialogCancel>
+                      <AlertDialogAction
+                        className={buttonVariants({ variant: "destructive" })}
+                        onClick={() =>
+                          removeTeam.mutate({
+                            teamId: team.id,
+                            organizationId
+                          })
+                        }
+                      >
+                        <Trash2 data-icon="inline-start" />
+                        {localization.deleteTeam}
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
               )}
-            </div>
-          </DialogFooter>
-        </form>
+
+              <div className="flex flex-col-reverse gap-2 sm:flex-row">
+                <DialogClose
+                  className={buttonVariants({ variant: "outline" })}
+                  disabled={pending}
+                  type="button"
+                >
+                  {authLocalization.settings.cancel}
+                </DialogClose>
+                {canEdit && (
+                  <form.AuthFormSubmitButton
+                    disabled={pending || (teamLimitReached && !team)}
+                  >
+                    {team
+                      ? authLocalization.settings.saveChanges
+                      : localization.createTeam}
+                  </form.AuthFormSubmitButton>
+                )}
+              </div>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/next-shadcn-example/src/components/auth/settings/account/user-profile.tsx
+++ b/examples/next-shadcn-example/src/components/auth/settings/account/user-profile.tsx
@@ -1,22 +1,26 @@
 "use client"
 
 import {
-  type AdditionalFieldValue,
-  parseAdditionalFieldValue
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type { UsernameAuthClient } from "@better-auth-ui/core/plugins/username"
 import { useAuth, useSession, useUpdateUser } from "@better-auth-ui/react"
-import { type SyntheticEvent, useState } from "react"
+import { useEffect, useMemo } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Spinner } from "@/components/ui/spinner"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "../../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../../auth-form"
 import { ChangeAvatar } from "./change-avatar"
 
 export type UserProfileProps = {
@@ -34,49 +38,39 @@ export function UserProfile({ className }: UserProfileProps) {
     useAuth<UsernameAuthClient>()
   const { data: session } = useSession(authClient)
 
-  const { mutate: updateUser, isPending } = useUpdateUser(authClient, {
+  const { mutateAsync: updateUser, isPending } = useUpdateUser(authClient, {
     onSuccess: () => toast.success(localization.settings.profileUpdatedSuccess)
   })
 
-  const [fieldErrors, setFieldErrors] = useState<{
-    name?: string
-  }>({})
-
-  async function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const name = formData.get("name") as string
-
-    const additionalFieldValues: Record<string, unknown> = {}
-
-    for (const field of additionalFields ?? []) {
-      if (field.profile === false || field.readOnly) continue
-      const value = parseAdditionalFieldValue(
-        field,
-        formData.get(field.name) as string | null
-      )
-
-      if (field.validate) {
-        try {
-          await field.validate(value)
-        } catch (error) {
-          toast.error(error instanceof Error ? error.message : String(error))
-          return
-        }
-      }
-
-      // `null` = explicit clear (forward to backend); `undefined` = omitted.
-      if (value !== undefined) {
-        additionalFieldValues[field.name] = value
-      }
+  const profileFields = useMemo(
+    () => additionalFields?.filter((field) => field.profile !== false) ?? [],
+    [additionalFields]
+  )
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(profileFields),
+      name: ""
+    },
+    onSubmit: async ({ value }) => {
+      await updateUser({
+        name: value.name,
+        ...getAdditionalFieldSubmitValues(profileFields, value.additionalFields)
+      })
     }
+  })
 
-    updateUser({
-      name,
-      ...additionalFieldValues
+  useEffect(() => {
+    if (!session) return
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(
+        fieldsWithModelValues(
+          profileFields,
+          session.user as Record<string, unknown>
+        )
+      ),
+      name: session.user.name
     })
-  }
+  }, [form, profileFields, session])
 
   return (
     <div>
@@ -84,101 +78,101 @@ export function UserProfile({ className }: UserProfileProps) {
         {localization.settings.userProfile}
       </h2>
 
-      <form onSubmit={handleSubmit}>
-        <Card className={cn(className)}>
-          <CardContent className="flex flex-col gap-6">
-            <ChangeAvatar />
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card className={cn(className)}>
+            <CardContent className="flex flex-col gap-6">
+              <ChangeAvatar />
 
-            <Field data-invalid={!!fieldErrors.name}>
-              <FieldLabel htmlFor="name">{localization.auth.name}</FieldLabel>
+              <form.AppField
+                name="name"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
-              {session ? (
-                <Input
-                  key={session?.user.name}
-                  id="name"
-                  name="name"
-                  autoComplete="name"
-                  defaultValue={session?.user.name}
-                  placeholder={localization.auth.name}
-                  disabled={isPending}
-                  required
-                  onChange={() => {
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      name: undefined
-                    }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="name">
+                        {localization.auth.name}
+                      </FieldLabel>
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      name: (e.target as HTMLInputElement).validationMessage
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.name}
-                />
-              ) : (
-                <Skeleton>
-                  <Input className="invisible" />
-                </Skeleton>
-              )}
+                      {session ? (
+                        <Input
+                          id="name"
+                          name={field.name}
+                          autoComplete="name"
+                          placeholder={localization.auth.name}
+                          disabled={isPending}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          aria-invalid={isInvalid}
+                        />
+                      ) : (
+                        <Skeleton>
+                          <Input className="invisible" />
+                        </Skeleton>
+                      )}
 
-              <FieldError>{fieldErrors.name}</FieldError>
-            </Field>
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
 
-            {additionalFields?.map((field) => {
-              if (field.profile === false) return null
+              {profileFields.map((configuredField) => {
+                if (!session) {
+                  if (configuredField.inputType === "hidden") {
+                    return null
+                  }
 
-              if (!session) {
-                if (field.inputType === "hidden") {
-                  return null
+                  return (
+                    <Skeleton key={configuredField.name}>
+                      <Input className="invisible" />
+                    </Skeleton>
+                  )
                 }
 
                 return (
-                  <Skeleton key={field.name}>
-                    <Input className="invisible" />
-                  </Skeleton>
+                  <form.AppField
+                    key={configuredField.name}
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={isPending}
+                      />
+                    )}
+                  </form.AppField>
                 )
-              }
+              })}
+            </CardContent>
 
-              const value = (session.user as Record<string, unknown>)[
-                field.name
-              ]
-
-              // Re-mount when the session value loads so the field's
-              // uncontrolled `defaultValue` reflects the latest data.
-              const key = `${field.name}:${
-                value instanceof Date
-                  ? value.toISOString()
-                  : String(value ?? "")
-              }`
-
-              return (
-                <AdditionalField
-                  key={key}
-                  name={field.name}
-                  field={{
-                    ...field,
-                    // `defaultValue` is sign-up-only; on the profile we
-                    // always seed from the session.
-                    defaultValue: value as AdditionalFieldValue | null
-                  }}
-                  isPending={isPending}
-                />
-              )
-            })}
-          </CardContent>
-
-          <CardFooter>
-            <Button type="submit" size="sm" disabled={isPending || !session}>
-              {isPending && <Spinner />}
-
-              {localization.settings.saveChanges}
-            </Button>
-          </CardFooter>
-        </Card>
-      </form>
+            <CardFooter>
+              <form.AuthFormSubmitButton
+                size="sm"
+                disabled={isPending || !session}
+              >
+                {localization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/examples/next-shadcn-example/src/components/auth/sign-up.tsx
+++ b/examples/next-shadcn-example/src/components/auth/sign-up.tsx
@@ -2,9 +2,10 @@
 
 import {
   authMutationKeys,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
   getAuthLinkURL,
   isPasswordCompromisedError,
-  parseAdditionalFieldValue,
   validateEmailAddress,
   validateMatchingValue,
   validateStringLength
@@ -17,8 +18,7 @@ import {
 } from "@better-auth-ui/react"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { useRef, useState } from "react"
-import { toast } from "sonner"
+import { useMemo, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Field,
@@ -36,8 +36,11 @@ import {
   InputGroupInput
 } from "@/components/ui/input-group"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "./additional-field"
-import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "./auth-form"
 import { PasswordStrengthMeter } from "./password-strength-meter"
 import { ProviderButtons, type SocialLayout } from "./provider-buttons"
 
@@ -136,9 +139,13 @@ export function SignUp({
     useState(false)
 
   const [isCompromised, setIsCompromised] = useState(false)
-  const additionalFieldValuesRef = useRef<Record<string, unknown>>({})
+  const signUpFields = useMemo(
+    () => additionalFields?.filter((field) => field.signUp) ?? [],
+    [additionalFields]
+  )
   const form = useAuthForm({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(signUpFields),
       confirmPassword: "",
       email: "",
       name: "",
@@ -150,7 +157,10 @@ export function SignUp({
           name: emailAndPassword?.name === false ? "" : value.name,
           email: value.email.trim(),
           password: value.password,
-          ...additionalFieldValuesRef.current,
+          ...getAdditionalFieldSubmitValues(
+            signUpFields,
+            value.additionalFields
+          ),
           fetchOptions
         })
       } catch {
@@ -158,35 +168,6 @@ export function SignUp({
       }
     }
   })
-
-  const prepareSubmit = async (formElement: HTMLFormElement) => {
-    const formData = new FormData(formElement)
-
-    const additionalFieldValues: Record<string, unknown> = {}
-
-    for (const field of additionalFields ?? []) {
-      if (!field.signUp || field.readOnly) continue
-      const value = parseAdditionalFieldValue(
-        field,
-        formData.get(field.name) as string | null
-      )
-
-      if (field.validate) {
-        try {
-          await field.validate(value)
-        } catch (error) {
-          toast.error(error instanceof Error ? error.message : String(error))
-          return false
-        }
-      }
-
-      if (value !== undefined) {
-        additionalFieldValues[field.name] = value
-      }
-    }
-
-    additionalFieldValuesRef.current = additionalFieldValues
-  }
 
   const showSeparator =
     emailAndPassword?.enabled && socialProviders && socialProviders.length > 0
@@ -218,7 +199,7 @@ export function SignUp({
 
           {emailAndPassword?.enabled && (
             <form.AppForm>
-              <form.AuthFormRoot prepareSubmit={prepareSubmit}>
+              <form.AuthFormRoot>
                 <FieldGroup>
                   {emailAndPassword.name !== false && (
                     <form.AppField
@@ -306,16 +287,25 @@ export function SignUp({
                     }}
                   </form.AppField>
 
-                  {additionalFields?.map(
-                    (field) =>
-                      field.signUp === "above" && (
-                        <AdditionalField
-                          key={field.name}
-                          name={field.name}
-                          field={field}
-                          isPending={isPending}
-                          optionalLabel={localization.auth.optional}
-                        />
+                  {signUpFields.map(
+                    (configuredField) =>
+                      configuredField.signUp === "above" && (
+                        <form.AppField
+                          key={configuredField.name}
+                          name={`additionalFields.${configuredField.name}`}
+                          validators={getAuthAdditionalFieldValidators(
+                            configuredField,
+                            localization.auth.fieldRequired
+                          )}
+                        >
+                          {(field) => (
+                            <field.AuthFormAdditionalField
+                              field={configuredField}
+                              isPending={isPending}
+                              optionalLabel={localization.auth.optional}
+                            />
+                          )}
+                        </form.AppField>
                       )
                   )}
 
@@ -503,17 +493,25 @@ export function SignUp({
                     </form.AppField>
                   )}
 
-                  {additionalFields?.map(
-                    (field) =>
-                      field.signUp &&
-                      field.signUp !== "above" && (
-                        <AdditionalField
-                          key={field.name}
-                          name={field.name}
-                          field={field}
-                          isPending={isPending}
-                          optionalLabel={localization.auth.optional}
-                        />
+                  {signUpFields.map(
+                    (configuredField) =>
+                      configuredField.signUp !== "above" && (
+                        <form.AppField
+                          key={configuredField.name}
+                          name={`additionalFields.${configuredField.name}`}
+                          validators={getAuthAdditionalFieldValidators(
+                            configuredField,
+                            localization.auth.fieldRequired
+                          )}
+                        >
+                          {(field) => (
+                            <field.AuthFormAdditionalField
+                              field={configuredField}
+                              isPending={isPending}
+                              optionalLabel={localization.auth.optional}
+                            />
+                          )}
+                        </form.AppField>
                       )
                   )}
 

--- a/examples/next-shadcn-example/src/components/auth/username/username-field.tsx
+++ b/examples/next-shadcn-example/src/components/auth/username/username-field.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getFormFieldErrors } from "@better-auth-ui/core"
 import type { UsernameAuthClient } from "@better-auth-ui/core/plugins/username"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useIsUsernameAvailable } from "@better-auth-ui/react/plugins/username"
@@ -25,6 +26,11 @@ import { usernamePlugin } from "@/lib/auth/username-plugin"
 export function UsernameField({
   name,
   field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
   isPending
 }: AdditionalFieldProps) {
   const { authClient, localization: authLocalization } =
@@ -38,8 +44,9 @@ export function UsernameField({
   } = useAuthPlugin(usernamePlugin)
 
   const currentUsername = String(field.defaultValue ?? "")
-  const [value, setValue] = useState(currentUsername)
-  const [error, setError] = useState<string>()
+  const username = typeof value === "string" ? value : ""
+  const [nativeError, setNativeError] = useState<string>()
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
   const {
     mutate: requestAvailability,
@@ -64,8 +71,8 @@ export function UsernameField({
   )
 
   function handleChange(next: string) {
-    setValue(next)
-    setError(undefined)
+    onChange(next || null)
+    setNativeError(undefined)
     resetAvailability()
 
     if (checkAvailability) {
@@ -74,10 +81,12 @@ export function UsernameField({
   }
 
   const isCheckingAvailability =
-    !!checkAvailability && !!value.trim() && value.trim() !== currentUsername
+    !!checkAvailability &&
+    !!username.trim() &&
+    username.trim() !== currentUsername
 
   return (
-    <Field data-invalid={!!error}>
+    <Field data-invalid={isInvalid || !!nativeError}>
       <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
       <InputGroup>
@@ -97,7 +106,8 @@ export function UsernameField({
           disabled={isPending}
           required={field.required}
           readOnly={field.readOnly}
-          value={value}
+          value={username}
+          onBlur={onBlur}
           onChange={(e) => handleChange(e.target.value)}
           onInvalid={(e) => {
             e.preventDefault()
@@ -113,9 +123,9 @@ export function UsernameField({
                     "{{max}}",
                     String(maxUsernameLength)
                   )
-            setError(msg)
+            setNativeError(msg)
           }}
-          aria-invalid={!!error}
+          aria-invalid={isInvalid || !!nativeError}
           placeholder={field.placeholder}
         />
 
@@ -141,7 +151,7 @@ export function UsernameField({
         )}
       </InputGroup>
 
-      <FieldError>{error}</FieldError>
+      <FieldError errors={fieldErrors}>{nativeError}</FieldError>
     </Field>
   )
 }

--- a/examples/start-shadcn-baseui-example/src/components/auth/additional-field.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/additional-field.tsx
@@ -2,6 +2,8 @@
 
 import {
   type AdditionalField as AdditionalFieldConfig,
+  type AdditionalFieldFormValue,
+  getFormFieldErrors,
   resolveInputType
 } from "@better-auth-ui/core"
 import { useAuth, useCopyToClipboard } from "@better-auth-ui/react"
@@ -55,9 +57,19 @@ import { cn } from "@/lib/utils"
 export type AdditionalFieldProps = {
   name: string
   field: AdditionalFieldConfig
+  value: AdditionalFieldFormValue
+  onBlur: () => void
+  onChange: (value: AdditionalFieldFormValue) => void
+  isInvalid?: boolean
+  errors?: unknown[]
   isPending?: boolean
   /** Complete suffix appended to labels for fields that are not required. */
   optionalLabel?: string
+}
+
+function valueToString(value: AdditionalFieldFormValue) {
+  if (value == null) return ""
+  return value instanceof Date ? value.toISOString() : String(value)
 }
 
 /** Convert a `defaultValue` into a `Date` for the calendar. */
@@ -125,6 +137,11 @@ function CopyButton({
 export function AdditionalField({
   name,
   field: configuredField,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
   isPending,
   optionalLabel
 }: AdditionalFieldProps) {
@@ -141,6 +158,7 @@ export function AdditionalField({
         }
       : configuredField
   const inputType = resolveInputType(field)
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
   if (field.render) {
     const FieldRenderer = field.render as ComponentType<AdditionalFieldProps>
@@ -148,6 +166,11 @@ export function AdditionalField({
       <FieldRenderer
         name={name}
         field={field}
+        value={value}
+        onBlur={onBlur}
+        onChange={onChange}
+        isInvalid={isInvalid}
+        errors={errors}
         isPending={isPending}
         optionalLabel={optionalLabel}
       />
@@ -156,38 +179,29 @@ export function AdditionalField({
 
   if (inputType === "hidden") {
     return (
-      <input
-        type="hidden"
-        name={name}
-        value={
-          field.defaultValue == null
-            ? ""
-            : field.defaultValue instanceof Date
-              ? field.defaultValue.toISOString()
-              : String(field.defaultValue)
-        }
-      />
+      <input type="hidden" name={name} value={valueToString(value)} readOnly />
     )
   }
 
   if (inputType === "textarea") {
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <Textarea
           id={name}
           name={name}
-          defaultValue={
-            field.defaultValue == null ? undefined : String(field.defaultValue)
-          }
+          value={valueToString(value)}
+          onBlur={onBlur}
+          onChange={(event) => onChange(event.target.value || null)}
           placeholder={field.placeholder}
           required={field.required}
           readOnly={field.readOnly}
           disabled={isPending}
+          aria-invalid={isInvalid}
         />
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
@@ -196,7 +210,7 @@ export function AdditionalField({
     const maxFractionDigits = field.formatOptions?.maximumFractionDigits
 
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <Input
@@ -210,82 +224,102 @@ export function AdditionalField({
             field.step ??
             (maxFractionDigits ? 1 / 10 ** maxFractionDigits : undefined)
           }
-          defaultValue={
-            field.defaultValue == null
-              ? undefined
-              : typeof field.defaultValue === "number"
-                ? field.defaultValue
-                : String(field.defaultValue)
+          value={typeof value === "number" ? value : ""}
+          onBlur={onBlur}
+          onChange={(event) =>
+            onChange(
+              event.target.value === "" ? null : event.target.valueAsNumber
+            )
           }
           placeholder={field.placeholder}
           required={field.required}
           readOnly={field.readOnly}
           disabled={isPending}
+          aria-invalid={isInvalid}
         />
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "slider") {
-    return <SliderField name={name} field={field} isPending={isPending} />
+    return (
+      <SliderField
+        name={name}
+        field={field}
+        value={value}
+        onBlur={onBlur}
+        onChange={onChange}
+        isInvalid={isInvalid}
+        errors={errors}
+        isPending={isPending}
+      />
+    )
   }
 
   if (inputType === "switch") {
     return (
-      <Field orientation="horizontal">
+      <Field data-invalid={isInvalid} orientation="horizontal">
         <Switch
           id={name}
           name={name}
-          defaultChecked={
-            field.defaultValue === true || field.defaultValue === "true"
-          }
+          checked={value === true}
+          onBlur={onBlur}
+          onCheckedChange={onChange}
           disabled={isPending || field.readOnly}
+          aria-invalid={isInvalid}
         />
 
         <FieldContent>
           <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
         </FieldContent>
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "checkbox") {
     return (
-      <Field orientation="horizontal">
+      <Field data-invalid={isInvalid} orientation="horizontal">
         <Checkbox
           id={name}
           name={name}
-          defaultChecked={
-            field.defaultValue === true || field.defaultValue === "true"
-          }
+          checked={value === true}
+          onBlur={onBlur}
+          onCheckedChange={(checked) => onChange(checked === true)}
           required={field.required}
           disabled={isPending || field.readOnly}
+          aria-invalid={isInvalid}
         />
 
         <FieldContent>
           <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
         </FieldContent>
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "select") {
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <Select
           items={field.options ?? []}
           name={name}
-          defaultValue={
-            field.defaultValue != null ? String(field.defaultValue) : undefined
-          }
+          value={valueToString(value) || undefined}
+          onValueChange={(nextValue) => onChange(nextValue)}
           required={field.required}
           disabled={isPending || field.readOnly}
         >
-          <SelectTrigger id={name} className="w-full">
+          <SelectTrigger
+            id={name}
+            className="w-full"
+            onBlur={onBlur}
+            aria-invalid={isInvalid}
+          >
             <SelectValue placeholder={field.placeholder} />
           </SelectTrigger>
 
@@ -300,26 +334,34 @@ export function AdditionalField({
           </SelectContent>
         </Select>
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "combobox") {
+    const selectedOption = field.options?.find(
+      (option) => option.value === valueToString(value)
+    )
+
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <Combobox
           items={field.options ?? []}
           name={name}
-          defaultValue={
-            field.defaultValue != null ? String(field.defaultValue) : undefined
-          }
+          value={selectedOption ?? null}
+          onValueChange={(option) => onChange(option?.value ?? null)}
           required={field.required}
           disabled={isPending || field.readOnly}
         >
-          <ComboboxInput placeholder={field.placeholder} id={name} />
+          <ComboboxInput
+            placeholder={field.placeholder}
+            id={name}
+            onBlur={onBlur}
+            aria-invalid={isInvalid}
+          />
 
           <ComboboxContent>
             <ComboboxEmpty>No items found.</ComboboxEmpty>
@@ -334,20 +376,52 @@ export function AdditionalField({
           </ComboboxContent>
         </Combobox>
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "date" || inputType === "datetime") {
-    return <DateInput name={name} field={field} isPending={isPending} />
+    return (
+      <DateInput
+        name={name}
+        field={field}
+        value={value}
+        onBlur={onBlur}
+        onChange={onChange}
+        isInvalid={isInvalid}
+        errors={errors}
+        isPending={isPending}
+      />
+    )
   }
 
-  return <InputField name={name} field={field} isPending={isPending} />
+  return (
+    <InputField
+      name={name}
+      field={field}
+      value={value}
+      onBlur={onBlur}
+      onChange={onChange}
+      isInvalid={isInvalid}
+      errors={errors}
+      isPending={isPending}
+    />
+  )
 }
 
-function InputField({ name, field, isPending }: AdditionalFieldProps) {
+function InputField({
+  name,
+  field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
+  isPending
+}: AdditionalFieldProps) {
   const inputRef = useRef<HTMLInputElement>(null)
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
   const hasPrefix = field.prefix != null
   const hasSuffix = field.suffix != null || field.copyable
@@ -364,7 +438,7 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
 
   if (hasPrefix || hasSuffix) {
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <InputGroup>
@@ -381,15 +455,14 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
             type={nativeInputType}
             inputMode={nativeInputMode}
             step={nativeStep}
-            defaultValue={
-              field.defaultValue == null
-                ? undefined
-                : String(field.defaultValue)
-            }
+            value={valueToString(value)}
+            onBlur={onBlur}
+            onChange={(event) => onChange(event.target.value || null)}
             placeholder={field.placeholder}
             required={field.required}
             readOnly={field.readOnly}
             disabled={isPending}
+            aria-invalid={isInvalid}
           />
 
           {field.copyable ? (
@@ -408,13 +481,13 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
           )}
         </InputGroup>
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   return (
-    <Field>
+    <Field data-invalid={isInvalid}>
       <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
       <Input
@@ -423,16 +496,17 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
         type={nativeInputType}
         inputMode={nativeInputMode}
         step={nativeStep}
-        defaultValue={
-          field.defaultValue == null ? undefined : String(field.defaultValue)
-        }
+        value={valueToString(value)}
+        onBlur={onBlur}
+        onChange={(event) => onChange(event.target.value || null)}
         placeholder={field.placeholder}
         required={field.required}
         readOnly={field.readOnly}
         disabled={isPending}
+        aria-invalid={isInvalid}
       />
 
-      <FieldError />
+      <FieldError errors={fieldErrors} />
     </Field>
   )
 }
@@ -442,44 +516,51 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
  * it next to the label and control the state to keep the displayed value in
  * sync. The selected value is submitted via the underlying Radix `name` prop.
  */
-function SliderField({ name, field, isPending }: AdditionalFieldProps) {
+function SliderField({
+  name,
+  field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
+  isPending
+}: AdditionalFieldProps) {
   const maxFractionDigits = field.formatOptions?.maximumFractionDigits
   const min = field.min ?? 0
   const max = field.max ?? 100
   const step =
     field.step ?? (maxFractionDigits ? 1 / 10 ** maxFractionDigits : 1)
-  const initial =
-    typeof field.defaultValue === "number"
-      ? field.defaultValue
-      : field.defaultValue != null && !Number.isNaN(Number(field.defaultValue))
-        ? Number(field.defaultValue)
-        : min
-
-  const [value, setValue] = useState<number>(initial)
+  const numericValue = typeof value === "number" ? value : min
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
   const formatter = new Intl.NumberFormat(undefined, field.formatOptions)
 
   return (
-    <Field>
+    <Field data-invalid={isInvalid}>
       <div className="flex items-center justify-between gap-2">
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
         <span className="text-sm text-muted-foreground tabular-nums">
-          {formatter.format(value)}
+          {formatter.format(numericValue)}
         </span>
       </div>
 
       <Slider
         id={name}
         name={name}
-        value={[value]}
-        onValueChange={(v) => setValue((Array.isArray(v) ? v[0] : v) ?? min)}
+        value={[numericValue]}
+        onBlur={onBlur}
+        onValueChange={(nextValue) =>
+          onChange((Array.isArray(nextValue) ? nextValue[0] : nextValue) ?? min)
+        }
         min={min}
         max={max}
         step={step}
         disabled={isPending || field.readOnly}
+        aria-invalid={isInvalid}
       />
 
-      <FieldError />
+      <FieldError errors={fieldErrors} />
     </Field>
   )
 }
@@ -489,68 +570,42 @@ function SliderField({ name, field, isPending }: AdditionalFieldProps) {
  * (optionally) `<input type="time">` for the time. Submits the combined ISO
  * value via a hidden `<input>` so it shows up in `FormData`.
  */
-function DateInput({ name, field, isPending }: AdditionalFieldProps) {
+function DateInput({
+  name,
+  field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
+  isPending
+}: AdditionalFieldProps) {
   const { localization } = useAuth()
   const inputType = resolveInputType(field)
   const isDateTime = inputType === "datetime"
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
-  const [date, setDate] = useState<Date | undefined>(toDate(field.defaultValue))
+  const date = toDate(value)
   const [time, setTime] = useState<string>(
     isDateTime && date ? formatTime(date) : ""
   )
   const [open, setOpen] = useState(false)
-  const [error, setError] = useState<string>()
 
   // Compose the hidden form value: ISO date for "date", ISO datetime for
   // "datetime" (date + time).
-  let formValue = ""
-  if (date) {
-    if (isDateTime && time && time.trim() !== "") {
-      const [h = "0", m = "0", s = "0"] = time.split(":")
-      const combined = new Date(date)
-      combined.setHours(Number(h), Number(m), Number(s), 0)
-      formValue = combined.toISOString()
-    } else {
-      // Anchor to local midnight then serialize as ISO so the downstream
-      // `parseAdditionalFieldValue` parses the same calendar day regardless
-      // of timezone (a bare "YYYY-MM-DD" would be parsed as UTC midnight).
-      // Datetime fields with a blank time also fall through here, defaulting
-      // the time to local midnight since the parsed value is always a `Date`.
-      const localMidnight = new Date(date)
-      localMidnight.setHours(0, 0, 0, 0)
-      formValue = localMidnight.toISOString()
-    }
-  }
-
   return (
-    <Field data-invalid={!!error}>
+    <Field data-invalid={isInvalid}>
       <FieldLabel htmlFor={`${name}-date`}>{field.label}</FieldLabel>
 
       <div className="relative flex gap-2">
-        {/* Visually-hidden input so required constraint validation fires on submit.
-            onInvalid suppresses the native browser balloon and routes the message
-            through the styled <FieldError> below — matching the pattern used by
-            the Name / Email / Password fields in the sign-up form. */}
-        <input
-          aria-label={typeof field.label === "string" ? field.label : name}
-          type="text"
-          name={name}
-          value={formValue}
-          onChange={() => {}}
-          required={field.required}
-          tabIndex={-1}
-          className="sr-only"
-          onInvalid={(e) => {
-            e.preventDefault()
-            setError((e.target as HTMLInputElement).validationMessage)
-          }}
-        />
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger
             type="button"
             id={`${name}-date`}
             data-empty={!date}
-            aria-invalid={!!error}
+            aria-invalid={isInvalid}
+            aria-required={field.required}
+            onBlur={onBlur}
             disabled={isPending || field.readOnly}
             className={cn(
               buttonVariants({ variant: "outline" }),
@@ -570,8 +625,24 @@ function DateInput({ name, field, isPending }: AdditionalFieldProps) {
               defaultMonth={date}
               captionLayout="dropdown"
               onSelect={(value) => {
-                setDate(value)
-                if (value) setError(undefined)
+                if (!value) {
+                  onChange(null)
+                } else {
+                  const nextValue = new Date(value)
+                  if (isDateTime && time.trim()) {
+                    const [hours = "0", minutes = "0", seconds = "0"] =
+                      time.split(":")
+                    nextValue.setHours(
+                      Number(hours),
+                      Number(minutes),
+                      Number(seconds),
+                      0
+                    )
+                  } else {
+                    nextValue.setHours(0, 0, 0, 0)
+                  }
+                  onChange(nextValue)
+                }
                 if (!isDateTime) setOpen(false)
               }}
             />
@@ -589,7 +660,21 @@ function DateInput({ name, field, isPending }: AdditionalFieldProps) {
               id={`${name}-time`}
               step="1"
               value={time}
-              onChange={(e) => setTime(e.target.value)}
+              onChange={(event) => {
+                const nextTime = event.target.value
+                setTime(nextTime)
+                if (!date) return
+                const nextValue = new Date(date)
+                const [hours = "0", minutes = "0", seconds = "0"] =
+                  nextTime.split(":")
+                nextValue.setHours(
+                  Number(hours),
+                  Number(minutes),
+                  Number(seconds),
+                  0
+                )
+                onChange(nextValue)
+              }}
               disabled={isPending || field.readOnly}
               className="appearance-none bg-background [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
             />
@@ -597,7 +682,7 @@ function DateInput({ name, field, isPending }: AdditionalFieldProps) {
         )}
       </div>
 
-      <FieldError>{error}</FieldError>
+      <FieldError errors={fieldErrors} />
     </Field>
   )
 }

--- a/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
@@ -1,8 +1,10 @@
 "use client"
 
 import {
-  type AdditionalFieldValue,
-  parseAdditionalFieldValues
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  getClampedTablePageIndex
 } from "@better-auth-ui/core"
 import {
   type AdminAuthClient,
@@ -54,10 +56,8 @@ import {
   useDeferredValue,
   useEffect,
   useMemo,
-  useRef,
   useState
 } from "react"
-import { AdditionalField } from "@/components/auth/additional-field"
 import { UserAvatar } from "@/components/auth/user/user-avatar"
 import {
   AlertDialog,
@@ -123,7 +123,7 @@ import {
 } from "@/components/ui/table"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { adminPlugin } from "@/lib/auth/admin-plugin"
-import { useAuthForm } from "../auth-form"
+import { getAuthAdditionalFieldValidators, useAuthForm } from "../auth-form"
 
 import { createAdminColumnHelper, useAdminTable } from "./admin-table"
 
@@ -214,6 +214,8 @@ export function AdminUsers({
   const [searchField, setSearchField] = useState<SearchField>("email")
   const [searchOperator, setSearchOperator] =
     useState<SearchOperator>("contains")
+  const [createOpen, setCreateOpen] = useState(false)
+  const deferredSearch = useDeferredValue(globalFilter.trim())
   const status = String(
     columnFilters.find((filter) => filter.id === "status")?.value ?? "all"
   ) as StatusFilter
@@ -231,8 +233,6 @@ export function AdminUsers({
     { label: localization.active, value: "active" },
     { label: localization.banned, value: "banned" }
   ]
-  const [createOpen, setCreateOpen] = useState(false)
-  const deferredSearch = useDeferredValue(globalFilter.trim())
   const primarySort = sorting[0]
   const sortBy = primarySort?.id === "name" ? "name" : "createdAt"
   const sortDirection = primarySort?.desc ? "desc" : "asc"
@@ -284,6 +284,18 @@ export function AdminUsers({
   const canGet = useAdminPermission(auth.authClient, { user: ["get"] })
 
   const total = users.data?.total ?? 0
+
+  useEffect(() => {
+    if (!users.isSuccess) return
+    const pageIndex = getClampedTablePageIndex(
+      pagination.pageIndex,
+      pagination.pageSize,
+      total
+    )
+    if (pageIndex !== pagination.pageIndex) {
+      setPaginationState((current) => ({ ...current, pageIndex }))
+    }
+  }, [pagination.pageIndex, pagination.pageSize, total, users.isSuccess])
   const setPagination = (updater: Updater<PaginationState>) =>
     setPaginationState((current) => functionalUpdate(updater, current))
   const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
@@ -706,40 +718,45 @@ function CreateUserDialog({
   const auth = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
   const { data: session } = useSession(auth.authClient)
-  const [formError, setFormError] = useState<string>()
-  const canSetRole = useAdminPermission(auth.authClient, {
-    user: ["set-role"]
-  })
   const createUser = useMutation(
     createAdminUserOptions(auth.authClient, session?.user.id)
   )
-  const additionalFieldValuesRef = useRef<
-    Record<string, AdditionalFieldValue | null>
-  >({})
+  const canSetRole = useAdminPermission(auth.authClient, {
+    user: ["set-role"]
+  })
+  const additionalFields = auth.additionalFields ?? []
   const form = useAuthForm({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(additionalFields),
       email: "",
       emailVerified: false,
       name: "",
       password: "",
       roles: [config.defaultRole]
     },
-    onSubmit: ({ value }) => {
-      createUser.mutate(
-        {
-          data: {
-            ...additionalFieldValuesRef.current,
-            emailVerified: value.emailVerified
+    onSubmit: async ({ value }) => {
+      try {
+        await createUser.mutateAsync(
+          {
+            data: {
+              ...getAdditionalFieldSubmitValues(
+                additionalFields,
+                value.additionalFields
+              ),
+              emailVerified: value.emailVerified
+            },
+            email: value.email,
+            name: value.name,
+            password: value.password,
+            ...(canSetRole.data?.success
+              ? { role: asAdminRoles(value.roles) }
+              : {})
           },
-          email: value.email,
-          name: value.name,
-          password: value.password,
-          ...(canSetRole.data?.success
-            ? { role: asAdminRoles(value.roles) }
-            : {})
-        },
-        { onSuccess: close }
-      )
+          { onSuccess: close }
+        )
+      } catch {
+        // The mutation reports the error through its configured handler.
+      }
     }
   })
 
@@ -750,26 +767,8 @@ function CreateUserDialog({
 
   const close = () => {
     form.reset()
-    setFormError(undefined)
     createUser.reset()
     onOpenChange(false)
-  }
-  const submit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const data = new FormData(event.currentTarget)
-    let additionalFieldValues: Record<string, AdditionalFieldValue | null>
-    try {
-      additionalFieldValues = await parseAdditionalFieldValues(
-        auth.additionalFields ?? [],
-        data
-      )
-    } catch (error) {
-      setFormError(error instanceof Error ? error.message : String(error))
-      return
-    }
-    setFormError(undefined)
-    additionalFieldValuesRef.current = additionalFieldValues
-    await form.handleSubmit()
   }
 
   return (
@@ -778,168 +777,177 @@ function CreateUserDialog({
       onOpenChange={(value) => (value ? onOpenChange(true) : close())}
     >
       <DialogContent>
-        <form className="flex flex-col gap-4" onSubmit={submit}>
-          <DialogHeader>
-            <DialogTitle>{config.localization.createUser}</DialogTitle>
-            <DialogDescription>
-              {config.localization.usersDescription}
-            </DialogDescription>
-          </DialogHeader>
-          <FieldGroup>
-            <form.Field name="name">
-              {(field) => (
-                <Field>
-                  <FieldLabel htmlFor="admin-create-name">
-                    {config.localization.name}
-                  </FieldLabel>
-                  <InputGroup>
-                    <InputGroupInput
-                      id="admin-create-name"
-                      name={field.name}
-                      onChange={(event) =>
-                        field.handleChange(event.target.value)
-                      }
-                      required
-                      value={field.state.value}
-                    />
-                  </InputGroup>
-                </Field>
-              )}
-            </form.Field>
-            <form.Field name="email">
-              {(field) => (
-                <Field>
-                  <FieldLabel htmlFor="admin-create-email">
-                    {config.localization.email}
-                  </FieldLabel>
-                  <InputGroup>
-                    <InputGroupInput
-                      autoComplete="off"
-                      id="admin-create-email"
-                      name={field.name}
-                      onChange={(event) =>
-                        field.handleChange(event.target.value)
-                      }
-                      required
-                      type="email"
-                      value={field.state.value}
-                    />
-                  </InputGroup>
-                </Field>
-              )}
-            </form.Field>
-            <form.Field name="password">
-              {(field) => (
-                <Field>
-                  <FieldLabel htmlFor="admin-create-password">
-                    {config.localization.password}
-                  </FieldLabel>
-                  <InputGroup>
-                    <InputGroupInput
-                      autoComplete="new-password"
-                      id="admin-create-password"
-                      name={field.name}
-                      onChange={(event) =>
-                        field.handleChange(event.target.value)
-                      }
-                      required
-                      type="password"
-                      value={field.state.value}
-                    />
-                  </InputGroup>
-                </Field>
-              )}
-            </form.Field>
-            {canSetRole.isPending ? (
-              <Skeleton className="h-16 w-full" />
-            ) : canSetRole.data?.success ? (
-              <FieldSet>
-                <FieldLegend variant="label">
-                  {config.localization.role}
-                </FieldLegend>
-                <form.Field name="roles">
-                  {(field) =>
-                    config.allowMultipleRoles ? (
-                      <FieldGroup data-slot="checkbox-group">
-                        {config.roles.map((role) => (
-                          <Field key={role} orientation="horizontal">
-                            <Checkbox
-                              checked={field.state.value.includes(role)}
-                              id={`admin-create-role-${role}`}
-                              onCheckedChange={(checked) => {
-                                const next = checked
-                                  ? [...field.state.value, role]
-                                  : field.state.value.filter(
-                                      (item) => item !== role
-                                    )
-                                if (next.length) field.handleChange(next)
-                              }}
-                            />
-                            <FieldLabel htmlFor={`admin-create-role-${role}`}>
-                              {role}
-                            </FieldLabel>
-                          </Field>
-                        ))}
-                      </FieldGroup>
-                    ) : (
-                      <RadioGroup
-                        onValueChange={(role) => field.handleChange([role])}
-                        value={field.state.value[0] ?? ""}
-                      >
-                        {config.roles.map((role) => (
-                          <Field key={role} orientation="horizontal">
-                            <RadioGroupItem
-                              id={`admin-create-role-${role}`}
-                              value={role}
-                            />
-                            <FieldLabel htmlFor={`admin-create-role-${role}`}>
-                              {role}
-                            </FieldLabel>
-                          </Field>
-                        ))}
-                      </RadioGroup>
-                    )
-                  }
-                </form.Field>
-              </FieldSet>
-            ) : null}
-            <form.Field name="emailVerified">
-              {(field) => (
-                <Field orientation="horizontal">
-                  <Switch
-                    checked={field.state.value}
-                    id="admin-create-email-verified"
-                    onCheckedChange={field.handleChange}
-                  />
-                  <FieldContent>
-                    <FieldLabel htmlFor="admin-create-email-verified">
-                      {config.localization.emailVerified}
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-4">
+            <DialogHeader>
+              <DialogTitle>{config.localization.createUser}</DialogTitle>
+              <DialogDescription>
+                {config.localization.usersDescription}
+              </DialogDescription>
+            </DialogHeader>
+            <FieldGroup>
+              <form.Field name="name">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="admin-create-name">
+                      {config.localization.name}
                     </FieldLabel>
-                  </FieldContent>
-                </Field>
-              )}
-            </form.Field>
-            {auth.additionalFields?.map((field) => (
-              <AdditionalField
-                field={field}
-                isPending={createUser.isPending}
-                key={field.name}
-                name={field.name}
-              />
-            ))}
-          </FieldGroup>
-          <FieldError>
-            {formError ?? getAdminErrorMessage(createUser.error)}
-          </FieldError>
-          <DialogFooter>
-            <Button onClick={close} type="button" variant="outline">
-              {config.localization.cancel}
-            </Button>
-            <Button disabled={createUser.isPending} type="submit">
-              {config.localization.createUser}
-            </Button>
-          </DialogFooter>
-        </form>
+                    <InputGroup>
+                      <InputGroupInput
+                        id="admin-create-name"
+                        name={field.name}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        required
+                        value={field.state.value}
+                      />
+                    </InputGroup>
+                  </Field>
+                )}
+              </form.Field>
+              <form.Field name="email">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="admin-create-email">
+                      {config.localization.email}
+                    </FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        autoComplete="off"
+                        id="admin-create-email"
+                        name={field.name}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        required
+                        type="email"
+                        value={field.state.value}
+                      />
+                    </InputGroup>
+                  </Field>
+                )}
+              </form.Field>
+              <form.Field name="password">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="admin-create-password">
+                      {config.localization.password}
+                    </FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        autoComplete="new-password"
+                        id="admin-create-password"
+                        name={field.name}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        required
+                        type="password"
+                        value={field.state.value}
+                      />
+                    </InputGroup>
+                  </Field>
+                )}
+              </form.Field>
+              {canSetRole.isPending ? (
+                <Skeleton className="h-16 w-full" />
+              ) : canSetRole.data?.success ? (
+                <FieldSet>
+                  <FieldLegend variant="label">
+                    {config.localization.role}
+                  </FieldLegend>
+                  <form.Field name="roles">
+                    {(field) =>
+                      config.allowMultipleRoles ? (
+                        <FieldGroup data-slot="checkbox-group">
+                          {config.roles.map((role) => (
+                            <Field key={role} orientation="horizontal">
+                              <Checkbox
+                                checked={field.state.value.includes(role)}
+                                id={`admin-create-role-${role}`}
+                                onCheckedChange={(checked) => {
+                                  const next = checked
+                                    ? [...field.state.value, role]
+                                    : field.state.value.filter(
+                                        (item) => item !== role
+                                      )
+                                  if (next.length) field.handleChange(next)
+                                }}
+                              />
+                              <FieldLabel htmlFor={`admin-create-role-${role}`}>
+                                {role}
+                              </FieldLabel>
+                            </Field>
+                          ))}
+                        </FieldGroup>
+                      ) : (
+                        <RadioGroup
+                          onValueChange={(role) => field.handleChange([role])}
+                          value={field.state.value[0] ?? ""}
+                        >
+                          {config.roles.map((role) => (
+                            <Field key={role} orientation="horizontal">
+                              <RadioGroupItem
+                                id={`admin-create-role-${role}`}
+                                value={role}
+                              />
+                              <FieldLabel htmlFor={`admin-create-role-${role}`}>
+                                {role}
+                              </FieldLabel>
+                            </Field>
+                          ))}
+                        </RadioGroup>
+                      )
+                    }
+                  </form.Field>
+                </FieldSet>
+              ) : null}
+              <form.Field name="emailVerified">
+                {(field) => (
+                  <Field orientation="horizontal">
+                    <Switch
+                      checked={field.state.value}
+                      id="admin-create-email-verified"
+                      onCheckedChange={field.handleChange}
+                    />
+                    <FieldContent>
+                      <FieldLabel htmlFor="admin-create-email-verified">
+                        {config.localization.emailVerified}
+                      </FieldLabel>
+                    </FieldContent>
+                  </Field>
+                )}
+              </form.Field>
+              {additionalFields.map((configuredField) => (
+                <form.AppField
+                  key={configuredField.name}
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    auth.localization.auth.fieldRequired
+                  )}
+                >
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      isPending={createUser.isPending}
+                    />
+                  )}
+                </form.AppField>
+              ))}
+            </FieldGroup>
+            <FieldError>{getAdminErrorMessage(createUser.error)}</FieldError>
+            <DialogFooter>
+              <Button onClick={close} type="button" variant="outline">
+                {config.localization.cancel}
+              </Button>
+              <form.AuthFormSubmitButton disabled={createUser.isPending}>
+                {config.localization.createUser}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )
@@ -1038,21 +1046,13 @@ function UserInspector({
   const [banReason, setBanReason] = useState("")
   const [banDuration, setBanDuration] = useState("")
   const banDurationSeconds = getBanDurationSeconds(banDuration)
-  const [profileError, setProfileError] = useState<string>()
   const [passwordOpen, setPasswordOpen] = useState(false)
   const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
-  const profileUserId = useRef(user?.id)
   const isSelf = user?.id === actor?.user.id
 
   const updateUser = useMutation(
     updateAdminUserOptions(auth.authClient, actor?.user.id)
   )
-
-  useEffect(() => {
-    if (profileUserId.current === user?.id) return
-    profileUserId.current = user?.id
-    setProfileError(undefined)
-  }, [user?.id])
 
   useEffect(() => {
     if (user?.id) updateUser.reset()
@@ -1081,11 +1081,17 @@ function UserInspector({
   const revokeSessions = useMutation(
     revokeAdminUserSessionsOptions(auth.authClient, actor?.user.id, userId)
   )
-  const profileAdditionalFieldValuesRef = useRef<
-    Record<string, AdditionalFieldValue | null>
-  >({})
+  const configuredUserFields = useMemo(
+    () =>
+      fieldsWithModelValues(
+        auth.additionalFields ?? [],
+        user ? (user as unknown as Record<string, unknown>) : {}
+      ),
+    [auth.additionalFields, user]
+  )
   const profileForm = useAuthForm({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredUserFields),
       email: "",
       emailVerified: false,
       name: "",
@@ -1100,7 +1106,10 @@ function UserInspector({
           updateUser.mutateAsync({
             userId: user.id,
             data: {
-              ...profileAdditionalFieldValuesRef.current,
+              ...getAdditionalFieldSubmitValues(
+                configuredUserFields,
+                value.additionalFields
+              ),
               name: value.name.trim(),
               ...(canSetEmail.data?.success
                 ? {
@@ -1132,6 +1141,7 @@ function UserInspector({
 
   useEffect(() => {
     profileForm.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredUserFields),
       email: user?.email ?? "",
       emailVerified: user?.emailVerified ?? false,
       name: user?.name ?? "",
@@ -1144,6 +1154,7 @@ function UserInspector({
   }, [
     config.allowMultipleRoles,
     config.defaultRole,
+    configuredUserFields,
     profileForm.reset,
     user?.email,
     user?.emailVerified,
@@ -1224,29 +1235,6 @@ function UserInspector({
           ? config.localization.revokeAllSessions
           : config.localization.impersonateUser
 
-  const saveUser = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!user) return
-
-    if (canUpdate.data?.success) {
-      const formData = new FormData(event.currentTarget)
-      let additionalFieldValues: Record<string, AdditionalFieldValue | null>
-      try {
-        additionalFieldValues = await parseAdditionalFieldValues(
-          auth.additionalFields ?? [],
-          formData
-        )
-      } catch (error) {
-        setProfileError(error instanceof Error ? error.message : String(error))
-        return
-      }
-      setProfileError(undefined)
-      profileAdditionalFieldValuesRef.current = additionalFieldValues
-    }
-
-    await profileForm.handleSubmit()
-  }
-
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
@@ -1292,7 +1280,7 @@ function UserInspector({
                                 !canImpersonateAdmins.data?.success)) ||
                             isSelf
                           }
-                          onClick={() => setDangerousAction("impersonate")}
+                          onSelect={() => setDangerousAction("impersonate")}
                         >
                           <LogInIcon />
                           {config.localization.impersonateUser}
@@ -1342,336 +1330,346 @@ function UserInspector({
                 ))}
               </TabsList>
               <TabsContent className="min-h-0 overflow-hidden" value="overview">
-                <form
-                  className="grid h-full grid-rows-[minmax(0,1fr)_auto]"
-                  onSubmit={saveUser}
-                >
-                  <div className="overflow-y-auto">
-                    <section className="flex flex-col gap-5 p-6">
-                      <h3 className="font-medium">
-                        {config.localization.profileAndAccess}
-                      </h3>
-                      <FieldGroup className="grid gap-5 md:grid-cols-2">
-                        <profileForm.Field name="name">
-                          {(field) => (
-                            <Field>
-                              <FieldLabel htmlFor="admin-user-name">
-                                {config.localization.name}
-                              </FieldLabel>
-                              <InputGroup>
-                                <InputGroupInput
-                                  disabled={!canUpdate.data?.success}
-                                  id="admin-user-name"
-                                  name={field.name}
-                                  value={field.state.value}
-                                  onChange={(event) =>
-                                    field.handleChange(event.target.value)
-                                  }
-                                />
-                              </InputGroup>
-                            </Field>
-                          )}
-                        </profileForm.Field>
-                        <profileForm.Field name="email">
-                          {(field) => (
-                            <Field>
-                              <FieldLabel htmlFor="admin-user-email">
-                                {config.localization.email}
-                              </FieldLabel>
-                              <InputGroup>
-                                <InputGroupInput
+                <profileForm.AppForm>
+                  <profileForm.AuthFormRoot className="grid h-full grid-rows-[minmax(0,1fr)_auto]">
+                    <div className="overflow-y-auto">
+                      <section className="flex flex-col gap-5 p-6">
+                        <h3 className="font-medium">
+                          {config.localization.profileAndAccess}
+                        </h3>
+                        <FieldGroup className="grid gap-5 md:grid-cols-2">
+                          <profileForm.Field name="name">
+                            {(field) => (
+                              <Field>
+                                <FieldLabel htmlFor="admin-user-name">
+                                  {config.localization.name}
+                                </FieldLabel>
+                                <InputGroup>
+                                  <InputGroupInput
+                                    disabled={!canUpdate.data?.success}
+                                    id="admin-user-name"
+                                    name={field.name}
+                                    value={field.state.value}
+                                    onChange={(event) =>
+                                      field.handleChange(event.target.value)
+                                    }
+                                  />
+                                </InputGroup>
+                              </Field>
+                            )}
+                          </profileForm.Field>
+                          <profileForm.Field name="email">
+                            {(field) => (
+                              <Field>
+                                <FieldLabel htmlFor="admin-user-email">
+                                  {config.localization.email}
+                                </FieldLabel>
+                                <InputGroup>
+                                  <InputGroupInput
+                                    disabled={
+                                      !canUpdate.data?.success ||
+                                      !canSetEmail.data?.success
+                                    }
+                                    id="admin-user-email"
+                                    name={field.name}
+                                    onChange={(event) =>
+                                      field.handleChange(event.target.value)
+                                    }
+                                    required
+                                    type="email"
+                                    value={field.state.value}
+                                  />
+                                </InputGroup>
+                              </Field>
+                            )}
+                          </profileForm.Field>
+                          <profileForm.Field name="emailVerified">
+                            {(field) => (
+                              <Field orientation="horizontal">
+                                <Switch
+                                  checked={field.state.value}
                                   disabled={
                                     !canUpdate.data?.success ||
                                     !canSetEmail.data?.success
                                   }
-                                  id="admin-user-email"
-                                  name={field.name}
-                                  onChange={(event) =>
-                                    field.handleChange(event.target.value)
-                                  }
-                                  required
-                                  type="email"
-                                  value={field.state.value}
+                                  id="admin-user-email-verified"
+                                  onCheckedChange={field.handleChange}
                                 />
-                              </InputGroup>
-                            </Field>
-                          )}
-                        </profileForm.Field>
-                        <profileForm.Field name="emailVerified">
-                          {(field) => (
-                            <Field orientation="horizontal">
-                              <Switch
-                                checked={field.state.value}
-                                disabled={
-                                  !canUpdate.data?.success ||
-                                  !canSetEmail.data?.success
-                                }
-                                id="admin-user-email-verified"
-                                onCheckedChange={field.handleChange}
-                              />
-                              <FieldContent>
-                                <FieldLabel htmlFor="admin-user-email-verified">
-                                  {config.localization.emailVerified}
-                                </FieldLabel>
-                              </FieldContent>
-                            </Field>
-                          )}
-                        </profileForm.Field>
-                        <FieldSet>
-                          <FieldLegend variant="label">
-                            {config.localization.role}
-                          </FieldLegend>
-                          <profileForm.Field name="roles">
-                            {(field) =>
-                              config.allowMultipleRoles ? (
-                                <FieldGroup
-                                  className="flex-row flex-wrap gap-4"
-                                  data-slot="checkbox-group"
-                                >
-                                  {config.roles.map((item) => (
-                                    <Field key={item} orientation="horizontal">
-                                      <Checkbox
-                                        checked={field.state.value.includes(
-                                          item
-                                        )}
-                                        disabled={
-                                          isSelf || !canSetRole.data?.success
-                                        }
-                                        id={`admin-user-role-${item}`}
-                                        onCheckedChange={(checked) => {
-                                          const next = checked
-                                            ? [...field.state.value, item]
-                                            : field.state.value.filter(
-                                                (role) => role !== item
-                                              )
-                                          if (next.length)
-                                            field.handleChange(next)
-                                        }}
-                                      />
-                                      <FieldLabel
-                                        htmlFor={`admin-user-role-${item}`}
-                                      >
-                                        {item}
-                                      </FieldLabel>
-                                    </Field>
-                                  ))}
-                                </FieldGroup>
-                              ) : (
-                                <RadioGroup
-                                  className="flex-row flex-wrap gap-4"
-                                  disabled={isSelf || !canSetRole.data?.success}
-                                  onValueChange={(role) =>
-                                    field.handleChange([role])
-                                  }
-                                  value={field.state.value[0] ?? ""}
-                                >
-                                  {config.roles.map((item) => (
-                                    <Field key={item} orientation="horizontal">
-                                      <RadioGroupItem
-                                        id={`admin-user-role-${item}`}
-                                        value={item}
-                                      />
-                                      <FieldLabel
-                                        htmlFor={`admin-user-role-${item}`}
-                                      >
-                                        {item}
-                                      </FieldLabel>
-                                    </Field>
-                                  ))}
-                                </RadioGroup>
-                              )
-                            }
+                                <FieldContent>
+                                  <FieldLabel htmlFor="admin-user-email-verified">
+                                    {config.localization.emailVerified}
+                                  </FieldLabel>
+                                </FieldContent>
+                              </Field>
+                            )}
                           </profileForm.Field>
-                        </FieldSet>
-                        {auth.additionalFields?.map((field) => {
-                          const value = (
-                            user as unknown as Record<string, unknown>
-                          )[field.name]
-                          return (
-                            <AdditionalField
-                              field={{
-                                ...field,
-                                defaultValue:
-                                  value as AdditionalFieldValue | null
-                              }}
-                              isPending={
-                                updateUser.isPending || !canUpdate.data?.success
+                          <FieldSet>
+                            <FieldLegend variant="label">
+                              {config.localization.role}
+                            </FieldLegend>
+                            <profileForm.Field name="roles">
+                              {(field) =>
+                                config.allowMultipleRoles ? (
+                                  <FieldGroup
+                                    className="flex-row flex-wrap gap-4"
+                                    data-slot="checkbox-group"
+                                  >
+                                    {config.roles.map((item) => (
+                                      <Field
+                                        key={item}
+                                        orientation="horizontal"
+                                      >
+                                        <Checkbox
+                                          checked={field.state.value.includes(
+                                            item
+                                          )}
+                                          disabled={
+                                            isSelf || !canSetRole.data?.success
+                                          }
+                                          id={`admin-user-role-${item}`}
+                                          onCheckedChange={(checked) => {
+                                            const next = checked
+                                              ? [...field.state.value, item]
+                                              : field.state.value.filter(
+                                                  (role) => role !== item
+                                                )
+                                            if (next.length)
+                                              field.handleChange(next)
+                                          }}
+                                        />
+                                        <FieldLabel
+                                          htmlFor={`admin-user-role-${item}`}
+                                        >
+                                          {item}
+                                        </FieldLabel>
+                                      </Field>
+                                    ))}
+                                  </FieldGroup>
+                                ) : (
+                                  <RadioGroup
+                                    className="flex-row flex-wrap gap-4"
+                                    disabled={
+                                      isSelf || !canSetRole.data?.success
+                                    }
+                                    onValueChange={(role) =>
+                                      field.handleChange([role])
+                                    }
+                                    value={field.state.value[0] ?? ""}
+                                  >
+                                    {config.roles.map((item) => (
+                                      <Field
+                                        key={item}
+                                        orientation="horizontal"
+                                      >
+                                        <RadioGroupItem
+                                          id={`admin-user-role-${item}`}
+                                          value={item}
+                                        />
+                                        <FieldLabel
+                                          htmlFor={`admin-user-role-${item}`}
+                                        >
+                                          {item}
+                                        </FieldLabel>
+                                      </Field>
+                                    ))}
+                                  </RadioGroup>
+                                )
                               }
-                              key={`${user.id}-${field.name}-${String(value ?? "")}`}
-                              name={field.name}
-                            />
-                          )
-                        })}
-                      </FieldGroup>
-                      <FieldError>
-                        {profileError ??
-                          getAdminErrorMessage(updateUser.error) ??
-                          getAdminErrorMessage(setRoleMutation.error)}
-                      </FieldError>
-                    </section>
-                    <Separator />
-                    <section className="flex flex-col gap-4 p-6">
-                      <h3 className="font-medium">
-                        {config.localization.accountInformation}
-                      </h3>
-                      <dl className="grid gap-x-8 gap-y-4 text-sm sm:grid-cols-2">
-                        <div className="flex flex-col gap-1">
-                          <dt className="text-muted-foreground">
-                            {config.localization.userId}
-                          </dt>
-                          <dd className="flex min-w-0 items-center gap-1">
-                            <code className="truncate text-xs">{user.id}</code>
-                            <Button
-                              aria-label={config.localization.copyUserId}
-                              onClick={() =>
-                                navigator.clipboard.writeText(user.id)
-                              }
-                              size="icon-xs"
-                              type="button"
-                              variant="ghost"
+                            </profileForm.Field>
+                          </FieldSet>
+                          {configuredUserFields.map((configuredField) => (
+                            <profileForm.AppField
+                              key={configuredField.name}
+                              name={`additionalFields.${configuredField.name}`}
+                              validators={getAuthAdditionalFieldValidators(
+                                configuredField,
+                                auth.localization.auth.fieldRequired
+                              )}
                             >
-                              <CopyIcon />
-                            </Button>
-                          </dd>
-                        </div>
-                        <div className="flex flex-col gap-1">
-                          <dt className="text-muted-foreground">
-                            {config.localization.created}
-                          </dt>
-                          <dd>{formatDate(user.createdAt)}</dd>
-                        </div>
-                        <div className="flex flex-col gap-1">
-                          <dt className="text-muted-foreground">
-                            {config.localization.status}
-                          </dt>
-                          <dd>
-                            <Badge
-                              variant={
-                                user.banned ? "destructive" : "secondary"
-                              }
-                            >
-                              {user.banned
-                                ? config.localization.banned
-                                : config.localization.active}
-                            </Badge>
-                          </dd>
-                        </div>
-                        {user.banned && user.banReason ? (
-                          <div className="flex flex-col gap-1">
-                            <dt className="text-muted-foreground">
-                              {config.localization.banReason}
-                            </dt>
-                            <dd>{user.banReason}</dd>
-                          </div>
-                        ) : null}
-                        {user.banned && user.banExpires ? (
-                          <div className="flex flex-col gap-1">
-                            <dt className="text-muted-foreground">
-                              {config.localization.banExpires}
-                            </dt>
-                            <dd>{formatDate(user.banExpires)}</dd>
-                          </div>
-                        ) : null}
-                      </dl>
-                    </section>
-                    <Separator />
-                    <section className="flex flex-col gap-4 p-6">
-                      <h3 className="font-medium">
-                        {config.localization.security}
-                      </h3>
-                      <div>
-                        <Button
-                          disabled={
-                            canSetPassword.isPending ||
-                            !canSetPassword.data?.success
-                          }
-                          onClick={() => setPasswordOpen(true)}
-                          type="button"
-                          variant="outline"
-                        >
-                          <KeyRoundIcon />
-                          {config.localization.setPassword}
-                        </Button>
-                      </div>
-                    </section>
-                    <Separator />
-                    <section className="flex flex-col gap-4 p-6">
-                      <h3 className="font-medium">
-                        {config.localization.dangerZone}
-                      </h3>
-                      <div className="flex flex-wrap gap-2">
-                        <Button
-                          disabled={
-                            canBan.isPending || !canBan.data?.success || isSelf
-                          }
-                          onClick={() =>
-                            user.banned
-                              ? unban.mutate({ userId: user.id })
-                              : setDangerousAction("ban")
-                          }
-                          type="button"
-                          variant="outline"
-                        >
-                          <BanIcon />
-                          {user.banned
-                            ? config.localization.unbanUser
-                            : config.localization.banUser}
-                        </Button>
-                        <Button
-                          disabled={
-                            canDelete.isPending ||
-                            !canDelete.data?.success ||
-                            isSelf
-                          }
-                          onClick={() => setDangerousAction("delete")}
-                          type="button"
-                          variant="destructive"
-                        >
-                          <Trash2Icon />
-                          {config.localization.deleteUser}
-                        </Button>
-                      </div>
-                      {unban.error ? (
+                              {(field) => (
+                                <field.AuthFormAdditionalField
+                                  field={configuredField}
+                                  isPending={
+                                    updateUser.isPending ||
+                                    !canUpdate.data?.success
+                                  }
+                                />
+                              )}
+                            </profileForm.AppField>
+                          ))}
+                        </FieldGroup>
                         <FieldError>
-                          {getAdminErrorMessage(unban.error)}
+                          {getAdminErrorMessage(updateUser.error) ??
+                            getAdminErrorMessage(setRoleMutation.error)}
                         </FieldError>
-                      ) : null}
-                    </section>
-                  </div>
-                  <div className="flex flex-col-reverse gap-2 border-t bg-muted/50 px-6 py-4 sm:flex-row sm:justify-end">
-                    <Button
-                      onClick={() => onOpenChange(false)}
-                      type="button"
-                      variant="outline"
-                    >
-                      {config.localization.cancel}
-                    </Button>
-                    <profileForm.Subscribe
-                      selector={(state) => [
-                        state.values.name,
-                        state.values.email
-                      ]}
-                    >
-                      {([name, email]) => (
-                        <Button
-                          disabled={
-                            !name.trim() ||
-                            !email.trim() ||
-                            updateUser.isPending ||
-                            setRoleMutation.isPending ||
-                            canUpdate.isPending ||
-                            canSetRole.isPending ||
-                            (!canUpdate.data?.success &&
-                              (!canSetRole.data?.success || isSelf))
-                          }
-                          type="submit"
-                        >
-                          {config.localization.saveChanges}
-                        </Button>
-                      )}
-                    </profileForm.Subscribe>
-                  </div>
-                </form>
+                      </section>
+                      <Separator />
+                      <section className="flex flex-col gap-4 p-6">
+                        <h3 className="font-medium">
+                          {config.localization.accountInformation}
+                        </h3>
+                        <dl className="grid gap-x-8 gap-y-4 text-sm sm:grid-cols-2">
+                          <div className="flex flex-col gap-1">
+                            <dt className="text-muted-foreground">
+                              {config.localization.userId}
+                            </dt>
+                            <dd className="flex min-w-0 items-center gap-1">
+                              <code className="truncate text-xs">
+                                {user.id}
+                              </code>
+                              <Button
+                                aria-label={config.localization.copyUserId}
+                                onClick={() =>
+                                  navigator.clipboard.writeText(user.id)
+                                }
+                                size="icon-xs"
+                                type="button"
+                                variant="ghost"
+                              >
+                                <CopyIcon />
+                              </Button>
+                            </dd>
+                          </div>
+                          <div className="flex flex-col gap-1">
+                            <dt className="text-muted-foreground">
+                              {config.localization.created}
+                            </dt>
+                            <dd>{formatDate(user.createdAt)}</dd>
+                          </div>
+                          <div className="flex flex-col gap-1">
+                            <dt className="text-muted-foreground">
+                              {config.localization.status}
+                            </dt>
+                            <dd>
+                              <Badge
+                                variant={
+                                  user.banned ? "destructive" : "secondary"
+                                }
+                              >
+                                {user.banned
+                                  ? config.localization.banned
+                                  : config.localization.active}
+                              </Badge>
+                            </dd>
+                          </div>
+                          {user.banned && user.banReason ? (
+                            <div className="flex flex-col gap-1">
+                              <dt className="text-muted-foreground">
+                                {config.localization.banReason}
+                              </dt>
+                              <dd>{user.banReason}</dd>
+                            </div>
+                          ) : null}
+                          {user.banned && user.banExpires ? (
+                            <div className="flex flex-col gap-1">
+                              <dt className="text-muted-foreground">
+                                {config.localization.banExpires}
+                              </dt>
+                              <dd>{formatDate(user.banExpires)}</dd>
+                            </div>
+                          ) : null}
+                        </dl>
+                      </section>
+                      <Separator />
+                      <section className="flex flex-col gap-4 p-6">
+                        <h3 className="font-medium">
+                          {config.localization.security}
+                        </h3>
+                        <div>
+                          <Button
+                            disabled={
+                              canSetPassword.isPending ||
+                              !canSetPassword.data?.success
+                            }
+                            onClick={() => setPasswordOpen(true)}
+                            type="button"
+                            variant="outline"
+                          >
+                            <KeyRoundIcon />
+                            {config.localization.setPassword}
+                          </Button>
+                        </div>
+                      </section>
+                      <Separator />
+                      <section className="flex flex-col gap-4 p-6">
+                        <h3 className="font-medium">
+                          {config.localization.dangerZone}
+                        </h3>
+                        <div className="flex flex-wrap gap-2">
+                          <Button
+                            disabled={
+                              canBan.isPending ||
+                              !canBan.data?.success ||
+                              isSelf
+                            }
+                            onClick={() =>
+                              user.banned
+                                ? unban.mutate({ userId: user.id })
+                                : setDangerousAction("ban")
+                            }
+                            type="button"
+                            variant="outline"
+                          >
+                            <BanIcon />
+                            {user.banned
+                              ? config.localization.unbanUser
+                              : config.localization.banUser}
+                          </Button>
+                          <Button
+                            disabled={
+                              canDelete.isPending ||
+                              !canDelete.data?.success ||
+                              isSelf
+                            }
+                            onClick={() => setDangerousAction("delete")}
+                            type="button"
+                            variant="destructive"
+                          >
+                            <Trash2Icon />
+                            {config.localization.deleteUser}
+                          </Button>
+                        </div>
+                        {unban.error ? (
+                          <FieldError>
+                            {getAdminErrorMessage(unban.error)}
+                          </FieldError>
+                        ) : null}
+                      </section>
+                    </div>
+                    <div className="flex flex-col-reverse gap-2 border-t bg-muted/50 px-6 py-4 sm:flex-row sm:justify-end">
+                      <Button
+                        onClick={() => onOpenChange(false)}
+                        type="button"
+                        variant="outline"
+                      >
+                        {config.localization.cancel}
+                      </Button>
+                      <profileForm.Subscribe
+                        selector={(state) => [
+                          state.values.name,
+                          state.values.email
+                        ]}
+                      >
+                        {([name, email]) => (
+                          <profileForm.AuthFormSubmitButton
+                            disabled={
+                              !name.trim() ||
+                              !email.trim() ||
+                              updateUser.isPending ||
+                              setRoleMutation.isPending ||
+                              canUpdate.isPending ||
+                              canSetRole.isPending ||
+                              (!canUpdate.data?.success &&
+                                (!canSetRole.data?.success || isSelf))
+                            }
+                          >
+                            {config.localization.saveChanges}
+                          </profileForm.AuthFormSubmitButton>
+                        )}
+                      </profileForm.Subscribe>
+                    </div>
+                  </profileForm.AuthFormRoot>
+                </profileForm.AppForm>
               </TabsContent>
               <TabsContent
                 className="min-h-0 overflow-y-auto p-6"

--- a/examples/start-shadcn-baseui-example/src/components/auth/auth-form.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/auth-form.tsx
@@ -1,23 +1,22 @@
 "use client"
 
-import { getFormFieldErrors } from "@better-auth-ui/core"
-import { createFormHook, createFormHookContexts } from "@tanstack/react-form"
 import {
-  type ComponentProps,
-  createContext,
-  type FormEvent,
-  useContext,
-  useRef,
-  useState
-} from "react"
+  type AdditionalField as AdditionalFieldConfig,
+  type AdditionalFieldFormValue,
+  getFormFieldErrors,
+  validateAdditionalFieldRequired,
+  validateAdditionalFieldValue
+} from "@better-auth-ui/core"
+import { createFormHook, createFormHookContexts } from "@tanstack/react-form"
+import { type ComponentProps, type FormEvent, useRef } from "react"
 
 import { Button } from "@/components/ui/button"
 import { FieldError } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
+import { AdditionalField, type AdditionalFieldProps } from "./additional-field"
 
 const { fieldContext, formContext, useFieldContext, useFormContext } =
   createFormHookContexts()
-const AuthFormPreparationContext = createContext(false)
 
 export function focusFirstInvalidAuthFormControl(form: HTMLFormElement) {
   requestAnimationFrame(() => {
@@ -41,53 +40,42 @@ function AuthFormFieldError() {
 }
 
 type AuthFormRootProps = Omit<ComponentProps<"form">, "onSubmit"> & {
-  prepareSubmit?: (
-    form: HTMLFormElement
-  ) => boolean | undefined | Promise<boolean | undefined>
+  onBeforeSubmit?: () => void
 }
 
 function AuthFormRoot({
   children,
-  prepareSubmit,
+  onBeforeSubmit,
   ...props
 }: AuthFormRootProps) {
   const form = useFormContext()
-  const preparingRef = useRef(false)
-  const [isPreparing, setIsPreparing] = useState(false)
+  const submittingRef = useRef(false)
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    if (preparingRef.current || form.state.isSubmitting) return
+    if (submittingRef.current || form.state.isSubmitting) return
 
     const formElement = event.currentTarget
-    preparingRef.current = true
-    setIsPreparing(true)
-
-    let shouldSubmit = true
+    onBeforeSubmit?.()
+    submittingRef.current = true
     try {
-      shouldSubmit = (await prepareSubmit?.(formElement)) !== false
+      await form.handleSubmit()
+      if (!form.state.isValid) focusFirstInvalidAuthFormControl(formElement)
     } finally {
-      preparingRef.current = false
-      setIsPreparing(false)
+      submittingRef.current = false
     }
-
-    if (!shouldSubmit) return
-    await form.handleSubmit()
-    if (!form.state.isValid) focusFirstInvalidAuthFormControl(formElement)
   }
 
   return (
-    <AuthFormPreparationContext.Provider value={isPreparing}>
-      <form
-        {...props}
-        onInvalid={(event) =>
-          focusFirstInvalidAuthFormControl(event.currentTarget)
-        }
-        onSubmit={submit}
-      >
-        {children}
-      </form>
-    </AuthFormPreparationContext.Provider>
+    <form
+      {...props}
+      onInvalid={(event) =>
+        focusFirstInvalidAuthFormControl(event.currentTarget)
+      }
+      onSubmit={submit}
+    >
+      {children}
+    </form>
   )
 }
 
@@ -97,7 +85,6 @@ function AuthFormSubmitButton({
   ...props
 }: ComponentProps<typeof Button>) {
   const form = useFormContext()
-  const isPreparing = useContext(AuthFormPreparationContext)
 
   return (
     <form.Subscribe
@@ -106,10 +93,10 @@ function AuthFormSubmitButton({
       {([canSubmit, isSubmitting]) => (
         <Button
           {...props}
-          disabled={disabled || isPreparing || !canSubmit || isSubmitting}
+          disabled={disabled || !canSubmit || isSubmitting}
           type="submit"
         >
-          {isPreparing || isSubmitting ? <Spinner /> : null}
+          {isSubmitting ? <Spinner /> : null}
           {children}
         </Button>
       )}
@@ -117,8 +104,32 @@ function AuthFormSubmitButton({
   )
 }
 
+type AuthFormAdditionalFieldProps = Omit<
+  AdditionalFieldProps,
+  "errors" | "isInvalid" | "name" | "onBlur" | "onChange" | "value"
+>
+
+function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
+  const field = useFieldContext<AdditionalFieldFormValue>()
+  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+
+  return (
+    <AdditionalField
+      {...props}
+      errors={
+        isInvalid ? getFormFieldErrors(field.state.meta.errors) : undefined
+      }
+      isInvalid={isInvalid}
+      name={field.name}
+      onBlur={field.handleBlur}
+      onChange={field.handleChange}
+      value={field.state.value}
+    />
+  )
+}
+
 export const { useAppForm: useAuthForm } = createFormHook({
-  fieldComponents: { AuthFormFieldError },
+  fieldComponents: { AuthFormAdditionalField, AuthFormFieldError },
   fieldContext,
   formComponents: { AuthFormRoot, AuthFormSubmitButton },
   formContext
@@ -132,4 +143,18 @@ export function isAuthFormFieldInvalid({
   isValid: boolean
 }) {
   return isTouched && !isValid
+}
+
+export function getAuthAdditionalFieldValidators(
+  field: AdditionalFieldConfig,
+  requiredMessage: string
+) {
+  return {
+    onChange: ({ value }: { value: AdditionalFieldFormValue }) =>
+      validateAdditionalFieldRequired(field, value, requiredMessage),
+    onChangeAsync: field.validate
+      ? ({ value }: { value: AdditionalFieldFormValue }) =>
+          validateAdditionalFieldValue(field, value)
+      : undefined
+  }
 }

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/create-organization-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/create-organization-dialog.tsx
@@ -1,13 +1,16 @@
 "use client"
 
-import { parseAdditionalFieldValue } from "@better-auth-ui/core"
+import {
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useCreateOrganization } from "@better-auth-ui/react/plugins/organization"
 import { Briefcase } from "lucide-react"
-import { type SyntheticEvent, useEffect, useRef, useState } from "react"
-import { toast } from "sonner"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useEffect, useRef, useState } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -17,11 +20,14 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 import { SlugField, sanitizeSlug } from "./slug-field"
 
 /** Props for the `CreateOrganizationDialog` component. */
@@ -44,150 +50,153 @@ export function CreateOrganizationDialog({
   } = useAuthPlugin(organizationPlugin)
   const hideSlug = hideSlugProp ?? pluginHideSlug ?? false
 
-  const [name, setName] = useState("")
-  const [slug, setSlug] = useState("")
   const [slugEdited, setSlugEdited] = useState(false)
-  const [nameError, setNameError] = useState<string>()
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const submissionLocked = useRef(false)
+  const submissionGeneration = useRef(0)
+  const submissionAttemptGeneration = useRef(0)
 
-  const { mutate: createOrganization, isPending: isCreating } =
-    useCreateOrganization(authClient, {
-      onSuccess: () => onOpenChange(false),
-      onSettled: () => {
-        submissionLocked.current = false
-        setIsSubmitting(false)
-      }
-    })
+  const { mutateAsync: createOrganization } = useCreateOrganization(authClient)
 
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    if (submissionLocked.current) return
-
-    submissionLocked.current = true
-    setIsSubmitting(true)
-    const formData = new FormData(e.currentTarget)
-    const additionalValues: Record<string, unknown> = {}
-    try {
-      for (const field of additionalFields) {
-        const value = parseAdditionalFieldValue(
-          field,
-          formData.get(field.name) as string | null
-        )
-        await field.validate?.(value)
-        if (value !== undefined) additionalValues[field.name] = value
-      }
-    } catch (error) {
-      submissionLocked.current = false
-      setIsSubmitting(false)
-      toast.error(error instanceof Error ? error.message : String(error))
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(additionalFields),
+      name: "",
+      slug: ""
+    },
+    onSubmit: async ({ value }) => {
+      const generation = submissionAttemptGeneration.current
+      if (generation !== submissionGeneration.current) return
+      await createOrganization({
+        ...getAdditionalFieldSubmitValues(
+          additionalFields,
+          value.additionalFields
+        ),
+        name: value.name,
+        slug: hideSlug ? undefined : value.slug
+      })
+      if (generation === submissionGeneration.current) onOpenChange(false)
     }
-    createOrganization({
-      ...additionalValues,
-      name,
-      slug: hideSlug ? undefined : slug
-    })
-  }
-
-  const isPending = isCreating || isSubmitting
+  })
 
   useEffect(() => {
     if (!open) {
-      setSlug("")
-      setName("")
+      submissionGeneration.current += 1
+      form.reset()
       setSlugEdited(false)
-      setNameError(undefined)
     }
-  }, [open])
-
-  useEffect(() => {
-    if (slugEdited) return
-    setSlug(sanitizeSlug(name))
-  }, [name, slugEdited])
+  }, [form, open])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Briefcase />
-              {organizationLocalization.createOrganization}
-            </DialogTitle>
+        <form.AppForm>
+          <form.AuthFormRoot
+            className="flex flex-col gap-6"
+            onBeforeSubmit={() => {
+              submissionAttemptGeneration.current = submissionGeneration.current
+            }}
+          >
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Briefcase />
+                {organizationLocalization.createOrganization}
+              </DialogTitle>
 
-            <DialogDescription>
-              {organizationLocalization.organizationsDescription}
-            </DialogDescription>
-          </DialogHeader>
+              <DialogDescription>
+                {organizationLocalization.organizationsDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <div className="flex flex-col gap-4">
-            <Field data-invalid={!!nameError}>
-              <FieldLabel htmlFor="create-organization-name">
-                {organizationLocalization.name}
-              </FieldLabel>
-
-              <Input
-                id="create-organization-name"
+            <div className="flex flex-col gap-4">
+              <form.AppField
                 name="name"
-                autoFocus
-                required
-                placeholder={organizationLocalization.namePlaceholder}
-                value={name}
-                onChange={(e) => {
-                  setName(e.target.value)
-                  setNameError(undefined)
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired,
+                      trim: true
+                    })
                 }}
-                onInvalid={(e) => {
-                  e.preventDefault()
-                  setNameError(localization.auth.fieldRequired)
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="create-organization-name">
+                        {organizationLocalization.name}
+                      </FieldLabel>
+
+                      <Input
+                        id="create-organization-name"
+                        name={field.name}
+                        autoFocus
+                        placeholder={organizationLocalization.namePlaceholder}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => {
+                          const value = event.target.value
+                          field.handleChange(value)
+                          if (!slugEdited) {
+                            form.setFieldValue("slug", sanitizeSlug(value))
+                          }
+                        }}
+                        aria-invalid={isInvalid}
+                      />
+
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
                 }}
-                aria-invalid={!!nameError}
-                disabled={isPending}
-              />
+              </form.AppField>
 
-              <FieldError>{nameError}</FieldError>
-            </Field>
+              {!hideSlug && (
+                <form.AppField name="slug">
+                  {(field) => (
+                    <SlugField
+                      id="create-organization-slug"
+                      value={field.state.value}
+                      onChange={(value) => {
+                        field.handleChange(value)
+                        setSlugEdited(true)
+                      }}
+                    />
+                  )}
+                </form.AppField>
+              )}
 
-            {!hideSlug && (
-              <SlugField
-                id="create-organization-slug"
-                value={slug}
-                onChange={(value) => {
-                  setSlug(value)
-                  setSlugEdited(true)
-                }}
-                disabled={isPending}
-              />
-            )}
+              {additionalFields.map((configuredField) => (
+                <form.AppField
+                  key={configuredField.name}
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    localization.auth.fieldRequired
+                  )}
+                >
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      optionalLabel={localization.settings.optional}
+                    />
+                  )}
+                </form.AppField>
+              ))}
+            </div>
 
-            {additionalFields.map((field) => (
-              <AdditionalField
-                key={field.name}
-                field={field}
-                isPending={isPending}
-                name={field.name}
-                optionalLabel={localization.settings.optional}
-              />
-            ))}
-          </div>
+            <DialogFooter>
+              <DialogClose
+                className={buttonVariants({ variant: "outline" })}
+                type="button"
+              >
+                {localization.settings.cancel}
+              </DialogClose>
 
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              disabled={isPending}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Spinner />}
-
-              {organizationLocalization.createOrganization}
-            </Button>
-          </DialogFooter>
-        </form>
+              <form.AuthFormSubmitButton>
+                {organizationLocalization.createOrganization}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/invite-member-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/invite-member-dialog.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { parseAdditionalFieldValues } from "@better-auth-ui/core"
+import {
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateEmailAddress
+} from "@better-auth-ui/core"
 import {
   mergeOrganizationRoleLabels,
   type OrganizationAuthClient,
@@ -17,16 +21,9 @@ import {
   useListTeams
 } from "@better-auth-ui/react/plugins/organization"
 import { ChevronDown, UserPlus } from "lucide-react"
-import {
-  type SyntheticEvent,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from "react"
+import { useEffect, useMemo, useRef } from "react"
 import { toast } from "sonner"
-import { AdditionalField } from "@/components/auth/additional-field"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -42,7 +39,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import {
   Select,
@@ -52,9 +49,13 @@ import {
   SelectTrigger,
   SelectValue
 } from "@/components/ui/select"
-import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 
 /** Props for the `InviteMemberDialog` component. */
 export type InviteMemberDialogProps = {
@@ -106,16 +107,6 @@ export function InviteMemberDialog({
     () => mergeOrganizationRoleLabels(roles, dynamicRoles.data),
     [dynamicRoles.data, roles]
   )
-
-  const [selectedRoles, setSelectedRoles] = useState(() => {
-    const fallback = pickDefaultRole(Object.keys(assignableRoles))
-    return fallback ? [fallback] : []
-  })
-  const [teamId, setTeamId] = useState("")
-  const [emailError, setEmailError] = useState<string>()
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const activeOrganizationId = activeOrganization?.id
-  const previousOrganizationId = useRef(activeOrganizationId)
   const roleItems = Object.entries(assignableRoles).map(([value, label]) => ({
     label,
     value
@@ -123,28 +114,10 @@ export function InviteMemberDialog({
   const teamItems =
     teams.data?.map((team) => ({ label: team.name, value: team.id })) ?? []
 
-  useEffect(() => {
-    setSelectedRoles((current) => {
-      const keys = Object.keys(assignableRoles)
-      const kept = current.filter((entry) => keys.includes(entry))
+  const activeOrganizationId = activeOrganization?.id
+  const previousOrganizationId = useRef(activeOrganizationId)
 
-      if (kept.length > 0) return allowMultipleRoles ? kept : kept.slice(0, 1)
-
-      const fallback = pickDefaultRole(keys)
-      return fallback ? [fallback] : []
-    })
-  }, [allowMultipleRoles, assignableRoles])
-
-  useEffect(() => {
-    const organizationChanged =
-      previousOrganizationId.current !== activeOrganizationId
-
-    if (open || organizationChanged) setTeamId("")
-    if (!open) setEmailError(undefined)
-    previousOrganizationId.current = activeOrganizationId
-  }, [open, activeOrganizationId])
-
-  const { mutate: inviteMember, isPending: isInviting } = useInviteMember(
+  const { mutateAsync: inviteMember, isPending: isInviting } = useInviteMember(
     authClient as OrganizationTeamsAuthClient,
     {
       onSuccess: () => {
@@ -154,247 +127,328 @@ export function InviteMemberDialog({
     }
   )
 
-  const isRoleValid = selectedRoles.length > 0
-
-  const roleSummary = selectedRoles
-    .map((entry) => assignableRoles[entry] ?? entry)
-    .join(", ")
-
-  const toggleRole = (role: string) => {
-    setSelectedRoles((current) =>
-      current.includes(role)
-        ? current.filter((entry) => entry !== role)
-        : [...current, role]
-    )
-  }
-
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (
-      !activeOrganizationId ||
-      !canInvite.data?.success ||
-      !isRoleValid ||
-      atInvitationLimit
-    )
-      return
-
-    const formData = new FormData(e.currentTarget)
-    const invitationEmail = (formData.get("email") as string).trim()
-    const invitationRoles = [...selectedRoles] as Parameters<
-      typeof inviteMember
-    >[0]["role"]
-    const selectedTeamId = teams.data?.some((team) => team.id === teamId)
-      ? teamId
-      : undefined
-
-    setIsSubmitting(true)
-    let invitationValues: Record<string, unknown>
-    try {
-      invitationValues = await parseAdditionalFieldValues(
-        invitationFields,
-        formData
-      )
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      setIsSubmitting(false)
-      return
-    }
-
-    inviteMember(
-      {
-        ...invitationValues,
-        email: invitationEmail,
-        organizationId: activeOrganizationId,
-        role: invitationRoles,
-        teamId: selectedTeamId
-      },
-      { onSettled: () => setIsSubmitting(false) }
-    )
-  }
-
   const atInvitationLimit =
     invitationLimit !== undefined &&
     (invitations.data?.filter((invitation) => invitation.status === "pending")
       .length ?? 0) >= invitationLimit
 
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(invitationFields),
+      email: "",
+      roles: [] as string[],
+      teamId: ""
+    },
+    onSubmit: async ({ value }) => {
+      if (
+        !activeOrganizationId ||
+        !canInvite.data?.success ||
+        value.roles.length === 0 ||
+        atInvitationLimit
+      )
+        return
+
+      const teamId = teams.data?.some((team) => team.id === value.teamId)
+        ? value.teamId
+        : undefined
+
+      try {
+        await inviteMember({
+          ...getAdditionalFieldSubmitValues(
+            invitationFields,
+            value.additionalFields
+          ),
+          email: value.email.trim(),
+          organizationId: activeOrganizationId,
+          role: value.roles as Parameters<typeof inviteMember>[0]["role"],
+          teamId
+        })
+      } catch {
+        // The mutation reports the error through its configured handler.
+      }
+    }
+  })
+
+  useEffect(() => {
+    const keys = Object.keys(assignableRoles)
+    const current = form.getFieldValue("roles")
+    const kept = current.filter((entry) => keys.includes(entry))
+    const roles =
+      kept.length > 0
+        ? allowMultipleRoles
+          ? kept
+          : kept.slice(0, 1)
+        : (() => {
+            const fallback = pickDefaultRole(keys)
+            return fallback ? [fallback] : []
+          })()
+
+    form.setFieldValue("roles", roles)
+  }, [allowMultipleRoles, assignableRoles, form])
+
+  useEffect(() => {
+    const organizationChanged =
+      previousOrganizationId.current !== activeOrganizationId
+
+    if (open || organizationChanged) {
+      const fallback = pickDefaultRole(Object.keys(assignableRoles))
+      form.reset({
+        additionalFields: getAdditionalFieldDefaultValues(invitationFields),
+        email: "",
+        roles: fallback ? [fallback] : [],
+        teamId: ""
+      })
+    }
+    previousOrganizationId.current = activeOrganizationId
+  }, [activeOrganizationId, assignableRoles, form, invitationFields, open])
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <UserPlus />
-              {organizationLocalization.inviteMember}
-            </DialogTitle>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <UserPlus />
+                {organizationLocalization.inviteMember}
+              </DialogTitle>
 
-            <DialogDescription>
-              {organizationLocalization.inviteMemberDescription}
-            </DialogDescription>
-          </DialogHeader>
+              <DialogDescription>
+                {organizationLocalization.inviteMemberDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <div className="flex flex-col gap-4">
-            <Field data-invalid={!!emailError}>
-              <FieldLabel htmlFor="invite-member-email">
-                {localization.auth.email}
-              </FieldLabel>
-
-              <Input
-                id="invite-member-email"
+            <div className="flex flex-col gap-4">
+              <form.AppField
                 name="email"
-                type="email"
-                autoFocus
-                required
-                placeholder={localization.auth.email}
-                disabled={isInviting}
-                onChange={() => setEmailError(undefined)}
-                onInvalid={(e) => {
-                  e.preventDefault()
-                  const el = e.target as HTMLInputElement
-                  const msg = el.validity.valueMissing
-                    ? localization.auth.fieldRequired
-                    : localization.auth.invalidEmail
-                  setEmailError(msg)
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
                 }}
-                aria-invalid={!!emailError}
-              />
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
-              <FieldError>{emailError}</FieldError>
-            </Field>
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="invite-member-email">
+                        {localization.auth.email}
+                      </FieldLabel>
+                      <Input
+                        id="invite-member-email"
+                        name={field.name}
+                        type="email"
+                        autoFocus
+                        placeholder={localization.auth.email}
+                        disabled={isInviting}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        aria-invalid={isInvalid}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
 
-            <Field>
-              <FieldLabel htmlFor="invite-member-role">
-                {organizationLocalization.role}
-              </FieldLabel>
+              <form.AppField
+                name="roles"
+                validators={{
+                  onChange: ({ value }) =>
+                    value.length > 0
+                      ? undefined
+                      : localization.auth.fieldRequired
+                }}
+              >
+                {(field) => {
+                  const selectedRoles = field.state.value
+                  const roleSummary = selectedRoles
+                    .map((entry) => assignableRoles[entry] ?? entry)
+                    .join(", ")
+                  const toggleRole = (role: string) =>
+                    field.handleChange(
+                      selectedRoles.includes(role)
+                        ? selectedRoles.filter((entry) => entry !== role)
+                        : [...selectedRoles, role]
+                    )
 
-              {allowMultipleRoles ? (
-                <DropdownMenu>
-                  <DropdownMenuTrigger
-                    id="invite-member-role"
-                    disabled={isInviting}
-                    className={cn(
-                      buttonVariants({ variant: "outline" }),
-                      "w-full justify-between font-normal"
-                    )}
-                  >
-                    <span
-                      className={cn(!roleSummary && "text-muted-foreground")}
+                  return (
+                    <Field
+                      data-invalid={isAuthFormFieldInvalid(field.state.meta)}
                     >
-                      {roleSummary || organizationLocalization.selectRoles}
-                    </span>
-                    <ChevronDown className="opacity-50" />
-                  </DropdownMenuTrigger>
+                      <FieldLabel htmlFor="invite-member-role">
+                        {organizationLocalization.role}
+                      </FieldLabel>
+                      {allowMultipleRoles ? (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger
+                            id="invite-member-role"
+                            disabled={isInviting}
+                            className={cn(
+                              buttonVariants({ variant: "outline" }),
+                              "w-full justify-between font-normal"
+                            )}
+                          >
+                            <span
+                              className={cn(
+                                !roleSummary && "text-muted-foreground"
+                              )}
+                            >
+                              {roleSummary ||
+                                organizationLocalization.selectRoles}
+                            </span>
+                            <ChevronDown className="opacity-50" />
+                          </DropdownMenuTrigger>
 
-                  <DropdownMenuContent align="start">
-                    {roleItems.map((item) => {
-                      const checked = selectedRoles.includes(item.value)
+                          <DropdownMenuContent
+                            align="start"
+                            className="w-(--radix-dropdown-menu-trigger-width)"
+                          >
+                            {Object.entries(assignableRoles).map(
+                              ([key, label]) => {
+                                const checked = selectedRoles.includes(key)
 
-                      return (
-                        <DropdownMenuCheckboxItem
-                          key={item.value}
-                          checked={checked}
-                          disabled={checked && selectedRoles.length === 1}
-                          onCheckedChange={() => toggleRole(item.value)}
+                                return (
+                                  <DropdownMenuCheckboxItem
+                                    key={key}
+                                    checked={checked}
+                                    disabled={
+                                      checked && selectedRoles.length === 1
+                                    }
+                                    onSelect={(event) => {
+                                      event.preventDefault()
+                                      toggleRole(key)
+                                    }}
+                                  >
+                                    {label}
+                                  </DropdownMenuCheckboxItem>
+                                )
+                              }
+                            )}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      ) : (
+                        <Select
+                          disabled={isInviting}
+                          items={roleItems}
+                          onValueChange={(role) =>
+                            role && field.handleChange([role])
+                          }
+                          value={selectedRoles[0] ?? ""}
                         >
-                          {item.label}
-                        </DropdownMenuCheckboxItem>
-                      )
-                    })}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              ) : (
-                <Select
-                  disabled={isInviting}
-                  items={roleItems}
-                  onValueChange={(role) => role && setSelectedRoles([role])}
-                  value={selectedRoles[0] ?? ""}
-                >
-                  <SelectTrigger id="invite-member-role" className="w-full">
-                    <SelectValue
-                      placeholder={organizationLocalization.selectRoles}
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      {roleItems.map((item) => (
-                        <SelectItem key={item.value} value={item.value}>
-                          {item.label}
-                        </SelectItem>
-                      ))}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
+                          <SelectTrigger
+                            id="invite-member-role"
+                            className="w-full"
+                          >
+                            <SelectValue
+                              placeholder={organizationLocalization.selectRoles}
+                            />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              {Object.entries(assignableRoles).map(
+                                ([key, label]) => (
+                                  <SelectItem key={key} value={key}>
+                                    {label}
+                                  </SelectItem>
+                                )
+                              )}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      )}
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+
+              {teamsEnabled && (
+                <form.AppField name="teamId">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="invite-member-team">
+                        {organizationLocalization.team}
+                      </FieldLabel>
+                      <Select
+                        items={teamItems}
+                        value={field.state.value}
+                        onValueChange={(value) =>
+                          field.handleChange(value ?? "")
+                        }
+                        disabled={isInviting}
+                      >
+                        <SelectTrigger
+                          id="invite-member-team"
+                          className="w-full"
+                        >
+                          <SelectValue
+                            placeholder={organizationLocalization.selectTeam}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectGroup>
+                            {teamItems.map((item) => (
+                              <SelectItem key={item.value} value={item.value}>
+                                {item.label}
+                              </SelectItem>
+                            ))}
+                          </SelectGroup>
+                        </SelectContent>
+                      </Select>
+                    </Field>
+                  )}
+                </form.AppField>
               )}
 
-              <FieldError />
-            </Field>
-
-            {teamsEnabled && (
-              <Field>
-                <FieldLabel htmlFor="invite-member-team">
-                  {organizationLocalization.team}
-                </FieldLabel>
-                <Select
-                  items={teamItems}
-                  value={teamId}
-                  onValueChange={(value) => setTeamId(value ?? "")}
-                  disabled={isInviting}
+              {invitationFields.map((configuredField) => (
+                <form.AppField
+                  key={configuredField.name}
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    localization.auth.fieldRequired
+                  )}
                 >
-                  <SelectTrigger id="invite-member-team" className="w-full">
-                    <SelectValue
-                      placeholder={organizationLocalization.selectTeam}
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      isPending={isInviting}
+                      optionalLabel={localization.settings.optional}
                     />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      {teamItems.map((item) => (
-                        <SelectItem key={item.value} value={item.value}>
-                          {item.label}
-                        </SelectItem>
-                      ))}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
-              </Field>
-            )}
+                  )}
+                </form.AppField>
+              ))}
+            </div>
 
-            {invitationFields.map((field) => (
-              <AdditionalField
-                key={field.name}
-                field={field}
-                name={field.name}
-                isPending={isInviting || isSubmitting}
-                optionalLabel={localization.settings.optional}
-              />
-            ))}
-          </div>
+            <DialogFooter>
+              <DialogClose
+                className={buttonVariants({ variant: "outline" })}
+                disabled={isInviting}
+                type="button"
+              >
+                {localization.settings.cancel}
+              </DialogClose>
 
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              disabled={isInviting || isSubmitting}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-
-            <Button
-              type="submit"
-              disabled={
-                isInviting ||
-                isSubmitting ||
-                !isRoleValid ||
-                atInvitationLimit ||
-                canInvite.isPending ||
-                !canInvite.data?.success
-              }
-            >
-              {(isInviting || isSubmitting) && <Spinner />}
-
-              {organizationLocalization.inviteMember}
-            </Button>
-          </DialogFooter>
-        </form>
+              <form.AuthFormSubmitButton
+                disabled={
+                  isInviting ||
+                  atInvitationLimit ||
+                  canInvite.isPending ||
+                  !canInvite.data?.success
+                }
+              >
+                {organizationLocalization.inviteMember}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-profile.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-profile.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { parseAdditionalFieldValue } from "@better-auth-ui/core"
+import {
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
@@ -8,18 +13,20 @@ import {
   useHasPermission,
   useUpdateOrganization
 } from "@better-auth-ui/react/plugins/organization"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 import { ChangeOrganizationLogo } from "./change-organization-logo"
 import { SlugField } from "./slug-field"
 
@@ -48,44 +55,46 @@ export function OrganizationProfile({
     permissions: { organization: ["update"] }
   })
 
-  const [slug, setSlug] = useState(activeOrganization?.slug ?? "")
-
-  useEffect(() => {
-    setSlug(activeOrganization?.slug ?? "")
-  }, [activeOrganization?.slug])
-
-  const { mutate: commitOrganizationUpdate, isPending } = useUpdateOrganization(
-    authClient,
-    {
+  const { mutateAsync: commitOrganizationUpdate, isPending } =
+    useUpdateOrganization(authClient, {
       onSuccess: () =>
         toast.success(organizationLocalization.organizationUpdatedSuccess)
-    }
-  )
-
-  async function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    if (!activeOrganization || !canUpdate.data?.success) return
-    const formData = new FormData(e.currentTarget)
-    const name = formData.get("name") as string
-    const additionalValues: Record<string, unknown> = {}
-    try {
-      for (const field of additionalFields) {
-        const value = parseAdditionalFieldValue(
-          field,
-          formData.get(field.name) as string | null
-        )
-        await field.validate?.(value)
-        if (value !== undefined) additionalValues[field.name] = value
-      }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      return
-    }
-
-    commitOrganizationUpdate({
-      data: { ...additionalValues, name, ...(!hideSlug && { slug }) }
     })
-  }
+
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(additionalFields),
+      name: "",
+      slug: ""
+    },
+    onSubmit: async ({ value }) => {
+      if (!activeOrganization || !canUpdate.data?.success) return
+      await commitOrganizationUpdate({
+        data: {
+          ...getAdditionalFieldSubmitValues(
+            additionalFields,
+            value.additionalFields
+          ),
+          name: value.name,
+          ...(!hideSlug && { slug: value.slug })
+        }
+      })
+    }
+  })
+
+  useEffect(() => {
+    if (!activeOrganization) return
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(
+        fieldsWithModelValues(
+          additionalFields,
+          activeOrganization as Record<string, unknown>
+        )
+      ),
+      name: activeOrganization.name,
+      slug: activeOrganization.slug
+    })
+  }, [activeOrganization, additionalFields, form])
 
   const nameInputId = `${activeOrganization?.id ?? "org"}-name`
   const slugInputId = `${activeOrganization?.id ?? "org"}-slug`
@@ -100,76 +109,104 @@ export function OrganizationProfile({
 
       <Card className={className}>
         <CardContent>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <ChangeOrganizationLogo />
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-4">
+              <ChangeOrganizationLogo />
 
-            <Field>
-              <FieldLabel htmlFor={nameInputId}>
-                {organizationLocalization.name}
-              </FieldLabel>
-
-              {activeOrganization ? (
-                <Input
-                  key={activeOrganization.id}
-                  id={nameInputId}
-                  name="name"
-                  defaultValue={activeOrganization.name}
-                  autoComplete="organization"
-                  placeholder={organizationLocalization.namePlaceholder}
-                  disabled={formDisabled}
-                />
-              ) : (
-                <Skeleton className="h-8 w-full rounded-md" />
-              )}
-
-              <FieldError />
-            </Field>
-
-            {!hideSlug &&
-              (activeOrganization ? (
-                <SlugField
-                  id={slugInputId}
-                  value={slug}
-                  onChange={setSlug}
-                  currentSlug={activeOrganization.slug}
-                  disabled={formDisabled}
-                />
-              ) : (
-                <Field>
-                  <FieldLabel>{organizationLocalization.slug}</FieldLabel>
-                  <Skeleton className="h-8 w-full rounded-md" />
-                </Field>
-              ))}
-
-            {activeOrganization &&
-              additionalFields.map((field) => (
-                <AdditionalField
-                  key={field.name}
-                  field={{
-                    ...field,
-                    defaultValue: (
-                      activeOrganization as Record<string, unknown>
-                    )[field.name] as never
-                  }}
-                  isPending={formDisabled}
-                  name={field.name}
-                  optionalLabel={localization.settings.optional}
-                />
-              ))}
-
-            {(canUpdate.isPending || canUpdate.data?.success) && (
-              <Button
-                type="submit"
-                disabled={formDisabled || !activeOrganization}
-                size="sm"
-                className="mt-1 w-fit"
+              <form.AppField
+                name="name"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
               >
-                {isPending && <Spinner />}
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
-                {localization.settings.saveChanges}
-              </Button>
-            )}
-          </form>
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor={nameInputId}>
+                        {organizationLocalization.name}
+                      </FieldLabel>
+
+                      {activeOrganization ? (
+                        <Input
+                          id={nameInputId}
+                          name={field.name}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          autoComplete="organization"
+                          placeholder={organizationLocalization.namePlaceholder}
+                          disabled={formDisabled}
+                          aria-invalid={isInvalid}
+                        />
+                      ) : (
+                        <Skeleton className="h-8 w-full rounded-md" />
+                      )}
+
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+
+              {!hideSlug &&
+                (activeOrganization ? (
+                  <form.AppField name="slug">
+                    {(field) => (
+                      <SlugField
+                        id={slugInputId}
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        currentSlug={activeOrganization.slug}
+                        disabled={formDisabled}
+                      />
+                    )}
+                  </form.AppField>
+                ) : (
+                  <Field>
+                    <FieldLabel>{organizationLocalization.slug}</FieldLabel>
+                    <Skeleton className="h-8 w-full rounded-md" />
+                  </Field>
+                ))}
+
+              {activeOrganization &&
+                additionalFields.map((configuredField) => (
+                  <form.AppField
+                    key={configuredField.name}
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={formDisabled}
+                        optionalLabel={localization.settings.optional}
+                      />
+                    )}
+                  </form.AppField>
+                ))}
+
+              {(canUpdate.isPending || canUpdate.data?.success) && (
+                <form.AuthFormSubmitButton
+                  disabled={formDisabled || !activeOrganization}
+                  size="sm"
+                  className="mt-1 w-fit"
+                >
+                  {localization.settings.saveChanges}
+                </form.AuthFormSubmitButton>
+              )}
+            </form.AuthFormRoot>
+          </form.AppForm>
         </CardContent>
       </Card>
     </div>

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-roles.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-roles.tsx
@@ -3,7 +3,9 @@
 import {
   type AdditionalFields,
   fieldsWithModelValues,
-  parseAdditionalFieldValues
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type { OrganizationRolesAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
@@ -16,7 +18,7 @@ import {
   useUpdateRole
 } from "@better-auth-ui/react/plugins/organization"
 import { Filter, Pencil, Plus, Search, Trash2, X } from "lucide-react"
-import { type FormEvent, useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -67,7 +69,11 @@ import {
 } from "@/components/ui/table"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 import { OrganizationSortableTableHead } from "./organization-sortable-table-head"
 import {
   createOrganizationColumnHelper,
@@ -620,9 +626,6 @@ function RoleDialog({
   const { authClient, localization: authLocalization } =
     useAuth<OrganizationRolesAuthClient>()
   const { localization } = useAuthPlugin(organizationPlugin)
-  const [name, setName] = useState("")
-  const [permission, setPermission] = useState<Record<string, string[]>>({})
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const createRole = useCreateRole(authClient, organizationId, {
     onSuccess: () => {
       toast.success(localization.roleCreated)
@@ -636,154 +639,207 @@ function RoleDialog({
     }
   })
 
-  useEffect(() => {
-    if (!open) return
-    setName(role?.role ?? "")
-    setPermission(role?.permission ?? {})
-  }, [open, role])
+  const configuredRoleFields = useMemo(
+    () => fieldsWithModelValues(roleFields, role ?? {}),
+    [role, roleFields]
+  )
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredRoleFields),
+      name: role?.role ?? "",
+      permission: role?.permission ?? ({} as Record<string, string[]>)
+    },
+    onSubmit: async ({ value }) => {
+      const roleName = value.name.trim()
+      if (!roleName) return
 
-  async function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    const roleName = name.trim()
-    if (!roleName) return
+      try {
+        if (
+          Object.values(value.permission).some((actions) => actions.length > 0)
+        ) {
+          const access = await authClient.organization.hasPermission({
+            organizationId,
+            permissions: value.permission as Parameters<
+              OrganizationRolesAuthClient["organization"]["hasPermission"]
+            >[0]["permissions"]
+          })
 
-    setIsSubmitting(true)
-    try {
-      if (Object.values(permission).some((actions) => actions.length > 0)) {
-        const access = await authClient.organization.hasPermission({
-          organizationId,
-          permissions: permission as Parameters<
-            OrganizationRolesAuthClient["organization"]["hasPermission"]
-          >[0]["permissions"]
-        })
-
-        if (access.error || !access.data?.success) {
-          toast.error(localization.permissionsLimitedDescription)
-          setIsSubmitting(false)
-          return
+          if (access.error || !access.data?.success) {
+            toast.error(localization.permissionsLimitedDescription)
+            return
+          }
         }
-      }
 
-      const additionalFields = await parseAdditionalFieldValues(
-        roleFields,
-        new FormData(event.currentTarget)
-      )
-      if (role) {
-        updateRole.mutate(
-          {
+        const additionalFields = getAdditionalFieldSubmitValues(
+          configuredRoleFields,
+          value.additionalFields
+        )
+        if (role) {
+          await updateRole.mutateAsync({
             organizationId,
             roleId: role.id,
-            data: { ...additionalFields, roleName, permission }
-          },
-          { onSettled: () => setIsSubmitting(false) }
-        )
-      } else {
-        createRole.mutate(
-          {
+            data: {
+              ...additionalFields,
+              roleName,
+              permission: value.permission
+            }
+          })
+        } else {
+          await createRole.mutateAsync({
             organizationId,
             role: roleName,
-            permission,
+            permission: value.permission,
             additionalFields
-          },
-          { onSettled: () => setIsSubmitting(false) }
-        )
+          })
+        }
+      } catch {
+        // The mutation reports the error through its configured handler.
       }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      setIsSubmitting(false)
     }
-  }
+  })
 
-  const pending = createRole.isPending || updateRole.isPending || isSubmitting
+  useEffect(() => {
+    if (!open) return
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredRoleFields),
+      name: role?.role ?? "",
+      permission: role?.permission ?? {}
+    })
+  }, [configuredRoleFields, form, open, role?.permission, role?.role])
+
+  const pending = createRole.isPending || updateRole.isPending
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
-        <form className="flex flex-col gap-6" onSubmit={submit}>
-          <DialogHeader>
-            <DialogTitle>
-              {role ? localization.editRole : localization.createRole}
-            </DialogTitle>
-            <DialogDescription>
-              {localization.rolesDescription}
-            </DialogDescription>
-          </DialogHeader>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle>
+                {role ? localization.editRole : localization.createRole}
+              </DialogTitle>
+              <DialogDescription>
+                {localization.rolesDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <Field>
-            <FieldLabel htmlFor="organization-role-name">
-              {localization.roleName}
-            </FieldLabel>
-            <Input
-              id="organization-role-name"
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              placeholder={localization.roleNamePlaceholder}
-              disabled={pending}
-              required
-            />
-          </Field>
-
-          {fieldsWithModelValues(roleFields, role ?? {}).map((field) => (
-            <AdditionalField
-              key={field.name}
-              field={field}
-              name={field.name}
-              isPending={pending}
-              optionalLabel={authLocalization.settings.optional}
-            />
-          ))}
-
-          <fieldset className="flex flex-col gap-4">
-            <legend className="text-sm font-medium">
-              {localization.permissions}
-            </legend>
-            {Object.entries(registry).map(([resource, definition]) => (
-              <div className="flex flex-col gap-2" key={resource}>
-                <p className="text-sm font-medium">
-                  {definition.label ?? resource}
-                </p>
-                <div className="grid gap-3 sm:grid-cols-2">
-                  {Object.entries(definition.actions).map(([action, label]) => (
-                    <RolePermissionCheckbox
-                      action={action}
-                      checked={permission[resource]?.includes(action) ?? false}
-                      key={action}
-                      label={label}
-                      onCheckedChange={(selected) =>
-                        setPermission((current) => ({
-                          ...current,
-                          [resource]: selected
-                            ? [...(current[resource] ?? []), action]
-                            : (current[resource] ?? []).filter(
-                                (entry) => entry !== action
-                              )
-                        }))
-                      }
-                      organizationId={organizationId}
-                      pending={pending}
-                      resource={resource}
-                    />
-                  ))}
-                </div>
-              </div>
-            ))}
-          </fieldset>
-
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={pending}
-              onClick={() => onOpenChange(false)}
+            <form.AppField
+              name="name"
+              validators={{
+                onChange: ({ value }) =>
+                  validateStringLength(value, {
+                    requiredMessage: authLocalization.auth.fieldRequired,
+                    trim: true
+                  })
+              }}
             >
-              {authLocalization.settings.cancel}
-            </Button>
-            <Button type="submit" disabled={pending || !name.trim()}>
-              {pending && <Spinner />}
-              {authLocalization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
-        </form>
+              {(field) => {
+                const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                return (
+                  <Field data-invalid={isInvalid}>
+                    <FieldLabel htmlFor="organization-role-name">
+                      {localization.roleName}
+                    </FieldLabel>
+                    <Input
+                      aria-invalid={isInvalid}
+                      disabled={pending}
+                      id="organization-role-name"
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      placeholder={localization.roleNamePlaceholder}
+                      value={field.state.value}
+                    />
+                    <field.AuthFormFieldError />
+                  </Field>
+                )
+              }}
+            </form.AppField>
+
+            {configuredRoleFields.map((configuredField) => (
+              <form.AppField
+                key={configuredField.name}
+                name={`additionalFields.${configuredField.name}`}
+                validators={getAuthAdditionalFieldValidators(
+                  configuredField,
+                  authLocalization.auth.fieldRequired
+                )}
+              >
+                {(field) => (
+                  <field.AuthFormAdditionalField
+                    field={configuredField}
+                    isPending={pending}
+                    optionalLabel={authLocalization.settings.optional}
+                  />
+                )}
+              </form.AppField>
+            ))}
+
+            <form.AppField name="permission">
+              {(field) => (
+                <fieldset className="flex flex-col gap-4">
+                  <legend className="text-sm font-medium">
+                    {localization.permissions}
+                  </legend>
+                  {Object.entries(registry).map(([resource, definition]) => (
+                    <div className="flex flex-col gap-2" key={resource}>
+                      <p className="text-sm font-medium">
+                        {definition.label ?? resource}
+                      </p>
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        {Object.entries(definition.actions).map(
+                          ([action, label]) => (
+                            <RolePermissionCheckbox
+                              action={action}
+                              checked={
+                                field.state.value[resource]?.includes(action) ??
+                                false
+                              }
+                              key={action}
+                              label={label}
+                              onCheckedChange={(selected) =>
+                                field.handleChange({
+                                  ...field.state.value,
+                                  [resource]: selected
+                                    ? [
+                                        ...(field.state.value[resource] ?? []),
+                                        action
+                                      ]
+                                    : (
+                                        field.state.value[resource] ?? []
+                                      ).filter((entry) => entry !== action)
+                                })
+                              }
+                              organizationId={organizationId}
+                              pending={pending}
+                              resource={resource}
+                            />
+                          )
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </fieldset>
+              )}
+            </form.AppField>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={pending}
+                onClick={() => onOpenChange(false)}
+              >
+                {authLocalization.settings.cancel}
+              </Button>
+              <form.AuthFormSubmitButton disabled={pending}>
+                {authLocalization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-teams.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-teams.tsx
@@ -3,7 +3,9 @@
 import {
   type AdditionalFields,
   fieldsWithModelValues,
-  parseAdditionalFieldValues
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type { OrganizationTeamsAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
@@ -28,7 +30,7 @@ import {
   UserRoundMinus,
   Users
 } from "lucide-react"
-import { type FormEvent, useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 import {
   AlertDialog,
@@ -64,7 +66,11 @@ import {
 } from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 
 type Team = { id: string; name: string; [key: string]: unknown }
 
@@ -231,8 +237,6 @@ function TeamDialog({
     organizationId,
     permissions: { member: ["delete"] }
   })
-  const [name, setName] = useState("")
-  const [isSubmittingFields, setIsSubmittingFields] = useState(false)
   const [userId, setUserId] = useState("")
   const createTeam = useCreateTeam(authClient, {
     onSuccess: () => {
@@ -273,272 +277,308 @@ function TeamDialog({
     ? localization.activeTeamRemovalDisabled
     : localization.lastTeamRemovalDisabled
 
+  const configuredTeamFields = useMemo(
+    () => fieldsWithModelValues(teamFields, team ?? {}),
+    [team, teamFields]
+  )
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredTeamFields),
+      name: team?.name ?? ""
+    },
+    onSubmit: async ({ value }) => {
+      const name = value.name.trim()
+      if (!name || !organizationId || (!team && teamLimitReached)) return
+      if (team && !canUpdate.data?.success) return
+
+      const data = {
+        ...getAdditionalFieldSubmitValues(
+          configuredTeamFields,
+          value.additionalFields
+        ),
+        name,
+        organizationId
+      }
+
+      try {
+        if (team) await updateTeam.mutateAsync({ teamId: team.id, data })
+        else await createTeam.mutateAsync(data)
+      } catch {
+        // The mutation reports the error through its configured handler.
+      }
+    }
+  })
+
   useEffect(() => {
     if (!open) return
-    setName(team?.name ?? "")
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredTeamFields),
+      name: team?.name ?? ""
+    })
     setUserId("")
-  }, [open, team])
+  }, [configuredTeamFields, form, open, team?.name])
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const trimmedName = name.trim()
-    if (!trimmedName || !organizationId || (!team && teamLimitReached)) return
-    if (team && !canUpdate.data?.success) return
-
-    setIsSubmittingFields(true)
-    try {
-      const values = await parseAdditionalFieldValues(
-        teamFields,
-        new FormData(event.currentTarget)
-      )
-      if (team) {
-        updateTeam.mutate(
-          {
-            teamId: team.id,
-            data: { ...values, name: trimmedName, organizationId }
-          },
-          { onSettled: () => setIsSubmittingFields(false) }
-        )
-      } else {
-        createTeam.mutate(
-          { ...values, name: trimmedName, organizationId },
-          { onSettled: () => setIsSubmittingFields(false) }
-        )
-      }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      setIsSubmittingFields(false)
-    }
-  }
-
-  const pending =
-    createTeam.isPending || updateTeam.isPending || isSubmittingFields
+  const pending = createTeam.isPending || updateTeam.isPending
   const canEdit = !team || canUpdate.data?.success === true
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
-        <form className="flex flex-col gap-6" onSubmit={handleSubmit}>
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Users />
-              {team ? localization.renameTeam : localization.createTeam}
-            </DialogTitle>
-            <DialogDescription>
-              {localization.teamsDescription}
-            </DialogDescription>
-          </DialogHeader>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Users />
+                {team ? localization.renameTeam : localization.createTeam}
+              </DialogTitle>
+              <DialogDescription>
+                {localization.teamsDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <div className="flex flex-col gap-4">
-            <Field>
-              <FieldLabel htmlFor="organization-team-name">
-                {localization.name}
-              </FieldLabel>
-              <Input
-                autoFocus
-                disabled={pending || !canEdit}
-                id="organization-team-name"
-                onChange={(event) => setName(event.target.value)}
-                required
-                value={name}
-              />
-            </Field>
-
-            {fieldsWithModelValues(teamFields, team ?? {}).map((field) => (
-              <AdditionalField
-                field={field}
-                isPending={pending || !canEdit}
-                key={field.name}
-                name={field.name}
-                optionalLabel={authLocalization.settings.optional}
-              />
-            ))}
-          </div>
-
-          {team && canListMembers && (
-            <div className="flex flex-col gap-4 border-t pt-5">
-              <div>
-                <h3 className="text-sm font-medium">
-                  {localization.teamMembers}
-                </h3>
-                <p className="text-sm text-muted-foreground">
-                  {localization.addTeamMember}
-                </p>
-              </div>
-
-              {(canAddMember.isPending || canAddMember.data?.success) && (
-                <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-end">
-                  <Field className="flex-1">
-                    <FieldLabel>{localization.addTeamMember}</FieldLabel>
-                    <Select
-                      disabled={canAddMember.isPending || memberLimitReached}
-                      items={availableMembers}
-                      onValueChange={(value) => setUserId(value ?? "")}
-                      value={userId}
-                    >
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder={localization.selectMember} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectGroup>
-                          {availableMembers.map((member) => (
-                            <SelectItem key={member.value} value={member.value}>
-                              {member.label}
-                            </SelectItem>
-                          ))}
-                        </SelectGroup>
-                      </SelectContent>
-                    </Select>
-                  </Field>
-                  <Button
-                    disabled={
-                      canAddMember.isPending ||
-                      !userId ||
-                      addMember.isPending ||
-                      memberLimitReached
-                    }
-                    onClick={() => {
-                      if (!canAddMember.data?.success || !userId) return
-                      addMember.mutate({
-                        teamId: team.id,
-                        userId,
-                        organizationId
-                      })
-                    }}
-                    type="button"
-                  >
-                    <UserPlus data-icon="inline-start" />
-                    {localization.addTeamMember}
-                  </Button>
-                </div>
-              )}
-
-              {canAddMember.data?.success && memberLimitReached && (
-                <p className="text-sm text-destructive" role="alert">
-                  {localization.teamMemberLimitReached}
-                </p>
-              )}
-
-              <div className="flex flex-col gap-2">
-                {teamMembers.isPending && <Spinner />}
-                {teamMembers.data?.map((teamMember) => {
-                  const member = organizationMembers.find(
-                    (candidate) => candidate.userId === teamMember.userId
-                  )
+            <div className="flex flex-col gap-4">
+              <form.AppField
+                name="name"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: authLocalization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
                   return (
-                    <div
-                      className="flex items-center justify-between gap-3 rounded-md border px-3 py-2"
-                      key={teamMember.id}
-                    >
-                      <span className="truncate text-sm">
-                        {member?.user.name ||
-                          member?.user.email ||
-                          teamMember.userId}
-                      </span>
-                      {(canRemoveMember.isPending ||
-                        canRemoveMember.data?.success) && (
-                        <Button
-                          aria-label={localization.removeTeamMember}
-                          disabled={
-                            canRemoveMember.isPending || removeMember.isPending
-                          }
-                          onClick={() => {
-                            if (!canRemoveMember.data?.success) return
-                            removeMember.mutate({
-                              teamId: team.id,
-                              userId: teamMember.userId,
-                              organizationId
-                            })
-                          }}
-                          size="icon-sm"
-                          type="button"
-                          variant="ghost"
-                        >
-                          <UserRoundMinus />
-                        </Button>
-                      )}
-                    </div>
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="organization-team-name">
+                        {localization.name}
+                      </FieldLabel>
+                      <Input
+                        aria-invalid={isInvalid}
+                        autoFocus
+                        disabled={pending || !canEdit}
+                        id="organization-team-name"
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        value={field.state.value}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
                   )
-                })}
-              </div>
-            </div>
-          )}
+                }}
+              </form.AppField>
 
-          {team && !canRemoveTeam && canDelete.data?.success && (
-            <p className="text-sm text-muted-foreground">
-              {teamRemovalDisabledReason}
-            </p>
-          )}
-
-          <DialogFooter className="sm:justify-between">
-            {team && (canDelete.isPending || canDelete.data?.success) && (
-              <AlertDialog>
-                <AlertDialogTrigger
-                  className={buttonVariants({ variant: "destructive" })}
-                  disabled={
-                    canDelete.isPending ||
-                    removeTeam.isPending ||
-                    !canRemoveTeam
-                  }
-                  type="button"
+              {configuredTeamFields.map((configuredField) => (
+                <form.AppField
+                  key={configuredField.name}
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    authLocalization.auth.fieldRequired
+                  )}
                 >
-                  <Trash2 data-icon="inline-start" />
-                  {localization.deleteTeam}
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>
-                      {localization.deleteTeam}
-                    </AlertDialogTitle>
-                    <AlertDialogDescription>
-                      {localization.deleteTeamDescription}
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>
-                      {authLocalization.settings.cancel}
-                    </AlertDialogCancel>
-                    <AlertDialogAction
-                      className={buttonVariants({ variant: "destructive" })}
-                      onClick={() =>
-                        removeTeam.mutate({
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      isPending={pending || !canEdit}
+                      optionalLabel={authLocalization.settings.optional}
+                    />
+                  )}
+                </form.AppField>
+              ))}
+            </div>
+
+            {team && canListMembers && (
+              <div className="flex flex-col gap-4 border-t pt-5">
+                <div>
+                  <h3 className="text-sm font-medium">
+                    {localization.teamMembers}
+                  </h3>
+                  <p className="text-sm text-muted-foreground">
+                    {localization.addTeamMember}
+                  </p>
+                </div>
+
+                {(canAddMember.isPending || canAddMember.data?.success) && (
+                  <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-end">
+                    <Field className="flex-1">
+                      <FieldLabel>{localization.addTeamMember}</FieldLabel>
+                      <Select
+                        disabled={canAddMember.isPending || memberLimitReached}
+                        items={availableMembers}
+                        onValueChange={(value) => setUserId(value ?? "")}
+                        value={userId}
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue
+                            placeholder={localization.selectMember}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectGroup>
+                            {availableMembers.map((member) => (
+                              <SelectItem
+                                key={member.value}
+                                value={member.value}
+                              >
+                                {member.label}
+                              </SelectItem>
+                            ))}
+                          </SelectGroup>
+                        </SelectContent>
+                      </Select>
+                    </Field>
+                    <Button
+                      disabled={
+                        canAddMember.isPending ||
+                        !userId ||
+                        addMember.isPending ||
+                        memberLimitReached
+                      }
+                      onClick={() => {
+                        if (!canAddMember.data?.success || !userId) return
+                        addMember.mutate({
                           teamId: team.id,
+                          userId,
                           organizationId
                         })
-                      }
+                      }}
+                      type="button"
                     >
-                      <Trash2 data-icon="inline-start" />
-                      {localization.deleteTeam}
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
+                      <UserPlus data-icon="inline-start" />
+                      {localization.addTeamMember}
+                    </Button>
+                  </div>
+                )}
+
+                {canAddMember.data?.success && memberLimitReached && (
+                  <p className="text-sm text-destructive" role="alert">
+                    {localization.teamMemberLimitReached}
+                  </p>
+                )}
+
+                <div className="flex flex-col gap-2">
+                  {teamMembers.isPending && <Spinner />}
+                  {teamMembers.data?.map((teamMember) => {
+                    const member = organizationMembers.find(
+                      (candidate) => candidate.userId === teamMember.userId
+                    )
+                    return (
+                      <div
+                        className="flex items-center justify-between gap-3 rounded-md border px-3 py-2"
+                        key={teamMember.id}
+                      >
+                        <span className="truncate text-sm">
+                          {member?.user.name ||
+                            member?.user.email ||
+                            teamMember.userId}
+                        </span>
+                        {(canRemoveMember.isPending ||
+                          canRemoveMember.data?.success) && (
+                          <Button
+                            aria-label={localization.removeTeamMember}
+                            disabled={
+                              canRemoveMember.isPending ||
+                              removeMember.isPending
+                            }
+                            onClick={() => {
+                              if (!canRemoveMember.data?.success) return
+                              removeMember.mutate({
+                                teamId: team.id,
+                                userId: teamMember.userId,
+                                organizationId
+                              })
+                            }}
+                            size="icon-sm"
+                            type="button"
+                            variant="ghost"
+                          >
+                            <UserRoundMinus />
+                          </Button>
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
             )}
 
-            <div className="flex flex-col-reverse gap-2 sm:flex-row">
-              <DialogClose
-                className={buttonVariants({ variant: "outline" })}
-                disabled={pending}
-                type="button"
-              >
-                {authLocalization.settings.cancel}
-              </DialogClose>
-              {canEdit && (
-                <Button
-                  disabled={
-                    pending || !name.trim() || (teamLimitReached && !team)
-                  }
-                  type="submit"
-                >
-                  {pending && <Spinner />}
-                  {team
-                    ? authLocalization.settings.saveChanges
-                    : localization.createTeam}
-                </Button>
+            {team && !canRemoveTeam && canDelete.data?.success && (
+              <p className="text-sm text-muted-foreground">
+                {teamRemovalDisabledReason}
+              </p>
+            )}
+
+            <DialogFooter className="sm:justify-between">
+              {team && (canDelete.isPending || canDelete.data?.success) && (
+                <AlertDialog>
+                  <AlertDialogTrigger
+                    className={buttonVariants({ variant: "destructive" })}
+                    disabled={
+                      canDelete.isPending ||
+                      removeTeam.isPending ||
+                      !canRemoveTeam
+                    }
+                    type="button"
+                  >
+                    <Trash2 data-icon="inline-start" />
+                    {localization.deleteTeam}
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>
+                        {localization.deleteTeam}
+                      </AlertDialogTitle>
+                      <AlertDialogDescription>
+                        {localization.deleteTeamDescription}
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>
+                        {authLocalization.settings.cancel}
+                      </AlertDialogCancel>
+                      <AlertDialogAction
+                        className={buttonVariants({ variant: "destructive" })}
+                        onClick={() =>
+                          removeTeam.mutate({
+                            teamId: team.id,
+                            organizationId
+                          })
+                        }
+                      >
+                        <Trash2 data-icon="inline-start" />
+                        {localization.deleteTeam}
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
               )}
-            </div>
-          </DialogFooter>
-        </form>
+
+              <div className="flex flex-col-reverse gap-2 sm:flex-row">
+                <DialogClose
+                  className={buttonVariants({ variant: "outline" })}
+                  disabled={pending}
+                  type="button"
+                >
+                  {authLocalization.settings.cancel}
+                </DialogClose>
+                {canEdit && (
+                  <form.AuthFormSubmitButton
+                    disabled={pending || (teamLimitReached && !team)}
+                  >
+                    {team
+                      ? authLocalization.settings.saveChanges
+                      : localization.createTeam}
+                  </form.AuthFormSubmitButton>
+                )}
+              </div>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-shadcn-baseui-example/src/components/auth/settings/account/user-profile.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/settings/account/user-profile.tsx
@@ -1,22 +1,26 @@
 "use client"
 
 import {
-  type AdditionalFieldValue,
-  parseAdditionalFieldValue
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type { UsernameAuthClient } from "@better-auth-ui/core/plugins/username"
 import { useAuth, useSession, useUpdateUser } from "@better-auth-ui/react"
-import { type SyntheticEvent, useState } from "react"
+import { useEffect, useMemo } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Spinner } from "@/components/ui/spinner"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "../../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../../auth-form"
 import { ChangeAvatar } from "./change-avatar"
 
 export type UserProfileProps = {
@@ -34,49 +38,39 @@ export function UserProfile({ className }: UserProfileProps) {
     useAuth<UsernameAuthClient>()
   const { data: session } = useSession(authClient)
 
-  const { mutate: updateUser, isPending } = useUpdateUser(authClient, {
+  const { mutateAsync: updateUser, isPending } = useUpdateUser(authClient, {
     onSuccess: () => toast.success(localization.settings.profileUpdatedSuccess)
   })
 
-  const [fieldErrors, setFieldErrors] = useState<{
-    name?: string
-  }>({})
-
-  async function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const name = formData.get("name") as string
-
-    const additionalFieldValues: Record<string, unknown> = {}
-
-    for (const field of additionalFields ?? []) {
-      if (field.profile === false || field.readOnly) continue
-      const value = parseAdditionalFieldValue(
-        field,
-        formData.get(field.name) as string | null
-      )
-
-      if (field.validate) {
-        try {
-          await field.validate(value)
-        } catch (error) {
-          toast.error(error instanceof Error ? error.message : String(error))
-          return
-        }
-      }
-
-      // `null` = explicit clear (forward to backend); `undefined` = omitted.
-      if (value !== undefined) {
-        additionalFieldValues[field.name] = value
-      }
+  const profileFields = useMemo(
+    () => additionalFields?.filter((field) => field.profile !== false) ?? [],
+    [additionalFields]
+  )
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(profileFields),
+      name: ""
+    },
+    onSubmit: async ({ value }) => {
+      await updateUser({
+        name: value.name,
+        ...getAdditionalFieldSubmitValues(profileFields, value.additionalFields)
+      })
     }
+  })
 
-    updateUser({
-      name,
-      ...additionalFieldValues
+  useEffect(() => {
+    if (!session) return
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(
+        fieldsWithModelValues(
+          profileFields,
+          session.user as Record<string, unknown>
+        )
+      ),
+      name: session.user.name
     })
-  }
+  }, [form, profileFields, session])
 
   return (
     <div>
@@ -84,101 +78,101 @@ export function UserProfile({ className }: UserProfileProps) {
         {localization.settings.userProfile}
       </h2>
 
-      <form onSubmit={handleSubmit}>
-        <Card className={cn(className)}>
-          <CardContent className="flex flex-col gap-6">
-            <ChangeAvatar />
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card className={cn(className)}>
+            <CardContent className="flex flex-col gap-6">
+              <ChangeAvatar />
 
-            <Field data-invalid={!!fieldErrors.name}>
-              <FieldLabel htmlFor="name">{localization.auth.name}</FieldLabel>
+              <form.AppField
+                name="name"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
-              {session ? (
-                <Input
-                  key={session?.user.name}
-                  id="name"
-                  name="name"
-                  autoComplete="name"
-                  defaultValue={session?.user.name}
-                  placeholder={localization.auth.name}
-                  disabled={isPending}
-                  required
-                  onChange={() => {
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      name: undefined
-                    }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="name">
+                        {localization.auth.name}
+                      </FieldLabel>
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      name: (e.target as HTMLInputElement).validationMessage
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.name}
-                />
-              ) : (
-                <Skeleton>
-                  <Input className="invisible" />
-                </Skeleton>
-              )}
+                      {session ? (
+                        <Input
+                          id="name"
+                          name={field.name}
+                          autoComplete="name"
+                          placeholder={localization.auth.name}
+                          disabled={isPending}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          aria-invalid={isInvalid}
+                        />
+                      ) : (
+                        <Skeleton>
+                          <Input className="invisible" />
+                        </Skeleton>
+                      )}
 
-              <FieldError>{fieldErrors.name}</FieldError>
-            </Field>
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
 
-            {additionalFields?.map((field) => {
-              if (field.profile === false) return null
+              {profileFields.map((configuredField) => {
+                if (!session) {
+                  if (configuredField.inputType === "hidden") {
+                    return null
+                  }
 
-              if (!session) {
-                if (field.inputType === "hidden") {
-                  return null
+                  return (
+                    <Skeleton key={configuredField.name}>
+                      <Input className="invisible" />
+                    </Skeleton>
+                  )
                 }
 
                 return (
-                  <Skeleton key={field.name}>
-                    <Input className="invisible" />
-                  </Skeleton>
+                  <form.AppField
+                    key={configuredField.name}
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={isPending}
+                      />
+                    )}
+                  </form.AppField>
                 )
-              }
+              })}
+            </CardContent>
 
-              const value = (session.user as Record<string, unknown>)[
-                field.name
-              ]
-
-              // Re-mount when the session value loads so the field's
-              // uncontrolled `defaultValue` reflects the latest data.
-              const key = `${field.name}:${
-                value instanceof Date
-                  ? value.toISOString()
-                  : String(value ?? "")
-              }`
-
-              return (
-                <AdditionalField
-                  key={key}
-                  name={field.name}
-                  field={{
-                    ...field,
-                    // `defaultValue` is sign-up-only; on the profile we
-                    // always seed from the session.
-                    defaultValue: value as AdditionalFieldValue | null
-                  }}
-                  isPending={isPending}
-                />
-              )
-            })}
-          </CardContent>
-
-          <CardFooter>
-            <Button type="submit" size="sm" disabled={isPending || !session}>
-              {isPending && <Spinner />}
-
-              {localization.settings.saveChanges}
-            </Button>
-          </CardFooter>
-        </Card>
-      </form>
+            <CardFooter>
+              <form.AuthFormSubmitButton
+                size="sm"
+                disabled={isPending || !session}
+              >
+                {localization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/examples/start-shadcn-baseui-example/src/components/auth/sign-up.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/sign-up.tsx
@@ -2,9 +2,10 @@
 
 import {
   authMutationKeys,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
   getAuthLinkURL,
   isPasswordCompromisedError,
-  parseAdditionalFieldValue,
   validateEmailAddress,
   validateMatchingValue,
   validateStringLength
@@ -17,8 +18,7 @@ import {
 } from "@better-auth-ui/react"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { useRef, useState } from "react"
-import { toast } from "sonner"
+import { useMemo, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Field,
@@ -36,8 +36,11 @@ import {
   InputGroupInput
 } from "@/components/ui/input-group"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "./additional-field"
-import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "./auth-form"
 import { PasswordStrengthMeter } from "./password-strength-meter"
 import { ProviderButtons, type SocialLayout } from "./provider-buttons"
 
@@ -136,9 +139,13 @@ export function SignUp({
     useState(false)
 
   const [isCompromised, setIsCompromised] = useState(false)
-  const additionalFieldValuesRef = useRef<Record<string, unknown>>({})
+  const signUpFields = useMemo(
+    () => additionalFields?.filter((field) => field.signUp) ?? [],
+    [additionalFields]
+  )
   const form = useAuthForm({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(signUpFields),
       confirmPassword: "",
       email: "",
       name: "",
@@ -150,7 +157,10 @@ export function SignUp({
           name: emailAndPassword?.name === false ? "" : value.name,
           email: value.email.trim(),
           password: value.password,
-          ...additionalFieldValuesRef.current,
+          ...getAdditionalFieldSubmitValues(
+            signUpFields,
+            value.additionalFields
+          ),
           fetchOptions
         })
       } catch {
@@ -158,35 +168,6 @@ export function SignUp({
       }
     }
   })
-
-  const prepareSubmit = async (formElement: HTMLFormElement) => {
-    const formData = new FormData(formElement)
-
-    const additionalFieldValues: Record<string, unknown> = {}
-
-    for (const field of additionalFields ?? []) {
-      if (!field.signUp || field.readOnly) continue
-      const value = parseAdditionalFieldValue(
-        field,
-        formData.get(field.name) as string | null
-      )
-
-      if (field.validate) {
-        try {
-          await field.validate(value)
-        } catch (error) {
-          toast.error(error instanceof Error ? error.message : String(error))
-          return false
-        }
-      }
-
-      if (value !== undefined) {
-        additionalFieldValues[field.name] = value
-      }
-    }
-
-    additionalFieldValuesRef.current = additionalFieldValues
-  }
 
   const showSeparator =
     emailAndPassword?.enabled && socialProviders && socialProviders.length > 0
@@ -218,7 +199,7 @@ export function SignUp({
 
           {emailAndPassword?.enabled && (
             <form.AppForm>
-              <form.AuthFormRoot prepareSubmit={prepareSubmit}>
+              <form.AuthFormRoot>
                 <FieldGroup>
                   {emailAndPassword.name !== false && (
                     <form.AppField
@@ -306,16 +287,25 @@ export function SignUp({
                     }}
                   </form.AppField>
 
-                  {additionalFields?.map(
-                    (field) =>
-                      field.signUp === "above" && (
-                        <AdditionalField
-                          key={field.name}
-                          name={field.name}
-                          field={field}
-                          isPending={isPending}
-                          optionalLabel={localization.auth.optional}
-                        />
+                  {signUpFields.map(
+                    (configuredField) =>
+                      configuredField.signUp === "above" && (
+                        <form.AppField
+                          key={configuredField.name}
+                          name={`additionalFields.${configuredField.name}`}
+                          validators={getAuthAdditionalFieldValidators(
+                            configuredField,
+                            localization.auth.fieldRequired
+                          )}
+                        >
+                          {(field) => (
+                            <field.AuthFormAdditionalField
+                              field={configuredField}
+                              isPending={isPending}
+                              optionalLabel={localization.auth.optional}
+                            />
+                          )}
+                        </form.AppField>
                       )
                   )}
 
@@ -503,17 +493,25 @@ export function SignUp({
                     </form.AppField>
                   )}
 
-                  {additionalFields?.map(
-                    (field) =>
-                      field.signUp &&
-                      field.signUp !== "above" && (
-                        <AdditionalField
-                          key={field.name}
-                          name={field.name}
-                          field={field}
-                          isPending={isPending}
-                          optionalLabel={localization.auth.optional}
-                        />
+                  {signUpFields.map(
+                    (configuredField) =>
+                      configuredField.signUp !== "above" && (
+                        <form.AppField
+                          key={configuredField.name}
+                          name={`additionalFields.${configuredField.name}`}
+                          validators={getAuthAdditionalFieldValidators(
+                            configuredField,
+                            localization.auth.fieldRequired
+                          )}
+                        >
+                          {(field) => (
+                            <field.AuthFormAdditionalField
+                              field={configuredField}
+                              isPending={isPending}
+                              optionalLabel={localization.auth.optional}
+                            />
+                          )}
+                        </form.AppField>
                       )
                   )}
 

--- a/examples/start-shadcn-baseui-example/src/components/auth/username/username-field.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/username/username-field.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getFormFieldErrors } from "@better-auth-ui/core"
 import type { UsernameAuthClient } from "@better-auth-ui/core/plugins/username"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useIsUsernameAvailable } from "@better-auth-ui/react/plugins/username"
@@ -25,6 +26,11 @@ import { usernamePlugin } from "@/lib/auth/username-plugin"
 export function UsernameField({
   name,
   field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
   isPending
 }: AdditionalFieldProps) {
   const { authClient, localization: authLocalization } =
@@ -38,8 +44,9 @@ export function UsernameField({
   } = useAuthPlugin(usernamePlugin)
 
   const currentUsername = String(field.defaultValue ?? "")
-  const [value, setValue] = useState(currentUsername)
-  const [error, setError] = useState<string>()
+  const username = typeof value === "string" ? value : ""
+  const [nativeError, setNativeError] = useState<string>()
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
   const {
     mutate: requestAvailability,
@@ -64,8 +71,8 @@ export function UsernameField({
   )
 
   function handleChange(next: string) {
-    setValue(next)
-    setError(undefined)
+    onChange(next || null)
+    setNativeError(undefined)
     resetAvailability()
 
     if (checkAvailability) {
@@ -74,10 +81,12 @@ export function UsernameField({
   }
 
   const isCheckingAvailability =
-    !!checkAvailability && !!value.trim() && value.trim() !== currentUsername
+    !!checkAvailability &&
+    !!username.trim() &&
+    username.trim() !== currentUsername
 
   return (
-    <Field data-invalid={!!error}>
+    <Field data-invalid={isInvalid || !!nativeError}>
       <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
       <InputGroup>
@@ -97,7 +106,8 @@ export function UsernameField({
           disabled={isPending}
           required={field.required}
           readOnly={field.readOnly}
-          value={value}
+          value={username}
+          onBlur={onBlur}
           onChange={(e) => handleChange(e.target.value)}
           onInvalid={(e) => {
             e.preventDefault()
@@ -113,9 +123,9 @@ export function UsernameField({
                     "{{max}}",
                     String(maxUsernameLength)
                   )
-            setError(msg)
+            setNativeError(msg)
           }}
-          aria-invalid={!!error}
+          aria-invalid={isInvalid || !!nativeError}
           placeholder={field.placeholder}
         />
 
@@ -141,7 +151,7 @@ export function UsernameField({
         )}
       </InputGroup>
 
-      <FieldError>{error}</FieldError>
+      <FieldError errors={fieldErrors}>{nativeError}</FieldError>
     </Field>
   )
 }

--- a/examples/start-shadcn-example/src/components/auth/additional-field.tsx
+++ b/examples/start-shadcn-example/src/components/auth/additional-field.tsx
@@ -2,6 +2,8 @@
 
 import {
   type AdditionalField as AdditionalFieldConfig,
+  type AdditionalFieldFormValue,
+  getFormFieldErrors,
   resolveInputType
 } from "@better-auth-ui/core"
 import { useAuth, useCopyToClipboard } from "@better-auth-ui/react"
@@ -54,9 +56,19 @@ import { cn } from "@/lib/utils"
 export type AdditionalFieldProps = {
   name: string
   field: AdditionalFieldConfig
+  value: AdditionalFieldFormValue
+  onBlur: () => void
+  onChange: (value: AdditionalFieldFormValue) => void
+  isInvalid?: boolean
+  errors?: unknown[]
   isPending?: boolean
   /** Complete suffix appended to labels for fields that are not required. */
   optionalLabel?: string
+}
+
+function valueToString(value: AdditionalFieldFormValue) {
+  if (value == null) return ""
+  return value instanceof Date ? value.toISOString() : String(value)
 }
 
 /** Convert a `defaultValue` into a `Date` for the calendar. */
@@ -124,6 +136,11 @@ function CopyButton({
 export function AdditionalField({
   name,
   field: configuredField,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
   isPending,
   optionalLabel
 }: AdditionalFieldProps) {
@@ -140,6 +157,7 @@ export function AdditionalField({
         }
       : configuredField
   const inputType = resolveInputType(field)
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
   if (field.render) {
     const FieldRenderer = field.render as ComponentType<AdditionalFieldProps>
@@ -147,6 +165,11 @@ export function AdditionalField({
       <FieldRenderer
         name={name}
         field={field}
+        value={value}
+        onBlur={onBlur}
+        onChange={onChange}
+        isInvalid={isInvalid}
+        errors={errors}
         isPending={isPending}
         optionalLabel={optionalLabel}
       />
@@ -155,38 +178,29 @@ export function AdditionalField({
 
   if (inputType === "hidden") {
     return (
-      <input
-        type="hidden"
-        name={name}
-        value={
-          field.defaultValue == null
-            ? ""
-            : field.defaultValue instanceof Date
-              ? field.defaultValue.toISOString()
-              : String(field.defaultValue)
-        }
-      />
+      <input type="hidden" name={name} value={valueToString(value)} readOnly />
     )
   }
 
   if (inputType === "textarea") {
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <Textarea
           id={name}
           name={name}
-          defaultValue={
-            field.defaultValue == null ? undefined : String(field.defaultValue)
-          }
+          value={valueToString(value)}
+          onBlur={onBlur}
+          onChange={(event) => onChange(event.target.value || null)}
           placeholder={field.placeholder}
           required={field.required}
           readOnly={field.readOnly}
           disabled={isPending}
+          aria-invalid={isInvalid}
         />
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
@@ -195,7 +209,7 @@ export function AdditionalField({
     const maxFractionDigits = field.formatOptions?.maximumFractionDigits
 
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <Input
@@ -209,81 +223,101 @@ export function AdditionalField({
             field.step ??
             (maxFractionDigits ? 1 / 10 ** maxFractionDigits : undefined)
           }
-          defaultValue={
-            field.defaultValue == null
-              ? undefined
-              : typeof field.defaultValue === "number"
-                ? field.defaultValue
-                : String(field.defaultValue)
+          value={typeof value === "number" ? value : ""}
+          onBlur={onBlur}
+          onChange={(event) =>
+            onChange(
+              event.target.value === "" ? null : event.target.valueAsNumber
+            )
           }
           placeholder={field.placeholder}
           required={field.required}
           readOnly={field.readOnly}
           disabled={isPending}
+          aria-invalid={isInvalid}
         />
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "slider") {
-    return <SliderField name={name} field={field} isPending={isPending} />
+    return (
+      <SliderField
+        name={name}
+        field={field}
+        value={value}
+        onBlur={onBlur}
+        onChange={onChange}
+        isInvalid={isInvalid}
+        errors={errors}
+        isPending={isPending}
+      />
+    )
   }
 
   if (inputType === "switch") {
     return (
-      <Field orientation="horizontal">
+      <Field data-invalid={isInvalid} orientation="horizontal">
         <Switch
           id={name}
           name={name}
-          defaultChecked={
-            field.defaultValue === true || field.defaultValue === "true"
-          }
+          checked={value === true}
+          onBlur={onBlur}
+          onCheckedChange={onChange}
           disabled={isPending || field.readOnly}
+          aria-invalid={isInvalid}
         />
 
         <FieldContent>
           <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
         </FieldContent>
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "checkbox") {
     return (
-      <Field orientation="horizontal">
+      <Field data-invalid={isInvalid} orientation="horizontal">
         <Checkbox
           id={name}
           name={name}
-          defaultChecked={
-            field.defaultValue === true || field.defaultValue === "true"
-          }
+          checked={value === true}
+          onBlur={onBlur}
+          onCheckedChange={(checked) => onChange(checked === true)}
           required={field.required}
           disabled={isPending || field.readOnly}
+          aria-invalid={isInvalid}
         />
 
         <FieldContent>
           <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
         </FieldContent>
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "select") {
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <Select
           name={name}
-          defaultValue={
-            field.defaultValue != null ? String(field.defaultValue) : undefined
-          }
+          value={valueToString(value) || undefined}
+          onValueChange={(nextValue) => onChange(nextValue)}
           required={field.required}
           disabled={isPending || field.readOnly}
         >
-          <SelectTrigger id={name} className="w-full">
+          <SelectTrigger
+            id={name}
+            className="w-full"
+            onBlur={onBlur}
+            aria-invalid={isInvalid}
+          >
             <SelectValue placeholder={field.placeholder} />
           </SelectTrigger>
 
@@ -296,26 +330,34 @@ export function AdditionalField({
           </SelectContent>
         </Select>
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "combobox") {
+    const selectedOption = field.options?.find(
+      (option) => option.value === valueToString(value)
+    )
+
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <Combobox
           items={field.options ?? []}
           name={name}
-          defaultValue={
-            field.defaultValue != null ? String(field.defaultValue) : undefined
-          }
+          value={selectedOption ?? null}
+          onValueChange={(option) => onChange(option?.value ?? null)}
           required={field.required}
           disabled={isPending || field.readOnly}
         >
-          <ComboboxInput placeholder={field.placeholder} id={name} />
+          <ComboboxInput
+            placeholder={field.placeholder}
+            id={name}
+            onBlur={onBlur}
+            aria-invalid={isInvalid}
+          />
 
           <ComboboxContent>
             <ComboboxEmpty>No items found.</ComboboxEmpty>
@@ -330,20 +372,52 @@ export function AdditionalField({
           </ComboboxContent>
         </Combobox>
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   if (inputType === "date" || inputType === "datetime") {
-    return <DateInput name={name} field={field} isPending={isPending} />
+    return (
+      <DateInput
+        name={name}
+        field={field}
+        value={value}
+        onBlur={onBlur}
+        onChange={onChange}
+        isInvalid={isInvalid}
+        errors={errors}
+        isPending={isPending}
+      />
+    )
   }
 
-  return <InputField name={name} field={field} isPending={isPending} />
+  return (
+    <InputField
+      name={name}
+      field={field}
+      value={value}
+      onBlur={onBlur}
+      onChange={onChange}
+      isInvalid={isInvalid}
+      errors={errors}
+      isPending={isPending}
+    />
+  )
 }
 
-function InputField({ name, field, isPending }: AdditionalFieldProps) {
+function InputField({
+  name,
+  field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
+  isPending
+}: AdditionalFieldProps) {
   const inputRef = useRef<HTMLInputElement>(null)
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
   const hasPrefix = field.prefix != null
   const hasSuffix = field.suffix != null || field.copyable
@@ -360,7 +434,7 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
 
   if (hasPrefix || hasSuffix) {
     return (
-      <Field>
+      <Field data-invalid={isInvalid}>
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
         <InputGroup>
@@ -377,15 +451,14 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
             type={nativeInputType}
             inputMode={nativeInputMode}
             step={nativeStep}
-            defaultValue={
-              field.defaultValue == null
-                ? undefined
-                : String(field.defaultValue)
-            }
+            value={valueToString(value)}
+            onBlur={onBlur}
+            onChange={(event) => onChange(event.target.value || null)}
             placeholder={field.placeholder}
             required={field.required}
             readOnly={field.readOnly}
             disabled={isPending}
+            aria-invalid={isInvalid}
           />
 
           {field.copyable ? (
@@ -404,13 +477,13 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
           )}
         </InputGroup>
 
-        <FieldError />
+        <FieldError errors={fieldErrors} />
       </Field>
     )
   }
 
   return (
-    <Field>
+    <Field data-invalid={isInvalid}>
       <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
       <Input
@@ -419,16 +492,17 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
         type={nativeInputType}
         inputMode={nativeInputMode}
         step={nativeStep}
-        defaultValue={
-          field.defaultValue == null ? undefined : String(field.defaultValue)
-        }
+        value={valueToString(value)}
+        onBlur={onBlur}
+        onChange={(event) => onChange(event.target.value || null)}
         placeholder={field.placeholder}
         required={field.required}
         readOnly={field.readOnly}
         disabled={isPending}
+        aria-invalid={isInvalid}
       />
 
-      <FieldError />
+      <FieldError errors={fieldErrors} />
     </Field>
   )
 }
@@ -438,44 +512,51 @@ function InputField({ name, field, isPending }: AdditionalFieldProps) {
  * it next to the label and control the state to keep the displayed value in
  * sync. The selected value is submitted via the underlying Radix `name` prop.
  */
-function SliderField({ name, field, isPending }: AdditionalFieldProps) {
+function SliderField({
+  name,
+  field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
+  isPending
+}: AdditionalFieldProps) {
   const maxFractionDigits = field.formatOptions?.maximumFractionDigits
   const min = field.min ?? 0
   const max = field.max ?? 100
   const step =
     field.step ?? (maxFractionDigits ? 1 / 10 ** maxFractionDigits : 1)
-  const initial =
-    typeof field.defaultValue === "number"
-      ? field.defaultValue
-      : field.defaultValue != null && !Number.isNaN(Number(field.defaultValue))
-        ? Number(field.defaultValue)
-        : min
-
-  const [value, setValue] = useState<number>(initial)
+  const numericValue = typeof value === "number" ? value : min
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
   const formatter = new Intl.NumberFormat(undefined, field.formatOptions)
 
   return (
-    <Field>
+    <Field data-invalid={isInvalid}>
       <div className="flex items-center justify-between gap-2">
         <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
         <span className="text-sm text-muted-foreground tabular-nums">
-          {formatter.format(value)}
+          {formatter.format(numericValue)}
         </span>
       </div>
 
       <Slider
         id={name}
         name={name}
-        value={[value]}
-        onValueChange={(v) => setValue((Array.isArray(v) ? v[0] : v) ?? min)}
+        value={[numericValue]}
+        onBlur={onBlur}
+        onValueChange={(nextValue) =>
+          onChange((Array.isArray(nextValue) ? nextValue[0] : nextValue) ?? min)
+        }
         min={min}
         max={max}
         step={step}
         disabled={isPending || field.readOnly}
+        aria-invalid={isInvalid}
       />
 
-      <FieldError />
+      <FieldError errors={fieldErrors} />
     </Field>
   )
 }
@@ -485,68 +566,42 @@ function SliderField({ name, field, isPending }: AdditionalFieldProps) {
  * (optionally) `<input type="time">` for the time. Submits the combined ISO
  * value via a hidden `<input>` so it shows up in `FormData`.
  */
-function DateInput({ name, field, isPending }: AdditionalFieldProps) {
+function DateInput({
+  name,
+  field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
+  isPending
+}: AdditionalFieldProps) {
   const { localization } = useAuth()
   const inputType = resolveInputType(field)
   const isDateTime = inputType === "datetime"
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
-  const [date, setDate] = useState<Date | undefined>(toDate(field.defaultValue))
+  const date = toDate(value)
   const [time, setTime] = useState<string>(
     isDateTime && date ? formatTime(date) : ""
   )
   const [open, setOpen] = useState(false)
-  const [error, setError] = useState<string>()
 
   // Compose the hidden form value: ISO date for "date", ISO datetime for
   // "datetime" (date + time).
-  let formValue = ""
-  if (date) {
-    if (isDateTime && time && time.trim() !== "") {
-      const [h = "0", m = "0", s = "0"] = time.split(":")
-      const combined = new Date(date)
-      combined.setHours(Number(h), Number(m), Number(s), 0)
-      formValue = combined.toISOString()
-    } else {
-      // Anchor to local midnight then serialize as ISO so the downstream
-      // `parseAdditionalFieldValue` parses the same calendar day regardless
-      // of timezone (a bare "YYYY-MM-DD" would be parsed as UTC midnight).
-      // Datetime fields with a blank time also fall through here, defaulting
-      // the time to local midnight since the parsed value is always a `Date`.
-      const localMidnight = new Date(date)
-      localMidnight.setHours(0, 0, 0, 0)
-      formValue = localMidnight.toISOString()
-    }
-  }
-
   return (
-    <Field data-invalid={!!error}>
+    <Field data-invalid={isInvalid}>
       <FieldLabel htmlFor={`${name}-date`}>{field.label}</FieldLabel>
 
       <div className="relative flex gap-2">
-        {/* Visually-hidden input so required constraint validation fires on submit.
-            onInvalid suppresses the native browser balloon and routes the message
-            through the styled <FieldError> below — matching the pattern used by
-            the Name / Email / Password fields in the sign-up form. */}
-        <input
-          aria-label={typeof field.label === "string" ? field.label : name}
-          type="text"
-          name={name}
-          value={formValue}
-          onChange={() => {}}
-          required={field.required}
-          tabIndex={-1}
-          className="sr-only"
-          onInvalid={(e) => {
-            e.preventDefault()
-            setError((e.target as HTMLInputElement).validationMessage)
-          }}
-        />
         <Popover open={open} onOpenChange={setOpen}>
           <PopoverTrigger
             type="button"
             id={`${name}-date`}
             data-empty={!date}
-            aria-invalid={!!error}
+            aria-invalid={isInvalid}
+            aria-required={field.required}
+            onBlur={onBlur}
             disabled={isPending || field.readOnly}
             className={cn(
               buttonVariants({ variant: "outline" }),
@@ -566,8 +621,24 @@ function DateInput({ name, field, isPending }: AdditionalFieldProps) {
               defaultMonth={date}
               captionLayout="dropdown"
               onSelect={(value) => {
-                setDate(value)
-                if (value) setError(undefined)
+                if (!value) {
+                  onChange(null)
+                } else {
+                  const nextValue = new Date(value)
+                  if (isDateTime && time.trim()) {
+                    const [hours = "0", minutes = "0", seconds = "0"] =
+                      time.split(":")
+                    nextValue.setHours(
+                      Number(hours),
+                      Number(minutes),
+                      Number(seconds),
+                      0
+                    )
+                  } else {
+                    nextValue.setHours(0, 0, 0, 0)
+                  }
+                  onChange(nextValue)
+                }
                 if (!isDateTime) setOpen(false)
               }}
             />
@@ -585,7 +656,21 @@ function DateInput({ name, field, isPending }: AdditionalFieldProps) {
               id={`${name}-time`}
               step="1"
               value={time}
-              onChange={(e) => setTime(e.target.value)}
+              onChange={(event) => {
+                const nextTime = event.target.value
+                setTime(nextTime)
+                if (!date) return
+                const nextValue = new Date(date)
+                const [hours = "0", minutes = "0", seconds = "0"] =
+                  nextTime.split(":")
+                nextValue.setHours(
+                  Number(hours),
+                  Number(minutes),
+                  Number(seconds),
+                  0
+                )
+                onChange(nextValue)
+              }}
               disabled={isPending || field.readOnly}
               className="appearance-none bg-background [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none"
             />
@@ -593,7 +678,7 @@ function DateInput({ name, field, isPending }: AdditionalFieldProps) {
         )}
       </div>
 
-      <FieldError>{error}</FieldError>
+      <FieldError errors={fieldErrors} />
     </Field>
   )
 }

--- a/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -1,9 +1,10 @@
 "use client"
 
 import {
-  type AdditionalFieldValue,
-  getClampedTablePageIndex,
-  parseAdditionalFieldValues
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  getClampedTablePageIndex
 } from "@better-auth-ui/core"
 import {
   type AdminAuthClient,
@@ -55,10 +56,8 @@ import {
   useDeferredValue,
   useEffect,
   useMemo,
-  useRef,
   useState
 } from "react"
-import { AdditionalField } from "@/components/auth/additional-field"
 import { UserAvatar } from "@/components/auth/user/user-avatar"
 import {
   AlertDialog,
@@ -123,7 +122,7 @@ import {
 } from "@/components/ui/table"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { adminPlugin } from "@/lib/auth/admin-plugin"
-import { useAuthForm } from "../auth-form"
+import { getAuthAdditionalFieldValidators, useAuthForm } from "../auth-form"
 
 import { createAdminColumnHelper, useAdminTable } from "./admin-table"
 
@@ -691,18 +690,16 @@ function CreateUserDialog({
   const auth = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
   const { data: session } = useSession(auth.authClient)
-  const [formError, setFormError] = useState<string>()
   const createUser = useMutation(
     createAdminUserOptions(auth.authClient, session?.user.id)
   )
   const canSetRole = useAdminPermission(auth.authClient, {
     user: ["set-role"]
   })
-  const additionalFieldValuesRef = useRef<
-    Record<string, AdditionalFieldValue | null>
-  >({})
+  const additionalFields = auth.additionalFields ?? []
   const form = useAuthForm({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(additionalFields),
       email: "",
       emailVerified: false,
       name: "",
@@ -714,7 +711,10 @@ function CreateUserDialog({
         await createUser.mutateAsync(
           {
             data: {
-              ...additionalFieldValuesRef.current,
+              ...getAdditionalFieldSubmitValues(
+                additionalFields,
+                value.additionalFields
+              ),
               emailVerified: value.emailVerified
             },
             email: value.email,
@@ -739,24 +739,8 @@ function CreateUserDialog({
 
   const close = () => {
     form.reset()
-    setFormError(undefined)
     createUser.reset()
     onOpenChange(false)
-  }
-  const prepareSubmit = async (formElement: HTMLFormElement) => {
-    const data = new FormData(formElement)
-    let additionalFieldValues: Record<string, AdditionalFieldValue | null>
-    try {
-      additionalFieldValues = await parseAdditionalFieldValues(
-        auth.additionalFields ?? [],
-        data
-      )
-    } catch (error) {
-      setFormError(error instanceof Error ? error.message : String(error))
-      return false
-    }
-    setFormError(undefined)
-    additionalFieldValuesRef.current = additionalFieldValues
   }
 
   return (
@@ -766,10 +750,7 @@ function CreateUserDialog({
     >
       <DialogContent>
         <form.AppForm>
-          <form.AuthFormRoot
-            className="flex flex-col gap-4"
-            prepareSubmit={prepareSubmit}
-          >
+          <form.AuthFormRoot className="flex flex-col gap-4">
             <DialogHeader>
               <DialogTitle>{config.localization.createUser}</DialogTitle>
               <DialogDescription>
@@ -910,18 +891,25 @@ function CreateUserDialog({
                   </Field>
                 )}
               </form.Field>
-              {auth.additionalFields?.map((field) => (
-                <AdditionalField
-                  field={field}
-                  isPending={createUser.isPending}
-                  key={field.name}
-                  name={field.name}
-                />
+              {additionalFields.map((configuredField) => (
+                <form.AppField
+                  key={configuredField.name}
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    auth.localization.auth.fieldRequired
+                  )}
+                >
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      isPending={createUser.isPending}
+                    />
+                  )}
+                </form.AppField>
               ))}
             </FieldGroup>
-            <FieldError>
-              {formError ?? getAdminErrorMessage(createUser.error)}
-            </FieldError>
+            <FieldError>{getAdminErrorMessage(createUser.error)}</FieldError>
             <DialogFooter>
               <Button onClick={close} type="button" variant="outline">
                 {config.localization.cancel}
@@ -1030,21 +1018,13 @@ function UserInspector({
   const [banReason, setBanReason] = useState("")
   const [banDuration, setBanDuration] = useState("")
   const banDurationSeconds = getBanDurationSeconds(banDuration)
-  const [profileError, setProfileError] = useState<string>()
   const [passwordOpen, setPasswordOpen] = useState(false)
   const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
-  const profileUserId = useRef(user?.id)
   const isSelf = user?.id === actor?.user.id
 
   const updateUser = useMutation(
     updateAdminUserOptions(auth.authClient, actor?.user.id)
   )
-
-  useEffect(() => {
-    if (profileUserId.current === user?.id) return
-    profileUserId.current = user?.id
-    setProfileError(undefined)
-  }, [user?.id])
 
   useEffect(() => {
     if (user?.id) updateUser.reset()
@@ -1073,11 +1053,17 @@ function UserInspector({
   const revokeSessions = useMutation(
     revokeAdminUserSessionsOptions(auth.authClient, actor?.user.id, userId)
   )
-  const profileAdditionalFieldValuesRef = useRef<
-    Record<string, AdditionalFieldValue | null>
-  >({})
+  const configuredUserFields = useMemo(
+    () =>
+      fieldsWithModelValues(
+        auth.additionalFields ?? [],
+        user ? (user as unknown as Record<string, unknown>) : {}
+      ),
+    [auth.additionalFields, user]
+  )
   const profileForm = useAuthForm({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredUserFields),
       email: "",
       emailVerified: false,
       name: "",
@@ -1092,7 +1078,10 @@ function UserInspector({
           updateUser.mutateAsync({
             userId: user.id,
             data: {
-              ...profileAdditionalFieldValuesRef.current,
+              ...getAdditionalFieldSubmitValues(
+                configuredUserFields,
+                value.additionalFields
+              ),
               name: value.name.trim(),
               ...(canSetEmail.data?.success
                 ? {
@@ -1124,6 +1113,7 @@ function UserInspector({
 
   useEffect(() => {
     profileForm.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredUserFields),
       email: user?.email ?? "",
       emailVerified: user?.emailVerified ?? false,
       name: user?.name ?? "",
@@ -1136,6 +1126,7 @@ function UserInspector({
   }, [
     config.allowMultipleRoles,
     config.defaultRole,
+    configuredUserFields,
     profileForm.reset,
     user?.email,
     user?.emailVerified,
@@ -1215,26 +1206,6 @@ function UserInspector({
         : dangerousAction === "revokeAll"
           ? config.localization.revokeAllSessions
           : config.localization.impersonateUser
-
-  const prepareSaveUser = async (formElement: HTMLFormElement) => {
-    if (!user) return false
-
-    if (canUpdate.data?.success) {
-      const formData = new FormData(formElement)
-      let additionalFieldValues: Record<string, AdditionalFieldValue | null>
-      try {
-        additionalFieldValues = await parseAdditionalFieldValues(
-          auth.additionalFields ?? [],
-          formData
-        )
-      } catch (error) {
-        setProfileError(error instanceof Error ? error.message : String(error))
-        return false
-      }
-      setProfileError(undefined)
-      profileAdditionalFieldValuesRef.current = additionalFieldValues
-    }
-  }
 
   return (
     <>
@@ -1330,10 +1301,7 @@ function UserInspector({
               </TabsList>
               <TabsContent className="min-h-0 overflow-hidden" value="overview">
                 <profileForm.AppForm>
-                  <profileForm.AuthFormRoot
-                    className="grid h-full grid-rows-[minmax(0,1fr)_auto]"
-                    prepareSubmit={prepareSaveUser}
-                  >
+                  <profileForm.AuthFormRoot className="grid h-full grid-rows-[minmax(0,1fr)_auto]">
                     <div className="overflow-y-auto">
                       <section className="flex flex-col gap-5 p-6">
                         <h3 className="font-medium">
@@ -1479,30 +1447,29 @@ function UserInspector({
                               }
                             </profileForm.Field>
                           </FieldSet>
-                          {auth.additionalFields?.map((field) => {
-                            const value = (
-                              user as unknown as Record<string, unknown>
-                            )[field.name]
-                            return (
-                              <AdditionalField
-                                field={{
-                                  ...field,
-                                  defaultValue:
-                                    value as AdditionalFieldValue | null
-                                }}
-                                isPending={
-                                  updateUser.isPending ||
-                                  !canUpdate.data?.success
-                                }
-                                key={`${user.id}-${field.name}-${String(value ?? "")}`}
-                                name={field.name}
-                              />
-                            )
-                          })}
+                          {configuredUserFields.map((configuredField) => (
+                            <profileForm.AppField
+                              key={configuredField.name}
+                              name={`additionalFields.${configuredField.name}`}
+                              validators={getAuthAdditionalFieldValidators(
+                                configuredField,
+                                auth.localization.auth.fieldRequired
+                              )}
+                            >
+                              {(field) => (
+                                <field.AuthFormAdditionalField
+                                  field={configuredField}
+                                  isPending={
+                                    updateUser.isPending ||
+                                    !canUpdate.data?.success
+                                  }
+                                />
+                              )}
+                            </profileForm.AppField>
+                          ))}
                         </FieldGroup>
                         <FieldError>
-                          {profileError ??
-                            getAdminErrorMessage(updateUser.error) ??
+                          {getAdminErrorMessage(updateUser.error) ??
                             getAdminErrorMessage(setRoleMutation.error)}
                         </FieldError>
                       </section>

--- a/examples/start-shadcn-example/src/components/auth/auth-form.tsx
+++ b/examples/start-shadcn-example/src/components/auth/auth-form.tsx
@@ -1,23 +1,22 @@
 "use client"
 
-import { getFormFieldErrors } from "@better-auth-ui/core"
-import { createFormHook, createFormHookContexts } from "@tanstack/react-form"
 import {
-  type ComponentProps,
-  createContext,
-  type FormEvent,
-  useContext,
-  useRef,
-  useState
-} from "react"
+  type AdditionalField as AdditionalFieldConfig,
+  type AdditionalFieldFormValue,
+  getFormFieldErrors,
+  validateAdditionalFieldRequired,
+  validateAdditionalFieldValue
+} from "@better-auth-ui/core"
+import { createFormHook, createFormHookContexts } from "@tanstack/react-form"
+import { type ComponentProps, type FormEvent, useRef } from "react"
 
 import { Button } from "@/components/ui/button"
 import { FieldError } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
+import { AdditionalField, type AdditionalFieldProps } from "./additional-field"
 
 const { fieldContext, formContext, useFieldContext, useFormContext } =
   createFormHookContexts()
-const AuthFormPreparationContext = createContext(false)
 
 export function focusFirstInvalidAuthFormControl(form: HTMLFormElement) {
   requestAnimationFrame(() => {
@@ -41,53 +40,42 @@ function AuthFormFieldError() {
 }
 
 type AuthFormRootProps = Omit<ComponentProps<"form">, "onSubmit"> & {
-  prepareSubmit?: (
-    form: HTMLFormElement
-  ) => boolean | undefined | Promise<boolean | undefined>
+  onBeforeSubmit?: () => void
 }
 
 function AuthFormRoot({
   children,
-  prepareSubmit,
+  onBeforeSubmit,
   ...props
 }: AuthFormRootProps) {
   const form = useFormContext()
-  const preparingRef = useRef(false)
-  const [isPreparing, setIsPreparing] = useState(false)
+  const submittingRef = useRef(false)
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    if (preparingRef.current || form.state.isSubmitting) return
+    if (submittingRef.current || form.state.isSubmitting) return
 
     const formElement = event.currentTarget
-    preparingRef.current = true
-    setIsPreparing(true)
-
-    let shouldSubmit = true
+    onBeforeSubmit?.()
+    submittingRef.current = true
     try {
-      shouldSubmit = (await prepareSubmit?.(formElement)) !== false
+      await form.handleSubmit()
+      if (!form.state.isValid) focusFirstInvalidAuthFormControl(formElement)
     } finally {
-      preparingRef.current = false
-      setIsPreparing(false)
+      submittingRef.current = false
     }
-
-    if (!shouldSubmit) return
-    await form.handleSubmit()
-    if (!form.state.isValid) focusFirstInvalidAuthFormControl(formElement)
   }
 
   return (
-    <AuthFormPreparationContext.Provider value={isPreparing}>
-      <form
-        {...props}
-        onInvalid={(event) =>
-          focusFirstInvalidAuthFormControl(event.currentTarget)
-        }
-        onSubmit={submit}
-      >
-        {children}
-      </form>
-    </AuthFormPreparationContext.Provider>
+    <form
+      {...props}
+      onInvalid={(event) =>
+        focusFirstInvalidAuthFormControl(event.currentTarget)
+      }
+      onSubmit={submit}
+    >
+      {children}
+    </form>
   )
 }
 
@@ -97,7 +85,6 @@ function AuthFormSubmitButton({
   ...props
 }: ComponentProps<typeof Button>) {
   const form = useFormContext()
-  const isPreparing = useContext(AuthFormPreparationContext)
 
   return (
     <form.Subscribe
@@ -106,10 +93,10 @@ function AuthFormSubmitButton({
       {([canSubmit, isSubmitting]) => (
         <Button
           {...props}
-          disabled={disabled || isPreparing || !canSubmit || isSubmitting}
+          disabled={disabled || !canSubmit || isSubmitting}
           type="submit"
         >
-          {isPreparing || isSubmitting ? <Spinner /> : null}
+          {isSubmitting ? <Spinner /> : null}
           {children}
         </Button>
       )}
@@ -117,8 +104,32 @@ function AuthFormSubmitButton({
   )
 }
 
+type AuthFormAdditionalFieldProps = Omit<
+  AdditionalFieldProps,
+  "errors" | "isInvalid" | "name" | "onBlur" | "onChange" | "value"
+>
+
+function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
+  const field = useFieldContext<AdditionalFieldFormValue>()
+  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+
+  return (
+    <AdditionalField
+      {...props}
+      errors={
+        isInvalid ? getFormFieldErrors(field.state.meta.errors) : undefined
+      }
+      isInvalid={isInvalid}
+      name={field.name}
+      onBlur={field.handleBlur}
+      onChange={field.handleChange}
+      value={field.state.value}
+    />
+  )
+}
+
 export const { useAppForm: useAuthForm } = createFormHook({
-  fieldComponents: { AuthFormFieldError },
+  fieldComponents: { AuthFormAdditionalField, AuthFormFieldError },
   fieldContext,
   formComponents: { AuthFormRoot, AuthFormSubmitButton },
   formContext
@@ -132,4 +143,18 @@ export function isAuthFormFieldInvalid({
   isValid: boolean
 }) {
   return isTouched && !isValid
+}
+
+export function getAuthAdditionalFieldValidators(
+  field: AdditionalFieldConfig,
+  requiredMessage: string
+) {
+  return {
+    onChange: ({ value }: { value: AdditionalFieldFormValue }) =>
+      validateAdditionalFieldRequired(field, value, requiredMessage),
+    onChangeAsync: field.validate
+      ? ({ value }: { value: AdditionalFieldFormValue }) =>
+          validateAdditionalFieldValue(field, value)
+      : undefined
+  }
 }

--- a/examples/start-shadcn-example/src/components/auth/organization/create-organization-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/create-organization-dialog.tsx
@@ -1,13 +1,16 @@
 "use client"
 
-import { parseAdditionalFieldValue } from "@better-auth-ui/core"
+import {
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useCreateOrganization } from "@better-auth-ui/react/plugins/organization"
 import { Briefcase } from "lucide-react"
-import { type SyntheticEvent, useEffect, useRef, useState } from "react"
-import { toast } from "sonner"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useEffect, useRef, useState } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -17,11 +20,14 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 import { SlugField, sanitizeSlug } from "./slug-field"
 
 /** Props for the `CreateOrganizationDialog` component. */
@@ -44,150 +50,153 @@ export function CreateOrganizationDialog({
   } = useAuthPlugin(organizationPlugin)
   const hideSlug = hideSlugProp ?? pluginHideSlug ?? false
 
-  const [name, setName] = useState("")
-  const [slug, setSlug] = useState("")
   const [slugEdited, setSlugEdited] = useState(false)
-  const [nameError, setNameError] = useState<string>()
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const submissionLocked = useRef(false)
+  const submissionGeneration = useRef(0)
+  const submissionAttemptGeneration = useRef(0)
 
-  const { mutate: createOrganization, isPending: isCreating } =
-    useCreateOrganization(authClient, {
-      onSuccess: () => onOpenChange(false),
-      onSettled: () => {
-        submissionLocked.current = false
-        setIsSubmitting(false)
-      }
-    })
+  const { mutateAsync: createOrganization } = useCreateOrganization(authClient)
 
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    if (submissionLocked.current) return
-
-    submissionLocked.current = true
-    setIsSubmitting(true)
-    const formData = new FormData(e.currentTarget)
-    const additionalValues: Record<string, unknown> = {}
-    try {
-      for (const field of additionalFields) {
-        const value = parseAdditionalFieldValue(
-          field,
-          formData.get(field.name) as string | null
-        )
-        await field.validate?.(value)
-        if (value !== undefined) additionalValues[field.name] = value
-      }
-    } catch (error) {
-      submissionLocked.current = false
-      setIsSubmitting(false)
-      toast.error(error instanceof Error ? error.message : String(error))
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(additionalFields),
+      name: "",
+      slug: ""
+    },
+    onSubmit: async ({ value }) => {
+      const generation = submissionAttemptGeneration.current
+      if (generation !== submissionGeneration.current) return
+      await createOrganization({
+        ...getAdditionalFieldSubmitValues(
+          additionalFields,
+          value.additionalFields
+        ),
+        name: value.name,
+        slug: hideSlug ? undefined : value.slug
+      })
+      if (generation === submissionGeneration.current) onOpenChange(false)
     }
-    createOrganization({
-      ...additionalValues,
-      name,
-      slug: hideSlug ? undefined : slug
-    })
-  }
-
-  const isPending = isCreating || isSubmitting
+  })
 
   useEffect(() => {
     if (!open) {
-      setSlug("")
-      setName("")
+      submissionGeneration.current += 1
+      form.reset()
       setSlugEdited(false)
-      setNameError(undefined)
     }
-  }, [open])
-
-  useEffect(() => {
-    if (slugEdited) return
-    setSlug(sanitizeSlug(name))
-  }, [name, slugEdited])
+  }, [form, open])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Briefcase />
-              {organizationLocalization.createOrganization}
-            </DialogTitle>
+        <form.AppForm>
+          <form.AuthFormRoot
+            className="flex flex-col gap-6"
+            onBeforeSubmit={() => {
+              submissionAttemptGeneration.current = submissionGeneration.current
+            }}
+          >
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Briefcase />
+                {organizationLocalization.createOrganization}
+              </DialogTitle>
 
-            <DialogDescription>
-              {organizationLocalization.organizationsDescription}
-            </DialogDescription>
-          </DialogHeader>
+              <DialogDescription>
+                {organizationLocalization.organizationsDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <div className="flex flex-col gap-4">
-            <Field data-invalid={!!nameError}>
-              <FieldLabel htmlFor="create-organization-name">
-                {organizationLocalization.name}
-              </FieldLabel>
-
-              <Input
-                id="create-organization-name"
+            <div className="flex flex-col gap-4">
+              <form.AppField
                 name="name"
-                autoFocus
-                required
-                placeholder={organizationLocalization.namePlaceholder}
-                value={name}
-                onChange={(e) => {
-                  setName(e.target.value)
-                  setNameError(undefined)
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired,
+                      trim: true
+                    })
                 }}
-                onInvalid={(e) => {
-                  e.preventDefault()
-                  setNameError(localization.auth.fieldRequired)
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="create-organization-name">
+                        {organizationLocalization.name}
+                      </FieldLabel>
+
+                      <Input
+                        id="create-organization-name"
+                        name={field.name}
+                        autoFocus
+                        placeholder={organizationLocalization.namePlaceholder}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => {
+                          const value = event.target.value
+                          field.handleChange(value)
+                          if (!slugEdited) {
+                            form.setFieldValue("slug", sanitizeSlug(value))
+                          }
+                        }}
+                        aria-invalid={isInvalid}
+                      />
+
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
                 }}
-                aria-invalid={!!nameError}
-                disabled={isPending}
-              />
+              </form.AppField>
 
-              <FieldError>{nameError}</FieldError>
-            </Field>
+              {!hideSlug && (
+                <form.AppField name="slug">
+                  {(field) => (
+                    <SlugField
+                      id="create-organization-slug"
+                      value={field.state.value}
+                      onChange={(value) => {
+                        field.handleChange(value)
+                        setSlugEdited(true)
+                      }}
+                    />
+                  )}
+                </form.AppField>
+              )}
 
-            {!hideSlug && (
-              <SlugField
-                id="create-organization-slug"
-                value={slug}
-                onChange={(value) => {
-                  setSlug(value)
-                  setSlugEdited(true)
-                }}
-                disabled={isPending}
-              />
-            )}
+              {additionalFields.map((configuredField) => (
+                <form.AppField
+                  key={configuredField.name}
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    localization.auth.fieldRequired
+                  )}
+                >
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      optionalLabel={localization.settings.optional}
+                    />
+                  )}
+                </form.AppField>
+              ))}
+            </div>
 
-            {additionalFields.map((field) => (
-              <AdditionalField
-                key={field.name}
-                field={field}
-                isPending={isPending}
-                name={field.name}
-                optionalLabel={localization.settings.optional}
-              />
-            ))}
-          </div>
+            <DialogFooter>
+              <DialogClose
+                className={buttonVariants({ variant: "outline" })}
+                type="button"
+              >
+                {localization.settings.cancel}
+              </DialogClose>
 
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              disabled={isPending}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Spinner />}
-
-              {organizationLocalization.createOrganization}
-            </Button>
-          </DialogFooter>
-        </form>
+              <form.AuthFormSubmitButton>
+                {organizationLocalization.createOrganization}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-shadcn-example/src/components/auth/organization/invite-member-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/invite-member-dialog.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { parseAdditionalFieldValues } from "@better-auth-ui/core"
+import {
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateEmailAddress
+} from "@better-auth-ui/core"
 import {
   mergeOrganizationRoleLabels,
   type OrganizationAuthClient,
@@ -17,16 +21,9 @@ import {
   useListTeams
 } from "@better-auth-ui/react/plugins/organization"
 import { ChevronDown, UserPlus } from "lucide-react"
-import {
-  type SyntheticEvent,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from "react"
+import { useEffect, useMemo, useRef } from "react"
 import { toast } from "sonner"
-import { AdditionalField } from "@/components/auth/additional-field"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -42,7 +39,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import {
   Select,
@@ -52,9 +49,13 @@ import {
   SelectTrigger,
   SelectValue
 } from "@/components/ui/select"
-import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 
 /** Props for the `InviteMemberDialog` component. */
 export type InviteMemberDialogProps = {
@@ -107,38 +108,10 @@ export function InviteMemberDialog({
     [dynamicRoles.data, roles]
   )
 
-  const [selectedRoles, setSelectedRoles] = useState(() => {
-    const fallback = pickDefaultRole(Object.keys(assignableRoles))
-    return fallback ? [fallback] : []
-  })
-  const [teamId, setTeamId] = useState("")
-  const [emailError, setEmailError] = useState<string>()
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const activeOrganizationId = activeOrganization?.id
   const previousOrganizationId = useRef(activeOrganizationId)
 
-  useEffect(() => {
-    setSelectedRoles((current) => {
-      const keys = Object.keys(assignableRoles)
-      const kept = current.filter((entry) => keys.includes(entry))
-
-      if (kept.length > 0) return allowMultipleRoles ? kept : kept.slice(0, 1)
-
-      const fallback = pickDefaultRole(keys)
-      return fallback ? [fallback] : []
-    })
-  }, [allowMultipleRoles, assignableRoles])
-
-  useEffect(() => {
-    const organizationChanged =
-      previousOrganizationId.current !== activeOrganizationId
-
-    if (open || organizationChanged) setTeamId("")
-    if (!open) setEmailError(undefined)
-    previousOrganizationId.current = activeOrganizationId
-  }, [open, activeOrganizationId])
-
-  const { mutate: inviteMember, isPending: isInviting } = useInviteMember(
+  const { mutateAsync: inviteMember, isPending: isInviting } = useInviteMember(
     authClient as OrganizationTeamsAuthClient,
     {
       onSuccess: () => {
@@ -148,249 +121,322 @@ export function InviteMemberDialog({
     }
   )
 
-  const isRoleValid = selectedRoles.length > 0
-
-  const roleSummary = selectedRoles
-    .map((entry) => assignableRoles[entry] ?? entry)
-    .join(", ")
-
-  const toggleRole = (role: string) => {
-    setSelectedRoles((current) =>
-      current.includes(role)
-        ? current.filter((entry) => entry !== role)
-        : [...current, role]
-    )
-  }
-
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (
-      !activeOrganizationId ||
-      !canInvite.data?.success ||
-      !isRoleValid ||
-      atInvitationLimit
-    )
-      return
-
-    const formData = new FormData(e.currentTarget)
-    const invitationEmail = (formData.get("email") as string).trim()
-    const invitationRoles = [...selectedRoles] as Parameters<
-      typeof inviteMember
-    >[0]["role"]
-    const selectedTeamId = teams.data?.some((team) => team.id === teamId)
-      ? teamId
-      : undefined
-
-    setIsSubmitting(true)
-    let invitationValues: Record<string, unknown>
-    try {
-      invitationValues = await parseAdditionalFieldValues(
-        invitationFields,
-        formData
-      )
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      setIsSubmitting(false)
-      return
-    }
-
-    inviteMember(
-      {
-        ...invitationValues,
-        email: invitationEmail,
-        organizationId: activeOrganizationId,
-        role: invitationRoles,
-        teamId: selectedTeamId
-      },
-      { onSettled: () => setIsSubmitting(false) }
-    )
-  }
-
   const atInvitationLimit =
     invitationLimit !== undefined &&
     (invitations.data?.filter((invitation) => invitation.status === "pending")
       .length ?? 0) >= invitationLimit
 
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(invitationFields),
+      email: "",
+      roles: [] as string[],
+      teamId: ""
+    },
+    onSubmit: async ({ value }) => {
+      if (
+        !activeOrganizationId ||
+        !canInvite.data?.success ||
+        value.roles.length === 0 ||
+        atInvitationLimit
+      )
+        return
+
+      const teamId = teams.data?.some((team) => team.id === value.teamId)
+        ? value.teamId
+        : undefined
+
+      try {
+        await inviteMember({
+          ...getAdditionalFieldSubmitValues(
+            invitationFields,
+            value.additionalFields
+          ),
+          email: value.email.trim(),
+          organizationId: activeOrganizationId,
+          role: value.roles as Parameters<typeof inviteMember>[0]["role"],
+          teamId
+        })
+      } catch {
+        // The mutation reports the error through its configured handler.
+      }
+    }
+  })
+
+  useEffect(() => {
+    const keys = Object.keys(assignableRoles)
+    const current = form.getFieldValue("roles")
+    const kept = current.filter((entry) => keys.includes(entry))
+    const roles =
+      kept.length > 0
+        ? allowMultipleRoles
+          ? kept
+          : kept.slice(0, 1)
+        : (() => {
+            const fallback = pickDefaultRole(keys)
+            return fallback ? [fallback] : []
+          })()
+
+    form.setFieldValue("roles", roles)
+  }, [allowMultipleRoles, assignableRoles, form])
+
+  useEffect(() => {
+    const organizationChanged =
+      previousOrganizationId.current !== activeOrganizationId
+
+    if (open || organizationChanged) {
+      const fallback = pickDefaultRole(Object.keys(assignableRoles))
+      form.reset({
+        additionalFields: getAdditionalFieldDefaultValues(invitationFields),
+        email: "",
+        roles: fallback ? [fallback] : [],
+        teamId: ""
+      })
+    }
+    previousOrganizationId.current = activeOrganizationId
+  }, [activeOrganizationId, assignableRoles, form, invitationFields, open])
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <UserPlus />
-              {organizationLocalization.inviteMember}
-            </DialogTitle>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <UserPlus />
+                {organizationLocalization.inviteMember}
+              </DialogTitle>
 
-            <DialogDescription>
-              {organizationLocalization.inviteMemberDescription}
-            </DialogDescription>
-          </DialogHeader>
+              <DialogDescription>
+                {organizationLocalization.inviteMemberDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <div className="flex flex-col gap-4">
-            <Field data-invalid={!!emailError}>
-              <FieldLabel htmlFor="invite-member-email">
-                {localization.auth.email}
-              </FieldLabel>
-
-              <Input
-                id="invite-member-email"
+            <div className="flex flex-col gap-4">
+              <form.AppField
                 name="email"
-                type="email"
-                autoFocus
-                required
-                placeholder={localization.auth.email}
-                disabled={isInviting}
-                onChange={() => setEmailError(undefined)}
-                onInvalid={(e) => {
-                  e.preventDefault()
-                  const el = e.target as HTMLInputElement
-                  const msg = el.validity.valueMissing
-                    ? localization.auth.fieldRequired
-                    : localization.auth.invalidEmail
-                  setEmailError(msg)
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
                 }}
-                aria-invalid={!!emailError}
-              />
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
-              <FieldError>{emailError}</FieldError>
-            </Field>
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="invite-member-email">
+                        {localization.auth.email}
+                      </FieldLabel>
+                      <Input
+                        id="invite-member-email"
+                        name={field.name}
+                        type="email"
+                        autoFocus
+                        placeholder={localization.auth.email}
+                        disabled={isInviting}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        aria-invalid={isInvalid}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
 
-            <Field>
-              <FieldLabel htmlFor="invite-member-role">
-                {organizationLocalization.role}
-              </FieldLabel>
+              <form.AppField
+                name="roles"
+                validators={{
+                  onChange: ({ value }) =>
+                    value.length > 0
+                      ? undefined
+                      : localization.auth.fieldRequired
+                }}
+              >
+                {(field) => {
+                  const selectedRoles = field.state.value
+                  const roleSummary = selectedRoles
+                    .map((entry) => assignableRoles[entry] ?? entry)
+                    .join(", ")
+                  const toggleRole = (role: string) =>
+                    field.handleChange(
+                      selectedRoles.includes(role)
+                        ? selectedRoles.filter((entry) => entry !== role)
+                        : [...selectedRoles, role]
+                    )
 
-              {allowMultipleRoles ? (
-                <DropdownMenu>
-                  <DropdownMenuTrigger
-                    id="invite-member-role"
-                    disabled={isInviting}
-                    className={cn(
-                      buttonVariants({ variant: "outline" }),
-                      "w-full justify-between font-normal"
-                    )}
-                  >
-                    <span
-                      className={cn(!roleSummary && "text-muted-foreground")}
+                  return (
+                    <Field
+                      data-invalid={isAuthFormFieldInvalid(field.state.meta)}
                     >
-                      {roleSummary || organizationLocalization.selectRoles}
-                    </span>
-                    <ChevronDown className="opacity-50" />
-                  </DropdownMenuTrigger>
+                      <FieldLabel htmlFor="invite-member-role">
+                        {organizationLocalization.role}
+                      </FieldLabel>
+                      {allowMultipleRoles ? (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger
+                            id="invite-member-role"
+                            disabled={isInviting}
+                            className={cn(
+                              buttonVariants({ variant: "outline" }),
+                              "w-full justify-between font-normal"
+                            )}
+                          >
+                            <span
+                              className={cn(
+                                !roleSummary && "text-muted-foreground"
+                              )}
+                            >
+                              {roleSummary ||
+                                organizationLocalization.selectRoles}
+                            </span>
+                            <ChevronDown className="opacity-50" />
+                          </DropdownMenuTrigger>
 
-                  <DropdownMenuContent
-                    align="start"
-                    className="w-(--radix-dropdown-menu-trigger-width)"
-                  >
-                    {Object.entries(assignableRoles).map(([key, label]) => {
-                      const checked = selectedRoles.includes(key)
+                          <DropdownMenuContent
+                            align="start"
+                            className="w-(--radix-dropdown-menu-trigger-width)"
+                          >
+                            {Object.entries(assignableRoles).map(
+                              ([key, label]) => {
+                                const checked = selectedRoles.includes(key)
 
-                      return (
-                        <DropdownMenuCheckboxItem
-                          key={key}
-                          checked={checked}
-                          disabled={checked && selectedRoles.length === 1}
-                          onSelect={(event) => {
-                            event.preventDefault()
-                            toggleRole(key)
-                          }}
+                                return (
+                                  <DropdownMenuCheckboxItem
+                                    key={key}
+                                    checked={checked}
+                                    disabled={
+                                      checked && selectedRoles.length === 1
+                                    }
+                                    onSelect={(event) => {
+                                      event.preventDefault()
+                                      toggleRole(key)
+                                    }}
+                                  >
+                                    {label}
+                                  </DropdownMenuCheckboxItem>
+                                )
+                              }
+                            )}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      ) : (
+                        <Select
+                          disabled={isInviting}
+                          onValueChange={(role) => field.handleChange([role])}
+                          value={selectedRoles[0] ?? ""}
                         >
-                          {label}
-                        </DropdownMenuCheckboxItem>
-                      )
-                    })}
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              ) : (
-                <Select
-                  disabled={isInviting}
-                  onValueChange={(role) => setSelectedRoles([role])}
-                  value={selectedRoles[0] ?? ""}
-                >
-                  <SelectTrigger id="invite-member-role" className="w-full">
-                    <SelectValue
-                      placeholder={organizationLocalization.selectRoles}
-                    />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectGroup>
-                      {Object.entries(assignableRoles).map(([key, label]) => (
-                        <SelectItem key={key} value={key}>
-                          {label}
-                        </SelectItem>
-                      ))}
-                    </SelectGroup>
-                  </SelectContent>
-                </Select>
+                          <SelectTrigger
+                            id="invite-member-role"
+                            className="w-full"
+                          >
+                            <SelectValue
+                              placeholder={organizationLocalization.selectRoles}
+                            />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              {Object.entries(assignableRoles).map(
+                                ([key, label]) => (
+                                  <SelectItem key={key} value={key}>
+                                    {label}
+                                  </SelectItem>
+                                )
+                              )}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      )}
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+
+              {teamsEnabled && (
+                <form.AppField name="teamId">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="invite-member-team">
+                        {organizationLocalization.team}
+                      </FieldLabel>
+                      <Select
+                        value={field.state.value}
+                        onValueChange={(value) =>
+                          field.handleChange(value ?? "")
+                        }
+                        disabled={isInviting}
+                      >
+                        <SelectTrigger
+                          id="invite-member-team"
+                          className="w-full"
+                        >
+                          <SelectValue
+                            placeholder={organizationLocalization.selectTeam}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {teams.data?.map((team) => (
+                            <SelectItem key={team.id} value={team.id}>
+                              {team.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </Field>
+                  )}
+                </form.AppField>
               )}
 
-              <FieldError />
-            </Field>
-
-            {teamsEnabled && (
-              <Field>
-                <FieldLabel htmlFor="invite-member-team">
-                  {organizationLocalization.team}
-                </FieldLabel>
-                <Select
-                  value={teamId}
-                  onValueChange={(value) => setTeamId(value ?? "")}
-                  disabled={isInviting}
+              {invitationFields.map((configuredField) => (
+                <form.AppField
+                  key={configuredField.name}
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    localization.auth.fieldRequired
+                  )}
                 >
-                  <SelectTrigger id="invite-member-team" className="w-full">
-                    <SelectValue
-                      placeholder={organizationLocalization.selectTeam}
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      isPending={isInviting}
+                      optionalLabel={localization.settings.optional}
                     />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {teams.data?.map((team) => (
-                      <SelectItem key={team.id} value={team.id}>
-                        {team.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </Field>
-            )}
+                  )}
+                </form.AppField>
+              ))}
+            </div>
 
-            {invitationFields.map((field) => (
-              <AdditionalField
-                key={field.name}
-                field={field}
-                name={field.name}
-                isPending={isInviting || isSubmitting}
-                optionalLabel={localization.settings.optional}
-              />
-            ))}
-          </div>
+            <DialogFooter>
+              <DialogClose
+                className={buttonVariants({ variant: "outline" })}
+                disabled={isInviting}
+                type="button"
+              >
+                {localization.settings.cancel}
+              </DialogClose>
 
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              disabled={isInviting || isSubmitting}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-
-            <Button
-              type="submit"
-              disabled={
-                isInviting ||
-                isSubmitting ||
-                !isRoleValid ||
-                atInvitationLimit ||
-                canInvite.isPending ||
-                !canInvite.data?.success
-              }
-            >
-              {(isInviting || isSubmitting) && <Spinner />}
-
-              {organizationLocalization.inviteMember}
-            </Button>
-          </DialogFooter>
-        </form>
+              <form.AuthFormSubmitButton
+                disabled={
+                  isInviting ||
+                  atInvitationLimit ||
+                  canInvite.isPending ||
+                  !canInvite.data?.success
+                }
+              >
+                {organizationLocalization.inviteMember}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-profile.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-profile.tsx
@@ -1,6 +1,11 @@
 "use client"
 
-import { parseAdditionalFieldValue } from "@better-auth-ui/core"
+import {
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
@@ -8,18 +13,20 @@ import {
   useHasPermission,
   useUpdateOrganization
 } from "@better-auth-ui/react/plugins/organization"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 import { ChangeOrganizationLogo } from "./change-organization-logo"
 import { SlugField } from "./slug-field"
 
@@ -48,44 +55,46 @@ export function OrganizationProfile({
     permissions: { organization: ["update"] }
   })
 
-  const [slug, setSlug] = useState(activeOrganization?.slug ?? "")
-
-  useEffect(() => {
-    setSlug(activeOrganization?.slug ?? "")
-  }, [activeOrganization?.slug])
-
-  const { mutate: commitOrganizationUpdate, isPending } = useUpdateOrganization(
-    authClient,
-    {
+  const { mutateAsync: commitOrganizationUpdate, isPending } =
+    useUpdateOrganization(authClient, {
       onSuccess: () =>
         toast.success(organizationLocalization.organizationUpdatedSuccess)
-    }
-  )
-
-  async function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    if (!activeOrganization || !canUpdate.data?.success) return
-    const formData = new FormData(e.currentTarget)
-    const name = formData.get("name") as string
-    const additionalValues: Record<string, unknown> = {}
-    try {
-      for (const field of additionalFields) {
-        const value = parseAdditionalFieldValue(
-          field,
-          formData.get(field.name) as string | null
-        )
-        await field.validate?.(value)
-        if (value !== undefined) additionalValues[field.name] = value
-      }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      return
-    }
-
-    commitOrganizationUpdate({
-      data: { ...additionalValues, name, ...(!hideSlug && { slug }) }
     })
-  }
+
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(additionalFields),
+      name: "",
+      slug: ""
+    },
+    onSubmit: async ({ value }) => {
+      if (!activeOrganization || !canUpdate.data?.success) return
+      await commitOrganizationUpdate({
+        data: {
+          ...getAdditionalFieldSubmitValues(
+            additionalFields,
+            value.additionalFields
+          ),
+          name: value.name,
+          ...(!hideSlug && { slug: value.slug })
+        }
+      })
+    }
+  })
+
+  useEffect(() => {
+    if (!activeOrganization) return
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(
+        fieldsWithModelValues(
+          additionalFields,
+          activeOrganization as Record<string, unknown>
+        )
+      ),
+      name: activeOrganization.name,
+      slug: activeOrganization.slug
+    })
+  }, [activeOrganization, additionalFields, form])
 
   const nameInputId = `${activeOrganization?.id ?? "org"}-name`
   const slugInputId = `${activeOrganization?.id ?? "org"}-slug`
@@ -100,76 +109,104 @@ export function OrganizationProfile({
 
       <Card className={className}>
         <CardContent>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <ChangeOrganizationLogo />
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-4">
+              <ChangeOrganizationLogo />
 
-            <Field>
-              <FieldLabel htmlFor={nameInputId}>
-                {organizationLocalization.name}
-              </FieldLabel>
-
-              {activeOrganization ? (
-                <Input
-                  key={activeOrganization.id}
-                  id={nameInputId}
-                  name="name"
-                  defaultValue={activeOrganization.name}
-                  autoComplete="organization"
-                  placeholder={organizationLocalization.namePlaceholder}
-                  disabled={formDisabled}
-                />
-              ) : (
-                <Skeleton className="h-8 w-full rounded-md" />
-              )}
-
-              <FieldError />
-            </Field>
-
-            {!hideSlug &&
-              (activeOrganization ? (
-                <SlugField
-                  id={slugInputId}
-                  value={slug}
-                  onChange={setSlug}
-                  currentSlug={activeOrganization.slug}
-                  disabled={formDisabled}
-                />
-              ) : (
-                <Field>
-                  <FieldLabel>{organizationLocalization.slug}</FieldLabel>
-                  <Skeleton className="h-8 w-full rounded-md" />
-                </Field>
-              ))}
-
-            {activeOrganization &&
-              additionalFields.map((field) => (
-                <AdditionalField
-                  key={field.name}
-                  field={{
-                    ...field,
-                    defaultValue: (
-                      activeOrganization as Record<string, unknown>
-                    )[field.name] as never
-                  }}
-                  isPending={formDisabled}
-                  name={field.name}
-                  optionalLabel={localization.settings.optional}
-                />
-              ))}
-
-            {(canUpdate.isPending || canUpdate.data?.success) && (
-              <Button
-                type="submit"
-                disabled={formDisabled || !activeOrganization}
-                size="sm"
-                className="mt-1 w-fit"
+              <form.AppField
+                name="name"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
               >
-                {isPending && <Spinner />}
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
-                {localization.settings.saveChanges}
-              </Button>
-            )}
-          </form>
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor={nameInputId}>
+                        {organizationLocalization.name}
+                      </FieldLabel>
+
+                      {activeOrganization ? (
+                        <Input
+                          id={nameInputId}
+                          name={field.name}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          autoComplete="organization"
+                          placeholder={organizationLocalization.namePlaceholder}
+                          disabled={formDisabled}
+                          aria-invalid={isInvalid}
+                        />
+                      ) : (
+                        <Skeleton className="h-8 w-full rounded-md" />
+                      )}
+
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+
+              {!hideSlug &&
+                (activeOrganization ? (
+                  <form.AppField name="slug">
+                    {(field) => (
+                      <SlugField
+                        id={slugInputId}
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        currentSlug={activeOrganization.slug}
+                        disabled={formDisabled}
+                      />
+                    )}
+                  </form.AppField>
+                ) : (
+                  <Field>
+                    <FieldLabel>{organizationLocalization.slug}</FieldLabel>
+                    <Skeleton className="h-8 w-full rounded-md" />
+                  </Field>
+                ))}
+
+              {activeOrganization &&
+                additionalFields.map((configuredField) => (
+                  <form.AppField
+                    key={configuredField.name}
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={formDisabled}
+                        optionalLabel={localization.settings.optional}
+                      />
+                    )}
+                  </form.AppField>
+                ))}
+
+              {(canUpdate.isPending || canUpdate.data?.success) && (
+                <form.AuthFormSubmitButton
+                  disabled={formDisabled || !activeOrganization}
+                  size="sm"
+                  className="mt-1 w-fit"
+                >
+                  {localization.settings.saveChanges}
+                </form.AuthFormSubmitButton>
+              )}
+            </form.AuthFormRoot>
+          </form.AppForm>
         </CardContent>
       </Card>
     </div>

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-roles.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-roles.tsx
@@ -3,7 +3,9 @@
 import {
   type AdditionalFields,
   fieldsWithModelValues,
-  parseAdditionalFieldValues
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type { OrganizationRolesAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
@@ -16,7 +18,7 @@ import {
   useUpdateRole
 } from "@better-auth-ui/react/plugins/organization"
 import { Filter, Pencil, Plus, Search, Trash2, X } from "lucide-react"
-import { type FormEvent, useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -67,7 +69,11 @@ import {
 } from "@/components/ui/table"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 import { OrganizationSortableTableHead } from "./organization-sortable-table-head"
 import {
   createOrganizationColumnHelper,
@@ -620,9 +626,6 @@ function RoleDialog({
   const { authClient, localization: authLocalization } =
     useAuth<OrganizationRolesAuthClient>()
   const { localization } = useAuthPlugin(organizationPlugin)
-  const [name, setName] = useState("")
-  const [permission, setPermission] = useState<Record<string, string[]>>({})
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const createRole = useCreateRole(authClient, organizationId, {
     onSuccess: () => {
       toast.success(localization.roleCreated)
@@ -636,154 +639,207 @@ function RoleDialog({
     }
   })
 
-  useEffect(() => {
-    if (!open) return
-    setName(role?.role ?? "")
-    setPermission(role?.permission ?? {})
-  }, [open, role])
+  const configuredRoleFields = useMemo(
+    () => fieldsWithModelValues(roleFields, role ?? {}),
+    [role, roleFields]
+  )
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredRoleFields),
+      name: role?.role ?? "",
+      permission: role?.permission ?? ({} as Record<string, string[]>)
+    },
+    onSubmit: async ({ value }) => {
+      const roleName = value.name.trim()
+      if (!roleName) return
 
-  async function submit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault()
-    const roleName = name.trim()
-    if (!roleName) return
+      try {
+        if (
+          Object.values(value.permission).some((actions) => actions.length > 0)
+        ) {
+          const access = await authClient.organization.hasPermission({
+            organizationId,
+            permissions: value.permission as Parameters<
+              OrganizationRolesAuthClient["organization"]["hasPermission"]
+            >[0]["permissions"]
+          })
 
-    setIsSubmitting(true)
-    try {
-      if (Object.values(permission).some((actions) => actions.length > 0)) {
-        const access = await authClient.organization.hasPermission({
-          organizationId,
-          permissions: permission as Parameters<
-            OrganizationRolesAuthClient["organization"]["hasPermission"]
-          >[0]["permissions"]
-        })
-
-        if (access.error || !access.data?.success) {
-          toast.error(localization.permissionsLimitedDescription)
-          setIsSubmitting(false)
-          return
+          if (access.error || !access.data?.success) {
+            toast.error(localization.permissionsLimitedDescription)
+            return
+          }
         }
-      }
 
-      const additionalFields = await parseAdditionalFieldValues(
-        roleFields,
-        new FormData(event.currentTarget)
-      )
-      if (role) {
-        updateRole.mutate(
-          {
+        const additionalFields = getAdditionalFieldSubmitValues(
+          configuredRoleFields,
+          value.additionalFields
+        )
+        if (role) {
+          await updateRole.mutateAsync({
             organizationId,
             roleId: role.id,
-            data: { ...additionalFields, roleName, permission }
-          },
-          { onSettled: () => setIsSubmitting(false) }
-        )
-      } else {
-        createRole.mutate(
-          {
+            data: {
+              ...additionalFields,
+              roleName,
+              permission: value.permission
+            }
+          })
+        } else {
+          await createRole.mutateAsync({
             organizationId,
             role: roleName,
-            permission,
+            permission: value.permission,
             additionalFields
-          },
-          { onSettled: () => setIsSubmitting(false) }
-        )
+          })
+        }
+      } catch {
+        // The mutation reports the error through its configured handler.
       }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      setIsSubmitting(false)
     }
-  }
+  })
 
-  const pending = createRole.isPending || updateRole.isPending || isSubmitting
+  useEffect(() => {
+    if (!open) return
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredRoleFields),
+      name: role?.role ?? "",
+      permission: role?.permission ?? {}
+    })
+  }, [configuredRoleFields, form, open, role?.permission, role?.role])
+
+  const pending = createRole.isPending || updateRole.isPending
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
-        <form className="flex flex-col gap-6" onSubmit={submit}>
-          <DialogHeader>
-            <DialogTitle>
-              {role ? localization.editRole : localization.createRole}
-            </DialogTitle>
-            <DialogDescription>
-              {localization.rolesDescription}
-            </DialogDescription>
-          </DialogHeader>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle>
+                {role ? localization.editRole : localization.createRole}
+              </DialogTitle>
+              <DialogDescription>
+                {localization.rolesDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <Field>
-            <FieldLabel htmlFor="organization-role-name">
-              {localization.roleName}
-            </FieldLabel>
-            <Input
-              id="organization-role-name"
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              placeholder={localization.roleNamePlaceholder}
-              disabled={pending}
-              required
-            />
-          </Field>
-
-          {fieldsWithModelValues(roleFields, role ?? {}).map((field) => (
-            <AdditionalField
-              key={field.name}
-              field={field}
-              name={field.name}
-              isPending={pending}
-              optionalLabel={authLocalization.settings.optional}
-            />
-          ))}
-
-          <fieldset className="flex flex-col gap-4">
-            <legend className="text-sm font-medium">
-              {localization.permissions}
-            </legend>
-            {Object.entries(registry).map(([resource, definition]) => (
-              <div className="flex flex-col gap-2" key={resource}>
-                <p className="text-sm font-medium">
-                  {definition.label ?? resource}
-                </p>
-                <div className="grid gap-3 sm:grid-cols-2">
-                  {Object.entries(definition.actions).map(([action, label]) => (
-                    <RolePermissionCheckbox
-                      action={action}
-                      checked={permission[resource]?.includes(action) ?? false}
-                      key={action}
-                      label={label}
-                      onCheckedChange={(selected) =>
-                        setPermission((current) => ({
-                          ...current,
-                          [resource]: selected
-                            ? [...(current[resource] ?? []), action]
-                            : (current[resource] ?? []).filter(
-                                (entry) => entry !== action
-                              )
-                        }))
-                      }
-                      organizationId={organizationId}
-                      pending={pending}
-                      resource={resource}
-                    />
-                  ))}
-                </div>
-              </div>
-            ))}
-          </fieldset>
-
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              disabled={pending}
-              onClick={() => onOpenChange(false)}
+            <form.AppField
+              name="name"
+              validators={{
+                onChange: ({ value }) =>
+                  validateStringLength(value, {
+                    requiredMessage: authLocalization.auth.fieldRequired,
+                    trim: true
+                  })
+              }}
             >
-              {authLocalization.settings.cancel}
-            </Button>
-            <Button type="submit" disabled={pending || !name.trim()}>
-              {pending && <Spinner />}
-              {authLocalization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
-        </form>
+              {(field) => {
+                const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                return (
+                  <Field data-invalid={isInvalid}>
+                    <FieldLabel htmlFor="organization-role-name">
+                      {localization.roleName}
+                    </FieldLabel>
+                    <Input
+                      aria-invalid={isInvalid}
+                      disabled={pending}
+                      id="organization-role-name"
+                      name={field.name}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      placeholder={localization.roleNamePlaceholder}
+                      value={field.state.value}
+                    />
+                    <field.AuthFormFieldError />
+                  </Field>
+                )
+              }}
+            </form.AppField>
+
+            {configuredRoleFields.map((configuredField) => (
+              <form.AppField
+                key={configuredField.name}
+                name={`additionalFields.${configuredField.name}`}
+                validators={getAuthAdditionalFieldValidators(
+                  configuredField,
+                  authLocalization.auth.fieldRequired
+                )}
+              >
+                {(field) => (
+                  <field.AuthFormAdditionalField
+                    field={configuredField}
+                    isPending={pending}
+                    optionalLabel={authLocalization.settings.optional}
+                  />
+                )}
+              </form.AppField>
+            ))}
+
+            <form.AppField name="permission">
+              {(field) => (
+                <fieldset className="flex flex-col gap-4">
+                  <legend className="text-sm font-medium">
+                    {localization.permissions}
+                  </legend>
+                  {Object.entries(registry).map(([resource, definition]) => (
+                    <div className="flex flex-col gap-2" key={resource}>
+                      <p className="text-sm font-medium">
+                        {definition.label ?? resource}
+                      </p>
+                      <div className="grid gap-3 sm:grid-cols-2">
+                        {Object.entries(definition.actions).map(
+                          ([action, label]) => (
+                            <RolePermissionCheckbox
+                              action={action}
+                              checked={
+                                field.state.value[resource]?.includes(action) ??
+                                false
+                              }
+                              key={action}
+                              label={label}
+                              onCheckedChange={(selected) =>
+                                field.handleChange({
+                                  ...field.state.value,
+                                  [resource]: selected
+                                    ? [
+                                        ...(field.state.value[resource] ?? []),
+                                        action
+                                      ]
+                                    : (
+                                        field.state.value[resource] ?? []
+                                      ).filter((entry) => entry !== action)
+                                })
+                              }
+                              organizationId={organizationId}
+                              pending={pending}
+                              resource={resource}
+                            />
+                          )
+                        )}
+                      </div>
+                    </div>
+                  ))}
+                </fieldset>
+              )}
+            </form.AppField>
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                disabled={pending}
+                onClick={() => onOpenChange(false)}
+              >
+                {authLocalization.settings.cancel}
+              </Button>
+              <form.AuthFormSubmitButton disabled={pending}>
+                {authLocalization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-teams.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-teams.tsx
@@ -3,7 +3,9 @@
 import {
   type AdditionalFields,
   fieldsWithModelValues,
-  parseAdditionalFieldValues
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type { OrganizationTeamsAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
@@ -28,7 +30,7 @@ import {
   UserRoundMinus,
   Users
 } from "lucide-react"
-import { type FormEvent, useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 import {
   AlertDialog,
@@ -63,7 +65,11 @@ import {
 } from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 
 type Team = { id: string; name: string; [key: string]: unknown }
 
@@ -230,8 +236,6 @@ function TeamDialog({
     organizationId,
     permissions: { member: ["delete"] }
   })
-  const [name, setName] = useState("")
-  const [isSubmittingFields, setIsSubmittingFields] = useState(false)
   const [userId, setUserId] = useState("")
   const createTeam = useCreateTeam(authClient, {
     onSuccess: () => {
@@ -266,276 +270,309 @@ function TeamDialog({
     ? localization.activeTeamRemovalDisabled
     : localization.lastTeamRemovalDisabled
 
+  const configuredTeamFields = useMemo(
+    () => fieldsWithModelValues(teamFields, team ?? {}),
+    [team, teamFields]
+  )
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredTeamFields),
+      name: team?.name ?? ""
+    },
+    onSubmit: async ({ value }) => {
+      const name = value.name.trim()
+      if (!name || !organizationId || (!team && teamLimitReached)) return
+      if (team && !canUpdate.data?.success) return
+
+      const data = {
+        ...getAdditionalFieldSubmitValues(
+          configuredTeamFields,
+          value.additionalFields
+        ),
+        name,
+        organizationId
+      }
+
+      try {
+        if (team) await updateTeam.mutateAsync({ teamId: team.id, data })
+        else await createTeam.mutateAsync(data)
+      } catch {
+        // The mutation reports the error through its configured handler.
+      }
+    }
+  })
+
   useEffect(() => {
     if (!open) return
-    setName(team?.name ?? "")
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredTeamFields),
+      name: team?.name ?? ""
+    })
     setUserId("")
-  }, [open, team])
+  }, [configuredTeamFields, form, open, team?.name])
 
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const trimmedName = name.trim()
-    if (!trimmedName || !organizationId || (!team && teamLimitReached)) return
-    if (team && !canUpdate.data?.success) return
-
-    setIsSubmittingFields(true)
-    try {
-      const values = await parseAdditionalFieldValues(
-        teamFields,
-        new FormData(event.currentTarget)
-      )
-      if (team) {
-        updateTeam.mutate(
-          {
-            teamId: team.id,
-            data: { ...values, name: trimmedName, organizationId }
-          },
-          { onSettled: () => setIsSubmittingFields(false) }
-        )
-      } else {
-        createTeam.mutate(
-          { ...values, name: trimmedName, organizationId },
-          { onSettled: () => setIsSubmittingFields(false) }
-        )
-      }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      setIsSubmittingFields(false)
-    }
-  }
-
-  const pending =
-    createTeam.isPending || updateTeam.isPending || isSubmittingFields
+  const pending = createTeam.isPending || updateTeam.isPending
   const canEdit = !team || canUpdate.data?.success === true
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-lg">
-        <form className="flex flex-col gap-6" onSubmit={handleSubmit}>
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Users />
-              {team ? localization.renameTeam : localization.createTeam}
-            </DialogTitle>
-            <DialogDescription>
-              {localization.teamsDescription}
-            </DialogDescription>
-          </DialogHeader>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <Users />
+                {team ? localization.renameTeam : localization.createTeam}
+              </DialogTitle>
+              <DialogDescription>
+                {localization.teamsDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <div className="flex flex-col gap-4">
-            <Field>
-              <FieldLabel htmlFor="organization-team-name">
-                {localization.name}
-              </FieldLabel>
-              <Input
-                autoFocus
-                disabled={pending || !canEdit}
-                id="organization-team-name"
-                onChange={(event) => setName(event.target.value)}
-                required
-                value={name}
-              />
-            </Field>
-
-            {fieldsWithModelValues(teamFields, team ?? {}).map((field) => (
-              <AdditionalField
-                field={field}
-                isPending={pending || !canEdit}
-                key={field.name}
-                name={field.name}
-                optionalLabel={authLocalization.settings.optional}
-              />
-            ))}
-          </div>
-
-          {team && canListMembers && (
-            <div className="flex flex-col gap-4 border-t pt-5">
-              <div>
-                <h3 className="text-sm font-medium">
-                  {localization.teamMembers}
-                </h3>
-                <p className="text-sm text-muted-foreground">
-                  {localization.addTeamMember}
-                </p>
-              </div>
-
-              {(canAddMember.isPending || canAddMember.data?.success) && (
-                <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-end">
-                  <Field className="flex-1">
-                    <FieldLabel>{localization.addTeamMember}</FieldLabel>
-                    <Select
-                      disabled={canAddMember.isPending || memberLimitReached}
-                      onValueChange={(value) => setUserId(value ?? "")}
-                      value={userId}
-                    >
-                      <SelectTrigger className="w-full">
-                        <SelectValue placeholder={localization.selectMember} />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {organizationMembers
-                          .filter((member) => !memberIds.has(member.userId))
-                          .map((member) => (
-                            <SelectItem
-                              key={member.userId}
-                              value={member.userId}
-                            >
-                              {member.user.name || member.user.email}
-                            </SelectItem>
-                          ))}
-                      </SelectContent>
-                    </Select>
-                  </Field>
-                  <Button
-                    disabled={
-                      canAddMember.isPending ||
-                      !userId ||
-                      addMember.isPending ||
-                      memberLimitReached
-                    }
-                    onClick={() => {
-                      if (!canAddMember.data?.success || !userId) return
-                      addMember.mutate({
-                        teamId: team.id,
-                        userId,
-                        organizationId
-                      })
-                    }}
-                    type="button"
-                  >
-                    <UserPlus data-icon="inline-start" />
-                    {localization.addTeamMember}
-                  </Button>
-                </div>
-              )}
-
-              {canAddMember.data?.success && memberLimitReached && (
-                <p className="text-sm text-destructive" role="alert">
-                  {localization.teamMemberLimitReached}
-                </p>
-              )}
-
-              <div className="flex flex-col gap-2">
-                {teamMembers.isPending && <Spinner />}
-                {teamMembers.data?.map((teamMember) => {
-                  const member = organizationMembers.find(
-                    (candidate) => candidate.userId === teamMember.userId
-                  )
+            <div className="flex flex-col gap-4">
+              <form.AppField
+                name="name"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: authLocalization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
                   return (
-                    <div
-                      className="flex items-center justify-between gap-3 rounded-md border px-3 py-2"
-                      key={teamMember.id}
-                    >
-                      <span className="truncate text-sm">
-                        {member?.user.name ||
-                          member?.user.email ||
-                          teamMember.userId}
-                      </span>
-                      {(canRemoveMember.isPending ||
-                        canRemoveMember.data?.success) && (
-                        <Button
-                          aria-label={localization.removeTeamMember}
-                          disabled={
-                            canRemoveMember.isPending || removeMember.isPending
-                          }
-                          onClick={() => {
-                            if (!canRemoveMember.data?.success) return
-                            removeMember.mutate({
-                              teamId: team.id,
-                              userId: teamMember.userId,
-                              organizationId
-                            })
-                          }}
-                          size="icon-sm"
-                          type="button"
-                          variant="ghost"
-                        >
-                          <UserRoundMinus />
-                        </Button>
-                      )}
-                    </div>
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="organization-team-name">
+                        {localization.name}
+                      </FieldLabel>
+                      <Input
+                        aria-invalid={isInvalid}
+                        autoFocus
+                        disabled={pending || !canEdit}
+                        id="organization-team-name"
+                        name={field.name}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        value={field.state.value}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
                   )
-                })}
-              </div>
+                }}
+              </form.AppField>
+
+              {configuredTeamFields.map((configuredField) => (
+                <form.AppField
+                  key={configuredField.name}
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    authLocalization.auth.fieldRequired
+                  )}
+                >
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      isPending={pending || !canEdit}
+                      optionalLabel={authLocalization.settings.optional}
+                    />
+                  )}
+                </form.AppField>
+              ))}
             </div>
-          )}
 
-          {team && !canRemoveTeam && canDelete.data?.success && (
-            <p className="text-sm text-muted-foreground">
-              {teamRemovalDisabledReason}
-            </p>
-          )}
+            {team && canListMembers && (
+              <div className="flex flex-col gap-4 border-t pt-5">
+                <div>
+                  <h3 className="text-sm font-medium">
+                    {localization.teamMembers}
+                  </h3>
+                  <p className="text-sm text-muted-foreground">
+                    {localization.addTeamMember}
+                  </p>
+                </div>
 
-          <DialogFooter className="sm:justify-between">
-            {team && (canDelete.isPending || canDelete.data?.success) && (
-              <AlertDialog>
-                <AlertDialogTrigger asChild>
-                  <Button
-                    disabled={
-                      canDelete.isPending ||
-                      removeTeam.isPending ||
-                      !canRemoveTeam
-                    }
-                    type="button"
-                    variant="destructive"
-                  >
-                    <Trash2 data-icon="inline-start" />
-                    {localization.deleteTeam}
-                  </Button>
-                </AlertDialogTrigger>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>
-                      {localization.deleteTeam}
-                    </AlertDialogTitle>
-                    <AlertDialogDescription>
-                      {localization.deleteTeamDescription}
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel>
-                      {authLocalization.settings.cancel}
-                    </AlertDialogCancel>
-                    <AlertDialogAction
-                      className={buttonVariants({ variant: "destructive" })}
-                      onClick={() =>
-                        removeTeam.mutate({
+                {(canAddMember.isPending || canAddMember.data?.success) && (
+                  <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-end">
+                    <Field className="flex-1">
+                      <FieldLabel>{localization.addTeamMember}</FieldLabel>
+                      <Select
+                        disabled={canAddMember.isPending || memberLimitReached}
+                        onValueChange={(value) => setUserId(value ?? "")}
+                        value={userId}
+                      >
+                        <SelectTrigger className="w-full">
+                          <SelectValue
+                            placeholder={localization.selectMember}
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {organizationMembers
+                            .filter((member) => !memberIds.has(member.userId))
+                            .map((member) => (
+                              <SelectItem
+                                key={member.userId}
+                                value={member.userId}
+                              >
+                                {member.user.name || member.user.email}
+                              </SelectItem>
+                            ))}
+                        </SelectContent>
+                      </Select>
+                    </Field>
+                    <Button
+                      disabled={
+                        canAddMember.isPending ||
+                        !userId ||
+                        addMember.isPending ||
+                        memberLimitReached
+                      }
+                      onClick={() => {
+                        if (!canAddMember.data?.success || !userId) return
+                        addMember.mutate({
                           teamId: team.id,
+                          userId,
                           organizationId
                         })
+                      }}
+                      type="button"
+                    >
+                      <UserPlus data-icon="inline-start" />
+                      {localization.addTeamMember}
+                    </Button>
+                  </div>
+                )}
+
+                {canAddMember.data?.success && memberLimitReached && (
+                  <p className="text-sm text-destructive" role="alert">
+                    {localization.teamMemberLimitReached}
+                  </p>
+                )}
+
+                <div className="flex flex-col gap-2">
+                  {teamMembers.isPending && <Spinner />}
+                  {teamMembers.data?.map((teamMember) => {
+                    const member = organizationMembers.find(
+                      (candidate) => candidate.userId === teamMember.userId
+                    )
+                    return (
+                      <div
+                        className="flex items-center justify-between gap-3 rounded-md border px-3 py-2"
+                        key={teamMember.id}
+                      >
+                        <span className="truncate text-sm">
+                          {member?.user.name ||
+                            member?.user.email ||
+                            teamMember.userId}
+                        </span>
+                        {(canRemoveMember.isPending ||
+                          canRemoveMember.data?.success) && (
+                          <Button
+                            aria-label={localization.removeTeamMember}
+                            disabled={
+                              canRemoveMember.isPending ||
+                              removeMember.isPending
+                            }
+                            onClick={() => {
+                              if (!canRemoveMember.data?.success) return
+                              removeMember.mutate({
+                                teamId: team.id,
+                                userId: teamMember.userId,
+                                organizationId
+                              })
+                            }}
+                            size="icon-sm"
+                            type="button"
+                            variant="ghost"
+                          >
+                            <UserRoundMinus />
+                          </Button>
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              </div>
+            )}
+
+            {team && !canRemoveTeam && canDelete.data?.success && (
+              <p className="text-sm text-muted-foreground">
+                {teamRemovalDisabledReason}
+              </p>
+            )}
+
+            <DialogFooter className="sm:justify-between">
+              {team && (canDelete.isPending || canDelete.data?.success) && (
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <Button
+                      disabled={
+                        canDelete.isPending ||
+                        removeTeam.isPending ||
+                        !canRemoveTeam
                       }
+                      type="button"
+                      variant="destructive"
                     >
                       <Trash2 data-icon="inline-start" />
                       {localization.deleteTeam}
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-            )}
-
-            <div className="flex flex-col-reverse gap-2 sm:flex-row">
-              <DialogClose
-                className={buttonVariants({ variant: "outline" })}
-                disabled={pending}
-                type="button"
-              >
-                {authLocalization.settings.cancel}
-              </DialogClose>
-              {canEdit && (
-                <Button
-                  disabled={
-                    pending || !name.trim() || (teamLimitReached && !team)
-                  }
-                  type="submit"
-                >
-                  {pending && <Spinner />}
-                  {team
-                    ? authLocalization.settings.saveChanges
-                    : localization.createTeam}
-                </Button>
+                    </Button>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>
+                        {localization.deleteTeam}
+                      </AlertDialogTitle>
+                      <AlertDialogDescription>
+                        {localization.deleteTeamDescription}
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>
+                        {authLocalization.settings.cancel}
+                      </AlertDialogCancel>
+                      <AlertDialogAction
+                        className={buttonVariants({ variant: "destructive" })}
+                        onClick={() =>
+                          removeTeam.mutate({
+                            teamId: team.id,
+                            organizationId
+                          })
+                        }
+                      >
+                        <Trash2 data-icon="inline-start" />
+                        {localization.deleteTeam}
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
               )}
-            </div>
-          </DialogFooter>
-        </form>
+
+              <div className="flex flex-col-reverse gap-2 sm:flex-row">
+                <DialogClose
+                  className={buttonVariants({ variant: "outline" })}
+                  disabled={pending}
+                  type="button"
+                >
+                  {authLocalization.settings.cancel}
+                </DialogClose>
+                {canEdit && (
+                  <form.AuthFormSubmitButton
+                    disabled={pending || (teamLimitReached && !team)}
+                  >
+                    {team
+                      ? authLocalization.settings.saveChanges
+                      : localization.createTeam}
+                  </form.AuthFormSubmitButton>
+                )}
+              </div>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-shadcn-example/src/components/auth/settings/account/user-profile.tsx
+++ b/examples/start-shadcn-example/src/components/auth/settings/account/user-profile.tsx
@@ -1,22 +1,26 @@
 "use client"
 
 import {
-  type AdditionalFieldValue,
-  parseAdditionalFieldValue
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type { UsernameAuthClient } from "@better-auth-ui/core/plugins/username"
 import { useAuth, useSession, useUpdateUser } from "@better-auth-ui/react"
-import { type SyntheticEvent, useState } from "react"
+import { useEffect, useMemo } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Spinner } from "@/components/ui/spinner"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "../../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../../auth-form"
 import { ChangeAvatar } from "./change-avatar"
 
 export type UserProfileProps = {
@@ -34,49 +38,39 @@ export function UserProfile({ className }: UserProfileProps) {
     useAuth<UsernameAuthClient>()
   const { data: session } = useSession(authClient)
 
-  const { mutate: updateUser, isPending } = useUpdateUser(authClient, {
+  const { mutateAsync: updateUser, isPending } = useUpdateUser(authClient, {
     onSuccess: () => toast.success(localization.settings.profileUpdatedSuccess)
   })
 
-  const [fieldErrors, setFieldErrors] = useState<{
-    name?: string
-  }>({})
-
-  async function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const name = formData.get("name") as string
-
-    const additionalFieldValues: Record<string, unknown> = {}
-
-    for (const field of additionalFields ?? []) {
-      if (field.profile === false || field.readOnly) continue
-      const value = parseAdditionalFieldValue(
-        field,
-        formData.get(field.name) as string | null
-      )
-
-      if (field.validate) {
-        try {
-          await field.validate(value)
-        } catch (error) {
-          toast.error(error instanceof Error ? error.message : String(error))
-          return
-        }
-      }
-
-      // `null` = explicit clear (forward to backend); `undefined` = omitted.
-      if (value !== undefined) {
-        additionalFieldValues[field.name] = value
-      }
+  const profileFields = useMemo(
+    () => additionalFields?.filter((field) => field.profile !== false) ?? [],
+    [additionalFields]
+  )
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(profileFields),
+      name: ""
+    },
+    onSubmit: async ({ value }) => {
+      await updateUser({
+        name: value.name,
+        ...getAdditionalFieldSubmitValues(profileFields, value.additionalFields)
+      })
     }
+  })
 
-    updateUser({
-      name,
-      ...additionalFieldValues
+  useEffect(() => {
+    if (!session) return
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(
+        fieldsWithModelValues(
+          profileFields,
+          session.user as Record<string, unknown>
+        )
+      ),
+      name: session.user.name
     })
-  }
+  }, [form, profileFields, session])
 
   return (
     <div>
@@ -84,101 +78,101 @@ export function UserProfile({ className }: UserProfileProps) {
         {localization.settings.userProfile}
       </h2>
 
-      <form onSubmit={handleSubmit}>
-        <Card className={cn(className)}>
-          <CardContent className="flex flex-col gap-6">
-            <ChangeAvatar />
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card className={cn(className)}>
+            <CardContent className="flex flex-col gap-6">
+              <ChangeAvatar />
 
-            <Field data-invalid={!!fieldErrors.name}>
-              <FieldLabel htmlFor="name">{localization.auth.name}</FieldLabel>
+              <form.AppField
+                name="name"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
-              {session ? (
-                <Input
-                  key={session?.user.name}
-                  id="name"
-                  name="name"
-                  autoComplete="name"
-                  defaultValue={session?.user.name}
-                  placeholder={localization.auth.name}
-                  disabled={isPending}
-                  required
-                  onChange={() => {
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      name: undefined
-                    }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="name">
+                        {localization.auth.name}
+                      </FieldLabel>
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      name: (e.target as HTMLInputElement).validationMessage
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.name}
-                />
-              ) : (
-                <Skeleton>
-                  <Input className="invisible" />
-                </Skeleton>
-              )}
+                      {session ? (
+                        <Input
+                          id="name"
+                          name={field.name}
+                          autoComplete="name"
+                          placeholder={localization.auth.name}
+                          disabled={isPending}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          aria-invalid={isInvalid}
+                        />
+                      ) : (
+                        <Skeleton>
+                          <Input className="invisible" />
+                        </Skeleton>
+                      )}
 
-              <FieldError>{fieldErrors.name}</FieldError>
-            </Field>
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
 
-            {additionalFields?.map((field) => {
-              if (field.profile === false) return null
+              {profileFields.map((configuredField) => {
+                if (!session) {
+                  if (configuredField.inputType === "hidden") {
+                    return null
+                  }
 
-              if (!session) {
-                if (field.inputType === "hidden") {
-                  return null
+                  return (
+                    <Skeleton key={configuredField.name}>
+                      <Input className="invisible" />
+                    </Skeleton>
+                  )
                 }
 
                 return (
-                  <Skeleton key={field.name}>
-                    <Input className="invisible" />
-                  </Skeleton>
+                  <form.AppField
+                    key={configuredField.name}
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={isPending}
+                      />
+                    )}
+                  </form.AppField>
                 )
-              }
+              })}
+            </CardContent>
 
-              const value = (session.user as Record<string, unknown>)[
-                field.name
-              ]
-
-              // Re-mount when the session value loads so the field's
-              // uncontrolled `defaultValue` reflects the latest data.
-              const key = `${field.name}:${
-                value instanceof Date
-                  ? value.toISOString()
-                  : String(value ?? "")
-              }`
-
-              return (
-                <AdditionalField
-                  key={key}
-                  name={field.name}
-                  field={{
-                    ...field,
-                    // `defaultValue` is sign-up-only; on the profile we
-                    // always seed from the session.
-                    defaultValue: value as AdditionalFieldValue | null
-                  }}
-                  isPending={isPending}
-                />
-              )
-            })}
-          </CardContent>
-
-          <CardFooter>
-            <Button type="submit" size="sm" disabled={isPending || !session}>
-              {isPending && <Spinner />}
-
-              {localization.settings.saveChanges}
-            </Button>
-          </CardFooter>
-        </Card>
-      </form>
+            <CardFooter>
+              <form.AuthFormSubmitButton
+                size="sm"
+                disabled={isPending || !session}
+              >
+                {localization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/examples/start-shadcn-example/src/components/auth/sign-up.tsx
+++ b/examples/start-shadcn-example/src/components/auth/sign-up.tsx
@@ -2,9 +2,10 @@
 
 import {
   authMutationKeys,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
   getAuthLinkURL,
   isPasswordCompromisedError,
-  parseAdditionalFieldValue,
   validateEmailAddress,
   validateMatchingValue,
   validateStringLength
@@ -17,8 +18,7 @@ import {
 } from "@better-auth-ui/react"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { useRef, useState } from "react"
-import { toast } from "sonner"
+import { useMemo, useState } from "react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Field,
@@ -36,8 +36,11 @@ import {
   InputGroupInput
 } from "@/components/ui/input-group"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "./additional-field"
-import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "./auth-form"
 import { PasswordStrengthMeter } from "./password-strength-meter"
 import { ProviderButtons, type SocialLayout } from "./provider-buttons"
 
@@ -136,9 +139,13 @@ export function SignUp({
     useState(false)
 
   const [isCompromised, setIsCompromised] = useState(false)
-  const additionalFieldValuesRef = useRef<Record<string, unknown>>({})
+  const signUpFields = useMemo(
+    () => additionalFields?.filter((field) => field.signUp) ?? [],
+    [additionalFields]
+  )
   const form = useAuthForm({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(signUpFields),
       confirmPassword: "",
       email: "",
       name: "",
@@ -150,7 +157,10 @@ export function SignUp({
           name: emailAndPassword?.name === false ? "" : value.name,
           email: value.email.trim(),
           password: value.password,
-          ...additionalFieldValuesRef.current,
+          ...getAdditionalFieldSubmitValues(
+            signUpFields,
+            value.additionalFields
+          ),
           fetchOptions
         })
       } catch {
@@ -158,35 +168,6 @@ export function SignUp({
       }
     }
   })
-
-  const prepareSubmit = async (formElement: HTMLFormElement) => {
-    const formData = new FormData(formElement)
-
-    const additionalFieldValues: Record<string, unknown> = {}
-
-    for (const field of additionalFields ?? []) {
-      if (!field.signUp || field.readOnly) continue
-      const value = parseAdditionalFieldValue(
-        field,
-        formData.get(field.name) as string | null
-      )
-
-      if (field.validate) {
-        try {
-          await field.validate(value)
-        } catch (error) {
-          toast.error(error instanceof Error ? error.message : String(error))
-          return false
-        }
-      }
-
-      if (value !== undefined) {
-        additionalFieldValues[field.name] = value
-      }
-    }
-
-    additionalFieldValuesRef.current = additionalFieldValues
-  }
 
   const showSeparator =
     emailAndPassword?.enabled && socialProviders && socialProviders.length > 0
@@ -218,7 +199,7 @@ export function SignUp({
 
           {emailAndPassword?.enabled && (
             <form.AppForm>
-              <form.AuthFormRoot prepareSubmit={prepareSubmit}>
+              <form.AuthFormRoot>
                 <FieldGroup>
                   {emailAndPassword.name !== false && (
                     <form.AppField
@@ -306,16 +287,25 @@ export function SignUp({
                     }}
                   </form.AppField>
 
-                  {additionalFields?.map(
-                    (field) =>
-                      field.signUp === "above" && (
-                        <AdditionalField
-                          key={field.name}
-                          name={field.name}
-                          field={field}
-                          isPending={isPending}
-                          optionalLabel={localization.auth.optional}
-                        />
+                  {signUpFields.map(
+                    (configuredField) =>
+                      configuredField.signUp === "above" && (
+                        <form.AppField
+                          key={configuredField.name}
+                          name={`additionalFields.${configuredField.name}`}
+                          validators={getAuthAdditionalFieldValidators(
+                            configuredField,
+                            localization.auth.fieldRequired
+                          )}
+                        >
+                          {(field) => (
+                            <field.AuthFormAdditionalField
+                              field={configuredField}
+                              isPending={isPending}
+                              optionalLabel={localization.auth.optional}
+                            />
+                          )}
+                        </form.AppField>
                       )
                   )}
 
@@ -503,17 +493,25 @@ export function SignUp({
                     </form.AppField>
                   )}
 
-                  {additionalFields?.map(
-                    (field) =>
-                      field.signUp &&
-                      field.signUp !== "above" && (
-                        <AdditionalField
-                          key={field.name}
-                          name={field.name}
-                          field={field}
-                          isPending={isPending}
-                          optionalLabel={localization.auth.optional}
-                        />
+                  {signUpFields.map(
+                    (configuredField) =>
+                      configuredField.signUp !== "above" && (
+                        <form.AppField
+                          key={configuredField.name}
+                          name={`additionalFields.${configuredField.name}`}
+                          validators={getAuthAdditionalFieldValidators(
+                            configuredField,
+                            localization.auth.fieldRequired
+                          )}
+                        >
+                          {(field) => (
+                            <field.AuthFormAdditionalField
+                              field={configuredField}
+                              isPending={isPending}
+                              optionalLabel={localization.auth.optional}
+                            />
+                          )}
+                        </form.AppField>
                       )
                   )}
 

--- a/examples/start-shadcn-example/src/components/auth/username/username-field.tsx
+++ b/examples/start-shadcn-example/src/components/auth/username/username-field.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getFormFieldErrors } from "@better-auth-ui/core"
 import type { UsernameAuthClient } from "@better-auth-ui/core/plugins/username"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useIsUsernameAvailable } from "@better-auth-ui/react/plugins/username"
@@ -25,6 +26,11 @@ import { usernamePlugin } from "@/lib/auth/username-plugin"
 export function UsernameField({
   name,
   field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
   isPending
 }: AdditionalFieldProps) {
   const { authClient, localization: authLocalization } =
@@ -38,8 +44,9 @@ export function UsernameField({
   } = useAuthPlugin(usernamePlugin)
 
   const currentUsername = String(field.defaultValue ?? "")
-  const [value, setValue] = useState(currentUsername)
-  const [error, setError] = useState<string>()
+  const username = typeof value === "string" ? value : ""
+  const [nativeError, setNativeError] = useState<string>()
+  const fieldErrors = getFormFieldErrors(errors ?? [])
 
   const {
     mutate: requestAvailability,
@@ -64,8 +71,8 @@ export function UsernameField({
   )
 
   function handleChange(next: string) {
-    setValue(next)
-    setError(undefined)
+    onChange(next || null)
+    setNativeError(undefined)
     resetAvailability()
 
     if (checkAvailability) {
@@ -74,10 +81,12 @@ export function UsernameField({
   }
 
   const isCheckingAvailability =
-    !!checkAvailability && !!value.trim() && value.trim() !== currentUsername
+    !!checkAvailability &&
+    !!username.trim() &&
+    username.trim() !== currentUsername
 
   return (
-    <Field data-invalid={!!error}>
+    <Field data-invalid={isInvalid || !!nativeError}>
       <FieldLabel htmlFor={name}>{field.label}</FieldLabel>
 
       <InputGroup>
@@ -97,7 +106,8 @@ export function UsernameField({
           disabled={isPending}
           required={field.required}
           readOnly={field.readOnly}
-          value={value}
+          value={username}
+          onBlur={onBlur}
           onChange={(e) => handleChange(e.target.value)}
           onInvalid={(e) => {
             e.preventDefault()
@@ -113,9 +123,9 @@ export function UsernameField({
                     "{{max}}",
                     String(maxUsernameLength)
                   )
-            setError(msg)
+            setNativeError(msg)
           }}
-          aria-invalid={!!error}
+          aria-invalid={isInvalid || !!nativeError}
           placeholder={field.placeholder}
         />
 
@@ -141,7 +151,7 @@ export function UsernameField({
         )}
       </InputGroup>
 
-      <FieldError>{error}</FieldError>
+      <FieldError errors={fieldErrors}>{nativeError}</FieldError>
     </Field>
   )
 }

--- a/examples/start-solid-zaidan-example/registry.manifest.ts
+++ b/examples/start-solid-zaidan-example/registry.manifest.ts
@@ -173,6 +173,7 @@ const solidRegistryBaseManifest = {
       description:
         "Additional field renderer used by Solid sign-up and profile surfaces.",
       files: [
+        componentFile("src/components/auth/auth-form.tsx"),
         componentFile("src/components/auth/additional-field.tsx"),
         ...zaidanFormSupportFiles
       ]

--- a/examples/start-solid-zaidan-example/src/components/auth/additional-field.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/additional-field.tsx
@@ -1,10 +1,12 @@
 import {
   type AdditionalField as AdditionalFieldConfig,
+  type AdditionalFieldFormValue,
+  getFormFieldErrors,
   resolveInputType
 } from "@better-auth-ui/core"
 import { createCopyToClipboard, useAuth } from "@better-auth-ui/solid"
 import { CalendarIcon, Check, Copy } from "lucide-solid"
-import { createEffect, createMemo, createSignal, For, Show } from "solid-js"
+import { createSignal, For, Show } from "solid-js"
 import { toast } from "solid-sonner"
 import { Button } from "@/components/ui/button"
 import { Calendar } from "@/components/ui/calendar"
@@ -41,20 +43,25 @@ import { Textarea } from "@/components/ui/textarea"
 
 export type AdditionalFieldProps = {
   field: AdditionalFieldConfig
+  value: AdditionalFieldFormValue
+  onBlur: () => void
+  onChange: (value: AdditionalFieldFormValue) => void
+  isInvalid?: boolean
+  errors?: unknown[]
   isPending?: boolean
   name: string
   /** Complete suffix appended to labels for fields that are not required. */
   optionalLabel?: string
 }
 
-const valueToString = (value: AdditionalFieldConfig["defaultValue"]) =>
+const valueToString = (value: AdditionalFieldFormValue) =>
   value == null
     ? ""
     : value instanceof Date
       ? value.toISOString()
       : String(value)
 
-const toDate = (value: AdditionalFieldConfig["defaultValue"]) => {
+const toDate = (value: AdditionalFieldFormValue) => {
   if (value instanceof Date) return value
   if (typeof value !== "string") return undefined
 
@@ -69,6 +76,7 @@ const formatTime = (date: Date) => {
 
 export function AdditionalField(props: AdditionalFieldProps) {
   const inputType = () => resolveInputType(props.field)
+  const fieldErrors = () => getFormFieldErrors(props.errors ?? [])
   const label = () =>
     props.optionalLabel && !props.field.required
       ? `${String(props.field.label)}${props.optionalLabel}`
@@ -93,14 +101,14 @@ export function AdditionalField(props: AdditionalFieldProps) {
       <input
         name={props.name}
         type="hidden"
-        value={valueToString(props.field.defaultValue)}
+        value={valueToString(props.value)}
       />
     )
   }
 
   if (inputType() === "textarea") {
     return (
-      <Field>
+      <Field data-invalid={props.isInvalid}>
         <FieldLabel for={props.name}>{label()}</FieldLabel>
         <Textarea
           disabled={props.isPending}
@@ -108,10 +116,13 @@ export function AdditionalField(props: AdditionalFieldProps) {
           name={props.name}
           placeholder={props.field.placeholder}
           readonly={props.field.readOnly}
-          required={props.field.required}
-          value={valueToString(props.field.defaultValue)}
+          aria-invalid={props.isInvalid}
+          aria-required={props.field.required}
+          onBlur={props.onBlur}
+          onInput={(event) => props.onChange(event.currentTarget.value || null)}
+          value={valueToString(props.value)}
         />
-        <FieldError />
+        <FieldError errors={fieldErrors()} />
       </Field>
     )
   }
@@ -120,7 +131,7 @@ export function AdditionalField(props: AdditionalFieldProps) {
     const maxFractionDigits = props.field.formatOptions?.maximumFractionDigits
 
     return (
-      <Field>
+      <Field data-invalid={props.isInvalid}>
         <FieldLabel for={props.name}>{label()}</FieldLabel>
         <Input
           disabled={props.isPending}
@@ -131,15 +142,24 @@ export function AdditionalField(props: AdditionalFieldProps) {
           name={props.name}
           placeholder={props.field.placeholder}
           readonly={props.field.readOnly}
-          required={props.field.required}
+          aria-invalid={props.isInvalid}
+          aria-required={props.field.required}
+          onBlur={props.onBlur}
+          onInput={(event) =>
+            props.onChange(
+              event.currentTarget.value === ""
+                ? null
+                : event.currentTarget.valueAsNumber
+            )
+          }
           step={
             props.field.step ??
             (maxFractionDigits ? 1 / 10 ** maxFractionDigits : undefined)
           }
           type="number"
-          value={valueToString(props.field.defaultValue)}
+          value={typeof props.value === "number" ? props.value : ""}
         />
-        <FieldError />
+        <FieldError errors={fieldErrors()} />
       </Field>
     )
   }
@@ -150,55 +170,60 @@ export function AdditionalField(props: AdditionalFieldProps) {
 
   if (inputType() === "switch") {
     return (
-      <Field orientation="horizontal">
+      <Field data-invalid={props.isInvalid} orientation="horizontal">
         <Switch
-          defaultChecked={
-            props.field.defaultValue === true ||
-            valueToString(props.field.defaultValue) === "true"
-          }
+          checked={props.value === true}
           disabled={props.isPending || props.field.readOnly}
           id={props.name}
           name={props.name}
-          required={props.field.required}
+          onBlur={props.onBlur}
+          onChange={props.onChange}
+          validationState={props.isInvalid ? "invalid" : "valid"}
         />
         <FieldContent>
           <FieldLabel for={props.name}>{label()}</FieldLabel>
         </FieldContent>
+        <FieldError errors={fieldErrors()} />
       </Field>
     )
   }
 
   if (inputType() === "checkbox") {
     return (
-      <Field orientation="horizontal">
+      <Field data-invalid={props.isInvalid} orientation="horizontal">
         <Checkbox
-          defaultChecked={
-            props.field.defaultValue === true ||
-            valueToString(props.field.defaultValue) === "true"
-          }
+          checked={props.value === true}
           disabled={props.isPending || props.field.readOnly}
           id={props.name}
           name={props.name}
-          required={props.field.required}
+          onBlur={props.onBlur}
+          onChange={props.onChange}
+          validationState={props.isInvalid ? "invalid" : "valid"}
         />
         <FieldContent>
           <FieldLabel for={props.name}>{label()}</FieldLabel>
         </FieldContent>
+        <FieldError errors={fieldErrors()} />
       </Field>
     )
   }
 
   if (inputType() === "select") {
     return (
-      <Field>
+      <Field data-invalid={props.isInvalid}>
         <FieldLabel for={props.name}>{label()}</FieldLabel>
         <NativeSelect
           class="w-full"
           disabled={props.isPending || props.field.readOnly}
           id={props.name}
           name={props.name}
-          required={props.field.required}
-          value={valueToString(props.field.defaultValue)}
+          aria-invalid={props.isInvalid}
+          aria-required={props.field.required}
+          onBlur={props.onBlur}
+          onChange={(event) =>
+            props.onChange(event.currentTarget.value || null)
+          }
+          value={valueToString(props.value)}
         >
           <Show when={props.field.placeholder}>
             <NativeSelectOption disabled value="">
@@ -213,22 +238,22 @@ export function AdditionalField(props: AdditionalFieldProps) {
             )}
           </For>
         </NativeSelect>
-        <FieldError />
+        <FieldError errors={fieldErrors()} />
       </Field>
     )
   }
 
   if (inputType() === "combobox") {
     const options = props.field.options ?? []
-    const initialValue = options.find(
-      (option) => option.value === valueToString(props.field.defaultValue)
+    const selectedValue = options.find(
+      (option) => option.value === valueToString(props.value)
     )
 
     return (
-      <Field>
+      <Field data-invalid={props.isInvalid}>
         <FieldLabel for={props.name}>{label()}</FieldLabel>
         <Combobox
-          defaultValue={initialValue}
+          value={selectedValue}
           disabled={props.isPending || props.field.readOnly}
           itemComponent={(itemProps) => (
             <ComboboxItem item={itemProps.item}>
@@ -236,12 +261,14 @@ export function AdditionalField(props: AdditionalFieldProps) {
             </ComboboxItem>
           )}
           name={props.name}
+          onBlur={props.onBlur}
+          onChange={(option) => props.onChange(option?.value ?? null)}
           optionLabel="label"
           optionTextValue="label"
           optionValue="value"
           options={options}
           placeholder={props.field.placeholder}
-          required={props.field.required}
+          validationState={props.isInvalid ? "invalid" : "valid"}
         >
           <ComboboxInput
             class="w-full"
@@ -252,7 +279,7 @@ export function AdditionalField(props: AdditionalFieldProps) {
             <ComboboxEmpty>No items found.</ComboboxEmpty>
           </ComboboxContent>
         </Combobox>
-        <FieldError />
+        <FieldError errors={fieldErrors()} />
       </Field>
     )
   }
@@ -278,6 +305,7 @@ function InputField(props: LabeledAdditionalFieldProps) {
   const hasPrefix = () => props.field.prefix != null
   const hasSuffix = () =>
     props.field.suffix != null || props.field.copyable === true
+  const fieldErrors = () => getFormFieldErrors(props.errors ?? [])
 
   const copyValue = async () => {
     if (!inputRef?.value) return
@@ -287,7 +315,7 @@ function InputField(props: LabeledAdditionalFieldProps) {
 
   if (hasPrefix() || hasSuffix()) {
     return (
-      <Field>
+      <Field data-invalid={props.isInvalid}>
         <FieldLabel for={props.name}>{props.label}</FieldLabel>
         <InputGroup>
           <Show when={props.field.prefix}>
@@ -302,8 +330,13 @@ function InputField(props: LabeledAdditionalFieldProps) {
             placeholder={props.field.placeholder}
             readonly={props.field.readOnly}
             ref={inputRef}
-            required={props.field.required}
-            value={valueToString(props.field.defaultValue)}
+            aria-invalid={props.isInvalid}
+            aria-required={props.field.required}
+            onBlur={props.onBlur}
+            onInput={(event) =>
+              props.onChange(event.currentTarget.value || null)
+            }
+            value={valueToString(props.value)}
           />
           <Show
             when={props.field.copyable}
@@ -337,13 +370,13 @@ function InputField(props: LabeledAdditionalFieldProps) {
             </InputGroupAddon>
           </Show>
         </InputGroup>
-        <FieldError />
+        <FieldError errors={fieldErrors()} />
       </Field>
     )
   }
 
   return (
-    <Field>
+    <Field data-invalid={props.isInvalid}>
       <FieldLabel for={props.name}>{props.label}</FieldLabel>
       <Input
         disabled={props.isPending}
@@ -351,10 +384,13 @@ function InputField(props: LabeledAdditionalFieldProps) {
         name={props.name}
         placeholder={props.field.placeholder}
         readonly={props.field.readOnly}
-        required={props.field.required}
-        value={valueToString(props.field.defaultValue)}
+        aria-invalid={props.isInvalid}
+        aria-required={props.field.required}
+        onBlur={props.onBlur}
+        onInput={(event) => props.onChange(event.currentTarget.value || null)}
+        value={valueToString(props.value)}
       />
-      <FieldError />
+      <FieldError errors={fieldErrors()} />
     </Field>
   )
 }
@@ -365,24 +401,12 @@ function SliderField(props: LabeledAdditionalFieldProps) {
   const max = props.field.max ?? 100
   const step =
     props.field.step ?? (maxFractionDigits ? 1 / 10 ** maxFractionDigits : 1)
-  const defaultValue = () =>
-    typeof props.field.defaultValue === "number"
-      ? props.field.defaultValue
-      : props.field.defaultValue != null &&
-          !Number.isNaN(Number(props.field.defaultValue))
-        ? Number(props.field.defaultValue)
-        : min
-  const [value, setValue] = createSignal(defaultValue())
-  const [isDirty, setIsDirty] = createSignal(false)
+  const value = () => (typeof props.value === "number" ? props.value : min)
   const formatter = new Intl.NumberFormat(undefined, props.field.formatOptions)
-
-  createEffect(() => {
-    const nextValue = defaultValue()
-    if (!isDirty()) setValue(nextValue)
-  })
+  const fieldErrors = () => getFormFieldErrors(props.errors ?? [])
 
   return (
-    <Field>
+    <Field data-invalid={props.isInvalid}>
       <div class="flex items-center justify-between gap-2">
         <FieldLabel for={props.name}>{props.label}</FieldLabel>
         <span class="text-muted-foreground text-sm tabular-nums">
@@ -395,14 +419,14 @@ function SliderField(props: LabeledAdditionalFieldProps) {
         maxValue={max}
         minValue={min}
         name={props.name}
+        onBlur={props.onBlur}
         onChange={(values) => {
-          setIsDirty(true)
-          setValue(values[0] ?? min)
+          props.onChange(values[0] ?? min)
         }}
         step={step}
         value={[value()]}
       />
-      <FieldError />
+      <FieldError errors={fieldErrors()} />
     </Field>
   )
 }
@@ -410,64 +434,28 @@ function SliderField(props: LabeledAdditionalFieldProps) {
 function DateInput(props: LabeledAdditionalFieldProps) {
   const auth = useAuth()
   const isDateTime = () => resolveInputType(props.field) === "datetime"
-  const defaultDate = () => toDate(props.field.defaultValue)
-  const initialDate = defaultDate()
-  const [date, setDate] = createSignal<Date | undefined>(initialDate)
+  const date = () => toDate(props.value)
+  const initialDate = date()
   const [time, setTime] = createSignal(
     initialDate && isDateTime() ? formatTime(initialDate) : ""
   )
-  const [isDirty, setIsDirty] = createSignal(false)
   const [open, setOpen] = createSignal(false)
-  const [error, setError] = createSignal<string>()
-
-  createEffect(() => {
-    const nextDate = defaultDate()
-    if (isDirty()) return
-
-    setDate(nextDate)
-    setTime(nextDate && isDateTime() ? formatTime(nextDate) : "")
-    if (nextDate) setError(undefined)
-  })
-
-  const formValue = createMemo(() => {
-    const selectedDate = date()
-    if (!selectedDate) return ""
-
-    const value = new Date(selectedDate)
-    if (isDateTime() && time().trim()) {
-      const [hours = "0", minutes = "0", seconds = "0"] = time().split(":")
-      value.setHours(Number(hours), Number(minutes), Number(seconds), 0)
-    } else {
-      value.setHours(0, 0, 0, 0)
-    }
-    return value.toISOString()
-  })
+  const fieldErrors = () => getFormFieldErrors(props.errors ?? [])
 
   return (
-    <Field data-invalid={Boolean(error())}>
+    <Field data-invalid={props.isInvalid}>
       <FieldLabel for={`${props.name}-date`}>{props.label}</FieldLabel>
       <div class="relative flex gap-2">
-        <input
-          aria-label={props.label}
-          class="sr-only"
-          name={props.name}
-          onInvalid={(event) => {
-            event.preventDefault()
-            setError(event.currentTarget.validationMessage)
-          }}
-          required={props.field.required}
-          tabindex={-1}
-          type="text"
-          value={formValue()}
-        />
         <Popover onOpenChange={setOpen} open={open()}>
           <PopoverTrigger
-            aria-invalid={Boolean(error())}
+            aria-invalid={props.isInvalid}
+            aria-required={props.field.required}
             as={Button}
             class="flex-1 justify-between font-normal data-[empty=true]:text-muted-foreground"
             data-empty={!date()}
             disabled={props.isPending || props.field.readOnly}
             id={`${props.name}-date`}
+            onBlur={props.onBlur}
             type="button"
             variant="outline"
           >
@@ -482,9 +470,24 @@ function DateInput(props: LabeledAdditionalFieldProps) {
               mode="single"
               monthYearSelection
               onValueChange={(value) => {
-                setIsDirty(true)
-                setDate(value ?? undefined)
-                if (value) setError(undefined)
+                if (!value) {
+                  props.onChange(null)
+                } else {
+                  const nextValue = new Date(value)
+                  if (isDateTime() && time().trim()) {
+                    const [hours = "0", minutes = "0", seconds = "0"] =
+                      time().split(":")
+                    nextValue.setHours(
+                      Number(hours),
+                      Number(minutes),
+                      Number(seconds),
+                      0
+                    )
+                  } else {
+                    nextValue.setHours(0, 0, 0, 0)
+                  }
+                  props.onChange(nextValue)
+                }
                 if (!isDateTime()) setOpen(false)
               }}
               value={date() ?? null}
@@ -501,8 +504,20 @@ function DateInput(props: LabeledAdditionalFieldProps) {
               disabled={props.isPending || props.field.readOnly}
               id={`${props.name}-time`}
               onInput={(event) => {
-                setIsDirty(true)
-                setTime(event.currentTarget.value)
+                const nextTime = event.currentTarget.value
+                setTime(nextTime)
+                const selectedDate = date()
+                if (!selectedDate) return
+                const nextValue = new Date(selectedDate)
+                const [hours = "0", minutes = "0", seconds = "0"] =
+                  nextTime.split(":")
+                nextValue.setHours(
+                  Number(hours),
+                  Number(minutes),
+                  Number(seconds),
+                  0
+                )
+                props.onChange(nextValue)
               }}
               step="1"
               type="time"
@@ -511,7 +526,7 @@ function DateInput(props: LabeledAdditionalFieldProps) {
           </Field>
         </Show>
       </div>
-      <FieldError>{error()}</FieldError>
+      <FieldError errors={fieldErrors()} />
     </Field>
   )
 }

--- a/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
@@ -1,7 +1,8 @@
 import {
-  type AdditionalFieldValue,
-  getClampedTablePageIndex,
-  parseAdditionalFieldValues
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  getClampedTablePageIndex
 } from "@better-auth-ui/core"
 import {
   type AdminAuthClient,
@@ -45,7 +46,7 @@ import {
   Trash2,
   UserPlus
 } from "lucide-solid"
-import { createEffect, createMemo, createSignal, For, on, Show } from "solid-js"
+import { createEffect, createMemo, createSignal, For, Show } from "solid-js"
 import { Dynamic } from "solid-js/web"
 import {
   AlertDialog,
@@ -110,8 +111,7 @@ import {
 } from "@/components/ui/table"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "../additional-field"
-import { createAuthForm } from "../auth-form"
+import { createAuthForm, getAuthAdditionalFieldValidators } from "../auth-form"
 import { UserAvatar } from "../user/user-avatar"
 import { createAdminColumnHelper, createAdminTable } from "./admin-table"
 
@@ -632,10 +632,10 @@ function CreateUserDialog(props: {
   const canSetRole = useAdminPermission(authClient, () => ({
     user: ["set-role"]
   }))
-  const [formError, setFormError] = createSignal<string>()
-  let additionalFieldValues: Record<string, AdditionalFieldValue | null> = {}
+  const additionalFields = () => auth.additionalFields ?? []
   const form = createAuthForm(() => ({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(additionalFields()),
       email: "",
       emailVerified: false,
       name: "",
@@ -647,7 +647,10 @@ function CreateUserDialog(props: {
         await createUser.mutateAsync(
           {
             data: {
-              ...additionalFieldValues,
+              ...getAdditionalFieldSubmitValues(
+                additionalFields(),
+                value.additionalFields
+              ),
               emailVerified: value.emailVerified
             },
             email: value.email,
@@ -673,23 +676,7 @@ function CreateUserDialog(props: {
   const close = () => {
     createUser.reset()
     form.reset()
-    setFormError(undefined)
     props.onOpenChange(false)
-  }
-  const prepareSubmit = async (formElement: HTMLFormElement) => {
-    const data = new FormData(formElement)
-    let values: Record<string, AdditionalFieldValue | null>
-    try {
-      values = await parseAdditionalFieldValues(
-        auth.additionalFields ?? [],
-        data
-      )
-    } catch (error) {
-      setFormError(error instanceof Error ? error.message : String(error))
-      return false
-    }
-    setFormError(undefined)
-    additionalFieldValues = values
   }
 
   return (
@@ -699,10 +686,7 @@ function CreateUserDialog(props: {
     >
       <DialogContent>
         <form.AppForm>
-          <form.AuthFormRoot
-            class="flex flex-col gap-4"
-            prepareSubmit={prepareSubmit}
-          >
+          <form.AuthFormRoot class="flex flex-col gap-4">
             <DialogHeader>
               <DialogTitle>{config().localization.createUser}</DialogTitle>
               <DialogDescription>
@@ -852,18 +836,25 @@ function CreateUserDialog(props: {
                 </Field>
               )}
             </form.Field>
-            <For each={auth.additionalFields}>
-              {(field) => (
-                <AdditionalField
-                  field={field}
-                  isPending={createUser.isPending}
-                  name={field.name}
-                />
+            <For each={additionalFields()}>
+              {(configuredField) => (
+                <form.AppField
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    auth.localization.auth.fieldRequired
+                  )}
+                >
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      isPending={createUser.isPending}
+                    />
+                  )}
+                </form.AppField>
               )}
             </For>
-            <FieldError>
-              {formError() ?? getAdminErrorMessage(createUser.error)}
-            </FieldError>
+            <FieldError>{getAdminErrorMessage(createUser.error)}</FieldError>
             <DialogFooter>
               <Button onClick={close} type="button" variant="outline">
                 {config().localization.cancel}
@@ -956,7 +947,6 @@ function UserDialog(props: {
   const banDurationSeconds = createMemo(() =>
     getBanDurationSeconds(banDuration())
   )
-  const [profileError, setProfileError] = createSignal<string>()
   const [passwordOpen, setPasswordOpen] = createSignal(false)
   const [dangerousAction, setDangerousAction] = createSignal<DangerousAction>()
   const detail = () => user.data
@@ -980,12 +970,16 @@ function UserDialog(props: {
   const remove = useRemoveAdminUser(authClient)
   const revokeSession = useRevokeAdminUserSession(authClient, props.userId)
   const revokeSessions = useRevokeAdminUserSessions(authClient, props.userId)
-  let profileAdditionalFieldValues: Record<
-    string,
-    AdditionalFieldValue | null
-  > = {}
+  const configuredUserFields = () => {
+    const selectedUser = detail()
+    return fieldsWithModelValues(
+      auth.additionalFields ?? [],
+      selectedUser ? (selectedUser as unknown as Record<string, unknown>) : {}
+    )
+  }
   const profileForm = createAuthForm(() => ({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredUserFields()),
       email: "",
       emailVerified: false,
       name: "",
@@ -1001,7 +995,10 @@ function UserDialog(props: {
           updateUser.mutateAsync({
             userId: selectedUser.id,
             data: {
-              ...profileAdditionalFieldValues,
+              ...getAdditionalFieldSubmitValues(
+                configuredUserFields(),
+                value.additionalFields
+              ),
               name: value.name.trim(),
               ...(canSetEmail.data?.success
                 ? {
@@ -1031,31 +1028,20 @@ function UserDialog(props: {
     }
   }))
 
-  createEffect(
-    on(
-      () =>
-        [
-          detail()?.email,
-          detail()?.emailVerified,
-          detail()?.id,
-          detail()?.name,
-          detail()?.role
-        ] as const,
-      ([userEmail, userEmailVerified, _userId, userName, userRole]) => {
-        profileForm.reset({
-          email: userEmail ?? "",
-          emailVerified: userEmailVerified ?? false,
-          name: userName ?? "",
-          roles: parseAdminRoles(
-            userRole,
-            config().defaultRole,
-            config().allowMultipleRoles
-          )
-        })
-        setProfileError(undefined)
-      }
-    )
-  )
+  createEffect(() => {
+    const selectedUser = detail()
+    profileForm.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredUserFields()),
+      email: selectedUser?.email ?? "",
+      emailVerified: selectedUser?.emailVerified ?? false,
+      name: selectedUser?.name ?? "",
+      roles: parseAdminRoles(
+        selectedUser?.role,
+        config().defaultRole,
+        config().allowMultipleRoles
+      )
+    })
+  })
 
   const confirmDangerousAction = () => {
     const selectedUser = detail()
@@ -1130,27 +1116,6 @@ function UserDialog(props: {
         : dangerousAction() === "revokeAll"
           ? config().localization.revokeAllSessions
           : config().localization.impersonateUser
-
-  const prepareSaveUser = async (formElement: HTMLFormElement) => {
-    const selectedUser = detail()
-    if (!selectedUser) return false
-
-    if (canUpdate.data?.success) {
-      const formData = new FormData(formElement)
-      let additionalFieldValues: Record<string, AdditionalFieldValue | null>
-      try {
-        additionalFieldValues = await parseAdditionalFieldValues(
-          auth.additionalFields ?? [],
-          formData
-        )
-      } catch (error) {
-        setProfileError(error instanceof Error ? error.message : String(error))
-        return false
-      }
-      setProfileError(undefined)
-      profileAdditionalFieldValues = additionalFieldValues
-    }
-  }
 
   return (
     <>
@@ -1266,10 +1231,7 @@ function UserDialog(props: {
                   </TabsList>
                   <TabsContent class="min-h-0 overflow-hidden" value="overview">
                     <profileForm.AppForm>
-                      <profileForm.AuthFormRoot
-                        class="grid h-full grid-rows-[minmax(0,1fr)_auto]"
-                        prepareSubmit={prepareSaveUser}
-                      >
+                      <profileForm.AuthFormRoot class="grid h-full grid-rows-[minmax(0,1fr)_auto]">
                         <div class="overflow-y-auto">
                           <section class="flex flex-col gap-5 p-6">
                             <h3 class="font-medium">
@@ -1421,35 +1383,30 @@ function UserDialog(props: {
                                   </FieldSet>
                                 )}
                               </profileForm.Field>
-                              <For each={auth.additionalFields}>
-                                {(field) => {
-                                  const value = () =>
-                                    (
-                                      selectedUser() as unknown as Record<
-                                        string,
-                                        unknown
-                                      >
-                                    )[field.name]
-                                  return (
-                                    <AdditionalField
-                                      field={{
-                                        ...field,
-                                        defaultValue:
-                                          value() as AdditionalFieldValue | null
-                                      }}
-                                      isPending={
-                                        updateUser.isPending ||
-                                        !canUpdate.data?.success
-                                      }
-                                      name={field.name}
-                                    />
-                                  )
-                                }}
+                              <For each={configuredUserFields()}>
+                                {(configuredField) => (
+                                  <profileForm.AppField
+                                    name={`additionalFields.${configuredField.name}`}
+                                    validators={getAuthAdditionalFieldValidators(
+                                      configuredField,
+                                      auth.localization.auth.fieldRequired
+                                    )}
+                                  >
+                                    {(field) => (
+                                      <field.AuthFormAdditionalField
+                                        field={configuredField}
+                                        isPending={
+                                          updateUser.isPending ||
+                                          !canUpdate.data?.success
+                                        }
+                                      />
+                                    )}
+                                  </profileForm.AppField>
+                                )}
                               </For>
                             </FieldGroup>
                             <FieldError>
-                              {profileError() ??
-                                getAdminErrorMessage(updateUser.error) ??
+                              {getAdminErrorMessage(updateUser.error) ??
                                 getAdminErrorMessage(setRoleMutation.error)}
                             </FieldError>
                           </section>

--- a/examples/start-solid-zaidan-example/src/components/auth/auth-form.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/auth-form.tsx
@@ -1,22 +1,20 @@
-import { getFormFieldErrors } from "@better-auth-ui/core"
-import { createFormHook, createFormHookContexts } from "@tanstack/solid-form"
 import {
-  type Accessor,
-  type ComponentProps,
-  createContext,
-  createSignal,
-  Show,
-  splitProps,
-  useContext
-} from "solid-js"
+  type AdditionalField as AdditionalFieldConfig,
+  type AdditionalFieldFormValue,
+  getFormFieldErrors,
+  validateAdditionalFieldRequired,
+  validateAdditionalFieldValue
+} from "@better-auth-ui/core"
+import { createFormHook, createFormHookContexts } from "@tanstack/solid-form"
+import { type ComponentProps, Show, splitProps } from "solid-js"
 
 import { Button } from "@/components/ui/button"
 import { FieldError } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
+import { AdditionalField, type AdditionalFieldProps } from "./additional-field"
 
 const { fieldContext, formContext, useFieldContext, useFormContext } =
   createFormHookContexts()
-const AuthFormPreparationContext = createContext<Accessor<boolean>>(() => false)
 
 export function focusFirstInvalidAuthFormControl(form: HTMLFormElement) {
   requestAnimationFrame(() => {
@@ -51,50 +49,39 @@ function AuthFormFieldError() {
 }
 
 type AuthFormRootProps = Omit<ComponentProps<"form">, "onSubmit"> & {
-  prepareSubmit?: (
-    form: HTMLFormElement
-  ) => boolean | undefined | Promise<boolean | undefined>
+  onBeforeSubmit?: () => void
 }
 
 function AuthFormRoot(props: AuthFormRootProps) {
   const form = useFormContext()
-  const [local, formProps] = splitProps(props, ["prepareSubmit"])
-  const [isPreparing, setIsPreparing] = createSignal(false)
-  let preparing = false
+  const [local, formProps] = splitProps(props, ["onBeforeSubmit"])
+  let submitting = false
 
   const submit = async (event: SubmitEvent) => {
     event.preventDefault()
-    if (preparing || form.state.isSubmitting) return
+    if (submitting || form.state.isSubmitting) return
 
     const formElement = event.currentTarget as HTMLFormElement
-    preparing = true
-    setIsPreparing(true)
-
-    let shouldSubmit = true
+    local.onBeforeSubmit?.()
+    submitting = true
     try {
-      shouldSubmit = (await local.prepareSubmit?.(formElement)) !== false
+      await form.handleSubmit()
+      if (!form.state.isValid) focusFirstInvalidAuthFormControl(formElement)
     } finally {
-      preparing = false
-      setIsPreparing(false)
+      submitting = false
     }
-
-    if (!shouldSubmit) return
-    await form.handleSubmit()
-    if (!form.state.isValid) focusFirstInvalidAuthFormControl(formElement)
   }
 
   return (
-    <AuthFormPreparationContext.Provider value={isPreparing}>
-      <form
-        {...formProps}
-        on:invalid={{
-          capture: true,
-          handleEvent: (event) =>
-            focusFirstInvalidAuthFormControl(event.currentTarget)
-        }}
-        onSubmit={submit}
-      />
-    </AuthFormPreparationContext.Provider>
+    <form
+      {...formProps}
+      on:invalid={{
+        capture: true,
+        handleEvent: (event) =>
+          focusFirstInvalidAuthFormControl(event.currentTarget)
+      }}
+      onSubmit={submit}
+    />
   )
 }
 
@@ -102,7 +89,6 @@ function AuthFormSubmitButton(
   props: Omit<ComponentProps<typeof Button>, "class"> & { class?: string }
 ) {
   const form = useFormContext()
-  const isPreparing = useContext(AuthFormPreparationContext)
 
   return (
     <form.Subscribe
@@ -112,12 +98,10 @@ function AuthFormSubmitButton(
         <Button
           {...props}
           class={props.class}
-          disabled={
-            props.disabled || isPreparing() || !state()[0] || state()[1]
-          }
+          disabled={props.disabled || !state()[0] || state()[1]}
           type="submit"
         >
-          <Show when={isPreparing() || state()[1]}>
+          <Show when={state()[1]}>
             <Spinner />
           </Show>
           {props.children}
@@ -127,9 +111,47 @@ function AuthFormSubmitButton(
   )
 }
 
+type AuthFormAdditionalFieldProps = Omit<
+  AdditionalFieldProps,
+  "errors" | "isInvalid" | "name" | "onBlur" | "onChange" | "value"
+>
+
+function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
+  const field = useFieldContext<AdditionalFieldFormValue>()
+  const isInvalid = () => isAuthFormFieldInvalid(field().state.meta)
+
+  return (
+    <AdditionalField
+      {...props}
+      errors={
+        isInvalid() ? getFormFieldErrors(field().state.meta.errors) : undefined
+      }
+      isInvalid={isInvalid()}
+      name={field().name}
+      onBlur={field().handleBlur}
+      onChange={field().handleChange}
+      value={field().state.value}
+    />
+  )
+}
+
 export const { useAppForm: createAuthForm } = createFormHook({
-  fieldComponents: { AuthFormFieldError },
+  fieldComponents: { AuthFormAdditionalField, AuthFormFieldError },
   fieldContext,
   formComponents: { AuthFormRoot, AuthFormSubmitButton },
   formContext
 })
+
+export function getAuthAdditionalFieldValidators(
+  field: AdditionalFieldConfig,
+  requiredMessage: string
+) {
+  return {
+    onChange: ({ value }: { value: AdditionalFieldFormValue }) =>
+      validateAdditionalFieldRequired(field, value, requiredMessage),
+    onChangeAsync: field.validate
+      ? ({ value }: { value: AdditionalFieldFormValue }) =>
+          validateAdditionalFieldValue(field, value)
+      : undefined
+  }
+}

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/create-organization-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/create-organization-dialog.tsx
@@ -1,10 +1,14 @@
-import { parseAdditionalFieldValue } from "@better-auth-ui/core"
+import {
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  getFormFieldErrors,
+  validateStringLength
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import { useCreateOrganization } from "@better-auth-ui/solid/plugins/organization"
-import { BriefcaseBusiness, LoaderCircle } from "lucide-solid"
+import { BriefcaseBusiness } from "lucide-solid"
 import { createEffect, createSignal, For, Show } from "solid-js"
-import { toast } from "solid-sonner"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -15,10 +19,14 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldLabel } from "@/components/ui/field"
+import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  createAuthForm,
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid
+} from "../auth-form"
 import { SlugField, sanitizeSlug } from "./slug-field"
 
 export type CreateOrganizationDialogProps = {
@@ -31,131 +39,161 @@ export function CreateOrganizationDialog(props: CreateOrganizationDialogProps) {
   const auth = useAuth<OrganizationAuthClient>()
   const config = useAuthPlugin(organizationPlugin)
   const hideSlug = () => props.hideSlug ?? config.hideSlug ?? false
-  const [name, setName] = createSignal("")
-  const [slug, setSlug] = createSignal("")
   const [slugEdited, setSlugEdited] = createSignal(false)
-  const [isSubmitting, setIsSubmitting] = createSignal(false)
-  const createOrganization = useCreateOrganization(auth.authClient, () => ({
-    onSuccess: () => props.onOpenChange(false),
-    onSettled: () => setIsSubmitting(false)
+  let submissionGeneration = 0
+  let submissionAttemptGeneration = 0
+  const createOrganization = useCreateOrganization(auth.authClient)
+  const form = createAuthForm(() => ({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(
+        config.additionalFields
+      ),
+      name: "",
+      slug: ""
+    },
+    onSubmit: async ({ value }) => {
+      const generation = submissionAttemptGeneration
+      if (generation !== submissionGeneration) return
+      try {
+        await createOrganization.mutateAsync({
+          ...getAdditionalFieldSubmitValues(
+            config.additionalFields,
+            value.additionalFields
+          ),
+          name: value.name,
+          slug: hideSlug() ? undefined : value.slug
+        })
+        if (generation === submissionGeneration) props.onOpenChange(false)
+      } catch {
+        // The mutation reports the error through its configured handler.
+      }
+    }
   }))
   createEffect(() => {
     if (!props.open) {
-      setName("")
-      setSlug("")
+      submissionGeneration += 1
+      form.reset()
       setSlugEdited(false)
-      return
     }
-
-    if (slugEdited()) return
-
-    setSlug(sanitizeSlug(name()))
   })
-
-  const handleSubmit = async (event: SubmitEvent) => {
-    event.preventDefault()
-    if (isSubmitting()) return
-
-    setIsSubmitting(true)
-    const formData = new FormData(event.currentTarget as HTMLFormElement)
-    const additionalValues: Record<string, unknown> = {}
-    try {
-      for (const field of config.additionalFields) {
-        const value = parseAdditionalFieldValue(
-          field,
-          formData.get(field.name) as string | null
-        )
-        await field.validate?.(value)
-        if (value !== undefined) additionalValues[field.name] = value
-      }
-    } catch (error) {
-      setIsSubmitting(false)
-      toast.error(error instanceof Error ? error.message : String(error))
-      return
-    }
-    createOrganization.mutate({
-      ...additionalValues,
-      name: name(),
-      slug: hideSlug() ? undefined : slug()
-    })
-  }
-
-  const isPending = () => createOrganization.isPending || isSubmitting()
 
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
       <DialogContent>
-        <form class="flex flex-col gap-6" onSubmit={handleSubmit}>
-          <DialogHeader>
-            <div class="flex size-10 items-center justify-center rounded-md bg-muted">
-              <BriefcaseBusiness class="size-4.5" />
-            </div>
-            <DialogTitle>{config.localization.createOrganization}</DialogTitle>
-            <DialogDescription>
-              {config.localization.organizationsDescription}
-            </DialogDescription>
-          </DialogHeader>
+        <form.AppForm>
+          <form.AuthFormRoot
+            class="flex flex-col gap-6"
+            onBeforeSubmit={() => {
+              submissionAttemptGeneration = submissionGeneration
+            }}
+          >
+            <DialogHeader>
+              <div class="flex size-10 items-center justify-center rounded-md bg-muted">
+                <BriefcaseBusiness class="size-4.5" />
+              </div>
+              <DialogTitle>
+                {config.localization.createOrganization}
+              </DialogTitle>
+              <DialogDescription>
+                {config.localization.organizationsDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <Field>
-            <FieldLabel for="create-organization-name">
-              {config.localization.name}
-            </FieldLabel>
-            <Input
-              autofocus
-              disabled={isPending()}
-              id="create-organization-name"
+            <form.AppField
               name="name"
-              onInput={(event) => setName(event.currentTarget.value)}
-              placeholder={config.localization.namePlaceholder}
-              required
-              value={name()}
-            />
-          </Field>
-
-          <Show when={!hideSlug()}>
-            <SlugField
-              disabled={isPending()}
-              id="create-organization-slug"
-              onChange={(value) => {
-                setSlug(value)
-                setSlugEdited(true)
+              validators={{
+                onChange: ({ value }) =>
+                  validateStringLength(value, {
+                    requiredMessage: auth.localization.auth.fieldRequired,
+                    trim: true
+                  })
               }}
-              value={slug()}
-            />
-          </Show>
-
-          <For each={config.additionalFields}>
-            {(field) => (
-              <AdditionalField
-                field={field}
-                isPending={isPending()}
-                name={field.name}
-                optionalLabel={auth.localization.settings.optional}
-              />
-            )}
-          </For>
-
-          <DialogFooter>
-            <DialogClose
-              as={Button}
-              disabled={isPending()}
-              type="button"
-              variant="outline"
             >
-              {auth.localization.settings.cancel}
-            </DialogClose>
-            <Button disabled={isPending()} type="submit">
-              {isPending() ? (
-                <>
-                  <LoaderCircle class="size-4 animate-spin" />
-                  {config.localization.createOrganization}
-                </>
-              ) : (
-                config.localization.createOrganization
+              {(field) => {
+                const isInvalid = () =>
+                  isAuthFormFieldInvalid(field().state.meta)
+
+                return (
+                  <Field data-invalid={isInvalid()}>
+                    <FieldLabel for="create-organization-name">
+                      {config.localization.name}
+                    </FieldLabel>
+                    <Input
+                      aria-invalid={isInvalid()}
+                      autofocus
+                      disabled={createOrganization.isPending}
+                      id="create-organization-name"
+                      name={field().name}
+                      onBlur={field().handleBlur}
+                      onInput={(event) => {
+                        const value = event.currentTarget.value
+                        field().handleChange(value)
+                        if (!slugEdited()) {
+                          form.setFieldValue("slug", sanitizeSlug(value))
+                        }
+                      }}
+                      placeholder={config.localization.namePlaceholder}
+                      value={field().state.value}
+                    />
+                    <FieldError
+                      errors={getFormFieldErrors(field().state.meta.errors)}
+                    />
+                  </Field>
+                )
+              }}
+            </form.AppField>
+
+            <Show when={!hideSlug()}>
+              <form.AppField name="slug">
+                {(field) => (
+                  <SlugField
+                    disabled={createOrganization.isPending}
+                    id="create-organization-slug"
+                    onChange={(value) => {
+                      field().handleChange(value)
+                      setSlugEdited(true)
+                    }}
+                    value={field().state.value}
+                  />
+                )}
+              </form.AppField>
+            </Show>
+
+            <For each={config.additionalFields}>
+              {(configuredField) => (
+                <form.AppField
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    auth.localization.auth.fieldRequired
+                  )}
+                >
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      isPending={createOrganization.isPending}
+                      optionalLabel={auth.localization.settings.optional}
+                    />
+                  )}
+                </form.AppField>
               )}
-            </Button>
-          </DialogFooter>
-        </form>
+            </For>
+
+            <DialogFooter>
+              <DialogClose
+                as={Button}
+                disabled={createOrganization.isPending}
+                type="button"
+                variant="outline"
+              >
+                {auth.localization.settings.cancel}
+              </DialogClose>
+              <form.AuthFormSubmitButton>
+                {config.localization.createOrganization}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/invite-member-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/invite-member-dialog.tsx
@@ -1,4 +1,9 @@
-import { parseAdditionalFieldValues } from "@better-auth-ui/core"
+import {
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  getFormFieldErrors,
+  validateEmailAddress
+} from "@better-auth-ui/core"
 import type {
   InviteMemberParams,
   OrganizationAuthClient,
@@ -15,7 +20,7 @@ import {
   useListRoles,
   useListTeams
 } from "@better-auth-ui/solid/plugins/organization"
-import { createEffect, createMemo, createSignal, For, on, Show } from "solid-js"
+import { createEffect, createMemo, For, Show } from "solid-js"
 import { toast } from "solid-sonner"
 import { Button } from "@/components/ui/button"
 import { Checkbox } from "@/components/ui/checkbox"
@@ -28,11 +33,15 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldLabel } from "@/components/ui/field"
+import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { NativeSelect, NativeSelectOption } from "@/components/ui/native-select"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  createAuthForm,
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid
+} from "../auth-form"
 
 export type InviteMemberDialogProps = {
   open: boolean
@@ -79,21 +88,6 @@ export function InviteMemberDialog(props: InviteMemberDialogProps) {
     })
   )
   const invitations = useListOrganizationInvitations(auth.authClient)
-  const [email, setEmail] = createSignal("")
-  const [selectedRoles, setSelectedRoles] = createSignal<string[]>(
-    pickDefaultRole(roles()) ? [pickDefaultRole(roles())] : []
-  )
-  const toggleRole = (role: string, selected: boolean) =>
-    setSelectedRoles((current) => {
-      const next = selected
-        ? [...current, role]
-        : current.filter((entry) => entry !== role)
-
-      // An invitation always carries at least one role.
-      return next.length > 0 ? next : current
-    })
-  const [teamId, setTeamId] = createSignal("")
-  const [isSubmitting, setIsSubmitting] = createSignal(false)
   const inviteMember = useInviteMember(
     auth.authClient as OrganizationTeamsAuthClient,
     () => ({
@@ -104,228 +98,280 @@ export function InviteMemberDialog(props: InviteMemberDialogProps) {
     })
   )
 
+  const invitationLimitReached = createMemo(
+    () =>
+      config.invitationLimit !== undefined &&
+      (invitations.data?.filter((invitation) => invitation.status === "pending")
+        .length ?? 0) >= config.invitationLimit
+  )
+  const form = createAuthForm(() => ({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(
+        config.modelFields.invitation
+      ),
+      email: "",
+      roles: [] as string[],
+      teamId: ""
+    },
+    onSubmit: async ({ value }) => {
+      const organizationId = activeOrganization.data?.id
+      const teamId = teams.data?.some((team) => team.id === value.teamId)
+        ? value.teamId
+        : undefined
+
+      if (
+        !organizationId ||
+        !canInvite.data?.success ||
+        value.roles.length === 0 ||
+        invitationLimitReached()
+      )
+        return
+
+      const payload = {
+        ...getAdditionalFieldSubmitValues(
+          config.modelFields.invitation,
+          value.additionalFields
+        ),
+        email: value.email.trim(),
+        organizationId,
+        teamId,
+        role: value.roles as InviteMemberParams["role"]
+      } satisfies InviteMemberParams<OrganizationTeamsAuthClient>
+
+      try {
+        await inviteMember.mutateAsync(payload)
+      } catch {
+        // The mutation reports the error through its configured handler.
+      }
+    }
+  }))
+
   createEffect(() => {
     if (!props.open) {
-      setEmail("")
-      setSelectedRoles([pickDefaultRole(roles())].filter(Boolean))
+      form.reset({
+        additionalFields: getAdditionalFieldDefaultValues(
+          config.modelFields.invitation
+        ),
+        email: "",
+        roles: [pickDefaultRole(roles())].filter(Boolean),
+        teamId: ""
+      })
       return
     }
 
     const available = roles()
-    const kept = selectedRoles().filter((entry) => entry in available)
+    const current = form.getFieldValue("roles")
+    const kept = current.filter((entry) => entry in available)
     const allowed = config.allowMultipleRoles ? kept : kept.slice(0, 1)
+    const next =
+      allowed.length > 0
+        ? allowed
+        : [pickDefaultRole(available)].filter(Boolean)
 
     if (
-      allowed.length !== selectedRoles().length ||
-      allowed.some((role, index) => role !== selectedRoles()[index])
+      next.length !== current.length ||
+      next.some((role, index) => role !== current[index])
     ) {
-      setSelectedRoles(
-        allowed.length > 0
-          ? allowed
-          : [pickDefaultRole(available)].filter(Boolean)
-      )
+      form.setFieldValue("roles", next)
     }
   })
-
-  createEffect(
-    on([() => props.open, () => activeOrganization.data?.id], () =>
-      setTeamId("")
-    )
-  )
-
-  const handleSubmit = async (event: SubmitEvent) => {
-    event.preventDefault()
-
-    const atInvitationLimit =
-      config.invitationLimit !== undefined &&
-      (invitations.data?.filter((invitation) => invitation.status === "pending")
-        .length ?? 0) >= config.invitationLimit
-
-    const organizationId = activeOrganization.data?.id
-    const invitationEmail = email().trim()
-    const invitationRoles = [...selectedRoles()] as InviteMemberParams["role"]
-    const currentTeamId = teamId()
-    const selectedTeamId = teams.data?.some((team) => team.id === currentTeamId)
-      ? currentTeamId
-      : undefined
-
-    if (
-      !organizationId ||
-      !canInvite.data?.success ||
-      !invitationEmail ||
-      invitationRoles.length === 0 ||
-      atInvitationLimit
-    )
-      return
-
-    const formData = new FormData(event.currentTarget as HTMLFormElement)
-    setIsSubmitting(true)
-    let invitationValues: Record<string, unknown>
-    try {
-      invitationValues = await parseAdditionalFieldValues(
-        config.modelFields.invitation,
-        formData
-      )
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      setIsSubmitting(false)
-      return
-    }
-
-    const payload = {
-      ...invitationValues,
-      email: invitationEmail,
-      organizationId,
-      teamId: selectedTeamId,
-      role: invitationRoles
-    } satisfies InviteMemberParams<OrganizationTeamsAuthClient>
-
-    inviteMember.mutate(payload, { onSettled: () => setIsSubmitting(false) })
-  }
 
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
       <DialogContent>
-        <form class="flex flex-col gap-6" onSubmit={handleSubmit}>
-          <DialogHeader>
-            <DialogTitle>{config.localization.inviteMember}</DialogTitle>
-            <DialogDescription>
-              {config.localization.inviteMemberDescription}
-            </DialogDescription>
-          </DialogHeader>
+        <form.AppForm>
+          <form.AuthFormRoot class="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle>{config.localization.inviteMember}</DialogTitle>
+              <DialogDescription>
+                {config.localization.inviteMemberDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <Field>
-            <FieldLabel for="invite-member-email">
-              {auth.localization.auth.email}
-            </FieldLabel>
-            <Input
-              autofocus
-              disabled={inviteMember.isPending}
-              id="invite-member-email"
+            <form.AppField
               name="email"
-              onInput={(event) => setEmail(event.currentTarget.value)}
-              required
-              type="email"
-              value={email()}
-            />
-          </Field>
+              validators={{
+                onChange: ({ value }) =>
+                  validateEmailAddress(value, {
+                    invalidMessage: auth.localization.auth.invalidEmail,
+                    requiredMessage: auth.localization.auth.fieldRequired
+                  })
+              }}
+            >
+              {(field) => {
+                const isInvalid = () =>
+                  isAuthFormFieldInvalid(field().state.meta)
+                return (
+                  <Field data-invalid={isInvalid()}>
+                    <FieldLabel for="invite-member-email">
+                      {auth.localization.auth.email}
+                    </FieldLabel>
+                    <Input
+                      aria-invalid={isInvalid()}
+                      autofocus
+                      disabled={inviteMember.isPending}
+                      id="invite-member-email"
+                      name={field().name}
+                      onBlur={field().handleBlur}
+                      onInput={(event) =>
+                        field().handleChange(event.currentTarget.value)
+                      }
+                      type="email"
+                      value={field().state.value}
+                    />
+                    <FieldError
+                      errors={getFormFieldErrors(field().state.meta.errors)}
+                    />
+                  </Field>
+                )
+              }}
+            </form.AppField>
 
-          <Show
-            when={config.allowMultipleRoles}
-            fallback={
-              <Field>
-                <FieldLabel for="invite-member-role">
-                  {config.localization.role}
-                </FieldLabel>
-                <NativeSelect
-                  class="w-full"
-                  disabled={inviteMember.isPending}
-                  id="invite-member-role"
-                  onChange={(event) =>
-                    setSelectedRoles([event.currentTarget.value])
-                  }
-                  value={selectedRoles()[0] ?? ""}
-                >
-                  <For each={Object.entries(roles())}>
-                    {([value, label]) => (
-                      <NativeSelectOption value={value}>
-                        {label}
-                      </NativeSelectOption>
-                    )}
-                  </For>
-                </NativeSelect>
-              </Field>
-            }
-          >
-            <fieldset class="flex flex-col gap-2">
-              <legend class="font-medium text-sm">
-                {config.localization.role}
-              </legend>
-              <div class="flex flex-wrap gap-4">
-                <For each={Object.entries(roles())}>
-                  {([value, label]) => (
-                    <Field orientation="horizontal">
-                      <Checkbox
-                        checked={selectedRoles().includes(value)}
-                        disabled={inviteMember.isPending}
-                        id={`invite-member-role-${value}`}
-                        onChange={(selected) => toggleRole(value, selected)}
-                      />
-                      <FieldLabel for={`invite-member-role-${value}`}>
-                        {label}
+            <form.AppField
+              name="roles"
+              validators={{
+                onChange: ({ value }) =>
+                  value.length > 0
+                    ? undefined
+                    : auth.localization.auth.fieldRequired
+              }}
+            >
+              {(field) => (
+                <Show
+                  when={config.allowMultipleRoles}
+                  fallback={
+                    <Field>
+                      <FieldLabel for="invite-member-role">
+                        {config.localization.role}
                       </FieldLabel>
+                      <NativeSelect
+                        class="w-full"
+                        disabled={inviteMember.isPending}
+                        id="invite-member-role"
+                        onBlur={field().handleBlur}
+                        onChange={(event) =>
+                          field().handleChange([event.currentTarget.value])
+                        }
+                        value={field().state.value[0] ?? ""}
+                      >
+                        <For each={Object.entries(roles())}>
+                          {([value, label]) => (
+                            <NativeSelectOption value={value}>
+                              {label}
+                            </NativeSelectOption>
+                          )}
+                        </For>
+                      </NativeSelect>
                     </Field>
-                  )}
-                </For>
-              </div>
-            </fieldset>
-          </Show>
+                  }
+                >
+                  <fieldset class="flex flex-col gap-2">
+                    <legend class="font-medium text-sm">
+                      {config.localization.role}
+                    </legend>
+                    <div class="flex flex-wrap gap-4">
+                      <For each={Object.entries(roles())}>
+                        {([value, label]) => (
+                          <Field orientation="horizontal">
+                            <Checkbox
+                              checked={field().state.value.includes(value)}
+                              disabled={inviteMember.isPending}
+                              id={`invite-member-role-${value}`}
+                              onChange={(selected) => {
+                                const current = field().state.value
+                                const next = selected
+                                  ? [...current, value]
+                                  : current.filter((entry) => entry !== value)
+                                if (next.length > 0) field().handleChange(next)
+                              }}
+                            />
+                            <FieldLabel for={`invite-member-role-${value}`}>
+                              {label}
+                            </FieldLabel>
+                          </Field>
+                        )}
+                      </For>
+                    </div>
+                  </fieldset>
+                </Show>
+              )}
+            </form.AppField>
 
-          <Show when={config.teams}>
-            <Field>
-              <FieldLabel for="invite-member-team">
-                {config.localization.team}
-              </FieldLabel>
-              <NativeSelect
-                class="w-full"
+            <Show when={config.teams}>
+              <form.AppField name="teamId">
+                {(field) => (
+                  <Field>
+                    <FieldLabel for="invite-member-team">
+                      {config.localization.team}
+                    </FieldLabel>
+                    <NativeSelect
+                      class="w-full"
+                      disabled={inviteMember.isPending}
+                      id="invite-member-team"
+                      onBlur={field().handleBlur}
+                      onChange={(event) =>
+                        field().handleChange(event.currentTarget.value)
+                      }
+                      value={field().state.value}
+                    >
+                      <NativeSelectOption value="">
+                        {config.localization.selectTeam}
+                      </NativeSelectOption>
+                      <For each={teams.data}>
+                        {(team) => (
+                          <NativeSelectOption value={team.id}>
+                            {team.name}
+                          </NativeSelectOption>
+                        )}
+                      </For>
+                    </NativeSelect>
+                  </Field>
+                )}
+              </form.AppField>
+            </Show>
+
+            <For each={config.modelFields.invitation}>
+              {(configuredField) => (
+                <form.AppField
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    auth.localization.auth.fieldRequired
+                  )}
+                >
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      isPending={inviteMember.isPending}
+                      optionalLabel={auth.localization.settings.optional}
+                    />
+                  )}
+                </form.AppField>
+              )}
+            </For>
+
+            <DialogFooter>
+              <DialogClose
+                as={Button}
                 disabled={inviteMember.isPending}
-                id="invite-member-team"
-                onChange={(event) => setTeamId(event.currentTarget.value)}
-                value={teamId()}
+                type="button"
+                variant="outline"
               >
-                <NativeSelectOption value="">
-                  {config.localization.selectTeam}
-                </NativeSelectOption>
-                <For each={teams.data}>
-                  {(team) => (
-                    <NativeSelectOption value={team.id}>
-                      {team.name}
-                    </NativeSelectOption>
-                  )}
-                </For>
-              </NativeSelect>
-            </Field>
-          </Show>
-
-          <For each={config.modelFields.invitation}>
-            {(field) => (
-              <AdditionalField
-                field={field}
-                isPending={inviteMember.isPending || isSubmitting()}
-                name={field.name}
-                optionalLabel={auth.localization.settings.optional}
-              />
-            )}
-          </For>
-
-          <DialogFooter>
-            <DialogClose
-              as={Button}
-              disabled={inviteMember.isPending || isSubmitting()}
-              type="button"
-              variant="outline"
-            >
-              {auth.localization.settings.cancel}
-            </DialogClose>
-            <Button
-              disabled={
-                inviteMember.isPending ||
-                isSubmitting() ||
-                canInvite.isPending ||
-                !canInvite.data?.success ||
-                !email().trim() ||
-                selectedRoles().length === 0 ||
-                (config.invitationLimit !== undefined &&
-                  (invitations.data?.filter(
-                    (invitation) => invitation.status === "pending"
-                  ).length ?? 0) >= config.invitationLimit)
-              }
-              type="submit"
-            >
-              {config.localization.inviteMember}
-            </Button>
-          </DialogFooter>
-        </form>
+                {auth.localization.settings.cancel}
+              </DialogClose>
+              <form.AuthFormSubmitButton
+                disabled={
+                  inviteMember.isPending ||
+                  canInvite.isPending ||
+                  !canInvite.data?.success ||
+                  invitationLimitReached()
+                }
+              >
+                {config.localization.inviteMember}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-profile.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-profile.tsx
@@ -1,4 +1,10 @@
-import { parseAdditionalFieldValue } from "@better-auth-ui/core"
+import {
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  getFormFieldErrors,
+  validateStringLength
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import {
@@ -6,14 +12,17 @@ import {
   useHasPermission,
   useUpdateOrganization
 } from "@better-auth-ui/solid/plugins/organization"
-import { createEffect, createSignal, For, Show } from "solid-js"
+import { createEffect, For, Show } from "solid-js"
 import { toast } from "solid-sonner"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Field, FieldLabel } from "@/components/ui/field"
+import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  createAuthForm,
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid
+} from "../auth-form"
 import { ChangeOrganizationLogo } from "./change-organization-logo"
 import { SlugField } from "./slug-field"
 
@@ -34,41 +43,42 @@ export function OrganizationProfile(props: OrganizationProfileProps) {
     onSuccess: () =>
       toast.success(config.localization.organizationUpdatedSuccess)
   }))
-  const [name, setName] = createSignal("")
-  const [slug, setSlug] = createSignal("")
+  const form = createAuthForm(() => ({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(
+        config.additionalFields
+      ),
+      name: "",
+      slug: ""
+    },
+    onSubmit: async ({ value }) => {
+      if (!activeOrganization.data || !canUpdate.data?.success) return
+      await updateOrganization.mutateAsync({
+        data: {
+          ...getAdditionalFieldSubmitValues(
+            config.additionalFields,
+            value.additionalFields
+          ),
+          name: value.name,
+          ...(!hideSlug() && { slug: value.slug })
+        }
+      })
+    }
+  }))
   createEffect(() => {
     const organization = activeOrganization.data
     if (!organization) return
-    setName(organization.name)
-    setSlug(organization.slug)
-  })
-
-  const handleSubmit = async (event: SubmitEvent) => {
-    event.preventDefault()
-    if (!activeOrganization.data || !canUpdate.data?.success) return
-    const formData = new FormData(event.currentTarget as HTMLFormElement)
-    const additionalValues: Record<string, unknown> = {}
-    try {
-      for (const field of config.additionalFields) {
-        const value = parseAdditionalFieldValue(
-          field,
-          formData.get(field.name) as string | null
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(
+        fieldsWithModelValues(
+          config.additionalFields,
+          organization as Record<string, unknown>
         )
-        await field.validate?.(value)
-        if (value !== undefined) additionalValues[field.name] = value
-      }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      return
-    }
-    updateOrganization.mutate({
-      data: {
-        ...additionalValues,
-        name: name(),
-        ...(!hideSlug() && { slug: slug() })
-      }
+      ),
+      name: organization.name,
+      slug: organization.slug
     })
-  }
+  })
   const formDisabled = () =>
     updateOrganization.isPending ||
     canUpdate.isPending ||
@@ -81,69 +91,100 @@ export function OrganizationProfile(props: OrganizationProfileProps) {
       </h2>
       <Card>
         <CardContent>
-          <form class="flex flex-col gap-4" onSubmit={handleSubmit}>
-            <ChangeOrganizationLogo class="-ml-1" />
+          <form.AppForm>
+            <form.AuthFormRoot class="flex flex-col gap-4">
+              <ChangeOrganizationLogo class="-ml-1" />
 
-            <Field>
-              <FieldLabel for="organization-profile-name">
-                {config.localization.name}
-              </FieldLabel>
-              <Show when={activeOrganization.data}>
-                <Input
-                  disabled={formDisabled()}
-                  id="organization-profile-name"
-                  name="name"
-                  onInput={(event) => setName(event.currentTarget.value)}
-                  placeholder={config.localization.namePlaceholder}
-                  required
-                  value={name()}
-                />
+              <form.AppField
+                name="name"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: auth.localization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
+              >
+                {(field) => {
+                  const isInvalid = () =>
+                    isAuthFormFieldInvalid(field().state.meta)
+
+                  return (
+                    <Field data-invalid={isInvalid()}>
+                      <FieldLabel for="organization-profile-name">
+                        {config.localization.name}
+                      </FieldLabel>
+                      <Show when={activeOrganization.data}>
+                        <Input
+                          aria-invalid={isInvalid()}
+                          disabled={formDisabled()}
+                          id="organization-profile-name"
+                          name={field().name}
+                          onBlur={field().handleBlur}
+                          onInput={(event) =>
+                            field().handleChange(event.currentTarget.value)
+                          }
+                          placeholder={config.localization.namePlaceholder}
+                          value={field().state.value}
+                        />
+                      </Show>
+                      <FieldError
+                        errors={getFormFieldErrors(field().state.meta.errors)}
+                      />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+
+              <Show when={!hideSlug() && activeOrganization.data}>
+                {(organization) => (
+                  <form.AppField name="slug">
+                    {(field) => (
+                      <SlugField
+                        currentSlug={organization().slug}
+                        disabled={formDisabled()}
+                        id="organization-profile-slug"
+                        onChange={field().handleChange}
+                        value={field().state.value}
+                      />
+                    )}
+                  </form.AppField>
+                )}
               </Show>
-            </Field>
 
-            <Show when={!hideSlug() && activeOrganization.data}>
-              {(organization) => (
-                <SlugField
-                  currentSlug={organization().slug}
-                  disabled={formDisabled()}
-                  id="organization-profile-slug"
-                  onChange={setSlug}
-                  value={slug()}
-                />
-              )}
-            </Show>
-
-            <Show when={activeOrganization.data}>
-              {(organization) => (
+              <Show when={activeOrganization.data}>
                 <For each={config.additionalFields}>
-                  {(field) => (
-                    <AdditionalField
-                      field={{
-                        ...field,
-                        defaultValue: (
-                          organization() as Record<string, unknown>
-                        )[field.name] as never
-                      }}
-                      isPending={formDisabled()}
-                      name={field.name}
-                      optionalLabel={auth.localization.settings.optional}
-                    />
+                  {(configuredField) => (
+                    <form.AppField
+                      name={`additionalFields.${configuredField.name}`}
+                      validators={getAuthAdditionalFieldValidators(
+                        configuredField,
+                        auth.localization.auth.fieldRequired
+                      )}
+                    >
+                      {(field) => (
+                        <field.AuthFormAdditionalField
+                          field={configuredField}
+                          isPending={formDisabled()}
+                          optionalLabel={auth.localization.settings.optional}
+                        />
+                      )}
+                    </form.AppField>
                   )}
                 </For>
-              )}
-            </Show>
+              </Show>
 
-            <Show when={canUpdate.isPending || canUpdate.data?.success}>
-              <Button
-                class="mt-1 w-fit"
-                disabled={!activeOrganization.data || formDisabled()}
-                size="sm"
-                type="submit"
-              >
-                {auth.localization.settings.saveChanges}
-              </Button>
-            </Show>
-          </form>
+              <Show when={canUpdate.isPending || canUpdate.data?.success}>
+                <form.AuthFormSubmitButton
+                  class="mt-1 w-fit"
+                  disabled={!activeOrganization.data || formDisabled()}
+                  size="sm"
+                >
+                  {auth.localization.settings.saveChanges}
+                </form.AuthFormSubmitButton>
+              </Show>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </CardContent>
       </Card>
     </div>

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-roles.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-roles.tsx
@@ -1,7 +1,10 @@
 import {
   type AdditionalFields,
   fieldsWithModelValues,
-  parseAdditionalFieldValues
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  getFormFieldErrors,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type {
   OrganizationPermissionRegistry,
@@ -49,7 +52,7 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu"
-import { Field, FieldLabel } from "@/components/ui/field"
+import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import {
   InputGroup,
@@ -66,7 +69,11 @@ import {
   TableRow
 } from "@/components/ui/table"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  createAuthForm,
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid
+} from "../auth-form"
 import { OrganizationSortableTableHead } from "./organization-sortable-table-head"
 import {
   createOrganizationColumnHelper,
@@ -615,9 +622,6 @@ function RoleDialog(props: {
 }) {
   const auth = useAuth<OrganizationRolesAuthClient>()
   const config = useAuthPlugin(organizationPlugin)
-  const [name, setName] = createSignal("")
-  const [permission, setPermission] = createSignal<Record<string, string[]>>({})
-  const [isSubmitting, setIsSubmitting] = createSignal(false)
   const createRole = useCreateRole(
     auth.authClient,
     () => props.organizationId,
@@ -639,165 +643,217 @@ function RoleDialog(props: {
     })
   )
 
-  createEffect(() => {
-    if (!props.open) return
-    setName(props.role?.role ?? "")
-    setPermission(props.role?.permission ?? {})
-  })
+  const configuredRoleFields = () =>
+    fieldsWithModelValues(props.roleFields, props.role ?? {})
+  const form = createAuthForm(() => ({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredRoleFields()),
+      name: props.role?.role ?? "",
+      permission: props.role?.permission ?? ({} as Record<string, string[]>)
+    },
+    onSubmit: async ({ value }) => {
+      const roleName = value.name.trim()
+      if (!roleName) return
 
-  const submit = async (event: SubmitEvent) => {
-    event.preventDefault()
-    const roleName = name().trim()
-    if (!roleName) return
+      try {
+        const selectedPermissions = value.permission
+        if (
+          Object.values(selectedPermissions).some(
+            (actions) => actions.length > 0
+          )
+        ) {
+          const access = await auth.authClient.organization.hasPermission({
+            organizationId: props.organizationId,
+            permissions: selectedPermissions as Parameters<
+              OrganizationRolesAuthClient["organization"]["hasPermission"]
+            >[0]["permissions"]
+          })
 
-    setIsSubmitting(true)
-    try {
-      const selectedPermissions = permission()
-      if (
-        Object.values(selectedPermissions).some((actions) => actions.length > 0)
-      ) {
-        const access = await auth.authClient.organization.hasPermission({
-          organizationId: props.organizationId,
-          permissions: selectedPermissions as Parameters<
-            OrganizationRolesAuthClient["organization"]["hasPermission"]
-          >[0]["permissions"]
-        })
-
-        if (access.error || !access.data?.success) {
-          toast.error(config.localization.permissionsLimitedDescription)
-          setIsSubmitting(false)
-          return
+          if (access.error || !access.data?.success) {
+            toast.error(config.localization.permissionsLimitedDescription)
+            return
+          }
         }
-      }
 
-      const additionalFields = await parseAdditionalFieldValues(
-        props.roleFields,
-        new FormData(event.currentTarget as HTMLFormElement)
-      )
-      if (props.role) {
-        updateRole.mutate(
-          {
+        const additionalFields = getAdditionalFieldSubmitValues(
+          configuredRoleFields(),
+          value.additionalFields
+        )
+        if (props.role) {
+          await updateRole.mutateAsync({
             organizationId: props.organizationId,
             roleId: props.role.id,
-            data: { ...additionalFields, roleName, permission: permission() }
-          },
-          { onSettled: () => setIsSubmitting(false) }
-        )
-      } else {
-        createRole.mutate(
-          {
+            data: {
+              ...additionalFields,
+              roleName,
+              permission: value.permission
+            }
+          })
+        } else {
+          await createRole.mutateAsync({
             organizationId: props.organizationId,
             role: roleName,
-            permission: permission(),
+            permission: value.permission,
             additionalFields
-          },
-          { onSettled: () => setIsSubmitting(false) }
-        )
+          })
+        }
+      } catch {
+        // The mutation reports the error through its configured handler.
       }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      setIsSubmitting(false)
     }
-  }
+  }))
 
-  const pending = () =>
-    createRole.isPending || updateRole.isPending || isSubmitting()
+  createEffect(() => {
+    if (!props.open) return
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredRoleFields()),
+      name: props.role?.role ?? "",
+      permission: props.role?.permission ?? {}
+    })
+  })
+
+  const pending = () => createRole.isPending || updateRole.isPending
 
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
       <DialogContent class="max-h-[85vh] overflow-y-auto sm:max-w-lg">
-        <form class="flex flex-col gap-6" onSubmit={submit}>
-          <DialogHeader>
-            <DialogTitle>
-              {props.role
-                ? config.localization.editRole
-                : config.localization.createRole}
-            </DialogTitle>
-            <DialogDescription>
-              {config.localization.rolesDescription}
-            </DialogDescription>
-          </DialogHeader>
+        <form.AppForm>
+          <form.AuthFormRoot class="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle>
+                {props.role
+                  ? config.localization.editRole
+                  : config.localization.createRole}
+              </DialogTitle>
+              <DialogDescription>
+                {config.localization.rolesDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <Field>
-            <FieldLabel for="organization-role-name">
-              {config.localization.roleName}
-            </FieldLabel>
-            <Input
-              disabled={pending()}
-              id="organization-role-name"
-              onInput={(event) => setName(event.currentTarget.value)}
-              placeholder={config.localization.roleNamePlaceholder}
-              required
-              value={name()}
-            />
-          </Field>
+            <form.AppField
+              name="name"
+              validators={{
+                onChange: ({ value }) =>
+                  validateStringLength(value, {
+                    requiredMessage: auth.localization.auth.fieldRequired,
+                    trim: true
+                  })
+              }}
+            >
+              {(field) => {
+                const isInvalid = () =>
+                  isAuthFormFieldInvalid(field().state.meta)
+                return (
+                  <Field data-invalid={isInvalid()}>
+                    <FieldLabel for="organization-role-name">
+                      {config.localization.roleName}
+                    </FieldLabel>
+                    <Input
+                      aria-invalid={isInvalid()}
+                      disabled={pending()}
+                      id="organization-role-name"
+                      name={field().name}
+                      onBlur={field().handleBlur}
+                      onInput={(event) =>
+                        field().handleChange(event.currentTarget.value)
+                      }
+                      placeholder={config.localization.roleNamePlaceholder}
+                      value={field().state.value}
+                    />
+                    <FieldError
+                      errors={getFormFieldErrors(field().state.meta.errors)}
+                    />
+                  </Field>
+                )
+              }}
+            </form.AppField>
 
-          <For each={fieldsWithModelValues(props.roleFields, props.role ?? {})}>
-            {(field) => (
-              <AdditionalField
-                field={field}
-                isPending={pending()}
-                name={field.name}
-                optionalLabel={auth.localization.settings.optional}
-              />
-            )}
-          </For>
-
-          <fieldset class="flex flex-col gap-4">
-            <legend class="text-sm font-medium">
-              {config.localization.permissions}
-            </legend>
-            <For each={Object.entries(props.registry)}>
-              {([resource, definition]) => (
-                <div class="flex flex-col gap-2">
-                  <p class="text-sm font-medium">
-                    {definition.label ?? resource}
-                  </p>
-                  <div class="grid gap-3 sm:grid-cols-2">
-                    <For each={Object.entries(definition.actions)}>
-                      {([action, label]) => (
-                        <RolePermissionCheckbox
-                          action={action}
-                          checked={
-                            permission()[resource]?.includes(action) ?? false
-                          }
-                          label={label}
-                          onChange={(selected) =>
-                            setPermission((current) => ({
-                              ...current,
-                              [resource]: selected
-                                ? [...(current[resource] ?? []), action]
-                                : (current[resource] ?? []).filter(
-                                    (entry) => entry !== action
-                                  )
-                            }))
-                          }
-                          organizationId={props.organizationId}
-                          pending={pending()}
-                          resource={resource}
-                        />
-                      )}
-                    </For>
-                  </div>
-                </div>
+            <For each={configuredRoleFields()}>
+              {(configuredField) => (
+                <form.AppField
+                  name={`additionalFields.${configuredField.name}`}
+                  validators={getAuthAdditionalFieldValidators(
+                    configuredField,
+                    auth.localization.auth.fieldRequired
+                  )}
+                >
+                  {(field) => (
+                    <field.AuthFormAdditionalField
+                      field={configuredField}
+                      isPending={pending()}
+                      optionalLabel={auth.localization.settings.optional}
+                    />
+                  )}
+                </form.AppField>
               )}
             </For>
-          </fieldset>
 
-          <DialogFooter>
-            <Button
-              disabled={pending()}
-              onClick={() => props.onOpenChange(false)}
-              type="button"
-              variant="outline"
-            >
-              {auth.localization.settings.cancel}
-            </Button>
-            <Button disabled={pending() || !name().trim()} type="submit">
-              {auth.localization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
-        </form>
+            <form.AppField name="permission">
+              {(field) => (
+                <fieldset class="flex flex-col gap-4">
+                  <legend class="text-sm font-medium">
+                    {config.localization.permissions}
+                  </legend>
+                  <For each={Object.entries(props.registry)}>
+                    {([resource, definition]) => (
+                      <div class="flex flex-col gap-2">
+                        <p class="text-sm font-medium">
+                          {definition.label ?? resource}
+                        </p>
+                        <div class="grid gap-3 sm:grid-cols-2">
+                          <For each={Object.entries(definition.actions)}>
+                            {([action, label]) => (
+                              <RolePermissionCheckbox
+                                action={action}
+                                checked={
+                                  field().state.value[resource]?.includes(
+                                    action
+                                  ) ?? false
+                                }
+                                label={label}
+                                onChange={(selected) =>
+                                  field().handleChange({
+                                    ...field().state.value,
+                                    [resource]: selected
+                                      ? [
+                                          ...(field().state.value[resource] ??
+                                            []),
+                                          action
+                                        ]
+                                      : (
+                                          field().state.value[resource] ?? []
+                                        ).filter((entry) => entry !== action)
+                                  })
+                                }
+                                organizationId={props.organizationId}
+                                pending={pending()}
+                                resource={resource}
+                              />
+                            )}
+                          </For>
+                        </div>
+                      </div>
+                    )}
+                  </For>
+                </fieldset>
+              )}
+            </form.AppField>
+
+            <DialogFooter>
+              <Button
+                disabled={pending()}
+                onClick={() => props.onOpenChange(false)}
+                type="button"
+                variant="outline"
+              >
+                {auth.localization.settings.cancel}
+              </Button>
+              <form.AuthFormSubmitButton disabled={pending()}>
+                {auth.localization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-teams.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-teams.tsx
@@ -1,7 +1,10 @@
 import {
   type AdditionalFields,
   fieldsWithModelValues,
-  parseAdditionalFieldValues
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  getFormFieldErrors,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type { OrganizationTeamsAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/solid"
@@ -19,7 +22,6 @@ import {
   useUpdateTeam
 } from "@better-auth-ui/solid/plugins/organization"
 import {
-  LoaderCircle,
   Pencil,
   Plus,
   Trash2,
@@ -40,7 +42,7 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldLabel } from "@/components/ui/field"
+import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import {
   Select,
@@ -50,7 +52,11 @@ import {
   SelectValue
 } from "@/components/ui/select"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  createAuthForm,
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid
+} from "../auth-form"
 
 type MemberOption = { id: string; label: string }
 type Team = { id: string; name: string; [key: string]: unknown }
@@ -209,8 +215,6 @@ function TeamDialog(props: {
     organizationId: props.organizationId,
     permissions: { member: ["delete"] }
   }))
-  const [name, setName] = createSignal("")
-  const [isSubmittingFields, setIsSubmittingFields] = createSignal(false)
   const [selectedMember, setSelectedMember] = createSignal<MemberOption>()
   const createTeam = useCreateTeam(auth.authClient, () => ({
     onSuccess: () => {
@@ -256,293 +260,331 @@ function TeamDialog(props: {
       : config.localization.lastTeamRemovalDisabled
   const canEdit = () => !props.team || canUpdate.data?.success === true
 
+  const configuredTeamFields = () =>
+    fieldsWithModelValues(props.teamFields, props.team ?? {})
+  const form = createAuthForm(() => ({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredTeamFields()),
+      name: props.team?.name ?? ""
+    },
+    onSubmit: async ({ value }) => {
+      const name = value.name.trim()
+      if (
+        !name ||
+        !props.organizationId ||
+        (!props.team && props.teamLimitReached)
+      )
+        return
+      if (props.team && !canUpdate.data?.success) return
+
+      const data = {
+        ...getAdditionalFieldSubmitValues(
+          configuredTeamFields(),
+          value.additionalFields
+        ),
+        name,
+        organizationId: props.organizationId
+      }
+
+      try {
+        if (props.team) {
+          await updateTeam.mutateAsync({ teamId: props.team.id, data })
+        } else {
+          await createTeam.mutateAsync(data)
+        }
+      } catch {
+        // The mutation reports the error through its configured handler.
+      }
+    }
+  }))
+
   createEffect(() => {
     if (!props.open) return
-    setName(props.team?.name ?? "")
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredTeamFields()),
+      name: props.team?.name ?? ""
+    })
     setSelectedMember(undefined)
   })
 
-  const handleSubmit = async (event: SubmitEvent) => {
-    event.preventDefault()
-    const trimmedName = name().trim()
-    if (
-      !trimmedName ||
-      !props.organizationId ||
-      (!props.team && props.teamLimitReached)
-    )
-      return
-    if (props.team && !canUpdate.data?.success) return
-
-    setIsSubmittingFields(true)
-    try {
-      const values = await parseAdditionalFieldValues(
-        props.teamFields,
-        new FormData(event.currentTarget as HTMLFormElement)
-      )
-      if (props.team) {
-        updateTeam.mutate(
-          {
-            teamId: props.team.id,
-            data: {
-              ...values,
-              name: trimmedName,
-              organizationId: props.organizationId
-            }
-          },
-          { onSettled: () => setIsSubmittingFields(false) }
-        )
-      } else {
-        createTeam.mutate(
-          {
-            ...values,
-            name: trimmedName,
-            organizationId: props.organizationId
-          },
-          { onSettled: () => setIsSubmittingFields(false) }
-        )
-      }
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : String(error))
-      setIsSubmittingFields(false)
-    }
-  }
-
-  const pending = () =>
-    createTeam.isPending || updateTeam.isPending || isSubmittingFields()
+  const pending = () => createTeam.isPending || updateTeam.isPending
 
   return (
     <Dialog open={props.open} onOpenChange={props.onOpenChange}>
       <DialogContent class="max-h-[85vh] overflow-y-auto sm:max-w-lg">
-        <form class="flex flex-col gap-6" onSubmit={handleSubmit}>
-          <DialogHeader>
-            <div class="flex size-10 items-center justify-center rounded-md bg-muted">
-              <Users class="size-4.5" />
-            </div>
-            <DialogTitle>
-              {props.team
-                ? config.localization.renameTeam
-                : config.localization.createTeam}
-            </DialogTitle>
-            <DialogDescription>
-              {config.localization.teamsDescription}
-            </DialogDescription>
-          </DialogHeader>
-
-          <div class="flex flex-col gap-4">
-            <Field>
-              <FieldLabel for="organization-team-name">
-                {config.localization.name}
-              </FieldLabel>
-              <Input
-                autofocus
-                disabled={pending() || !canEdit()}
-                id="organization-team-name"
-                onInput={(event) => setName(event.currentTarget.value)}
-                required
-                value={name()}
-              />
-            </Field>
-
-            <For
-              each={fieldsWithModelValues(props.teamFields, props.team ?? {})}
-            >
-              {(field) => (
-                <AdditionalField
-                  field={field}
-                  isPending={pending() || !canEdit()}
-                  name={field.name}
-                  optionalLabel={auth.localization.settings.optional}
-                />
-              )}
-            </For>
-          </div>
-
-          <Show when={props.team && props.canListMembers}>
-            <div class="flex flex-col gap-4 border-t pt-5">
-              <div>
-                <h3 class="text-sm font-medium">
-                  {config.localization.teamMembers}
-                </h3>
-                <p class="text-sm text-muted-foreground">
-                  {config.localization.addTeamMember}
-                </p>
+        <form.AppForm>
+          <form.AuthFormRoot class="flex flex-col gap-6">
+            <DialogHeader>
+              <div class="flex size-10 items-center justify-center rounded-md bg-muted">
+                <Users class="size-4.5" />
               </div>
+              <DialogTitle>
+                {props.team
+                  ? config.localization.renameTeam
+                  : config.localization.createTeam}
+              </DialogTitle>
+              <DialogDescription>
+                {config.localization.teamsDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-              <Show when={canAddMember.isPending || canAddMember.data?.success}>
-                <div class="flex flex-col items-stretch gap-2 sm:flex-row sm:items-end">
-                  <Field class="flex-1">
-                    <FieldLabel>{config.localization.addTeamMember}</FieldLabel>
-                    <Select<MemberOption>
-                      disabled={canAddMember.isPending || memberLimitReached()}
-                      itemComponent={(itemProps) => (
-                        <SelectItem item={itemProps.item}>
-                          {itemProps.item.rawValue.label}
-                        </SelectItem>
-                      )}
-                      onChange={(value) =>
-                        setSelectedMember(value ?? undefined)
-                      }
-                      options={memberOptions()}
-                      optionTextValue="label"
-                      optionValue="id"
-                      value={selectedMember()}
-                    >
-                      <SelectTrigger class="w-full">
-                        <SelectValue<MemberOption>>
-                          {(state) =>
-                            (state.selectedOption() as MemberOption | undefined)
-                              ?.label
-                          }
-                        </SelectValue>
-                      </SelectTrigger>
-                      <SelectContent />
-                    </Select>
-                  </Field>
-                  <Button
-                    disabled={
-                      canAddMember.isPending ||
-                      !selectedMember() ||
-                      addMember.isPending ||
-                      memberLimitReached()
-                    }
-                    onClick={() => {
-                      const member = selectedMember()
-                      if (!canAddMember.data?.success || !member || !props.team)
-                        return
-                      addMember.mutate({
-                        teamId: props.team.id,
-                        userId: member.id,
-                        organizationId: props.organizationId
-                      })
-                    }}
-                    type="button"
-                  >
-                    <UserPlus />
-                    {config.localization.addTeamMember}
-                  </Button>
-                </div>
-              </Show>
-
-              <Show when={canAddMember.data?.success && memberLimitReached()}>
-                <p class="text-destructive text-sm" role="alert">
-                  {config.localization.teamMemberLimitReached}
-                </p>
-              </Show>
-
-              <div class="flex flex-col gap-2">
-                <For each={teamMembers.data}>
-                  {(teamMember) => {
-                    const member = () =>
-                      props.organizationMembers.find(
-                        (candidate) => candidate.userId === teamMember.userId
-                      )
-                    return (
-                      <div class="flex items-center justify-between gap-3 rounded-md border px-3 py-2">
-                        <span class="truncate text-sm">
-                          {member()?.user.name ||
-                            member()?.user.email ||
-                            teamMember.userId}
-                        </span>
-                        <Show
-                          when={
-                            canRemoveMember.isPending ||
-                            canRemoveMember.data?.success
-                          }
-                        >
-                          <Button
-                            aria-label={config.localization.removeTeamMember}
-                            disabled={
-                              canRemoveMember.isPending ||
-                              removeMember.isPending
-                            }
-                            onClick={() => {
-                              if (!canRemoveMember.data?.success || !props.team)
-                                return
-                              removeMember.mutate({
-                                teamId: props.team.id,
-                                userId: teamMember.userId,
-                                organizationId: props.organizationId
-                              })
-                            }}
-                            size="icon-sm"
-                            type="button"
-                            variant="ghost"
-                          >
-                            <UserRoundMinus />
-                          </Button>
-                        </Show>
-                      </div>
-                    )
-                  }}
-                </For>
-              </div>
-            </div>
-          </Show>
-
-          <Show
-            when={props.team && !canRemoveTeam() && canDelete.data?.success}
-          >
-            <p class="text-sm text-muted-foreground">
-              {teamRemovalDisabledReason()}
-            </p>
-          </Show>
-
-          <DialogFooter class="sm:justify-between">
-            <Show
-              when={
-                props.team && (canDelete.isPending || canDelete.data?.success)
-              }
-            >
-              <Button
-                disabled={
-                  canDelete.isPending ||
-                  removeTeam.isPending ||
-                  !canRemoveTeam()
-                }
-                onClick={() => {
-                  if (!props.team) return
-                  removeTeam.mutate({
-                    teamId: props.team.id,
-                    organizationId: props.organizationId
-                  })
+            <div class="flex flex-col gap-4">
+              <form.AppField
+                name="name"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: auth.localization.auth.fieldRequired,
+                      trim: true
+                    })
                 }}
-                type="button"
-                variant="destructive"
               >
-                <Trash2 />
-                {config.localization.deleteTeam}
-              </Button>
+                {(field) => {
+                  const isInvalid = () =>
+                    isAuthFormFieldInvalid(field().state.meta)
+                  return (
+                    <Field data-invalid={isInvalid()}>
+                      <FieldLabel for="organization-team-name">
+                        {config.localization.name}
+                      </FieldLabel>
+                      <Input
+                        aria-invalid={isInvalid()}
+                        autofocus
+                        disabled={pending() || !canEdit()}
+                        id="organization-team-name"
+                        name={field().name}
+                        onBlur={field().handleBlur}
+                        onInput={(event) =>
+                          field().handleChange(event.currentTarget.value)
+                        }
+                        value={field().state.value}
+                      />
+                      <FieldError
+                        errors={getFormFieldErrors(field().state.meta.errors)}
+                      />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+
+              <For each={configuredTeamFields()}>
+                {(configuredField) => (
+                  <form.AppField
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      auth.localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={pending() || !canEdit()}
+                        optionalLabel={auth.localization.settings.optional}
+                      />
+                    )}
+                  </form.AppField>
+                )}
+              </For>
+            </div>
+
+            <Show when={props.team && props.canListMembers}>
+              <div class="flex flex-col gap-4 border-t pt-5">
+                <div>
+                  <h3 class="text-sm font-medium">
+                    {config.localization.teamMembers}
+                  </h3>
+                  <p class="text-sm text-muted-foreground">
+                    {config.localization.addTeamMember}
+                  </p>
+                </div>
+
+                <Show
+                  when={canAddMember.isPending || canAddMember.data?.success}
+                >
+                  <div class="flex flex-col items-stretch gap-2 sm:flex-row sm:items-end">
+                    <Field class="flex-1">
+                      <FieldLabel>
+                        {config.localization.addTeamMember}
+                      </FieldLabel>
+                      <Select<MemberOption>
+                        disabled={
+                          canAddMember.isPending || memberLimitReached()
+                        }
+                        itemComponent={(itemProps) => (
+                          <SelectItem item={itemProps.item}>
+                            {itemProps.item.rawValue.label}
+                          </SelectItem>
+                        )}
+                        onChange={(value) =>
+                          setSelectedMember(value ?? undefined)
+                        }
+                        options={memberOptions()}
+                        optionTextValue="label"
+                        optionValue="id"
+                        value={selectedMember()}
+                      >
+                        <SelectTrigger class="w-full">
+                          <SelectValue<MemberOption>>
+                            {(state) =>
+                              (
+                                state.selectedOption() as
+                                  | MemberOption
+                                  | undefined
+                              )?.label
+                            }
+                          </SelectValue>
+                        </SelectTrigger>
+                        <SelectContent />
+                      </Select>
+                    </Field>
+                    <Button
+                      disabled={
+                        canAddMember.isPending ||
+                        !selectedMember() ||
+                        addMember.isPending ||
+                        memberLimitReached()
+                      }
+                      onClick={() => {
+                        const member = selectedMember()
+                        if (
+                          !canAddMember.data?.success ||
+                          !member ||
+                          !props.team
+                        )
+                          return
+                        addMember.mutate({
+                          teamId: props.team.id,
+                          userId: member.id,
+                          organizationId: props.organizationId
+                        })
+                      }}
+                      type="button"
+                    >
+                      <UserPlus />
+                      {config.localization.addTeamMember}
+                    </Button>
+                  </div>
+                </Show>
+
+                <Show when={canAddMember.data?.success && memberLimitReached()}>
+                  <p class="text-destructive text-sm" role="alert">
+                    {config.localization.teamMemberLimitReached}
+                  </p>
+                </Show>
+
+                <div class="flex flex-col gap-2">
+                  <For each={teamMembers.data}>
+                    {(teamMember) => {
+                      const member = () =>
+                        props.organizationMembers.find(
+                          (candidate) => candidate.userId === teamMember.userId
+                        )
+                      return (
+                        <div class="flex items-center justify-between gap-3 rounded-md border px-3 py-2">
+                          <span class="truncate text-sm">
+                            {member()?.user.name ||
+                              member()?.user.email ||
+                              teamMember.userId}
+                          </span>
+                          <Show
+                            when={
+                              canRemoveMember.isPending ||
+                              canRemoveMember.data?.success
+                            }
+                          >
+                            <Button
+                              aria-label={config.localization.removeTeamMember}
+                              disabled={
+                                canRemoveMember.isPending ||
+                                removeMember.isPending
+                              }
+                              onClick={() => {
+                                if (
+                                  !canRemoveMember.data?.success ||
+                                  !props.team
+                                )
+                                  return
+                                removeMember.mutate({
+                                  teamId: props.team.id,
+                                  userId: teamMember.userId,
+                                  organizationId: props.organizationId
+                                })
+                              }}
+                              size="icon-sm"
+                              type="button"
+                              variant="ghost"
+                            >
+                              <UserRoundMinus />
+                            </Button>
+                          </Show>
+                        </div>
+                      )
+                    }}
+                  </For>
+                </div>
+              </div>
             </Show>
 
-            <div class="flex flex-col-reverse gap-2 sm:flex-row">
-              <DialogClose
-                as={Button}
-                disabled={pending()}
-                type="button"
-                variant="outline"
+            <Show
+              when={props.team && !canRemoveTeam() && canDelete.data?.success}
+            >
+              <p class="text-sm text-muted-foreground">
+                {teamRemovalDisabledReason()}
+              </p>
+            </Show>
+
+            <DialogFooter class="sm:justify-between">
+              <Show
+                when={
+                  props.team && (canDelete.isPending || canDelete.data?.success)
+                }
               >
-                {auth.localization.settings.cancel}
-              </DialogClose>
-              <Show when={canEdit()}>
                 <Button
                   disabled={
-                    pending() ||
-                    !name().trim() ||
-                    (props.teamLimitReached && !props.team)
+                    canDelete.isPending ||
+                    removeTeam.isPending ||
+                    !canRemoveTeam()
                   }
-                  type="submit"
+                  onClick={() => {
+                    if (!props.team) return
+                    removeTeam.mutate({
+                      teamId: props.team.id,
+                      organizationId: props.organizationId
+                    })
+                  }}
+                  type="button"
+                  variant="destructive"
                 >
-                  <Show when={pending()}>
-                    <LoaderCircle class="animate-spin" />
-                  </Show>
-                  {props.team
-                    ? auth.localization.settings.saveChanges
-                    : config.localization.createTeam}
+                  <Trash2 />
+                  {config.localization.deleteTeam}
                 </Button>
               </Show>
-            </div>
-          </DialogFooter>
-        </form>
+
+              <div class="flex flex-col-reverse gap-2 sm:flex-row">
+                <DialogClose
+                  as={Button}
+                  disabled={pending()}
+                  type="button"
+                  variant="outline"
+                >
+                  {auth.localization.settings.cancel}
+                </DialogClose>
+                <Show when={canEdit()}>
+                  <form.AuthFormSubmitButton
+                    disabled={
+                      pending() || (props.teamLimitReached && !props.team)
+                    }
+                  >
+                    {props.team
+                      ? auth.localization.settings.saveChanges
+                      : config.localization.createTeam}
+                  </form.AuthFormSubmitButton>
+                </Show>
+              </div>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/settings/account/user-profile.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/settings/account/user-profile.tsx
@@ -1,15 +1,21 @@
 import {
-  type AdditionalFieldValue,
-  parseAdditionalFieldValue
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  getFormFieldErrors,
+  validateStringLength
 } from "@better-auth-ui/core"
 import { useAuth, useSession, useUpdateUser } from "@better-auth-ui/solid"
-import { createSignal, For } from "solid-js"
+import { createEffect, For } from "solid-js"
 import { toast } from "solid-sonner"
-import { AdditionalField } from "@/components/auth/additional-field"
+import {
+  createAuthForm,
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid
+} from "@/components/auth/auth-form"
 import { ChangeAvatar } from "@/components/auth/settings/account/change-avatar"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Field, FieldLabel } from "@/components/ui/field"
+import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
 
@@ -20,111 +26,127 @@ export type UserProfileProps = {
 export function UserProfile(props: UserProfileProps = {}) {
   const auth = useAuth()
   const session = useSession(auth.authClient)
-  const [name, setName] = createSignal("")
-  const { mutate: updateUser, isPending: updateUserPending } = useUpdateUser(
-    auth.authClient,
-    () => ({
+  const { mutateAsync: updateUser, isPending: updateUserPending } =
+    useUpdateUser(auth.authClient, () => ({
       onSuccess: () =>
         toast.success(auth.localization.settings.profileUpdatedSuccess)
-    })
-  )
+    }))
 
   const profileFields = () =>
     auth.additionalFields?.filter((field) => field.profile !== false) ?? []
-
-  const submitProfile = async (event: SubmitEvent) => {
-    event.preventDefault()
-
-    const formData = new FormData(event.currentTarget as HTMLFormElement)
-    const name = String(formData.get("name") ?? "")
-    const additionalFieldValues: Record<string, unknown> = {}
-
-    for (const field of auth.additionalFields ?? []) {
-      if (field.profile === false || field.readOnly) continue
-
-      const value = parseAdditionalFieldValue(
-        field,
-        formData.get(field.name) as string | null
-      )
-
-      if (field.validate) {
-        try {
-          await field.validate(value)
-        } catch (error) {
-          toast.error(error instanceof Error ? error.message : String(error))
-          return
-        }
-      }
-
-      if (value !== undefined) {
-        additionalFieldValues[field.name] = value
-      }
+  const form = createAuthForm(() => ({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(profileFields()),
+      name: ""
+    },
+    onSubmit: async ({ value }) => {
+      await updateUser({
+        name: value.name,
+        ...getAdditionalFieldSubmitValues(
+          profileFields(),
+          value.additionalFields
+        )
+      })
     }
+  }))
 
-    updateUser({
-      name,
-      ...additionalFieldValues
+  createEffect(() => {
+    const currentSession = session.data
+    if (!currentSession) return
+
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(
+        fieldsWithModelValues(
+          profileFields(),
+          currentSession.user as Record<string, unknown>
+        )
+      ),
+      name: currentSession.user.name
     })
-  }
+  })
 
   return (
     <div class={cn(props.class)}>
       <h2 class="mb-3 text-sm font-semibold">
         {auth.localization.settings.userProfile}
       </h2>
-      <form aria-label="Profile" onSubmit={submitProfile}>
-        <Card>
-          <CardContent class="flex flex-col gap-6">
-            <ChangeAvatar />
+      <form.AppForm>
+        <form.AuthFormRoot aria-label="Profile">
+          <Card>
+            <CardContent class="flex flex-col gap-6">
+              <ChangeAvatar />
 
-            <Field>
-              <FieldLabel for="settings-name">
-                {auth.localization.auth.name}
-              </FieldLabel>
-              <Input
-                autocomplete="name"
-                disabled={updateUserPending}
-                id="settings-name"
+              <form.AppField
                 name="name"
-                onInput={(event) => setName(event.currentTarget.value)}
-                placeholder={auth.localization.auth.name}
-                required
-                value={name() || (session.data?.user.name ?? "")}
-              />
-            </Field>
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: auth.localization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
+              >
+                {(field) => {
+                  const isInvalid = () =>
+                    isAuthFormFieldInvalid(field().state.meta)
 
-            <For each={profileFields()}>
-              {(field) => {
-                const value = () =>
-                  (session.data?.user as Record<string, unknown> | undefined)?.[
-                    field.name
-                  ]
+                  return (
+                    <Field data-invalid={isInvalid()}>
+                      <FieldLabel for="settings-name">
+                        {auth.localization.auth.name}
+                      </FieldLabel>
+                      <Input
+                        aria-invalid={isInvalid()}
+                        autocomplete="name"
+                        disabled={updateUserPending}
+                        id="settings-name"
+                        name={field().name}
+                        onBlur={field().handleBlur}
+                        onInput={(event) =>
+                          field().handleChange(event.currentTarget.value)
+                        }
+                        placeholder={auth.localization.auth.name}
+                        value={field().state.value}
+                      />
+                      <FieldError
+                        errors={getFormFieldErrors(field().state.meta.errors)}
+                      />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
 
-                return (
-                  <AdditionalField
-                    field={{
-                      ...field,
-                      defaultValue: value() as AdditionalFieldValue | null
-                    }}
-                    isPending={updateUserPending || !session.data}
-                    name={field.name}
-                  />
-                )
-              }}
-            </For>
-          </CardContent>
-          <CardFooter>
-            <Button
-              aria-label="Save changes"
-              disabled={updateUserPending || !session.data}
-              size="sm"
-              type="submit"
-            >
-              {auth.localization.settings.saveChanges}
-            </Button>
-          </CardFooter>
-        </Card>
-      </form>
+              <For each={profileFields()}>
+                {(configuredField) => (
+                  <form.AppField
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      auth.localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={updateUserPending || !session.data}
+                      />
+                    )}
+                  </form.AppField>
+                )}
+              </For>
+            </CardContent>
+            <CardFooter>
+              <form.AuthFormSubmitButton
+                aria-label="Save changes"
+                disabled={updateUserPending || !session.data}
+                size="sm"
+              >
+                {auth.localization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/examples/start-solid-zaidan-example/src/components/auth/sign-up.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/sign-up.tsx
@@ -1,9 +1,10 @@
 import {
   authQueryKeys,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
   getAuthLinkURL,
   getFormFieldErrors,
   isPasswordCompromisedError,
-  parseAdditionalFieldValue,
   validateEmailAddress,
   validateMatchingValue,
   validateStringLength
@@ -19,15 +20,17 @@ import {
 import { useQueryClient } from "@tanstack/solid-query"
 import { Eye, EyeOff } from "lucide-solid"
 import { createSignal, For, Show } from "solid-js"
-import { toast } from "solid-sonner"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
-import { AdditionalField } from "./additional-field"
-import { createAuthForm, isAuthFormFieldInvalid } from "./auth-form"
+import {
+  createAuthForm,
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid
+} from "./auth-form"
 import { PasswordStrengthMeter } from "./password-strength-meter"
 import { ProviderButtons, type SocialLayout } from "./provider-buttons"
 
@@ -98,9 +101,10 @@ export function SignUp(props: SignUpProps) {
     auth.additionalFields?.filter(
       (field) => field.signUp && field.signUp !== "above"
     ) ?? []
-  let additionalFieldValues: Record<string, unknown> = {}
+  const signUpFields = () => [...signUpFieldsAbove(), ...signUpFieldsBelow()]
   const form = createAuthForm(() => ({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(signUpFields()),
       confirmPassword: "",
       email: "",
       name: "",
@@ -113,42 +117,16 @@ export function SignUp(props: SignUpProps) {
           fetchOptions: fetchOptions(),
           name: auth.emailAndPassword.name ? value.name : "",
           password: value.password,
-          ...additionalFieldValues
+          ...getAdditionalFieldSubmitValues(
+            signUpFields(),
+            value.additionalFields
+          )
         } as Parameters<typeof signUp.mutate>[0])
       } catch {
         // The mutation reports the error through its configured handler.
       }
     }
   }))
-
-  const prepareSubmit = async (formElement: HTMLFormElement) => {
-    const formData = new FormData(formElement)
-    const values: Record<string, unknown> = {}
-
-    for (const field of auth.additionalFields ?? []) {
-      if (!field.signUp || field.readOnly) continue
-
-      const value = parseAdditionalFieldValue(
-        field,
-        formData.get(field.name) as string | null
-      )
-
-      if (field.validate) {
-        try {
-          await field.validate(value)
-        } catch (error) {
-          toast.error(error instanceof Error ? error.message : String(error))
-          return false
-        }
-      }
-
-      if (value !== undefined) {
-        values[field.name] = value
-      }
-    }
-
-    additionalFieldValues = values
-  }
 
   return (
     <Card class={cn("w-full max-w-sm", props.class)}>
@@ -172,7 +150,7 @@ export function SignUp(props: SignUpProps) {
         </Show>
 
         <form.AppForm>
-          <form.AuthFormRoot aria-label="Sign up" prepareSubmit={prepareSubmit}>
+          <form.AuthFormRoot aria-label="Sign up">
             <div class="flex flex-col gap-6">
               <Show when={auth.emailAndPassword.name}>
                 <form.AppField
@@ -259,13 +237,22 @@ export function SignUp(props: SignUpProps) {
                 }}
               </form.AppField>
               <For each={signUpFieldsAbove()}>
-                {(field) => (
-                  <AdditionalField
-                    field={field}
-                    isPending={signUp.isPending}
-                    name={field.name}
-                    optionalLabel={auth.localization.auth.optional}
-                  />
+                {(configuredField) => (
+                  <form.AppField
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      auth.localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={signUp.isPending}
+                        optionalLabel={auth.localization.auth.optional}
+                      />
+                    )}
+                  </form.AppField>
                 )}
               </For>
               <form.AppField
@@ -456,13 +443,22 @@ export function SignUp(props: SignUpProps) {
                 </form.AppField>
               </Show>
               <For each={signUpFieldsBelow()}>
-                {(field) => (
-                  <AdditionalField
-                    field={field}
-                    isPending={signUp.isPending}
-                    name={field.name}
-                    optionalLabel={auth.localization.auth.optional}
-                  />
+                {(configuredField) => (
+                  <form.AppField
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      auth.localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={signUp.isPending}
+                        optionalLabel={auth.localization.auth.optional}
+                      />
+                    )}
+                  </form.AppField>
                 )}
               </For>
               <Show when={captchaComponent()} keyed>

--- a/examples/start-solid-zaidan-example/src/components/auth/username/username-field.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/username/username-field.tsx
@@ -1,3 +1,4 @@
+import { getFormFieldErrors } from "@better-auth-ui/core"
 import type { UsernameAuthClient } from "@better-auth-ui/core/plugins/username"
 import { useAuth } from "@better-auth-ui/solid"
 import { useIsUsernameAvailable } from "@better-auth-ui/solid/plugins/username"
@@ -28,19 +29,20 @@ export function UsernameField(props: AdditionalFieldProps) {
         }
       | undefined
   const currentUsername = String(props.field.defaultValue ?? "")
-  const [value, setValue] = createSignal(currentUsername)
-  const [error, setError] = createSignal<string>()
+  const username = () => (typeof props.value === "string" ? props.value : "")
+  const [nativeError, setNativeError] = createSignal<string>()
+  const fieldErrors = () => getFormFieldErrors(props.errors ?? [])
   const availability = useIsUsernameAvailable(auth.authClient, () => ({
     onError: () => undefined
   }))
   const shouldCheckAvailability = () =>
     Boolean(usernamePlugin()?.isUsernameAvailable) &&
-    Boolean(value().trim()) &&
-    value().trim() !== currentUsername
+    Boolean(username().trim()) &&
+    username().trim() !== currentUsername
 
   const handleInput = (next: string) => {
-    setValue(next)
-    setError(undefined)
+    props.onChange(next || null)
+    setNativeError(undefined)
 
     if (shouldCheckAvailability()) {
       availability.mutate({ username: next.trim() })
@@ -50,27 +52,28 @@ export function UsernameField(props: AdditionalFieldProps) {
   }
 
   return (
-    <Field data-invalid={Boolean(error())}>
+    <Field data-invalid={props.isInvalid || Boolean(nativeError())}>
       <FieldLabel for={props.name}>{props.field.label}</FieldLabel>
       <InputGroup>
         <InputGroupInput
-          aria-invalid={Boolean(error())}
+          aria-invalid={props.isInvalid || Boolean(nativeError())}
           autocomplete="username"
           disabled={props.isPending}
           id={props.name}
           maxLength={usernamePlugin()?.maxUsernameLength}
           minLength={usernamePlugin()?.minUsernameLength}
           name={props.name}
+          onBlur={props.onBlur}
           onInput={(event) => handleInput(event.currentTarget.value)}
           onInvalid={(event) => {
             event.preventDefault()
-            setError(event.currentTarget.validationMessage)
+            setNativeError(event.currentTarget.validationMessage)
           }}
           placeholder={props.field.placeholder}
           readonly={props.field.readOnly}
           required={props.field.required}
           type="text"
-          value={value()}
+          value={username()}
         />
         <Show when={usernamePlugin()?.usernamePrefix}>
           {(usernamePrefix) => (
@@ -101,9 +104,7 @@ export function UsernameField(props: AdditionalFieldProps) {
           </InputGroupAddon>
         </Show>
       </InputGroup>
-      <Show when={error()}>
-        {(message) => <FieldError>{message()}</FieldError>}
-      </Show>
+      <FieldError errors={fieldErrors()}>{nativeError()}</FieldError>
     </Field>
   )
 }

--- a/examples/start-solid-zaidan-example/tests/auth-form.browser.test.tsx
+++ b/examples/start-solid-zaidan-example/tests/auth-form.browser.test.tsx
@@ -23,10 +23,7 @@ function NativeValidationForm() {
   )
 }
 
-function PendingAuthForm(props: {
-  onSubmit: () => void
-  prepareSubmit: () => Promise<boolean>
-}) {
+function PendingAuthForm(props: { onSubmit: () => Promise<void> }) {
   const form = createAuthForm(() => ({
     defaultValues: {},
     onSubmit: props.onSubmit
@@ -34,7 +31,7 @@ function PendingAuthForm(props: {
 
   return (
     <form.AppForm>
-      <form.AuthFormRoot prepareSubmit={props.prepareSubmit}>
+      <form.AuthFormRoot>
         <form.AuthFormSubmitButton>Submit</form.AuthFormSubmitButton>
       </form.AuthFormRoot>
     </form.AppForm>
@@ -55,16 +52,13 @@ describe("Solid auth form", () => {
     expect(document.activeElement).toBe(firstControl)
   })
 
-  it("rejects concurrent preparation and exposes its pending state", async () => {
-    let finishPreparation!: (result: boolean) => void
-    const preparation = new Promise<boolean>((resolve) => {
-      finishPreparation = resolve
+  it("rejects concurrent submission and exposes its pending state", async () => {
+    let finishSubmission!: () => void
+    const submission = new Promise<void>((resolve) => {
+      finishSubmission = resolve
     })
-    const prepareSubmit = vi.fn(() => preparation)
-    const onSubmit = vi.fn()
-    const view = render(() => (
-      <PendingAuthForm onSubmit={onSubmit} prepareSubmit={prepareSubmit} />
-    ))
+    const onSubmit = vi.fn(() => submission)
+    const view = render(() => <PendingAuthForm onSubmit={onSubmit} />)
     const formElement = view.container.querySelector("form")
     const submitButton = view.getByRole("button", { name: /Submit/ })
 
@@ -72,12 +66,12 @@ describe("Solid auth form", () => {
     fireEvent.submit(formElement as HTMLFormElement)
     fireEvent.submit(formElement as HTMLFormElement)
 
-    expect(prepareSubmit).toHaveBeenCalledOnce()
-    expect(submitButton).toBeDisabled()
+    await vi.waitFor(() => expect(onSubmit).toHaveBeenCalledOnce())
+    await vi.waitFor(() => expect(submitButton).toBeDisabled())
     expect(view.getByRole("status", { name: "Loading" })).toBeInTheDocument()
 
-    finishPreparation(true)
-    await vi.waitFor(() => expect(onSubmit).toHaveBeenCalledOnce())
+    finishSubmission()
+    await vi.waitFor(() => expect(submitButton).toBeEnabled())
   })
 })
 

--- a/examples/start-solid-zaidan-example/tests/auth-route.test.ts
+++ b/examples/start-solid-zaidan-example/tests/auth-route.test.ts
@@ -1580,28 +1580,20 @@ describe("Solid auth route component selection", () => {
       "utf8"
     )
 
-    expect(signUp).toContain("parseAdditionalFieldValue")
+    expect(signUp).toContain("getAdditionalFieldDefaultValues")
+    expect(signUp).toContain("getAdditionalFieldSubmitValues")
     expect(signUp).toContain('field.signUp === "above"')
     expect(signUp).toContain('field.signUp && field.signUp !== "above"')
-    expect(signUp).toContain("<AdditionalField")
-    expect(signUp).toContain("if (!field.signUp || field.readOnly) continue")
-    expect(signUp).toContain("await field.validate(value)")
-    expect(signUp).toContain("values[field.name] = value")
-    expect(signUp).toContain("additionalFieldValues = values")
-    expect(signUp).toContain("...additionalFieldValues")
+    expect(signUp).toContain("<field.AuthFormAdditionalField")
+    expect(signUp).toContain("getAuthAdditionalFieldValidators")
+    expect(signUp).toContain("value.additionalFields")
 
-    expect(userProfile).toContain("parseAdditionalFieldValue")
+    expect(userProfile).toContain("getAdditionalFieldDefaultValues")
+    expect(userProfile).toContain("getAdditionalFieldSubmitValues")
     expect(userProfile).toContain("field.profile !== false")
-    expect(userProfile).toContain("<AdditionalField")
-    expect(userProfile).toContain(
-      "if (field.profile === false || field.readOnly) continue"
-    )
-    expect(userProfile).toContain("await field.validate(value)")
-    expect(userProfile).toContain("additionalFieldValues[field.name] = value")
-    expect(userProfile).toContain("...additionalFieldValues")
-    expect(userProfile).toContain(
-      "defaultValue: value() as AdditionalFieldValue | null"
-    )
+    expect(userProfile).toContain("<field.AuthFormAdditionalField")
+    expect(userProfile).toContain("fieldsWithModelValues")
+    expect(userProfile).toContain("value.additionalFields")
   })
 
   it("keeps Auth view resolution reactive when the external view prop changes", () => {
@@ -1939,16 +1931,14 @@ describe("Solid auth route component selection", () => {
 
     expect(userProfile).toContain("useUpdateUser")
     expect(userProfile).toContain(
-      "const { mutate: updateUser, isPending: updateUserPending } = useUpdateUser"
+      "const { mutateAsync: updateUser, isPending: updateUserPending } ="
     )
-    expect(userProfile).toContain("onSubmit={submitProfile}")
-    expect(userProfile).toContain("const formData = new FormData")
-    expect(userProfile).toContain('formData.get("name")')
-    expect(userProfile).toContain("parseAdditionalFieldValue")
-    expect(userProfile).toContain("additionalFieldValues")
+    expect(userProfile).toContain("createAuthForm")
+    expect(userProfile).toContain("<form.AuthFormRoot")
+    expect(userProfile).toContain("getAdditionalFieldSubmitValues")
     expect(userProfile).toContain("updateUser({")
-    expect(userProfile).toContain("name,")
-    expect(userProfile).toContain("...additionalFieldValues")
+    expect(userProfile).toContain("name: value.name")
+    expect(userProfile).toContain("value.additionalFields")
     expect(userProfile).toContain("profileUpdatedSuccess")
     expect(userProfile).not.toContain(
       "Profile and avatar update mutations are not available in this Solid"
@@ -3645,10 +3635,7 @@ describe("Solid auth route component selection", () => {
     expect(inviteMemberDialog).toContain(
       "organizationId: activeOrganization.data?.id"
     )
-    expect(inviteMemberDialog).toContain(
-      "const invitationEmail = email().trim()"
-    )
-    expect(inviteMemberDialog).toContain("email: invitationEmail")
+    expect(inviteMemberDialog).toContain("email: value.email.trim()")
     expect(inviteMemberDialog).not.toContain("useCancelInvitation")
   })
 
@@ -3718,10 +3705,11 @@ describe("Solid auth route component selection", () => {
     expect(createDialog).toContain("open: boolean")
     expect(createDialog).toContain("onOpenChange: (open: boolean) => void")
     expect(createDialog).toContain("useCreateOrganization")
-    expect(createDialog).toContain("onSuccess: () => props.onOpenChange(false)")
-    expect(createDialog).toContain('setName("")')
-    expect(createDialog).toContain('setSlug("")')
-    expect(createDialog).toContain("setSlug(sanitizeSlug")
+    expect(createDialog).toContain("createAuthForm")
+    expect(createDialog).toContain("props.onOpenChange(false)")
+    expect(createDialog).toContain('name: ""')
+    expect(createDialog).toContain('slug: ""')
+    expect(createDialog).toContain('form.setFieldValue("slug", sanitizeSlug')
     expect(createDialog).toContain("SlugField")
     expect(createDialog).toContain('id="create-organization-slug"')
     expect(slugField).toContain("export function sanitizeSlug")

--- a/examples/start-solid-zaidan-example/tests/registry.test.ts
+++ b/examples/start-solid-zaidan-example/tests/registry.test.ts
@@ -1281,7 +1281,7 @@ describe("Solid registry isolation", () => {
     )
     expect(signUp).toContain("signUpFieldsAbove")
     expect(signUp).toContain("signUpFieldsBelow")
-    expect(signUp).toContain("parseAdditionalFieldValue")
+    expect(signUp).toContain("getAdditionalFieldSubmitValues")
     expect(signUp).toContain(
       "placeholder={auth.localization.auth.emailPlaceholder}"
     )
@@ -1692,8 +1692,10 @@ describe("Solid registry isolation", () => {
       /autocomplete=\{withPasskeyAutoFill\(\s*usernameAuth \? "username" : "email",\s*passkeyAutoFill\s*\)\}/
     )
 
-    expect(signUp).toContain("parseAdditionalFieldValue")
-    expect(signUp).toContain("additionalFieldValues")
+    expect(signUp).toContain("getAdditionalFieldSubmitValues")
+    expect(signUp).toContain(
+      "additionalFields: getAdditionalFieldDefaultValues"
+    )
     expect(signUp).not.toContain('name="username"')
     expect(signUp).not.toContain("username: username()")
   })

--- a/packages/core/src/config/additional-fields-config.ts
+++ b/packages/core/src/config/additional-fields-config.ts
@@ -4,6 +4,12 @@ export type AdditionalFieldType = "string" | "number" | "boolean" | "date"
 /** Runtime value held by an `AdditionalField` (matches `AdditionalFieldType`). */
 export type AdditionalFieldValue = string | number | boolean | Date
 
+/** Value stored for an additional field while it is owned by a form. */
+export type AdditionalFieldFormValue = AdditionalFieldValue | null
+
+/** Runtime additional-field values keyed by their configured model names. */
+export type AdditionalFieldFormValues = Record<string, AdditionalFieldFormValue>
+
 /** UI rendering choice. Default is inferred from `AdditionalField.type`. */
 export type AdditionalFieldInputType =
   | "input"
@@ -42,7 +48,16 @@ export type AdditionalFieldRenderProps = AdditionalFieldRegister extends {
   renderProps: infer P
 }
   ? P
-  : { name: string; field: AdditionalField; isPending?: boolean }
+  : {
+      name: string
+      field: AdditionalField
+      value: AdditionalFieldFormValue
+      onBlur: () => void
+      onChange: (value: AdditionalFieldFormValue) => void
+      isInvalid?: boolean
+      errors?: unknown[]
+      isPending?: boolean
+    }
 
 /** Resolved return type for `AdditionalField.render`. */
 export type AdditionalFieldRenderResult = AdditionalFieldRegister extends {
@@ -108,7 +123,7 @@ export interface AdditionalField {
    * Custom client-side validation. Throw an `Error` (the `message` is shown
    * to the user) when invalid; return / resolve normally when valid.
    *
-   * Receives the parsed value (after `parseAdditionalFieldValue`).
+   * Receives the current typed form value.
    */
   validate?: (
     value: AdditionalFieldValue | null | undefined
@@ -123,15 +138,78 @@ export interface AdditionalField {
   /** Render on the user profile. @default true */
   profile?: boolean
   /**
-   * Custom renderer. Replaces the host UI package's built-in input. Must emit
-   * an input named `field.name` so the value is captured by the form's
-   * `FormData`.
+   * Custom renderer. Replaces the host UI package's built-in input. Use the
+   * form bindings supplied by the host package to read and update its value.
    */
   render?: (props: AdditionalFieldRenderProps) => AdditionalFieldRenderResult
 }
 
 /** Ordered list of `AdditionalField` configurations. */
 export type AdditionalFields = AdditionalField[]
+
+/** Resolve the initial form value for a configured additional field. */
+export function getAdditionalFieldDefaultValue(
+  field: AdditionalField
+): AdditionalFieldFormValue {
+  if (field.defaultValue != null) return field.defaultValue
+  return field.type === "boolean" ? false : null
+}
+
+/** Build collision-safe form defaults for a runtime list of fields. */
+export function getAdditionalFieldDefaultValues(
+  fields: readonly AdditionalField[]
+): AdditionalFieldFormValues {
+  return Object.fromEntries(
+    fields.map((field) => [field.name, getAdditionalFieldDefaultValue(field)])
+  )
+}
+
+/** Keep only writable configured values when building an API payload. */
+export function getAdditionalFieldSubmitValues(
+  fields: readonly AdditionalField[],
+  values: AdditionalFieldFormValues
+): AdditionalFieldFormValues {
+  const submittedValues: AdditionalFieldFormValues = {}
+
+  for (const field of fields) {
+    if (!field.readOnly && field.name in values) {
+      submittedValues[field.name] = values[field.name] ?? null
+    }
+  }
+
+  return submittedValues
+}
+
+/** Validate required semantics without relying on native constraint state. */
+export function validateAdditionalFieldRequired(
+  field: AdditionalField,
+  value: AdditionalFieldFormValue,
+  requiredMessage: string
+): string | undefined {
+  if (!field.required) return undefined
+
+  const isMissing =
+    value == null ||
+    value === "" ||
+    (field.type === "boolean" && value !== true) ||
+    (typeof value === "number" && !Number.isFinite(value)) ||
+    (value instanceof Date && Number.isNaN(value.getTime()))
+
+  return isMissing ? requiredMessage : undefined
+}
+
+/** Run a configured custom validator and normalize thrown values as errors. */
+export async function validateAdditionalFieldValue(
+  field: AdditionalField,
+  value: AdditionalFieldFormValue
+): Promise<string | undefined> {
+  try {
+    await field.validate?.(value)
+    return undefined
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error)
+  }
+}
 
 /**
  * Convert a raw form value into the JS value Better Auth expects.

--- a/packages/core/tests/additional-fields-config.test.ts
+++ b/packages/core/tests/additional-fields-config.test.ts
@@ -4,9 +4,13 @@ import {
   type AdditionalField,
   fieldsWithModelValues,
   formatAdditionalFieldValue,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
   parseAdditionalFieldValue,
   parseAdditionalFieldValues,
-  resolveInputType
+  resolveInputType,
+  validateAdditionalFieldRequired,
+  validateAdditionalFieldValue
 } from "../src/config/additional-fields-config"
 
 const baseField = (overrides: Partial<AdditionalField>): AdditionalField =>
@@ -18,6 +22,48 @@ const baseField = (overrides: Partial<AdditionalField>): AdditionalField =>
   }) as AdditionalField
 
 describe("model field helpers", () => {
+  it("creates typed defaults and filters read-only submit values", () => {
+    const fields = [
+      baseField({ name: "nickname" }),
+      baseField({ name: "score", type: "number", defaultValue: 7 }),
+      baseField({ name: "enabled", type: "boolean" }),
+      baseField({ name: "internal", defaultValue: "secret", readOnly: true })
+    ]
+
+    const defaults = getAdditionalFieldDefaultValues(fields)
+
+    expect(defaults).toEqual({
+      nickname: null,
+      score: 7,
+      enabled: false,
+      internal: "secret"
+    })
+    expect(getAdditionalFieldSubmitValues(fields, defaults)).toEqual({
+      nickname: null,
+      score: 7,
+      enabled: false
+    })
+  })
+
+  it("normalizes required and configured validation errors", async () => {
+    const requiredField = baseField({ required: true })
+    const customField = baseField({
+      validate: async () => {
+        throw new Error("Already taken")
+      }
+    })
+
+    expect(
+      validateAdditionalFieldRequired(requiredField, null, "Required")
+    ).toBe("Required")
+    expect(
+      validateAdditionalFieldRequired(requiredField, "value", "Required")
+    ).toBeUndefined()
+    await expect(
+      validateAdditionalFieldValue(customField, "value")
+    ).resolves.toBe("Already taken")
+  })
+
   it("parses writable values, validates them, and omits read-only fields", async () => {
     const validate = vi.fn()
     const fields = [

--- a/packages/heroui/src/components/auth/additional-field.tsx
+++ b/packages/heroui/src/components/auth/additional-field.tsx
@@ -1,4 +1,7 @@
-import { resolveInputType } from "@better-auth-ui/core"
+import {
+  getFormFieldErrorMessage,
+  resolveInputType
+} from "@better-auth-ui/core"
 import { useAuth, useCopyToClipboard } from "@better-auth-ui/react"
 import { Check, Copy } from "@gravity-ui/icons"
 import {
@@ -123,6 +126,11 @@ function CopyButton({
 export function AdditionalField({
   name,
   field: configuredField,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
   isPending,
   optionalLabel,
   variant
@@ -146,6 +154,7 @@ export function AdditionalField({
         }
       : configuredField
   const inputVariant = variant === "transparent" ? "primary" : "secondary"
+  const errorMessage = getFormFieldErrorMessage(errors ?? [])
 
   if (field.render) {
     const FieldRenderer = field.render as ComponentType<AdditionalFieldProps>
@@ -153,6 +162,11 @@ export function AdditionalField({
       <FieldRenderer
         name={name}
         field={field}
+        value={value}
+        onBlur={onBlur}
+        onChange={onChange}
+        isInvalid={isInvalid}
+        errors={errors}
         isPending={isPending}
         optionalLabel={optionalLabel}
         variant={variant}
@@ -166,12 +180,13 @@ export function AdditionalField({
         type="hidden"
         name={name}
         value={
-          field.defaultValue == null
+          value == null
             ? ""
-            : field.defaultValue instanceof Date
-              ? field.defaultValue.toISOString()
-              : String(field.defaultValue)
+            : value instanceof Date
+              ? value.toISOString()
+              : String(value)
         }
+        readOnly
       />
     )
   }
@@ -180,21 +195,23 @@ export function AdditionalField({
     return (
       <TextField
         name={name}
-        defaultValue={
-          field.defaultValue == null ? undefined : String(field.defaultValue)
-        }
+        value={value == null ? "" : String(value)}
+        onBlur={onBlur}
+        onChange={(nextValue) => onChange(nextValue || null)}
+        isInvalid={isInvalid}
         isDisabled={isPending}
         isReadOnly={field.readOnly}
+        validationBehavior="aria"
       >
         <Label>{field.label}</Label>
 
         <TextArea
           placeholder={field.placeholder}
-          required={field.required}
+          aria-required={field.required}
           variant={inputVariant}
         />
 
-        <FieldError />
+        <FieldError>{errorMessage}</FieldError>
       </TextField>
     )
   }
@@ -205,13 +222,12 @@ export function AdditionalField({
     return (
       <NumberField
         name={name}
-        defaultValue={
-          typeof field.defaultValue === "number"
-            ? field.defaultValue
-            : field.defaultValue != null && field.defaultValue !== ""
-              ? Number(field.defaultValue)
-              : undefined
+        value={typeof value === "number" ? value : Number.NaN}
+        onBlur={onBlur}
+        onChange={(nextValue) =>
+          onChange(Number.isNaN(nextValue) ? null : nextValue)
         }
+        isInvalid={isInvalid}
         minValue={field.min}
         maxValue={field.max}
         step={
@@ -220,6 +236,7 @@ export function AdditionalField({
         formatOptions={field.formatOptions}
         isDisabled={isPending}
         isReadOnly={field.readOnly}
+        validationBehavior="aria"
         variant={inputVariant}
       >
         <Label>{field.label}</Label>
@@ -228,12 +245,12 @@ export function AdditionalField({
           <NumberField.DecrementButton />
           <NumberField.Input
             placeholder={field.placeholder}
-            required={field.required}
+            aria-required={field.required}
           />
           <NumberField.IncrementButton />
         </NumberField.Group>
 
-        <FieldError />
+        <FieldError>{errorMessage}</FieldError>
       </NumberField>
     )
   }
@@ -243,12 +260,11 @@ export function AdditionalField({
 
     return (
       <Slider
-        defaultValue={
-          typeof field.defaultValue === "number"
-            ? field.defaultValue
-            : field.defaultValue != null
-              ? Number(field.defaultValue)
-              : undefined
+        value={typeof value === "number" ? value : (field.min ?? 0)}
+        onChange={(nextValue) =>
+          onChange(
+            Array.isArray(nextValue) ? (nextValue[0] ?? null) : nextValue
+          )
         }
         minValue={field.min ?? 0}
         maxValue={field.max ?? 100}
@@ -266,8 +282,9 @@ export function AdditionalField({
 
         <Slider.Track>
           <Slider.Fill />
-          <Slider.Thumb name={name} />
+          <Slider.Thumb name={name} onBlur={onBlur} aria-invalid={isInvalid} />
         </Slider.Track>
+        <FieldError>{errorMessage}</FieldError>
       </Slider>
     )
   }
@@ -276,9 +293,10 @@ export function AdditionalField({
     return (
       <Switch
         name={name}
-        defaultSelected={
-          field.defaultValue === true || field.defaultValue === "true"
-        }
+        isSelected={value === true}
+        onBlur={onBlur}
+        onChange={onChange}
+        isInvalid={isInvalid}
         isDisabled={isPending}
         isReadOnly={field.readOnly}
       >
@@ -289,6 +307,7 @@ export function AdditionalField({
 
           {field.label}
         </Switch.Content>
+        <FieldError>{errorMessage}</FieldError>
       </Switch>
     )
   }
@@ -297,12 +316,13 @@ export function AdditionalField({
     return (
       <Checkbox
         name={name}
-        defaultSelected={
-          field.defaultValue === true || field.defaultValue === "true"
-        }
+        isSelected={value === true}
+        onBlur={onBlur}
+        onChange={onChange}
+        isInvalid={isInvalid}
         isDisabled={isPending}
         isReadOnly={field.readOnly}
-        isRequired={field.required}
+        aria-required={field.required}
         variant={inputVariant}
       >
         <Checkbox.Content>
@@ -312,6 +332,7 @@ export function AdditionalField({
 
           {field.label}
         </Checkbox.Content>
+        <FieldError>{errorMessage}</FieldError>
       </Checkbox>
     )
   }
@@ -321,12 +342,14 @@ export function AdditionalField({
       <Select
         className="[&[data-required=true]>.label]:after:content-none"
         name={name}
-        defaultValue={
-          field.defaultValue != null ? String(field.defaultValue) : undefined
-        }
+        value={value == null ? null : String(value)}
+        onBlur={onBlur}
+        onChange={(nextValue) => onChange(nextValue || null)}
+        isInvalid={isInvalid}
         placeholder={field.placeholder}
         isDisabled={isPending || field.readOnly}
-        isRequired={field.required}
+        aria-required={field.required}
+        validationBehavior="aria"
         variant={inputVariant}
         fullWidth
       >
@@ -355,7 +378,7 @@ export function AdditionalField({
           </ListBox>
         </Select.Popover>
 
-        <FieldError />
+        <FieldError>{errorMessage}</FieldError>
       </Select>
     )
   }
@@ -365,12 +388,14 @@ export function AdditionalField({
       <ComboBox
         className="[&[data-required=true]>.label]:after:content-none"
         name={name}
-        defaultSelectedKey={
-          field.defaultValue != null ? String(field.defaultValue) : undefined
-        }
+        selectedKey={value == null ? null : String(value)}
+        onBlur={onBlur}
+        onSelectionChange={(key) => onChange(key == null ? null : String(key))}
+        isInvalid={isInvalid}
         isDisabled={isPending}
         isReadOnly={field.readOnly}
-        isRequired={field.required}
+        aria-required={field.required}
+        validationBehavior="aria"
         variant={inputVariant}
         fullWidth
       >
@@ -399,26 +424,30 @@ export function AdditionalField({
           </ListBox>
         </ComboBox.Popover>
 
-        <FieldError />
+        <FieldError>{errorMessage}</FieldError>
       </ComboBox>
     )
   }
 
   if (inputType === "date" || inputType === "datetime") {
     const isDateTime = inputType === "datetime"
-    const defaultValue = isDateTime
-      ? toDateTimeValue(field.defaultValue)
-      : toDateValue(field.defaultValue)
+    const dateValue = isDateTime ? toDateTimeValue(value) : toDateValue(value)
 
     return (
       <DatePicker
         className="w-full [&[data-required=true]>.label]:after:content-none"
         name={name}
-        defaultValue={defaultValue as unknown as DateValue}
+        value={(dateValue ?? null) as DateValue | null}
+        onBlur={onBlur}
+        onChange={(nextValue) =>
+          onChange(nextValue?.toDate(getLocalTimeZone()) ?? null)
+        }
+        isInvalid={isInvalid}
         granularity={isDateTime ? "minute" : "day"}
         isDisabled={isPending}
         isReadOnly={field.readOnly}
-        isRequired={field.required}
+        aria-required={field.required}
+        validationBehavior="aria"
       >
         {({ state }) => (
           <>
@@ -436,7 +465,7 @@ export function AdditionalField({
               </DateField.Suffix>
             </DateField.Group>
 
-            <FieldError />
+            <FieldError>{errorMessage}</FieldError>
 
             <DatePicker.Popover className="flex flex-col gap-3">
               <Calendar
@@ -499,6 +528,11 @@ export function AdditionalField({
     <HeroInputField
       name={name}
       field={field}
+      value={value}
+      onBlur={onBlur}
+      onChange={onChange}
+      isInvalid={isInvalid}
+      errors={errors}
       isPending={isPending}
       variant={variant}
     />
@@ -508,6 +542,11 @@ export function AdditionalField({
 function HeroInputField({
   name,
   field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
   isPending,
   variant
 }: AdditionalFieldProps) {
@@ -526,16 +565,19 @@ function HeroInputField({
       : "numeric"
     : undefined
   const nativeStep = maxFractionDigits ? 1 / 10 ** maxFractionDigits : undefined
+  const errorMessage = getFormFieldErrorMessage(errors ?? [])
 
   if (hasPrefix || hasSuffix) {
     return (
       <TextField
         name={name}
-        defaultValue={
-          field.defaultValue == null ? undefined : String(field.defaultValue)
-        }
+        value={value == null ? "" : String(value)}
+        onBlur={onBlur}
+        onChange={(nextValue) => onChange(nextValue || null)}
+        isInvalid={isInvalid}
         isDisabled={isPending}
         isReadOnly={field.readOnly}
+        validationBehavior="aria"
       >
         <Label>{field.label}</Label>
 
@@ -545,7 +587,7 @@ function HeroInputField({
           <InputGroup.Input
             ref={inputRef}
             placeholder={field.placeholder}
-            required={field.required}
+            aria-required={field.required}
             type={nativeInputType}
             inputMode={nativeInputMode}
             step={nativeStep}
@@ -565,7 +607,7 @@ function HeroInputField({
           )}
         </InputGroup>
 
-        <FieldError />
+        <FieldError>{errorMessage}</FieldError>
       </TextField>
     )
   }
@@ -573,24 +615,26 @@ function HeroInputField({
   return (
     <TextField
       name={name}
-      defaultValue={
-        field.defaultValue == null ? undefined : String(field.defaultValue)
-      }
+      value={value == null ? "" : String(value)}
+      onBlur={onBlur}
+      onChange={(nextValue) => onChange(nextValue || null)}
+      isInvalid={isInvalid}
       isDisabled={isPending}
       isReadOnly={field.readOnly}
+      validationBehavior="aria"
     >
       <Label>{field.label}</Label>
 
       <Input
         placeholder={field.placeholder}
-        required={field.required}
+        aria-required={field.required}
         variant={inputVariant}
         type={nativeInputType}
         inputMode={nativeInputMode}
         step={nativeStep}
       />
 
-      <FieldError />
+      <FieldError>{errorMessage}</FieldError>
     </TextField>
   )
 }

--- a/packages/heroui/src/components/auth/admin/admin-users.tsx
+++ b/packages/heroui/src/components/auth/admin/admin-users.tsx
@@ -1,9 +1,10 @@
 "use client"
 
 import {
-  type AdditionalFieldValue,
-  getClampedTablePageIndex,
-  parseAdditionalFieldValues
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  getClampedTablePageIndex
 } from "@better-auth-ui/core"
 import {
   type AdminAuthClient,
@@ -72,12 +73,10 @@ import {
   useDeferredValue,
   useEffect,
   useMemo,
-  useRef,
   useState
 } from "react"
 import { adminPlugin } from "../../../lib/auth/admin-plugin"
-import { AdditionalField } from "../additional-field"
-import { useAuthForm } from "../auth-form"
+import { getAuthAdditionalFieldValidators, useAuthForm } from "../auth-form"
 import { UserAvatar } from "../user/user-avatar"
 import { createAdminColumnHelper, useAdminTable } from "./admin-table"
 
@@ -598,16 +597,17 @@ function CreateUserDialog({
   isOpen: boolean
   onOpenChange: (open: boolean) => void
 }) {
-  const { additionalFields, authClient } = useAuth<AdminAuthClient>()
+  const { additionalFields, authClient, localization } =
+    useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
   const createUser = useCreateAdminUser(authClient)
   const canSetRole = useAdminPermission(authClient, { user: ["set-role"] })
-  const [formError, setFormError] = useState<string>()
-  const additionalFieldValuesRef = useRef<
-    Record<string, AdditionalFieldValue | null>
-  >({})
+  const configuredAdditionalFields = additionalFields ?? []
   const form = useAuthForm({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(
+        configuredAdditionalFields
+      ),
       email: "",
       emailVerified: false,
       name: "",
@@ -619,7 +619,10 @@ function CreateUserDialog({
         await createUser.mutateAsync(
           {
             data: {
-              ...additionalFieldValuesRef.current,
+              ...getAdditionalFieldSubmitValues(
+                configuredAdditionalFields,
+                value.additionalFields
+              ),
               emailVerified: value.emailVerified
             },
             email: value.email,
@@ -645,23 +648,7 @@ function CreateUserDialog({
   const close = () => {
     createUser.reset()
     form.reset()
-    setFormError(undefined)
     onOpenChange(false)
-  }
-  const prepareSubmit = async (formElement: HTMLFormElement) => {
-    const data = new FormData(formElement)
-    let additionalFieldValues: Record<string, AdditionalFieldValue | null>
-    try {
-      additionalFieldValues = await parseAdditionalFieldValues(
-        additionalFields ?? [],
-        data
-      )
-    } catch (error) {
-      setFormError(error instanceof Error ? error.message : String(error))
-      return false
-    }
-    setFormError(undefined)
-    additionalFieldValuesRef.current = additionalFieldValues
   }
 
   return (
@@ -672,7 +659,7 @@ function CreateUserDialog({
       <AlertDialog.Container>
         <AlertDialog.Dialog>
           <form.AppForm>
-            <form.AuthFormRoot prepareSubmit={prepareSubmit}>
+            <form.AuthFormRoot>
               <AlertDialog.CloseTrigger />
               <AlertDialog.Header>
                 <AlertDialog.Icon status="default">
@@ -795,17 +782,26 @@ function CreateUserDialog({
                       </Switch>
                     )}
                   </form.Field>
-                  {additionalFields?.map((field) => (
-                    <AdditionalField
-                      field={field}
-                      isPending={createUser.isPending}
-                      key={field.name}
-                      name={field.name}
-                    />
+                  {configuredAdditionalFields.map((configuredField) => (
+                    <form.AppField
+                      key={configuredField.name}
+                      name={`additionalFields.${configuredField.name}`}
+                      validators={getAuthAdditionalFieldValidators(
+                        configuredField,
+                        localization.auth.fieldRequired
+                      )}
+                    >
+                      {(field) => (
+                        <field.AuthFormAdditionalField
+                          field={configuredField}
+                          isPending={createUser.isPending}
+                        />
+                      )}
+                    </form.AppField>
                   ))}
-                  {formError || createUser.error ? (
+                  {createUser.error ? (
                     <FieldError>
-                      {formError ?? getAdminErrorMessage(createUser.error)}
+                      {getAdminErrorMessage(createUser.error)}
                     </FieldError>
                   ) : null}
                 </div>
@@ -841,7 +837,7 @@ function UserDrawer({
   onOpenChange: (open: boolean) => void
   userId?: string
 }) {
-  const { additionalFields, authClient, navigate, plugins } =
+  const { additionalFields, authClient, localization, navigate, plugins } =
     useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
   const contributedTabs = useMemo(
@@ -909,7 +905,6 @@ function UserDrawer({
   const [banReason, setBanReason] = useState("")
   const [banDuration, setBanDuration] = useState("")
   const banDurationSeconds = getBanDurationSeconds(banDuration)
-  const [profileError, setProfileError] = useState<string>()
   const [passwordOpen, setPasswordOpen] = useState(false)
   const [dangerousAction, setDangerousAction] = useState<DangerousAction>()
   const detail = user.data
@@ -921,7 +916,6 @@ function UserDrawer({
     { user: ["impersonate-admins"] },
     { enabled: Boolean(userId && targetIsAdmin) }
   )
-  const profileUserId = useRef(detail?.id)
   const isSelf = detail?.id === actor?.user.id
   const updateUser = useUpdateAdminUser(authClient)
   const setRoleMutation = useSetAdminUserRole(authClient)
@@ -933,11 +927,17 @@ function UserDrawer({
   const revokeSession = useRevokeAdminUserSession(authClient, userId)
   const revokeSessions = useRevokeAdminUserSessions(authClient, userId)
 
-  const profileAdditionalFieldValuesRef = useRef<
-    Record<string, AdditionalFieldValue | null>
-  >({})
+  const configuredUserFields = useMemo(
+    () =>
+      fieldsWithModelValues(
+        additionalFields ?? [],
+        detail ? (detail as unknown as Record<string, unknown>) : {}
+      ),
+    [additionalFields, detail]
+  )
   const profileForm = useAuthForm({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredUserFields),
       email: "",
       emailVerified: false,
       name: "",
@@ -952,7 +952,10 @@ function UserDrawer({
           updateUser.mutateAsync({
             userId: detail.id,
             data: {
-              ...profileAdditionalFieldValuesRef.current,
+              ...getAdditionalFieldSubmitValues(
+                configuredUserFields,
+                value.additionalFields
+              ),
               name: value.name.trim(),
               ...(canSetEmail.data?.success
                 ? {
@@ -984,6 +987,7 @@ function UserDrawer({
 
   useEffect(() => {
     profileForm.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredUserFields),
       email: detail?.email ?? "",
       emailVerified: detail?.emailVerified ?? false,
       name: detail?.name ?? "",
@@ -996,18 +1000,13 @@ function UserDrawer({
   }, [
     config.allowMultipleRoles,
     config.defaultRole,
+    configuredUserFields,
     detail?.email,
     detail?.emailVerified,
     detail?.name,
     detail?.role,
     profileForm.reset
   ])
-
-  useEffect(() => {
-    if (profileUserId.current === detail?.id) return
-    profileUserId.current = detail?.id
-    setProfileError(undefined)
-  }, [detail?.id])
 
   const confirmDangerousAction = () => {
     if (!detail) return
@@ -1080,26 +1079,6 @@ function UserDrawer({
         : dangerousAction === "revokeAll"
           ? config.localization.revokeAllSessions
           : config.localization.impersonateUser
-
-  const prepareSaveUser = async (formElement: HTMLFormElement) => {
-    if (!detail) return false
-
-    if (canUpdate.data?.success) {
-      const formData = new FormData(formElement)
-      let additionalFieldValues: Record<string, AdditionalFieldValue | null>
-      try {
-        additionalFieldValues = await parseAdditionalFieldValues(
-          additionalFields ?? [],
-          formData
-        )
-      } catch (error) {
-        setProfileError(error instanceof Error ? error.message : String(error))
-        return false
-      }
-      setProfileError(undefined)
-      profileAdditionalFieldValuesRef.current = additionalFieldValues
-    }
-  }
 
   return (
     <>
@@ -1200,10 +1179,7 @@ function UserDrawer({
                   </Tabs.ListContainer>
                   <Tabs.Panel className="min-h-0 overflow-hidden" id="overview">
                     <profileForm.AppForm>
-                      <profileForm.AuthFormRoot
-                        className="grid h-full grid-rows-[minmax(0,1fr)_auto]"
-                        prepareSubmit={prepareSaveUser}
-                      >
+                      <profileForm.AuthFormRoot className="grid h-full grid-rows-[minmax(0,1fr)_auto]">
                         <div className="overflow-y-auto">
                           <section className="flex flex-col gap-5 p-6">
                             <h3 className="font-medium">
@@ -1311,30 +1287,29 @@ function UserDrawer({
                                   </Select>
                                 )}
                               </profileForm.Field>
-                              {additionalFields?.map((field) => {
-                                const value = (
-                                  detail as unknown as Record<string, unknown>
-                                )[field.name]
-                                return (
-                                  <AdditionalField
-                                    field={{
-                                      ...field,
-                                      defaultValue:
-                                        value as AdditionalFieldValue | null
-                                    }}
-                                    isPending={
-                                      updateUser.isPending ||
-                                      !canUpdate.data?.success
-                                    }
-                                    key={`${detail.id}-${field.name}-${String(value ?? "")}`}
-                                    name={field.name}
-                                  />
-                                )
-                              })}
+                              {configuredUserFields.map((configuredField) => (
+                                <profileForm.AppField
+                                  key={configuredField.name}
+                                  name={`additionalFields.${configuredField.name}`}
+                                  validators={getAuthAdditionalFieldValidators(
+                                    configuredField,
+                                    localization.auth.fieldRequired
+                                  )}
+                                >
+                                  {(field) => (
+                                    <field.AuthFormAdditionalField
+                                      field={configuredField}
+                                      isPending={
+                                        updateUser.isPending ||
+                                        !canUpdate.data?.success
+                                      }
+                                    />
+                                  )}
+                                </profileForm.AppField>
+                              ))}
                             </div>
                             <FieldError>
-                              {profileError ??
-                                getAdminErrorMessage(updateUser.error) ??
+                              {getAdminErrorMessage(updateUser.error) ??
                                 getAdminErrorMessage(setRoleMutation.error)}
                             </FieldError>
                           </section>

--- a/packages/heroui/src/components/auth/auth-form.tsx
+++ b/packages/heroui/src/components/auth/auth-form.tsx
@@ -1,19 +1,23 @@
-import { getFormFieldErrorMessage } from "@better-auth-ui/core"
+import {
+  type AdditionalField as AdditionalFieldConfig,
+  type AdditionalFieldFormValue,
+  getFormFieldErrorMessage,
+  getFormFieldErrors,
+  validateAdditionalFieldRequired,
+  validateAdditionalFieldValue
+} from "@better-auth-ui/core"
 import { Button, FieldError, Form, Spinner } from "@heroui/react"
 import { createFormHook, createFormHookContexts } from "@tanstack/react-form"
 import {
   type ComponentProps,
-  createContext,
   type FormEvent,
   type ReactNode,
-  useContext,
-  useRef,
-  useState
+  useRef
 } from "react"
+import { AdditionalField, type AdditionalFieldProps } from "./additional-field"
 
 const { fieldContext, formContext, useFieldContext, useFormContext } =
   createFormHookContexts()
-const AuthFormPreparationContext = createContext(false)
 
 export function focusFirstInvalidAuthFormControl(form: HTMLFormElement) {
   requestAnimationFrame(() => {
@@ -36,53 +40,42 @@ function AuthFormFieldError() {
 }
 
 type AuthFormRootProps = Omit<ComponentProps<typeof Form>, "onSubmit"> & {
-  prepareSubmit?: (
-    form: HTMLFormElement
-  ) => boolean | undefined | Promise<boolean | undefined>
+  onBeforeSubmit?: () => void
 }
 
 function AuthFormRoot({
   children,
-  prepareSubmit,
+  onBeforeSubmit,
   ...props
 }: AuthFormRootProps) {
   const form = useFormContext()
-  const preparingRef = useRef(false)
-  const [isPreparing, setIsPreparing] = useState(false)
+  const submittingRef = useRef(false)
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
-    if (preparingRef.current || form.state.isSubmitting) return
+    if (submittingRef.current || form.state.isSubmitting) return
 
     const formElement = event.currentTarget
-    preparingRef.current = true
-    setIsPreparing(true)
-
-    let shouldSubmit = true
+    onBeforeSubmit?.()
+    submittingRef.current = true
     try {
-      shouldSubmit = (await prepareSubmit?.(formElement)) !== false
+      await form.handleSubmit()
+      if (!form.state.isValid) focusFirstInvalidAuthFormControl(formElement)
     } finally {
-      preparingRef.current = false
-      setIsPreparing(false)
+      submittingRef.current = false
     }
-
-    if (!shouldSubmit) return
-    await form.handleSubmit()
-    if (!form.state.isValid) focusFirstInvalidAuthFormControl(formElement)
   }
 
   return (
-    <AuthFormPreparationContext.Provider value={isPreparing}>
-      <Form
-        {...props}
-        onInvalid={(event) =>
-          focusFirstInvalidAuthFormControl(event.currentTarget)
-        }
-        onSubmit={submit}
-      >
-        {children}
-      </Form>
-    </AuthFormPreparationContext.Provider>
+    <Form
+      {...props}
+      onInvalid={(event) =>
+        focusFirstInvalidAuthFormControl(event.currentTarget)
+      }
+      onSubmit={submit}
+    >
+      {children}
+    </Form>
   )
 }
 
@@ -92,7 +85,6 @@ function AuthFormSubmitButton({
   ...props
 }: Omit<ComponentProps<typeof Button>, "children"> & { children?: ReactNode }) {
   const form = useFormContext()
-  const isPreparing = useContext(AuthFormPreparationContext)
 
   return (
     <form.Subscribe
@@ -101,10 +93,10 @@ function AuthFormSubmitButton({
       {([canSubmit, isSubmitting]) => (
         <Button
           {...props}
-          isDisabled={isDisabled || isPreparing || !canSubmit || isSubmitting}
+          isDisabled={isDisabled || !canSubmit || isSubmitting}
           type="submit"
         >
-          {isPreparing || isSubmitting ? <Spinner /> : null}
+          {isSubmitting ? <Spinner /> : null}
           {children}
         </Button>
       )}
@@ -112,8 +104,32 @@ function AuthFormSubmitButton({
   )
 }
 
+type AuthFormAdditionalFieldProps = Omit<
+  AdditionalFieldProps,
+  "errors" | "isInvalid" | "name" | "onBlur" | "onChange" | "value"
+>
+
+function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
+  const field = useFieldContext<AdditionalFieldFormValue>()
+  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+
+  return (
+    <AdditionalField
+      {...props}
+      errors={
+        isInvalid ? getFormFieldErrors(field.state.meta.errors) : undefined
+      }
+      isInvalid={isInvalid}
+      name={field.name}
+      onBlur={field.handleBlur}
+      onChange={field.handleChange}
+      value={field.state.value}
+    />
+  )
+}
+
 export const { useAppForm: useAuthForm } = createFormHook({
-  fieldComponents: { AuthFormFieldError },
+  fieldComponents: { AuthFormAdditionalField, AuthFormFieldError },
   fieldContext,
   formComponents: { AuthFormRoot, AuthFormSubmitButton },
   formContext
@@ -127,4 +143,18 @@ export function isAuthFormFieldInvalid({
   isValid: boolean
 }) {
   return isTouched && !isValid
+}
+
+export function getAuthAdditionalFieldValidators(
+  field: AdditionalFieldConfig,
+  requiredMessage: string
+) {
+  return {
+    onChange: ({ value }: { value: AdditionalFieldFormValue }) =>
+      validateAdditionalFieldRequired(field, value, requiredMessage),
+    onChangeAsync: field.validate
+      ? ({ value }: { value: AdditionalFieldFormValue }) =>
+          validateAdditionalFieldValue(field, value)
+      : undefined
+  }
 }

--- a/packages/heroui/src/components/auth/organization/create-organization-dialog.tsx
+++ b/packages/heroui/src/components/auth/organization/create-organization-dialog.tsx
@@ -1,23 +1,21 @@
-import { parseAdditionalFieldValue } from "@better-auth-ui/core"
+import {
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useCreateOrganization } from "@better-auth-ui/react/plugins/organization"
 import { Briefcase } from "@gravity-ui/icons"
-import {
-  AlertDialog,
-  Button,
-  FieldError,
-  Form,
-  Input,
-  Label,
-  Spinner,
-  TextField,
-  toast
-} from "@heroui/react"
-import { type SyntheticEvent, useEffect, useRef, useState } from "react"
+import { AlertDialog, Button, Input, Label, TextField } from "@heroui/react"
+import { useEffect, useRef, useState } from "react"
 
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 import { SlugField, sanitizeSlug } from "./slug-field"
 
 /** Props for the {@link CreateOrganizationDialog} component. */
@@ -47,161 +45,165 @@ export function CreateOrganizationDialog({
   } = useAuthPlugin(organizationPlugin)
   const hideSlug = hideSlugProp ?? pluginHideSlug ?? false
 
-  const [name, setName] = useState("")
-  const [slug, setSlug] = useState("")
   const [slugEdited, setSlugEdited] = useState(false)
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const submissionLocked = useRef(false)
   const submissionGeneration = useRef(0)
+  const submissionAttemptGeneration = useRef(0)
 
-  const { mutate: createOrganization, isPending: isCreating } =
-    useCreateOrganization(authClient as OrganizationAuthClient)
+  const { mutateAsync: createOrganization, isPending } = useCreateOrganization(
+    authClient as OrganizationAuthClient
+  )
 
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    if (submissionLocked.current) return
-
-    const generation = ++submissionGeneration.current
-    submissionLocked.current = true
-    setIsSubmitting(true)
-    const formData = new FormData(e.currentTarget)
-    const additionalValues: Record<string, unknown> = {}
-    try {
-      for (const field of additionalFields) {
-        const value = parseAdditionalFieldValue(
-          field,
-          formData.get(field.name) as string | null
-        )
-        await field.validate?.(value)
-        if (value !== undefined) additionalValues[field.name] = value
-      }
-    } catch (error) {
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(additionalFields),
+      name: "",
+      slug: ""
+    },
+    onSubmit: async ({ value }) => {
+      const generation = submissionAttemptGeneration.current
       if (generation !== submissionGeneration.current) return
 
-      submissionLocked.current = false
-      setIsSubmitting(false)
-      toast.danger(error instanceof Error ? error.message : String(error))
-      return
-    }
-
-    if (generation !== submissionGeneration.current) return
-
-    createOrganization(
-      {
-        ...additionalValues,
-        name,
-        slug: hideSlug ? undefined : slug
-      },
-      {
-        onSuccess: () => {
-          if (generation === submissionGeneration.current) onOpenChange(false)
-        },
-        onSettled: () => {
-          if (generation !== submissionGeneration.current) return
-
-          submissionLocked.current = false
-          setIsSubmitting(false)
-        }
+      try {
+        await createOrganization({
+          ...getAdditionalFieldSubmitValues(
+            additionalFields,
+            value.additionalFields
+          ),
+          name: value.name,
+          slug: hideSlug ? undefined : value.slug
+        })
+        if (generation === submissionGeneration.current) onOpenChange(false)
+      } catch {
+        // The mutation reports the error through its configured handler.
       }
-    )
-  }
-
-  const isPending = isCreating || isSubmitting
+    }
+  })
 
   useEffect(() => {
     if (!isOpen) {
       submissionGeneration.current += 1
-      submissionLocked.current = false
-      setIsSubmitting(false)
-      setSlug("")
-      setName("")
+      form.reset()
       setSlugEdited(false)
     }
-  }, [isOpen])
-
-  useEffect(() => {
-    if (slugEdited) return
-    setSlug(sanitizeSlug(name))
-  }, [name, slugEdited])
+  }, [form, isOpen])
 
   return (
     <AlertDialog.Backdrop isOpen={isOpen} onOpenChange={onOpenChange}>
       <AlertDialog.Container>
         <AlertDialog.Dialog>
-          <Form onSubmit={handleSubmit}>
-            <AlertDialog.CloseTrigger />
+          <form.AppForm>
+            <form.AuthFormRoot
+              onBeforeSubmit={() => {
+                submissionAttemptGeneration.current =
+                  submissionGeneration.current
+              }}
+            >
+              <AlertDialog.CloseTrigger />
 
-            <AlertDialog.Header>
-              <AlertDialog.Icon status="default">
-                <Briefcase />
-              </AlertDialog.Icon>
+              <AlertDialog.Header>
+                <AlertDialog.Icon status="default">
+                  <Briefcase />
+                </AlertDialog.Icon>
 
-              <AlertDialog.Heading>
-                {organizationLocalization.createOrganization}
-              </AlertDialog.Heading>
-            </AlertDialog.Header>
+                <AlertDialog.Heading>
+                  {organizationLocalization.createOrganization}
+                </AlertDialog.Heading>
+              </AlertDialog.Header>
 
-            <AlertDialog.Body className="flex flex-col gap-4 overflow-visible">
-              <p className="text-muted text-sm">
-                {organizationLocalization.organizationsDescription}
-              </p>
+              <AlertDialog.Body className="flex flex-col gap-4 overflow-visible">
+                <p className="text-muted text-sm">
+                  {organizationLocalization.organizationsDescription}
+                </p>
 
-              <TextField
-                id="name"
-                name="name"
-                isDisabled={isPending}
-                value={name}
-                onChange={setName}
-                validate={(value) => {
-                  if (!value) return localization.auth.fieldRequired
-                }}
-              >
-                <Label>{organizationLocalization.name}</Label>
-
-                <Input
-                  required
-                  autoFocus
-                  placeholder={organizationLocalization.namePlaceholder}
-                  variant="secondary"
-                />
-
-                <FieldError />
-              </TextField>
-
-              {!hideSlug && (
-                <SlugField
-                  value={slug}
-                  onChange={(value) => {
-                    setSlug(value)
-                    setSlugEdited(true)
+                <form.AppField
+                  name="name"
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateStringLength(value, {
+                        requiredMessage: localization.auth.fieldRequired,
+                        trim: true
+                      })
                   }}
-                  isDisabled={isPending}
-                  variant="secondary"
-                />
-              )}
-              {additionalFields.map((field) => (
-                <AdditionalField
-                  field={field}
-                  isPending={isPending}
-                  key={field.name}
-                  name={field.name}
-                  optionalLabel={localization.settings.optional}
-                />
-              ))}
-            </AlertDialog.Body>
+                >
+                  {(field) => {
+                    const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
-            <AlertDialog.Footer>
-              <Button slot="close" variant="tertiary" isDisabled={isPending}>
-                {localization.settings.cancel}
-              </Button>
+                    return (
+                      <TextField
+                        id="name"
+                        name={field.name}
+                        isDisabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(value) => {
+                          field.handleChange(value)
+                          if (!slugEdited) {
+                            form.setFieldValue("slug", sanitizeSlug(value))
+                          }
+                        }}
+                        isInvalid={isInvalid || undefined}
+                        validationBehavior="aria"
+                      >
+                        <Label>{organizationLocalization.name}</Label>
 
-              <Button type="submit" isPending={isPending}>
-                {isPending && <Spinner color="current" size="sm" />}
+                        <Input
+                          autoFocus
+                          placeholder={organizationLocalization.namePlaceholder}
+                          variant="secondary"
+                        />
 
-                {organizationLocalization.createOrganization}
-              </Button>
-            </AlertDialog.Footer>
-          </Form>
+                        <field.AuthFormFieldError />
+                      </TextField>
+                    )
+                  }}
+                </form.AppField>
+
+                {!hideSlug && (
+                  <form.AppField name="slug">
+                    {(field) => (
+                      <SlugField
+                        value={field.state.value}
+                        onChange={(value) => {
+                          field.handleChange(value)
+                          setSlugEdited(true)
+                        }}
+                        isDisabled={isPending}
+                        variant="secondary"
+                      />
+                    )}
+                  </form.AppField>
+                )}
+                {additionalFields.map((configuredField) => (
+                  <form.AppField
+                    key={configuredField.name}
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={isPending}
+                        optionalLabel={localization.settings.optional}
+                      />
+                    )}
+                  </form.AppField>
+                ))}
+              </AlertDialog.Body>
+
+              <AlertDialog.Footer>
+                <Button slot="close" variant="tertiary" isDisabled={isPending}>
+                  {localization.settings.cancel}
+                </Button>
+
+                <form.AuthFormSubmitButton>
+                  {organizationLocalization.createOrganization}
+                </form.AuthFormSubmitButton>
+              </AlertDialog.Footer>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </AlertDialog.Dialog>
       </AlertDialog.Container>
     </AlertDialog.Backdrop>

--- a/packages/heroui/src/components/auth/organization/invite-member-dialog.tsx
+++ b/packages/heroui/src/components/auth/organization/invite-member-dialog.tsx
@@ -1,4 +1,8 @@
-import { parseAdditionalFieldValues } from "@better-auth-ui/core"
+import {
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateEmailAddress
+} from "@better-auth-ui/core"
 import {
   mergeOrganizationRoleLabels,
   type OrganizationAuthClient,
@@ -19,26 +23,21 @@ import {
   AlertDialog,
   Button,
   Checkbox,
-  FieldError,
-  Form,
   Input,
   Label,
   ListBox,
   Select,
-  Spinner,
   TextField,
   toast
 } from "@heroui/react"
-import {
-  type SyntheticEvent,
-  useEffect,
-  useMemo,
-  useRef,
-  useState
-} from "react"
+import { useEffect, useMemo, useRef } from "react"
 
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 
 /** Props for the {@link InviteMemberDialog} component. */
 export type InviteMemberDialogProps = {
@@ -102,37 +101,10 @@ export function InviteMemberDialog({
     invitationLimit !== undefined &&
     (invitations.data?.filter((invitation) => invitation.status === "pending")
       .length ?? 0) >= invitationLimit
-  const [teamIds, setTeamIds] = useState<string[]>([])
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const activeOrganizationId = activeOrganization?.id
   const previousOrganizationId = useRef(activeOrganizationId)
 
-  const [selectedRoles, setSelectedRoles] = useState(() => {
-    const fallback = pickDefaultRole(Object.keys(assignableRoles))
-    return fallback ? [fallback] : []
-  })
-
-  useEffect(() => {
-    setSelectedRoles((current) => {
-      const keys = Object.keys(assignableRoles)
-      const kept = current.filter((entry) => keys.includes(entry))
-
-      if (kept.length > 0) return allowMultipleRoles ? kept : kept.slice(0, 1)
-
-      const fallback = pickDefaultRole(keys)
-      return fallback ? [fallback] : []
-    })
-  }, [allowMultipleRoles, assignableRoles])
-
-  useEffect(() => {
-    const organizationChanged =
-      previousOrganizationId.current !== activeOrganizationId
-
-    if (isOpen || organizationChanged) setTeamIds([])
-    previousOrganizationId.current = activeOrganizationId
-  }, [isOpen, activeOrganizationId])
-
-  const { mutate: inviteMember, isPending: isInviting } = useInviteMember(
+  const { mutateAsync: inviteMember, isPending: isInviting } = useInviteMember(
     authClient as OrganizationTeamsAuthClient,
     {
       onSuccess: () => {
@@ -142,203 +114,258 @@ export function InviteMemberDialog({
     }
   )
 
-  const isRoleValid = selectedRoles.length > 0
-
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (
-      !activeOrganizationId ||
-      !canInvite.data?.success ||
-      !isRoleValid ||
-      invitationLimitReached
-    )
-      return
-
-    const formData = new FormData(e.currentTarget)
-    const invitationEmail = (formData.get("email") as string).trim()
-    const invitationRoles = [...selectedRoles] as Parameters<
-      typeof inviteMember
-    >[0]["role"]
-    const availableTeamIds = new Set(teams.data?.map((team) => team.id))
-    const selectedTeamIds = teamIds.filter((teamId) =>
-      availableTeamIds.has(teamId)
-    )
-
-    setIsSubmitting(true)
-    let invitationValues: Record<string, unknown>
-    try {
-      invitationValues = await parseAdditionalFieldValues(
-        invitationFields,
-        formData
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(invitationFields),
+      email: "",
+      roles: [] as string[],
+      teamIds: [] as string[]
+    },
+    onSubmit: async ({ value }) => {
+      if (
+        !activeOrganizationId ||
+        !canInvite.data?.success ||
+        value.roles.length === 0 ||
+        invitationLimitReached
       )
-    } catch (error) {
-      toast.danger(error instanceof Error ? error.message : String(error))
-      setIsSubmitting(false)
-      return
-    }
+        return
 
-    inviteMember(
-      {
-        ...invitationValues,
-        email: invitationEmail,
-        organizationId: activeOrganizationId,
-        role: invitationRoles,
-        ...(selectedTeamIds.length ? { teamId: selectedTeamIds } : {})
-      },
-      { onSettled: () => setIsSubmitting(false) }
-    )
-  }
+      const availableTeamIds = new Set(teams.data?.map((team) => team.id))
+      const teamIds = value.teamIds.filter((teamId) =>
+        availableTeamIds.has(teamId)
+      )
+
+      try {
+        await inviteMember({
+          ...getAdditionalFieldSubmitValues(
+            invitationFields,
+            value.additionalFields
+          ),
+          email: value.email.trim(),
+          organizationId: activeOrganizationId,
+          role: value.roles as Parameters<typeof inviteMember>[0]["role"],
+          ...(teamIds.length ? { teamId: teamIds } : {})
+        })
+      } catch {
+        // The mutation reports the error through its configured handler.
+      }
+    }
+  })
+
+  useEffect(() => {
+    const keys = Object.keys(assignableRoles)
+    const current = form.getFieldValue("roles")
+    const kept = current.filter((entry) => keys.includes(entry))
+    const roles =
+      kept.length > 0
+        ? allowMultipleRoles
+          ? kept
+          : kept.slice(0, 1)
+        : (() => {
+            const fallback = pickDefaultRole(keys)
+            return fallback ? [fallback] : []
+          })()
+
+    form.setFieldValue("roles", roles)
+  }, [allowMultipleRoles, assignableRoles, form])
+
+  useEffect(() => {
+    const organizationChanged =
+      previousOrganizationId.current !== activeOrganizationId
+
+    if (isOpen || organizationChanged) {
+      const fallback = pickDefaultRole(Object.keys(assignableRoles))
+      form.reset({
+        additionalFields: getAdditionalFieldDefaultValues(invitationFields),
+        email: "",
+        roles: fallback ? [fallback] : [],
+        teamIds: []
+      })
+    }
+    previousOrganizationId.current = activeOrganizationId
+  }, [activeOrganizationId, assignableRoles, form, invitationFields, isOpen])
 
   return (
     <AlertDialog.Backdrop isOpen={isOpen} onOpenChange={onOpenChange}>
       <AlertDialog.Container>
         <AlertDialog.Dialog>
-          <Form onSubmit={handleSubmit}>
-            <AlertDialog.CloseTrigger />
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <AlertDialog.CloseTrigger />
 
-            <AlertDialog.Header>
-              <AlertDialog.Icon status="default">
-                <PersonPlus />
-              </AlertDialog.Icon>
+              <AlertDialog.Header>
+                <AlertDialog.Icon status="default">
+                  <PersonPlus />
+                </AlertDialog.Icon>
 
-              <AlertDialog.Heading>
-                {organizationLocalization.inviteMember}
-              </AlertDialog.Heading>
-            </AlertDialog.Header>
+                <AlertDialog.Heading>
+                  {organizationLocalization.inviteMember}
+                </AlertDialog.Heading>
+              </AlertDialog.Header>
 
-            <AlertDialog.Body className="flex flex-col gap-4 overflow-visible">
-              <p className="text-muted text-sm">
-                {organizationLocalization.inviteMemberDescription}
-              </p>
-              {invitationLimitReached && (
-                <p className="text-danger text-sm" role="alert">
-                  {organizationLocalization.invitationLimitReached}
+              <AlertDialog.Body className="flex flex-col gap-4 overflow-visible">
+                <p className="text-muted text-sm">
+                  {organizationLocalization.inviteMemberDescription}
                 </p>
-              )}
-
-              <TextField
-                id="email"
-                name="email"
-                type="email"
-                isDisabled={isInviting || isSubmitting}
-                validate={(value) => {
-                  if (!value) return localization.auth.fieldRequired
-                  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
-                    return localization.auth.invalidEmail
-                }}
-              >
-                <Label>{localization.auth.email}</Label>
-
-                <Input
-                  autoFocus
-                  placeholder={localization.auth.email}
-                  variant="secondary"
-                  required
-                />
-
-                <FieldError />
-              </TextField>
-
-              <Select
-                name="role"
-                selectionMode={allowMultipleRoles ? "multiple" : "single"}
-                value={selectedRoles}
-                onChange={(keys) => {
-                  const next = [...(keys as Iterable<string>)]
-
-                  // An invitation always carries at least one role.
-                  if (next.length === 0) return
-
-                  setSelectedRoles(allowMultipleRoles ? next : next.slice(0, 1))
-                }}
-                isDisabled={isInviting || isSubmitting}
-                variant="secondary"
-                fullWidth
-              >
-                <Label>{organizationLocalization.role}</Label>
-
-                <Select.Trigger>
-                  <Select.Value />
-                  <Select.Indicator />
-                </Select.Trigger>
-
-                <Select.Popover>
-                  <ListBox
-                    selectionMode={allowMultipleRoles ? "multiple" : "single"}
-                  >
-                    {Object.entries(assignableRoles).map(([key, label]) => (
-                      <ListBox.Item key={key} id={key} textValue={label}>
-                        {label}
-
-                        <ListBox.ItemIndicator />
-                      </ListBox.Item>
-                    ))}
-                  </ListBox>
-                </Select.Popover>
-
-                <FieldError />
-              </Select>
-              {teamsEnabled && (teams.data?.length ?? 0) > 0 && (
-                <div className="flex flex-col gap-2">
-                  <Label>{organizationLocalization.teams}</Label>
-                  <div className="flex flex-wrap gap-3">
-                    {teams.data?.map((team) => (
-                      <Checkbox
-                        key={team.id}
-                        isSelected={teamIds.includes(team.id)}
-                        onChange={(selected) =>
-                          setTeamIds((current) =>
-                            selected
-                              ? [...current, team.id]
-                              : current.filter((id) => id !== team.id)
-                          )
-                        }
-                      >
-                        {team.name}
-                      </Checkbox>
-                    ))}
-                  </div>
-                </div>
-              )}
-              {invitationFields.map((field) => (
-                <AdditionalField
-                  key={field.name}
-                  field={field}
-                  name={field.name}
-                  isPending={isInviting || isSubmitting}
-                  optionalLabel={localization.settings.optional}
-                />
-              ))}
-            </AlertDialog.Body>
-
-            <AlertDialog.Footer>
-              <Button
-                slot="close"
-                variant="tertiary"
-                isDisabled={isInviting || isSubmitting}
-              >
-                {localization.settings.cancel}
-              </Button>
-
-              <Button
-                type="submit"
-                isPending={isInviting || isSubmitting}
-                isDisabled={
-                  !isRoleValid ||
-                  invitationLimitReached ||
-                  canInvite.isPending ||
-                  !canInvite.data?.success
-                }
-              >
-                {(isInviting || isSubmitting) && (
-                  <Spinner color="current" size="sm" />
+                {invitationLimitReached && (
+                  <p className="text-danger text-sm" role="alert">
+                    {organizationLocalization.invitationLimitReached}
+                  </p>
                 )}
 
-                {organizationLocalization.inviteMember}
-              </Button>
-            </AlertDialog.Footer>
-          </Form>
+                <form.AppField
+                  name="email"
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateEmailAddress(value, {
+                        invalidMessage: localization.auth.invalidEmail,
+                        requiredMessage: localization.auth.fieldRequired
+                      })
+                  }}
+                >
+                  {(field) => (
+                    <TextField
+                      id="email"
+                      name={field.name}
+                      type="email"
+                      isDisabled={isInviting}
+                      isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={field.handleChange}
+                    >
+                      <Label>{localization.auth.email}</Label>
+                      <Input
+                        autoFocus
+                        placeholder={localization.auth.email}
+                        variant="secondary"
+                      />
+                      <field.AuthFormFieldError />
+                    </TextField>
+                  )}
+                </form.AppField>
+
+                <form.AppField
+                  name="roles"
+                  validators={{
+                    onChange: ({ value }) =>
+                      value.length > 0
+                        ? undefined
+                        : localization.auth.fieldRequired
+                  }}
+                >
+                  {(field) => (
+                    <Select
+                      name={field.name}
+                      selectionMode={allowMultipleRoles ? "multiple" : "single"}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(keys) => {
+                        const next = [...(keys as Iterable<string>)]
+                        if (next.length === 0) return
+                        field.handleChange(
+                          allowMultipleRoles ? next : next.slice(0, 1)
+                        )
+                      }}
+                      isDisabled={isInviting}
+                      isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                      variant="secondary"
+                      fullWidth
+                    >
+                      <Label>{organizationLocalization.role}</Label>
+                      <Select.Trigger>
+                        <Select.Value />
+                        <Select.Indicator />
+                      </Select.Trigger>
+                      <Select.Popover>
+                        <ListBox
+                          selectionMode={
+                            allowMultipleRoles ? "multiple" : "single"
+                          }
+                        >
+                          {Object.entries(assignableRoles).map(
+                            ([key, label]) => (
+                              <ListBox.Item
+                                key={key}
+                                id={key}
+                                textValue={label}
+                              >
+                                {label}
+                                <ListBox.ItemIndicator />
+                              </ListBox.Item>
+                            )
+                          )}
+                        </ListBox>
+                      </Select.Popover>
+                      <field.AuthFormFieldError />
+                    </Select>
+                  )}
+                </form.AppField>
+                {teamsEnabled && (teams.data?.length ?? 0) > 0 && (
+                  <form.AppField name="teamIds">
+                    {(field) => (
+                      <div className="flex flex-col gap-2">
+                        <Label>{organizationLocalization.teams}</Label>
+                        <div className="flex flex-wrap gap-3">
+                          {teams.data?.map((team) => (
+                            <Checkbox
+                              key={team.id}
+                              isSelected={field.state.value.includes(team.id)}
+                              onChange={(selected) =>
+                                field.handleChange(
+                                  selected
+                                    ? [...field.state.value, team.id]
+                                    : field.state.value.filter(
+                                        (id) => id !== team.id
+                                      )
+                                )
+                              }
+                            >
+                              {team.name}
+                            </Checkbox>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </form.AppField>
+                )}
+                {invitationFields.map((configuredField) => (
+                  <form.AppField
+                    key={configuredField.name}
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={isInviting}
+                        optionalLabel={localization.settings.optional}
+                      />
+                    )}
+                  </form.AppField>
+                ))}
+              </AlertDialog.Body>
+
+              <AlertDialog.Footer>
+                <Button slot="close" variant="tertiary" isDisabled={isInviting}>
+                  {localization.settings.cancel}
+                </Button>
+
+                <form.AuthFormSubmitButton
+                  isDisabled={
+                    invitationLimitReached ||
+                    canInvite.isPending ||
+                    !canInvite.data?.success
+                  }
+                >
+                  {organizationLocalization.inviteMember}
+                </form.AuthFormSubmitButton>
+              </AlertDialog.Footer>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </AlertDialog.Dialog>
       </AlertDialog.Container>
     </AlertDialog.Backdrop>

--- a/packages/heroui/src/components/auth/organization/organization-profile.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-profile.tsx
@@ -1,4 +1,9 @@
-import { parseAdditionalFieldValue } from "@better-auth-ui/core"
+import {
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
+} from "@better-auth-ui/core"
 import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
@@ -7,23 +12,23 @@ import {
   useUpdateOrganization
 } from "@better-auth-ui/react/plugins/organization"
 import {
-  Button,
   Card,
   type CardProps,
   cn,
-  FieldError,
-  Form,
   Input,
   Label,
   Skeleton,
-  Spinner,
   TextField,
   toast
 } from "@heroui/react"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect } from "react"
 
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 import { ChangeOrganizationLogo } from "./change-organization-logo"
 import { SlugField } from "./slug-field"
 
@@ -57,45 +62,46 @@ export function OrganizationProfile({
     permissions: { organization: ["update"] }
   })
 
-  const [slug, setSlug] = useState(activeOrganization?.slug ?? "")
-
-  useEffect(() => {
-    setSlug(activeOrganization?.slug ?? "")
-  }, [activeOrganization?.slug])
-
-  const { mutate: commitOrganizationUpdate, isPending } = useUpdateOrganization(
-    authClient as OrganizationAuthClient,
-    {
+  const { mutateAsync: commitOrganizationUpdate, isPending } =
+    useUpdateOrganization(authClient as OrganizationAuthClient, {
       onSuccess: () =>
         toast.success(organizationLocalization.organizationUpdatedSuccess)
-    }
-  )
-
-  async function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    if (!activeOrganization || !canUpdate.data?.success) return
-
-    const formData = new FormData(e.currentTarget)
-    const name = formData.get("name") as string
-    const additionalValues: Record<string, unknown> = {}
-    try {
-      for (const field of additionalFields) {
-        const value = parseAdditionalFieldValue(
-          field,
-          formData.get(field.name) as string | null
-        )
-        await field.validate?.(value)
-        if (value !== undefined) additionalValues[field.name] = value
-      }
-    } catch (error) {
-      toast.danger(error instanceof Error ? error.message : String(error))
-      return
-    }
-
-    commitOrganizationUpdate({
-      data: { ...additionalValues, name, ...(!hideSlug && { slug }) }
     })
-  }
+
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(additionalFields),
+      name: "",
+      slug: ""
+    },
+    onSubmit: async ({ value }) => {
+      if (!activeOrganization || !canUpdate.data?.success) return
+      await commitOrganizationUpdate({
+        data: {
+          ...getAdditionalFieldSubmitValues(
+            additionalFields,
+            value.additionalFields
+          ),
+          name: value.name,
+          ...(!hideSlug && { slug: value.slug })
+        }
+      })
+    }
+  })
+
+  useEffect(() => {
+    if (!activeOrganization) return
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(
+        fieldsWithModelValues(
+          additionalFields,
+          activeOrganization as Record<string, unknown>
+        )
+      ),
+      name: activeOrganization.name,
+      slug: activeOrganization.slug
+    })
+  }, [activeOrganization, additionalFields, form])
 
   const inputVariant = variant === "transparent" ? "primary" : "secondary"
   const formDisabled =
@@ -109,77 +115,103 @@ export function OrganizationProfile({
 
       <Card className={cn(className)} variant={variant} {...props}>
         <Card.Content>
-          <Form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <ChangeOrganizationLogo />
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-4">
+              <ChangeOrganizationLogo />
 
-            <TextField
-              key={`${activeOrganization?.id}-${activeOrganization?.name}-name`}
-              name="name"
-              defaultValue={activeOrganization?.name}
-              isDisabled={formDisabled || !activeOrganization}
-            >
-              <Label>{organizationLocalization.name}</Label>
-
-              <Input
-                className={cn(!activeOrganization && "hidden")}
-                autoComplete="organization"
-                placeholder={organizationLocalization.namePlaceholder}
-                variant={inputVariant}
-              />
-
-              {!activeOrganization && (
-                <Skeleton className="h-10 w-full rounded-xl md:h-9" />
-              )}
-
-              <FieldError />
-            </TextField>
-
-            {!hideSlug &&
-              (activeOrganization ? (
-                <SlugField
-                  value={slug}
-                  onChange={setSlug}
-                  currentSlug={activeOrganization.slug}
-                  isDisabled={formDisabled}
-                  variant={inputVariant}
-                />
-              ) : (
-                <TextField isDisabled>
-                  <Label>{organizationLocalization.slug}</Label>
-                  <Skeleton className="h-10 w-full rounded-xl md:h-9" />
-                </TextField>
-              ))}
-            {activeOrganization &&
-              additionalFields.map((field) => (
-                <AdditionalField
-                  field={{
-                    ...field,
-                    defaultValue: (
-                      activeOrganization as Record<string, unknown>
-                    )[field.name] as never
-                  }}
-                  isPending={formDisabled}
-                  key={field.name}
-                  name={field.name}
-                  optionalLabel={localization.settings.optional}
-                  variant={variant}
-                />
-              ))}
-
-            {(canUpdate.isPending || canUpdate.data?.success) && (
-              <Button
-                type="submit"
-                isPending={isPending}
-                isDisabled={formDisabled || !activeOrganization}
-                size="sm"
-                className="mt-1"
+              <form.AppField
+                name="name"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
               >
-                {isPending && <Spinner color="current" size="sm" />}
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
-                {localization.settings.saveChanges}
-              </Button>
-            )}
-          </Form>
+                  return (
+                    <TextField
+                      name={field.name}
+                      isDisabled={formDisabled || !activeOrganization}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={field.handleChange}
+                      isInvalid={isInvalid || undefined}
+                      validationBehavior="aria"
+                    >
+                      <Label>{organizationLocalization.name}</Label>
+
+                      <Input
+                        className={cn(!activeOrganization && "hidden")}
+                        autoComplete="organization"
+                        placeholder={organizationLocalization.namePlaceholder}
+                        variant={inputVariant}
+                      />
+
+                      {!activeOrganization && (
+                        <Skeleton className="h-10 w-full rounded-xl md:h-9" />
+                      )}
+
+                      <field.AuthFormFieldError />
+                    </TextField>
+                  )
+                }}
+              </form.AppField>
+
+              {!hideSlug &&
+                (activeOrganization ? (
+                  <form.AppField name="slug">
+                    {(field) => (
+                      <SlugField
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        currentSlug={activeOrganization.slug}
+                        isDisabled={formDisabled}
+                        variant={inputVariant}
+                      />
+                    )}
+                  </form.AppField>
+                ) : (
+                  <TextField isDisabled>
+                    <Label>{organizationLocalization.slug}</Label>
+                    <Skeleton className="h-10 w-full rounded-xl md:h-9" />
+                  </TextField>
+                ))}
+              {activeOrganization &&
+                additionalFields.map((configuredField) => (
+                  <form.AppField
+                    key={configuredField.name}
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={formDisabled}
+                        optionalLabel={localization.settings.optional}
+                        variant={variant}
+                      />
+                    )}
+                  </form.AppField>
+                ))}
+
+              {(canUpdate.isPending || canUpdate.data?.success) && (
+                <form.AuthFormSubmitButton
+                  isDisabled={formDisabled || !activeOrganization}
+                  size="sm"
+                  className="mt-1"
+                >
+                  {localization.settings.saveChanges}
+                </form.AuthFormSubmitButton>
+              )}
+            </form.AuthFormRoot>
+          </form.AppForm>
         </Card.Content>
       </Card>
     </div>

--- a/packages/heroui/src/components/auth/organization/organization-roles.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-roles.tsx
@@ -1,7 +1,9 @@
 import {
   type AdditionalFields,
   fieldsWithModelValues,
-  parseAdditionalFieldValues
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type {
   OrganizationPermissionRegistry,
@@ -24,7 +26,6 @@ import {
   Checkbox,
   Chip,
   Dropdown,
-  Form,
   Input,
   Label,
   SearchField,
@@ -33,9 +34,13 @@ import {
   TextField,
   toast
 } from "@heroui/react"
-import { type FormEvent, useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 import { OrganizationSortableTableColumn } from "./organization-sortable-table-column"
 import {
   createOrganizationColumnHelper,
@@ -610,9 +615,6 @@ function RoleDialog({
   const { authClient, localization: authLocalization } = useAuth()
   const client = authClient as OrganizationRolesAuthClient
   const { localization } = useAuthPlugin(organizationPlugin)
-  const [name, setName] = useState("")
-  const [permission, setPermission] = useState<Record<string, string[]>>({})
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const createRole = useCreateRole(client, organizationId, {
     onSuccess: () => {
       toast.success(localization.roleCreated)
@@ -626,153 +628,202 @@ function RoleDialog({
     }
   })
 
-  useEffect(() => {
-    if (!isOpen) return
-    setName(role?.role ?? "")
-    setPermission(role?.permission ?? {})
-  }, [isOpen, role])
+  const configuredRoleFields = useMemo(
+    () => fieldsWithModelValues(roleFields, role ?? {}),
+    [role, roleFields]
+  )
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredRoleFields),
+      name: role?.role ?? "",
+      permission: role?.permission ?? ({} as Record<string, string[]>)
+    },
+    onSubmit: async ({ value }) => {
+      const roleName = value.name.trim()
+      if (!roleName) return
 
-  const submit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const roleName = name.trim()
-    if (!roleName) return
+      try {
+        if (
+          Object.values(value.permission).some((actions) => actions.length > 0)
+        ) {
+          const access = await client.organization.hasPermission({
+            organizationId,
+            permissions: value.permission as Parameters<
+              OrganizationRolesAuthClient["organization"]["hasPermission"]
+            >[0]["permissions"]
+          })
 
-    setIsSubmitting(true)
-    try {
-      if (Object.values(permission).some((actions) => actions.length > 0)) {
-        const access = await client.organization.hasPermission({
-          organizationId,
-          permissions: permission as Parameters<
-            OrganizationRolesAuthClient["organization"]["hasPermission"]
-          >[0]["permissions"]
-        })
-
-        if (access.error || !access.data?.success) {
-          toast.danger(localization.permissionsLimitedDescription)
-          setIsSubmitting(false)
-          return
+          if (access.error || !access.data?.success) {
+            toast.danger(localization.permissionsLimitedDescription)
+            return
+          }
         }
-      }
 
-      const additionalFields = await parseAdditionalFieldValues(
-        roleFields,
-        new FormData(event.currentTarget)
-      )
-      if (role) {
-        updateRole.mutate(
-          {
+        const additionalFields = getAdditionalFieldSubmitValues(
+          configuredRoleFields,
+          value.additionalFields
+        )
+        if (role) {
+          await updateRole.mutateAsync({
             organizationId,
             roleId: role.id,
-            data: { ...additionalFields, roleName, permission }
-          },
-          { onSettled: () => setIsSubmitting(false) }
-        )
-      } else {
-        createRole.mutate(
-          {
+            data: {
+              ...additionalFields,
+              roleName,
+              permission: value.permission
+            }
+          })
+        } else {
+          await createRole.mutateAsync({
             organizationId,
             role: roleName,
-            permission,
+            permission: value.permission,
             additionalFields
-          },
-          { onSettled: () => setIsSubmitting(false) }
-        )
+          })
+        }
+      } catch {
+        // The mutation reports the error through its configured handler.
       }
-    } catch (error) {
-      toast.danger(error instanceof Error ? error.message : String(error))
-      setIsSubmitting(false)
     }
-  }
+  })
 
-  const pending = createRole.isPending || updateRole.isPending || isSubmitting
+  useEffect(() => {
+    if (!isOpen) return
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredRoleFields),
+      name: role?.role ?? "",
+      permission: role?.permission ?? {}
+    })
+  }, [configuredRoleFields, form, isOpen, role?.permission, role?.role])
+
+  const pending = createRole.isPending || updateRole.isPending
 
   return (
     <AlertDialog.Backdrop isOpen={isOpen} onOpenChange={onOpenChange}>
       <AlertDialog.Container>
         <AlertDialog.Dialog className="max-w-xl">
-          <Form onSubmit={submit}>
-            <AlertDialog.CloseTrigger />
-            <AlertDialog.Header>
-              <AlertDialog.Heading>
-                {role ? localization.editRole : localization.createRole}
-              </AlertDialog.Heading>
-            </AlertDialog.Header>
-            <AlertDialog.Body className="flex max-h-[65vh] flex-col gap-5 overflow-y-auto">
-              <p className="text-sm text-muted">
-                {localization.rolesDescription}
-              </p>
-              <TextField isDisabled={pending} isRequired>
-                <Label>{localization.roleName}</Label>
-                <Input
-                  value={name}
-                  onChange={(event) => setName(event.target.value)}
-                  placeholder={localization.roleNamePlaceholder}
-                  variant="secondary"
-                />
-              </TextField>
-              {fieldsWithModelValues(roleFields, role ?? {}).map((field) => (
-                <AdditionalField
-                  key={field.name}
-                  field={field}
-                  name={field.name}
-                  isPending={pending}
-                  optionalLabel={authLocalization.settings.optional}
-                />
-              ))}
-              <fieldset className="flex flex-col gap-4">
-                <legend className="mb-3 text-sm font-medium">
-                  {localization.permissions}
-                </legend>
-                {Object.entries(registry).map(([resource, definition]) => (
-                  <div className="flex flex-col gap-2" key={resource}>
-                    <p className="text-sm font-medium">
-                      {definition.label ?? resource}
-                    </p>
-                    <div className="grid gap-3 sm:grid-cols-2">
-                      {Object.entries(definition.actions).map(
-                        ([action, label]) => (
-                          <RolePermissionCheckbox
-                            action={action}
-                            isSelected={
-                              permission[resource]?.includes(action) ?? false
-                            }
-                            key={action}
-                            label={label}
-                            onChange={(checked) =>
-                              setPermission((current) => ({
-                                ...current,
-                                [resource]: checked
-                                  ? [...(current[resource] ?? []), action]
-                                  : (current[resource] ?? []).filter(
-                                      (entry) => entry !== action
-                                    )
-                              }))
-                            }
-                            organizationId={organizationId}
-                            pending={pending}
-                            resource={resource}
-                          />
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <AlertDialog.CloseTrigger />
+              <AlertDialog.Header>
+                <AlertDialog.Heading>
+                  {role ? localization.editRole : localization.createRole}
+                </AlertDialog.Heading>
+              </AlertDialog.Header>
+              <AlertDialog.Body className="flex max-h-[65vh] flex-col gap-5 overflow-y-auto">
+                <p className="text-sm text-muted">
+                  {localization.rolesDescription}
+                </p>
+                <form.AppField
+                  name="name"
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateStringLength(value, {
+                        requiredMessage: authLocalization.auth.fieldRequired,
+                        trim: true
+                      })
+                  }}
+                >
+                  {(field) => (
+                    <TextField
+                      isDisabled={pending}
+                      isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                      name={field.name}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={field.handleChange}
+                    >
+                      <Label>{localization.roleName}</Label>
+                      <Input
+                        placeholder={localization.roleNamePlaceholder}
+                        variant="secondary"
+                      />
+                      <field.AuthFormFieldError />
+                    </TextField>
+                  )}
+                </form.AppField>
+                {configuredRoleFields.map((configuredField) => (
+                  <form.AppField
+                    key={configuredField.name}
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      authLocalization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={pending}
+                        optionalLabel={authLocalization.settings.optional}
+                      />
+                    )}
+                  </form.AppField>
+                ))}
+                <form.AppField name="permission">
+                  {(field) => (
+                    <fieldset className="flex flex-col gap-4">
+                      <legend className="mb-3 text-sm font-medium">
+                        {localization.permissions}
+                      </legend>
+                      {Object.entries(registry).map(
+                        ([resource, definition]) => (
+                          <div className="flex flex-col gap-2" key={resource}>
+                            <p className="text-sm font-medium">
+                              {definition.label ?? resource}
+                            </p>
+                            <div className="grid gap-3 sm:grid-cols-2">
+                              {Object.entries(definition.actions).map(
+                                ([action, label]) => (
+                                  <RolePermissionCheckbox
+                                    action={action}
+                                    isSelected={
+                                      field.state.value[resource]?.includes(
+                                        action
+                                      ) ?? false
+                                    }
+                                    key={action}
+                                    label={label}
+                                    onChange={(checked) =>
+                                      field.handleChange({
+                                        ...field.state.value,
+                                        [resource]: checked
+                                          ? [
+                                              ...(field.state.value[resource] ??
+                                                []),
+                                              action
+                                            ]
+                                          : (
+                                              field.state.value[resource] ?? []
+                                            ).filter(
+                                              (entry) => entry !== action
+                                            )
+                                      })
+                                    }
+                                    organizationId={organizationId}
+                                    pending={pending}
+                                    resource={resource}
+                                  />
+                                )
+                              )}
+                            </div>
+                          </div>
                         )
                       )}
-                    </div>
-                  </div>
-                ))}
-              </fieldset>
-            </AlertDialog.Body>
-            <AlertDialog.Footer>
-              <Button slot="close" variant="tertiary" isDisabled={pending}>
-                {authLocalization.settings.cancel}
-              </Button>
-              <Button
-                type="submit"
-                isDisabled={pending || !name.trim()}
-                isPending={pending}
-              >
-                {pending && <Spinner color="current" size="sm" />}
-                {authLocalization.settings.saveChanges}
-              </Button>
-            </AlertDialog.Footer>
-          </Form>
+                    </fieldset>
+                  )}
+                </form.AppField>
+              </AlertDialog.Body>
+              <AlertDialog.Footer>
+                <Button slot="close" variant="tertiary" isDisabled={pending}>
+                  {authLocalization.settings.cancel}
+                </Button>
+                <form.AuthFormSubmitButton isDisabled={pending}>
+                  {authLocalization.settings.saveChanges}
+                </form.AuthFormSubmitButton>
+              </AlertDialog.Footer>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </AlertDialog.Dialog>
       </AlertDialog.Container>
     </AlertDialog.Backdrop>

--- a/packages/heroui/src/components/auth/organization/organization-teams.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-teams.tsx
@@ -1,7 +1,9 @@
 import {
   type AdditionalFields,
   fieldsWithModelValues,
-  parseAdditionalFieldValues
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type { OrganizationTeamsAuthClient } from "@better-auth-ui/core/plugins/organization"
 import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
@@ -23,7 +25,6 @@ import {
   AlertDialog,
   Button,
   Card,
-  Form,
   Input,
   Label,
   ListBox,
@@ -32,9 +33,13 @@ import {
   TextField,
   toast
 } from "@heroui/react"
-import { type FormEvent, useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
-import { AdditionalField } from "../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 
 type Team = { id: string; name: string; [key: string]: unknown }
 
@@ -198,8 +203,6 @@ function TeamDialog({
     organizationId,
     permissions: { member: ["delete"] }
   })
-  const [name, setName] = useState("")
-  const [isSubmittingFields, setIsSubmittingFields] = useState(false)
   const [userId, setUserId] = useState<string>()
   const createTeam = useCreateTeam(client, {
     onSuccess: () => {
@@ -234,247 +237,277 @@ function TeamDialog({
     ? labels.activeTeamRemovalDisabled
     : labels.lastTeamRemovalDisabled
 
+  const configuredTeamFields = useMemo(
+    () => fieldsWithModelValues(teamFields, team ?? {}),
+    [team, teamFields]
+  )
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(configuredTeamFields),
+      name: team?.name ?? ""
+    },
+    onSubmit: async ({ value }) => {
+      const name = value.name.trim()
+      if (!name || !organizationId || (!team && teamLimitReached)) return
+      if (team && !canUpdate.data?.success) return
+
+      const data = {
+        ...getAdditionalFieldSubmitValues(
+          configuredTeamFields,
+          value.additionalFields
+        ),
+        name,
+        organizationId
+      }
+
+      try {
+        if (team) await updateTeam.mutateAsync({ teamId: team.id, data })
+        else await createTeam.mutateAsync(data)
+      } catch {
+        // The mutation reports the error through its configured handler.
+      }
+    }
+  })
+
   useEffect(() => {
     if (!isOpen) return
-    setName(team?.name ?? "")
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(configuredTeamFields),
+      name: team?.name ?? ""
+    })
     setUserId(undefined)
-  }, [isOpen, team])
+  }, [configuredTeamFields, form, isOpen, team?.name])
 
-  const submit = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const trimmedName = name.trim()
-    if (!trimmedName || !organizationId || (!team && teamLimitReached)) return
-    if (team && !canUpdate.data?.success) return
-
-    setIsSubmittingFields(true)
-    try {
-      const values = await parseAdditionalFieldValues(
-        teamFields,
-        new FormData(event.currentTarget)
-      )
-      if (team) {
-        updateTeam.mutate(
-          {
-            teamId: team.id,
-            data: { ...values, name: trimmedName, organizationId }
-          },
-          { onSettled: () => setIsSubmittingFields(false) }
-        )
-      } else {
-        createTeam.mutate(
-          { ...values, name: trimmedName, organizationId },
-          { onSettled: () => setIsSubmittingFields(false) }
-        )
-      }
-    } catch (error) {
-      toast.danger(error instanceof Error ? error.message : String(error))
-      setIsSubmittingFields(false)
-    }
-  }
-
-  const pending =
-    createTeam.isPending || updateTeam.isPending || isSubmittingFields
+  const pending = createTeam.isPending || updateTeam.isPending
   const canEdit = !team || canUpdate.data?.success === true
 
   return (
     <AlertDialog.Backdrop isOpen={isOpen} onOpenChange={onOpenChange}>
       <AlertDialog.Container>
         <AlertDialog.Dialog className="max-w-xl">
-          <Form onSubmit={submit}>
-            <AlertDialog.CloseTrigger />
-            <AlertDialog.Header>
-              <AlertDialog.Icon status="default">
-                {team ? <Pencil /> : <CirclePlus />}
-              </AlertDialog.Icon>
-              <AlertDialog.Heading>
-                {team ? labels.renameTeam : labels.createTeam}
-              </AlertDialog.Heading>
-            </AlertDialog.Header>
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <AlertDialog.CloseTrigger />
+              <AlertDialog.Header>
+                <AlertDialog.Icon status="default">
+                  {team ? <Pencil /> : <CirclePlus />}
+                </AlertDialog.Icon>
+                <AlertDialog.Heading>
+                  {team ? labels.renameTeam : labels.createTeam}
+                </AlertDialog.Heading>
+              </AlertDialog.Header>
 
-            <AlertDialog.Body className="flex max-h-[65vh] flex-col gap-5 overflow-y-auto">
-              <p className="text-muted text-sm">{labels.teamsDescription}</p>
+              <AlertDialog.Body className="flex max-h-[65vh] flex-col gap-5 overflow-y-auto">
+                <p className="text-muted text-sm">{labels.teamsDescription}</p>
 
-              <TextField isDisabled={pending || !canEdit} isRequired>
-                <Label>{labels.name}</Label>
-                <Input
-                  autoFocus
-                  onChange={(event) => setName(event.target.value)}
-                  value={name}
-                  variant="secondary"
-                />
-              </TextField>
+                <form.AppField
+                  name="name"
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateStringLength(value, {
+                        requiredMessage: localization.auth.fieldRequired,
+                        trim: true
+                      })
+                  }}
+                >
+                  {(field) => (
+                    <TextField
+                      isDisabled={pending || !canEdit}
+                      isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                      name={field.name}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={field.handleChange}
+                    >
+                      <Label>{labels.name}</Label>
+                      <Input autoFocus variant="secondary" />
+                      <field.AuthFormFieldError />
+                    </TextField>
+                  )}
+                </form.AppField>
 
-              {fieldsWithModelValues(teamFields, team ?? {}).map((field) => (
-                <AdditionalField
-                  field={field}
-                  isPending={pending || !canEdit}
-                  key={field.name}
-                  name={field.name}
-                  optionalLabel={localization.settings.optional}
-                />
-              ))}
+                {configuredTeamFields.map((configuredField) => (
+                  <form.AppField
+                    key={configuredField.name}
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={pending || !canEdit}
+                        optionalLabel={localization.settings.optional}
+                      />
+                    )}
+                  </form.AppField>
+                ))}
 
-              {team && canListMembers && (
-                <div className="flex flex-col gap-4 border-t pt-5">
-                  <div>
-                    <h3 className="text-sm font-medium">
-                      {labels.teamMembers}
-                    </h3>
-                    <p className="text-muted text-sm">{labels.addTeamMember}</p>
-                  </div>
-
-                  {(canAddMember.isPending || canAddMember.data?.success) && (
-                    <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-end">
-                      <Select
-                        className="flex-1"
-                        isDisabled={
-                          canAddMember.isPending || memberLimitReached
-                        }
-                        onChange={(value) => setUserId(String(value))}
-                        value={userId}
-                      >
-                        <Label>{labels.addTeamMember}</Label>
-                        <Select.Trigger>
-                          <Select.Value />
-                          <Select.Indicator />
-                        </Select.Trigger>
-                        <Select.Popover>
-                          <ListBox>
-                            {organizationMembers
-                              .filter((member) => !memberIds.has(member.userId))
-                              .map((member) => (
-                                <ListBox.Item
-                                  id={member.userId}
-                                  key={member.userId}
-                                  textValue={
-                                    member.user.name || member.user.email
-                                  }
-                                >
-                                  {member.user.name || member.user.email}
-                                  <ListBox.ItemIndicator />
-                                </ListBox.Item>
-                              ))}
-                          </ListBox>
-                        </Select.Popover>
-                      </Select>
-                      <Button
-                        isDisabled={
-                          canAddMember.isPending ||
-                          !userId ||
-                          addMember.isPending ||
-                          memberLimitReached
-                        }
-                        onPress={() => {
-                          if (!canAddMember.data?.success || !userId) return
-                          addMember.mutate({
-                            teamId: team.id,
-                            userId,
-                            organizationId
-                          })
-                        }}
-                        type="button"
-                      >
-                        <CirclePlus />
+                {team && canListMembers && (
+                  <div className="flex flex-col gap-4 border-t pt-5">
+                    <div>
+                      <h3 className="text-sm font-medium">
+                        {labels.teamMembers}
+                      </h3>
+                      <p className="text-muted text-sm">
                         {labels.addTeamMember}
-                      </Button>
+                      </p>
                     </div>
-                  )}
 
-                  {canAddMember.data?.success && memberLimitReached && (
-                    <p className="text-danger text-sm" role="alert">
-                      {labels.teamMemberLimitReached}
-                    </p>
-                  )}
-
-                  <div className="flex flex-col gap-2">
-                    {teamMembers.isPending && <Spinner />}
-                    {teamMembers.data?.map((teamMember) => {
-                      const member = organizationMembers.find(
-                        (candidate) => candidate.userId === teamMember.userId
-                      )
-                      return (
-                        <div
-                          className="flex items-center justify-between gap-3 rounded-lg border px-3 py-2"
-                          key={teamMember.id}
+                    {(canAddMember.isPending || canAddMember.data?.success) && (
+                      <div className="flex flex-col items-stretch gap-2 sm:flex-row sm:items-end">
+                        <Select
+                          className="flex-1"
+                          isDisabled={
+                            canAddMember.isPending || memberLimitReached
+                          }
+                          onChange={(value) => setUserId(String(value))}
+                          value={userId}
                         >
-                          <span className="truncate text-sm">
-                            {member?.user.name ||
-                              member?.user.email ||
-                              teamMember.userId}
-                          </span>
-                          {(canRemoveMember.isPending ||
-                            canRemoveMember.data?.success) && (
-                            <Button
-                              aria-label={labels.removeTeamMember}
-                              isDisabled={
-                                canRemoveMember.isPending ||
-                                removeMember.isPending
-                              }
-                              isIconOnly
-                              onPress={() => {
-                                if (!canRemoveMember.data?.success) return
-                                removeMember.mutate({
-                                  teamId: team.id,
-                                  userId: teamMember.userId,
-                                  organizationId
-                                })
-                              }}
-                              size="sm"
-                              type="button"
-                              variant="tertiary"
-                            >
-                              <TrashBin />
-                            </Button>
-                          )}
-                        </div>
-                      )
-                    })}
+                          <Label>{labels.addTeamMember}</Label>
+                          <Select.Trigger>
+                            <Select.Value />
+                            <Select.Indicator />
+                          </Select.Trigger>
+                          <Select.Popover>
+                            <ListBox>
+                              {organizationMembers
+                                .filter(
+                                  (member) => !memberIds.has(member.userId)
+                                )
+                                .map((member) => (
+                                  <ListBox.Item
+                                    id={member.userId}
+                                    key={member.userId}
+                                    textValue={
+                                      member.user.name || member.user.email
+                                    }
+                                  >
+                                    {member.user.name || member.user.email}
+                                    <ListBox.ItemIndicator />
+                                  </ListBox.Item>
+                                ))}
+                            </ListBox>
+                          </Select.Popover>
+                        </Select>
+                        <Button
+                          isDisabled={
+                            canAddMember.isPending ||
+                            !userId ||
+                            addMember.isPending ||
+                            memberLimitReached
+                          }
+                          onPress={() => {
+                            if (!canAddMember.data?.success || !userId) return
+                            addMember.mutate({
+                              teamId: team.id,
+                              userId,
+                              organizationId
+                            })
+                          }}
+                          type="button"
+                        >
+                          <CirclePlus />
+                          {labels.addTeamMember}
+                        </Button>
+                      </div>
+                    )}
+
+                    {canAddMember.data?.success && memberLimitReached && (
+                      <p className="text-danger text-sm" role="alert">
+                        {labels.teamMemberLimitReached}
+                      </p>
+                    )}
+
+                    <div className="flex flex-col gap-2">
+                      {teamMembers.isPending && <Spinner />}
+                      {teamMembers.data?.map((teamMember) => {
+                        const member = organizationMembers.find(
+                          (candidate) => candidate.userId === teamMember.userId
+                        )
+                        return (
+                          <div
+                            className="flex items-center justify-between gap-3 rounded-lg border px-3 py-2"
+                            key={teamMember.id}
+                          >
+                            <span className="truncate text-sm">
+                              {member?.user.name ||
+                                member?.user.email ||
+                                teamMember.userId}
+                            </span>
+                            {(canRemoveMember.isPending ||
+                              canRemoveMember.data?.success) && (
+                              <Button
+                                aria-label={labels.removeTeamMember}
+                                isDisabled={
+                                  canRemoveMember.isPending ||
+                                  removeMember.isPending
+                                }
+                                isIconOnly
+                                onPress={() => {
+                                  if (!canRemoveMember.data?.success) return
+                                  removeMember.mutate({
+                                    teamId: team.id,
+                                    userId: teamMember.userId,
+                                    organizationId
+                                  })
+                                }}
+                                size="sm"
+                                type="button"
+                                variant="tertiary"
+                              >
+                                <TrashBin />
+                              </Button>
+                            )}
+                          </div>
+                        )
+                      })}
+                    </div>
                   </div>
-                </div>
-              )}
+                )}
 
-              {team && !canRemoveTeam && canDelete.data?.success && (
-                <p className="text-muted text-sm">
-                  {teamRemovalDisabledReason}
-                </p>
-              )}
-            </AlertDialog.Body>
+                {team && !canRemoveTeam && canDelete.data?.success && (
+                  <p className="text-muted text-sm">
+                    {teamRemovalDisabledReason}
+                  </p>
+                )}
+              </AlertDialog.Body>
 
-            <AlertDialog.Footer>
-              {team && (canDelete.isPending || canDelete.data?.success) && (
-                <Button
-                  isDisabled={
-                    canDelete.isPending ||
-                    removeTeam.isPending ||
-                    !canRemoveTeam
-                  }
-                  onPress={() =>
-                    removeTeam.mutate({ teamId: team.id, organizationId })
-                  }
-                  type="button"
-                  variant="danger-soft"
-                >
-                  <TrashBin />
-                  {labels.deleteTeam}
+              <AlertDialog.Footer>
+                {team && (canDelete.isPending || canDelete.data?.success) && (
+                  <Button
+                    isDisabled={
+                      canDelete.isPending ||
+                      removeTeam.isPending ||
+                      !canRemoveTeam
+                    }
+                    onPress={() =>
+                      removeTeam.mutate({ teamId: team.id, organizationId })
+                    }
+                    type="button"
+                    variant="danger-soft"
+                  >
+                    <TrashBin />
+                    {labels.deleteTeam}
+                  </Button>
+                )}
+                <Button isDisabled={pending} slot="close" variant="tertiary">
+                  {localization.settings.cancel}
                 </Button>
-              )}
-              <Button isDisabled={pending} slot="close" variant="tertiary">
-                {localization.settings.cancel}
-              </Button>
-              {canEdit && (
-                <Button
-                  isDisabled={
-                    pending || !name.trim() || (teamLimitReached && !team)
-                  }
-                  isPending={pending}
-                  type="submit"
-                >
-                  {pending && <Spinner color="current" size="sm" />}
-                  {team ? localization.settings.saveChanges : labels.createTeam}
-                </Button>
-              )}
-            </AlertDialog.Footer>
-          </Form>
+                {canEdit && (
+                  <form.AuthFormSubmitButton
+                    isDisabled={pending || (teamLimitReached && !team)}
+                  >
+                    {team
+                      ? localization.settings.saveChanges
+                      : labels.createTeam}
+                  </form.AuthFormSubmitButton>
+                )}
+              </AlertDialog.Footer>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </AlertDialog.Dialog>
       </AlertDialog.Container>
     </AlertDialog.Backdrop>

--- a/packages/heroui/src/components/auth/settings/account/user-profile.tsx
+++ b/packages/heroui/src/components/auth/settings/account/user-profile.tsx
@@ -1,25 +1,27 @@
 import {
-  type AdditionalFieldValue,
-  parseAdditionalFieldValue
+  fieldsWithModelValues,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
+  validateStringLength
 } from "@better-auth-ui/core"
 import { useAuth, useSession, useUpdateUser } from "@better-auth-ui/react"
 import {
-  Button,
   Card,
   type CardProps,
   cn,
-  FieldError,
-  Form,
   Input,
   Label,
   Skeleton,
-  Spinner,
   TextField,
   toast
 } from "@heroui/react"
-import type { SyntheticEvent } from "react"
+import { useEffect, useMemo } from "react"
 
-import { AdditionalField } from "../../additional-field"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../../auth-form"
 import { ChangeAvatar } from "./change-avatar"
 
 export type UserProfileProps = {
@@ -39,44 +41,39 @@ export function UserProfile({
   const { additionalFields, authClient, localization } = useAuth()
   const { data: session } = useSession(authClient)
 
-  const { mutate: updateUser, isPending } = useUpdateUser(authClient, {
+  const { mutateAsync: updateUser, isPending } = useUpdateUser(authClient, {
     onSuccess: () => toast.success(localization.settings.profileUpdatedSuccess)
   })
 
-  async function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    const formData = new FormData(e.currentTarget)
-    const name = formData.get("name") as string
-
-    const additionalFieldValues: Record<string, unknown> = {}
-
-    for (const field of additionalFields ?? []) {
-      if (field.profile === false || field.readOnly) continue
-      const value = parseAdditionalFieldValue(
-        field,
-        formData.get(field.name) as string | null
-      )
-
-      if (field.validate) {
-        try {
-          await field.validate(value)
-        } catch (error) {
-          toast.danger(error instanceof Error ? error.message : String(error))
-          return
-        }
-      }
-
-      // `null` = explicit clear (forward to backend); `undefined` = omitted.
-      if (value !== undefined) {
-        additionalFieldValues[field.name] = value
-      }
+  const profileFields = useMemo(
+    () => additionalFields?.filter((field) => field.profile !== false) ?? [],
+    [additionalFields]
+  )
+  const form = useAuthForm({
+    defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(profileFields),
+      name: ""
+    },
+    onSubmit: async ({ value }) => {
+      await updateUser({
+        name: value.name,
+        ...getAdditionalFieldSubmitValues(profileFields, value.additionalFields)
+      })
     }
+  })
 
-    updateUser({
-      name,
-      ...additionalFieldValues
+  useEffect(() => {
+    if (!session) return
+    form.reset({
+      additionalFields: getAdditionalFieldDefaultValues(
+        fieldsWithModelValues(
+          profileFields,
+          session.user as Record<string, unknown>
+        )
+      ),
+      name: session.user.name
     })
-  }
+  }, [form, profileFields, session])
 
   return (
     <div>
@@ -86,84 +83,97 @@ export function UserProfile({
 
       <Card className={cn("p-4 gap-4", className)} variant={variant} {...props}>
         <Card.Content>
-          <Form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <ChangeAvatar />
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-4">
+              <ChangeAvatar />
 
-            <TextField
-              key={`${session?.user?.id}-${session?.user?.name}-name`}
-              name="name"
-              defaultValue={session?.user.name}
-              isDisabled={isPending || !session}
-            >
-              <Label>{localization.auth.name}</Label>
+              <form.AppField
+                name="name"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
-              <Input
-                className={cn(!session && "hidden")}
-                autoComplete="name"
-                placeholder={localization.auth.name}
-                variant={variant === "transparent" ? "primary" : "secondary"}
-              />
+                  return (
+                    <TextField
+                      name={field.name}
+                      isDisabled={isPending || !session}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={field.handleChange}
+                      isInvalid={isInvalid || undefined}
+                      validationBehavior="aria"
+                    >
+                      <Label>{localization.auth.name}</Label>
 
-              {!session && (
-                <Skeleton className="h-10 md:h-9 w-full rounded-xl" />
-              )}
+                      <Input
+                        className={cn(!session && "hidden")}
+                        autoComplete="name"
+                        placeholder={localization.auth.name}
+                        variant={
+                          variant === "transparent" ? "primary" : "secondary"
+                        }
+                      />
 
-              <FieldError />
-            </TextField>
+                      {!session && (
+                        <Skeleton className="h-10 md:h-9 w-full rounded-xl" />
+                      )}
 
-            {additionalFields
-              ?.filter((field) => field.profile !== false)
-              .map((field) => {
+                      <field.AuthFormFieldError />
+                    </TextField>
+                  )
+                }}
+              </form.AppField>
+
+              {profileFields.map((configuredField) => {
                 if (!session) {
-                  if (field.inputType === "hidden") {
+                  if (configuredField.inputType === "hidden") {
                     return null
                   }
 
                   return (
                     <Skeleton
-                      key={field.name}
+                      key={configuredField.name}
                       className="h-10 md:h-9 w-full rounded-xl"
                     />
                   )
                 }
 
-                const value = (session.user as Record<string, unknown>)[
-                  field.name
-                ]
-
-                // Re-mount when the user or the session value changes so the
-                // field's uncontrolled `defaultValue` reflects the latest data.
-                const key = `${session.user.id}-${field.name}-${
-                  value instanceof Date
-                    ? value.toISOString()
-                    : String(value ?? "")
-                }`
-
                 return (
-                  <AdditionalField
-                    key={key}
-                    name={field.name}
-                    field={{
-                      ...field,
-                      defaultValue: value as AdditionalFieldValue | null
-                    }}
-                    isPending={isPending}
-                    variant={variant}
-                  />
+                  <form.AppField
+                    key={configuredField.name}
+                    name={`additionalFields.${configuredField.name}`}
+                    validators={getAuthAdditionalFieldValidators(
+                      configuredField,
+                      localization.auth.fieldRequired
+                    )}
+                  >
+                    {(field) => (
+                      <field.AuthFormAdditionalField
+                        field={configuredField}
+                        isPending={isPending}
+                        variant={variant}
+                      />
+                    )}
+                  </form.AppField>
                 )
               })}
 
-            <Button
-              type="submit"
-              isPending={isPending}
-              isDisabled={!session}
-              size="sm"
-              className="self-start mt-1"
-            >
-              {isPending && <Spinner color="current" size="sm" />}
-              {localization.settings.saveChanges}
-            </Button>
-          </Form>
+              <form.AuthFormSubmitButton
+                isDisabled={!session}
+                size="sm"
+                className="self-start mt-1"
+              >
+                {localization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </Card.Content>
       </Card>
     </div>

--- a/packages/heroui/src/components/auth/sign-up.tsx
+++ b/packages/heroui/src/components/auth/sign-up.tsx
@@ -1,8 +1,9 @@
 import {
   authMutationKeys,
+  getAdditionalFieldDefaultValues,
+  getAdditionalFieldSubmitValues,
   getAuthLinkURL,
   isPasswordCompromisedError,
-  parseAdditionalFieldValue,
   validateEmailAddress,
   validateMatchingValue,
   validateStringLength
@@ -25,13 +26,15 @@ import {
   InputGroup,
   Label,
   Link,
-  TextField,
-  toast
+  TextField
 } from "@heroui/react"
 import { useIsMutating } from "@tanstack/react-query"
-import { useRef, useState } from "react"
-import { AdditionalField } from "./additional-field"
-import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
+import { useMemo, useState } from "react"
+import {
+  getAuthAdditionalFieldValidators,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "./auth-form"
 import { FieldSeparator } from "./field-separator"
 import { PasswordStrengthMeter } from "./password-strength-meter"
 import { ProviderButtons, type SocialLayout } from "./provider-buttons"
@@ -126,9 +129,13 @@ export function SignUp({
   const Captcha = plugins.find(
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
-  const additionalFieldValuesRef = useRef<Record<string, unknown>>({})
+  const signUpFields = useMemo(
+    () => additionalFields?.filter((field) => field.signUp) ?? [],
+    [additionalFields]
+  )
   const form = useAuthForm({
     defaultValues: {
+      additionalFields: getAdditionalFieldDefaultValues(signUpFields),
       confirmPassword: "",
       email: "",
       name: "",
@@ -140,7 +147,10 @@ export function SignUp({
           name: emailAndPassword?.name === false ? "" : value.name,
           email: value.email.trim(),
           password: value.password,
-          ...additionalFieldValuesRef.current,
+          ...getAdditionalFieldSubmitValues(
+            signUpFields,
+            value.additionalFields
+          ),
           fetchOptions
         })
       } catch {
@@ -148,35 +158,6 @@ export function SignUp({
       }
     }
   })
-
-  const prepareSubmit = async (formElement: HTMLFormElement) => {
-    const formData = new FormData(formElement)
-
-    const additionalFieldValues: Record<string, unknown> = {}
-
-    for (const field of additionalFields ?? []) {
-      if (!field.signUp || field.readOnly) continue
-      const value = parseAdditionalFieldValue(
-        field,
-        formData.get(field.name) as string | null
-      )
-
-      if (field.validate) {
-        try {
-          await field.validate(value)
-        } catch (error) {
-          toast.danger(error instanceof Error ? error.message : String(error))
-          return false
-        }
-      }
-
-      if (value !== undefined) {
-        additionalFieldValues[field.name] = value
-      }
-    }
-
-    additionalFieldValuesRef.current = additionalFieldValues
-  }
 
   const showSeparator = emailAndPassword?.enabled && !!socialProviders?.length
 
@@ -207,10 +188,7 @@ export function SignUp({
 
         {emailAndPassword?.enabled && (
           <form.AppForm>
-            <form.AuthFormRoot
-              className="flex flex-col gap-4"
-              prepareSubmit={prepareSubmit}
-            >
+            <form.AuthFormRoot className="flex flex-col gap-4">
               {emailAndPassword.name !== false && (
                 <form.AppField
                   name="name"
@@ -291,17 +269,26 @@ export function SignUp({
                 )}
               </form.AppField>
 
-              {additionalFields?.map(
-                (field) =>
-                  field.signUp === "above" && (
-                    <AdditionalField
-                      key={field.name}
-                      name={field.name}
-                      field={field}
-                      isPending={isPending}
-                      optionalLabel={localization.auth.optional}
-                      variant={variant}
-                    />
+              {signUpFields.map(
+                (configuredField) =>
+                  configuredField.signUp === "above" && (
+                    <form.AppField
+                      key={configuredField.name}
+                      name={`additionalFields.${configuredField.name}`}
+                      validators={getAuthAdditionalFieldValidators(
+                        configuredField,
+                        localization.auth.fieldRequired
+                      )}
+                    >
+                      {(field) => (
+                        <field.AuthFormAdditionalField
+                          field={configuredField}
+                          isPending={isPending}
+                          optionalLabel={localization.auth.optional}
+                          variant={variant}
+                        />
+                      )}
+                    </form.AppField>
                   )
               )}
 
@@ -477,18 +464,26 @@ export function SignUp({
                 </form.AppField>
               )}
 
-              {additionalFields?.map(
-                (field) =>
-                  field.signUp &&
-                  field.signUp !== "above" && (
-                    <AdditionalField
-                      key={field.name}
-                      name={field.name}
-                      field={field}
-                      isPending={isPending}
-                      optionalLabel={localization.auth.optional}
-                      variant={variant}
-                    />
+              {signUpFields.map(
+                (configuredField) =>
+                  configuredField.signUp !== "above" && (
+                    <form.AppField
+                      key={configuredField.name}
+                      name={`additionalFields.${configuredField.name}`}
+                      validators={getAuthAdditionalFieldValidators(
+                        configuredField,
+                        localization.auth.fieldRequired
+                      )}
+                    >
+                      {(field) => (
+                        <field.AuthFormAdditionalField
+                          field={configuredField}
+                          isPending={isPending}
+                          optionalLabel={localization.auth.optional}
+                          variant={variant}
+                        />
+                      )}
+                    </form.AppField>
                   )
               )}
 

--- a/packages/heroui/src/components/auth/username/username-field.tsx
+++ b/packages/heroui/src/components/auth/username/username-field.tsx
@@ -1,3 +1,4 @@
+import { getFormFieldErrorMessage } from "@better-auth-ui/core"
 import type { UsernameAuthClient } from "@better-auth-ui/core/plugins/username"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useIsUsernameAvailable } from "@better-auth-ui/react/plugins/username"
@@ -10,7 +11,6 @@ import {
   TextField
 } from "@heroui/react"
 import { useDebouncer } from "@tanstack/react-pacer"
-import { useState } from "react"
 import { usernamePlugin } from "../../../lib/auth/username-plugin"
 import type { AdditionalFieldProps } from "../additional-field"
 
@@ -23,6 +23,11 @@ import type { AdditionalFieldProps } from "../additional-field"
 export function UsernameField({
   name,
   field,
+  value,
+  onBlur,
+  onChange,
+  isInvalid,
+  errors,
   isPending,
   variant
 }: AdditionalFieldProps) {
@@ -36,7 +41,8 @@ export function UsernameField({
   } = useAuthPlugin(usernamePlugin)
 
   const currentUsername = String(field.defaultValue ?? "")
-  const [value, setValue] = useState(currentUsername)
+  const username = typeof value === "string" ? value : ""
+  const errorMessage = getFormFieldErrorMessage(errors ?? [])
 
   const {
     mutate: requestAvailability,
@@ -63,7 +69,7 @@ export function UsernameField({
   )
 
   function handleChange(next: string) {
-    setValue(next)
+    onChange(next || null)
     resetAvailability()
 
     if (checkAvailability) {
@@ -72,7 +78,9 @@ export function UsernameField({
   }
 
   const isCheckingAvailability =
-    !!checkAvailability && !!value.trim() && value.trim() !== currentUsername
+    !!checkAvailability &&
+    !!username.trim() &&
+    username.trim() !== currentUsername
 
   const { localization: authLocalization } = useAuth()
 
@@ -85,8 +93,10 @@ export function UsernameField({
       maxLength={maxUsernameLength}
       isDisabled={isPending}
       isReadOnly={field.readOnly}
-      value={value}
+      value={username}
+      onBlur={onBlur}
       onChange={handleChange}
+      isInvalid={isInvalid}
       validate={(val) => {
         if (!val) {
           if (field.required) return authLocalization.auth.fieldRequired
@@ -140,7 +150,7 @@ export function UsernameField({
         )}
       </InputGroup>
 
-      <FieldError />
+      <FieldError>{errorMessage}</FieldError>
     </TextField>
   )
 }

--- a/packages/heroui/src/lib/auth/auth-plugin.ts
+++ b/packages/heroui/src/lib/auth/auth-plugin.ts
@@ -1,4 +1,7 @@
-import type { AdditionalField as AdditionalFieldConfig } from "@better-auth-ui/core"
+import type {
+  AdditionalField as AdditionalFieldConfig,
+  AdditionalFieldFormValue
+} from "@better-auth-ui/core"
 import type {
   AccountCardProps,
   AuthPlugin as AuthPluginPrimitive,
@@ -16,6 +19,11 @@ import type { SocialLayout } from "../../components/auth/provider-buttons"
 export type AdditionalFieldProps = {
   name: string
   field: AdditionalFieldConfig
+  value: AdditionalFieldFormValue
+  onBlur: () => void
+  onChange: (value: AdditionalFieldFormValue) => void
+  isInvalid?: boolean
+  errors?: unknown[]
   isPending?: boolean
   /** Complete suffix appended to labels for fields that are not required. */
   optionalLabel?: string

--- a/packages/heroui/tests/auth-form.test.tsx
+++ b/packages/heroui/tests/auth-form.test.tsx
@@ -3,18 +3,12 @@ import { describe, expect, it, vi } from "vitest"
 
 import { useAuthForm } from "../src/components/auth/auth-form"
 
-function TestAuthForm({
-  onSubmit,
-  prepareSubmit
-}: {
-  onSubmit: () => void
-  prepareSubmit: () => Promise<boolean>
-}) {
+function TestAuthForm({ onSubmit }: { onSubmit: () => Promise<void> }) {
   const form = useAuthForm({ defaultValues: {}, onSubmit })
 
   return (
     <form.AppForm>
-      <form.AuthFormRoot prepareSubmit={prepareSubmit}>
+      <form.AuthFormRoot>
         <form.AuthFormSubmitButton>Continue</form.AuthFormSubmitButton>
       </form.AuthFormRoot>
     </form.AppForm>
@@ -22,16 +16,13 @@ function TestAuthForm({
 }
 
 describe("AuthFormRoot", () => {
-  it("rejects concurrent preparation and disables submission while pending", async () => {
-    let finishPreparation!: (result: boolean) => void
-    const preparation = new Promise<boolean>((resolve) => {
-      finishPreparation = resolve
+  it("rejects concurrent submission and disables the submit button", async () => {
+    let finishSubmission!: () => void
+    const submission = new Promise<void>((resolve) => {
+      finishSubmission = resolve
     })
-    const prepareSubmit = vi.fn(() => preparation)
-    const onSubmit = vi.fn()
-    const { container } = render(
-      <TestAuthForm onSubmit={onSubmit} prepareSubmit={prepareSubmit} />
-    )
+    const onSubmit = vi.fn(() => submission)
+    const { container } = render(<TestAuthForm onSubmit={onSubmit} />)
     const form = container.querySelector("form")
     const submitButton = screen.getByRole("button", { name: /Continue/ })
 
@@ -39,10 +30,10 @@ describe("AuthFormRoot", () => {
     fireEvent.submit(form as HTMLFormElement)
     fireEvent.submit(form as HTMLFormElement)
 
-    expect(prepareSubmit).toHaveBeenCalledOnce()
-    expect(submitButton).toBeDisabled()
-
-    finishPreparation(true)
     await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce())
+    await waitFor(() => expect(submitButton).toBeDisabled())
+
+    finishSubmission()
+    await waitFor(() => expect(submitButton).toBeEnabled())
   })
 })

--- a/packages/heroui/tests/sign-up.test.tsx
+++ b/packages/heroui/tests/sign-up.test.tsx
@@ -89,6 +89,51 @@ describe("<SignUp />", () => {
     })
   })
 
+  it("submits runtime-defined fields from TanStack Form state", async () => {
+    const user = userEvent.setup()
+    const signUpEmail = vi.fn(async () => ({ data: {}, error: null }))
+
+    render(
+      <AuthProvider
+        additionalFields={[
+          {
+            label: "Nickname",
+            name: "nickname",
+            signUp: true,
+            type: "string"
+          },
+          {
+            label: "Invite code",
+            name: "inviteCode",
+            required: true,
+            signUp: true,
+            type: "string"
+          }
+        ]}
+        authClient={createMockAuthClient(signUpEmail)}
+        navigate={() => {}}
+      >
+        <SignUp />
+      </AuthProvider>
+    )
+
+    await user.type(screen.getByLabelText("Name"), "Ada Lovelace")
+    await user.type(screen.getByLabelText("Email"), "ada@example.com")
+    await user.type(screen.getByLabelText("Password"), "correct horse battery")
+    await user.type(screen.getByLabelText("Nickname (optional)"), "Enchantress")
+    await user.type(screen.getByLabelText("Invite code"), "analytical-engine")
+    await user.click(screen.getByRole("button", { name: "Sign Up" }))
+
+    await waitFor(() =>
+      expect(signUpEmail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inviteCode: "analytical-engine",
+          nickname: "Enchantress"
+        })
+      )
+    )
+  })
+
   it("preserves the redirect target when continuing to email verification", async () => {
     const user = userEvent.setup()
     const navigate = vi.fn()

--- a/packages/heroui/tests/username.test.tsx
+++ b/packages/heroui/tests/username.test.tsx
@@ -1,6 +1,8 @@
+import type { AdditionalFieldFormValue } from "@better-auth-ui/core"
 import { QueryClient } from "@tanstack/react-query"
 import { act, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { useState } from "react"
 import { describe, expect, it, vi } from "vitest"
 
 import { AuthProvider } from "../src/components/auth/auth-provider"
@@ -191,6 +193,31 @@ function renderUsernameField(
   } = {}
 ) {
   const authClient = options.authClient ?? createUsernameFieldAuthClient()
+
+  function ControlledUsernameField() {
+    const [value, setValue] = useState<AdditionalFieldFormValue>(
+      options.defaultValue ?? null
+    )
+
+    return (
+      <UsernameField
+        name="username"
+        field={{
+          name: "username",
+          type: "string",
+          label: "Username",
+          placeholder: "Enter your username",
+          inputType: "input",
+          required: true,
+          defaultValue: options.defaultValue
+        }}
+        value={value}
+        onBlur={() => {}}
+        onChange={setValue}
+      />
+    )
+  }
+
   return {
     authClient,
     ...render(
@@ -200,18 +227,7 @@ function renderUsernameField(
         plugins={[usernamePlugin(options.pluginOptions)]}
         queryClient={createTestQueryClient()}
       >
-        <UsernameField
-          name="username"
-          field={{
-            name: "username",
-            type: "string",
-            label: "Username",
-            placeholder: "Enter your username",
-            inputType: "input",
-            required: true,
-            defaultValue: options.defaultValue
-          }}
-        />
+        <ControlledUsernameField />
       </AuthProvider>
     )
   }


### PR DESCRIPTION
## Summary

- register runtime-defined additional fields as controlled TanStack Form fields across shadcn, Base UI, HeroUI, Solid/Zaidan, Next, and the docs app
- move companion values, validation, resets, pending state, and payload construction into the same TanStack form state
- remove the manual prepareSubmit bridge while preserving submit re-entry protection and invalid-control focus
- include the shared auth form in the Solid registry dependency closure

## Validation

- `bun nx run-many -t typecheck --projects=@better-auth-ui/core,@better-auth-ui/heroui,start-shadcn-example,start-shadcn-baseui-example,start-solid-zaidan-example --nx-bail`
- `bun nx run docs:typecheck`
- `bun nx run @better-auth-ui/core:test -- --run`
- `bun nx run @better-auth-ui/heroui:test -- --run`
- `bun nx run start-solid-zaidan-example:test -- --run tests/auth-form.browser.test.tsx tests/auth-route.test.ts`
- `bun nx run start-solid-zaidan-example:test -- --run tests/registry.test.ts -t "installs complete Email OTP and Two-Factor dependency closures"`
- `bun nx run start-shadcn-example:registry:test`
- `bun nx affected -t lint --nx-bail`
- Biome check on all changed files

## Existing suite failures

The complete Solid example suite still has seven unrelated documentation and static-hosting assertions failing. The changed form/browser tests and registry dependency-closure tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom sign-up, profile, organization, team, role, invitation, and admin-user fields across authentication forms.
  * Added consistent field defaults, validation, inline error messages, and read-only field handling.
  * Added controlled input behavior for text, selection, date, slider, checkbox, and username fields.
* **Bug Fixes**
  * Prevented duplicate form submissions and improved pending-state feedback.
  * Ensured form values reset correctly when switching users or organizations.
* **Tests**
  * Added coverage for custom-field submission, validation, and concurrent submission handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->