### PR TITLE
refactor(forms): migrate remaining auth flows to TanStack Form

### DIFF
--- a/apps/docs/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/apps/docs/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -7,8 +7,8 @@ import {
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useCreateApiKey } from "@better-auth-ui/react/plugins/api-key"
 import { Key } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useState } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -35,6 +35,7 @@ import {
 } from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
+import { useAuthForm } from "../auth-form"
 import { NewApiKeyDialog } from "./new-api-key-dialog"
 
 export type CreateApiKeyDialogProps = {
@@ -66,10 +67,47 @@ export function CreateApiKeyDialog({
     (configuration) => configuration.organization === Boolean(organizationId)
   )
 
+  const form = useAuthForm({
+    defaultValues: {
+      configId: availableConfigurations[0]?.id ?? "",
+      expiration:
+        keyExpiration && keyExpiration.defaultInterval === null
+          ? "never"
+          : String((keyExpiration && keyExpiration.defaultInterval) ?? "never"),
+      name: ""
+    },
+    onSubmit: ({ value }) => {
+      const name = value.name.trim()
+      const expirationDays =
+        value.expiration !== "never" ? Number(value.expiration) : undefined
+      const expiresIn = expirationDays
+        ? apiKeyExpirationDaysToSeconds(expirationDays)
+        : undefined
+      const configId = value.configId.trim()
+      const resolvedConfigId =
+        configId || (organizationId ? "organization" : undefined)
+      const payload = {
+        ...(name ? { name } : {}),
+        ...(expiresIn ? { expiresIn } : {}),
+        ...(resolvedConfigId ? { configId: resolvedConfigId } : {}),
+        ...(organizationId ? { organizationId } : {})
+      }
+      createApiKey(Object.keys(payload).length > 0 ? payload : undefined, {
+        onSuccess: (result) => {
+          handleOpenChange(false)
+          setKeyName(name)
+          setSecretKey(result.key)
+          setIsNewKeyDialogOpen(true)
+        }
+      })
+    }
+  })
+
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {
       setKeyName(null)
       setSecretKey(null)
+      form.reset()
     }
 
     onOpenChange(nextOpen)
@@ -84,163 +122,149 @@ export function CreateApiKeyDialog({
     }
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.target as HTMLFormElement)
-    const name = (formData.get("name") as string).trim()
-    const expiration = formData.get("expiration")
-    const expirationDays =
-      typeof expiration === "string" && expiration !== "never"
-        ? Number(expiration)
-        : undefined
-    const expiresIn = expirationDays
-      ? apiKeyExpirationDaysToSeconds(expirationDays)
-      : undefined
-
-    const configId = String(formData.get("configId") ?? "").trim()
-    const resolvedConfigId =
-      configId || (organizationId ? "organization" : undefined)
-    const payload = {
-      ...(name ? { name } : {}),
-      ...(expiresIn ? { expiresIn } : {}),
-      ...(resolvedConfigId ? { configId: resolvedConfigId } : {}),
-      ...(organizationId ? { organizationId } : {})
-    }
-
-    createApiKey(Object.keys(payload).length > 0 ? payload : undefined, {
-      onSuccess: (result) => {
-        handleOpenChange(false)
-        setKeyName(name)
-        setSecretKey(result.key)
-        setIsNewKeyDialogOpen(true)
-      }
-    })
-  }
-
   return (
     <>
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <Key />
-                {apiKeyLocalization.createApiKey}
-              </DialogTitle>
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-6">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <Key />
+                  {apiKeyLocalization.createApiKey}
+                </DialogTitle>
 
-              <DialogDescription>
-                {apiKeyLocalization.apiKeysDescription}
-              </DialogDescription>
-            </DialogHeader>
+                <DialogDescription>
+                  {apiKeyLocalization.apiKeysDescription}
+                </DialogDescription>
+              </DialogHeader>
 
-            <FieldGroup>
-              <Field>
-                <FieldLabel htmlFor="api-key-name">
-                  {apiKeyLocalization.name}
-                </FieldLabel>
+              <FieldGroup>
+                <form.AppField name="name">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="api-key-name">
+                        {apiKeyLocalization.name}
+                      </FieldLabel>
 
-                <Input
-                  id="api-key-name"
-                  name="name"
-                  autoFocus
-                  placeholder={localization.settings.optional}
-                  disabled={isCreating}
-                />
+                      <Input
+                        id="api-key-name"
+                        name={field.name}
+                        autoFocus
+                        placeholder={localization.settings.optional}
+                        disabled={isCreating}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
 
-                <FieldError />
-              </Field>
+                      <FieldError />
+                    </Field>
+                  )}
+                </form.AppField>
 
-              {availableConfigurations.length > 0 && (
-                <Field>
-                  <FieldLabel htmlFor="api-key-configuration">
-                    {apiKeyLocalization.configuration}
-                  </FieldLabel>
-                  <Select
-                    name="configId"
-                    defaultValue={availableConfigurations[0]?.id}
-                    disabled={isCreating}
-                  >
-                    <SelectTrigger
-                      id="api-key-configuration"
-                      className="w-full"
-                    >
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        {availableConfigurations.map((configuration) => (
-                          <SelectItem
-                            key={configuration.id}
-                            value={configuration.id}
+                {availableConfigurations.length > 0 && (
+                  <form.AppField name="configId">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel htmlFor="api-key-configuration">
+                          {apiKeyLocalization.configuration}
+                        </FieldLabel>
+                        <Select
+                          name={field.name}
+                          value={field.state.value}
+                          onValueChange={(value) => field.handleChange(value)}
+                          disabled={isCreating}
+                        >
+                          <SelectTrigger
+                            id="api-key-configuration"
+                            className="w-full"
                           >
-                            {configuration.label}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </Field>
-              )}
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              {availableConfigurations.map((configuration) => (
+                                <SelectItem
+                                  key={configuration.id}
+                                  value={configuration.id}
+                                >
+                                  {configuration.label}
+                                </SelectItem>
+                              ))}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      </Field>
+                    )}
+                  </form.AppField>
+                )}
 
-              {keyExpiration ? (
-                <Field>
-                  <FieldLabel htmlFor="api-key-expiration">
-                    {apiKeyLocalization.expiration}
-                  </FieldLabel>
+                {keyExpiration ? (
+                  <form.AppField name="expiration">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel htmlFor="api-key-expiration">
+                          {apiKeyLocalization.expiration}
+                        </FieldLabel>
 
-                  <Select
-                    name="expiration"
-                    defaultValue={
-                      keyExpiration.defaultInterval === null
-                        ? "never"
-                        : String(keyExpiration.defaultInterval)
-                    }
-                    disabled={isCreating}
-                  >
-                    <SelectTrigger id="api-key-expiration" className="w-full">
-                      <SelectValue />
-                    </SelectTrigger>
+                        <Select
+                          name={field.name}
+                          value={field.state.value}
+                          onValueChange={(value) => field.handleChange(value)}
+                          disabled={isCreating}
+                        >
+                          <SelectTrigger
+                            id="api-key-expiration"
+                            className="w-full"
+                          >
+                            <SelectValue />
+                          </SelectTrigger>
 
-                    <SelectContent>
-                      <SelectGroup>
-                        {keyExpiration.intervals.map((days) => (
-                          <SelectItem key={days} value={String(days)}>
-                            {days.toLocaleString()}{" "}
-                            {days === 1
-                              ? apiKeyLocalization.day
-                              : apiKeyLocalization.days}
-                          </SelectItem>
-                        ))}
+                          <SelectContent>
+                            <SelectGroup>
+                              {keyExpiration.intervals.map((days) => (
+                                <SelectItem key={days} value={String(days)}>
+                                  {days.toLocaleString()}{" "}
+                                  {days === 1
+                                    ? apiKeyLocalization.day
+                                    : apiKeyLocalization.days}
+                                </SelectItem>
+                              ))}
 
-                        {keyExpiration.allowNever ? (
-                          <SelectItem value="never">
-                            {apiKeyLocalization.never}
-                          </SelectItem>
-                        ) : null}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </Field>
-              ) : null}
-            </FieldGroup>
+                              {keyExpiration.allowNever ? (
+                                <SelectItem value="never">
+                                  {apiKeyLocalization.never}
+                                </SelectItem>
+                              ) : null}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      </Field>
+                    )}
+                  </form.AppField>
+                ) : null}
+              </FieldGroup>
 
-            <DialogFooter>
-              <DialogClose
-                className={buttonVariants({ variant: "outline" })}
-                disabled={isCreating}
-                type="button"
-              >
-                {localization.settings.cancel}
-              </DialogClose>
+              <DialogFooter>
+                <DialogClose
+                  className={buttonVariants({ variant: "outline" })}
+                  disabled={isCreating}
+                  type="button"
+                >
+                  {localization.settings.cancel}
+                </DialogClose>
 
-              <Button type="submit" disabled={isCreating}>
-                {isCreating && <Spinner />}
+                <form.AuthFormSubmitButton disabled={isCreating}>
+                  {isCreating && <Spinner />}
 
-                {apiKeyLocalization.createApiKey}
-              </Button>
-            </DialogFooter>
-          </form>
+                  {apiKeyLocalization.createApiKey}
+                </form.AuthFormSubmitButton>
+              </DialogFooter>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </DialogContent>
       </Dialog>
 

--- a/apps/docs/src/components/auth/api-key/edit-api-key-dialog.tsx
+++ b/apps/docs/src/components/auth/api-key/edit-api-key-dialog.tsx
@@ -6,8 +6,8 @@ import type {
 } from "@better-auth-ui/core/plugins/api-key"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useUpdateApiKey } from "@better-auth-ui/react/plugins/api-key"
-import type { FormEvent } from "react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useEffect } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -25,6 +25,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
+import { useAuthForm } from "../auth-form"
 
 export function EditApiKeyDialog({
   apiKey,
@@ -41,53 +42,66 @@ export function EditApiKeyDialog({
   const updateApiKey = useUpdateApiKey(authClient, {
     onSuccess: () => onOpenChange(false)
   })
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    updateApiKey.mutate({
-      keyId: apiKey.id,
-      configId: apiKey.configId,
-      name: String(formData.get("name") ?? "").trim()
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { name: apiKey.name ?? "" },
+    onSubmit: ({ value }) =>
+      updateApiKey.mutate({
+        configId: apiKey.configId,
+        keyId: apiKey.id,
+        name: value.name.trim()
+      })
+  })
+  useEffect(() => {
+    if (open) form.reset({ name: apiKey.name ?? "" })
+  }, [apiKey.name, form, open])
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form className="flex flex-col gap-6" onSubmit={submit}>
-          <DialogHeader>
-            <DialogTitle>{labels.editApiKey}</DialogTitle>
-          </DialogHeader>
-          <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor={`api-key-name-${apiKey.id}`}>
-                {labels.name}
-              </FieldLabel>
-              <Input
-                id={`api-key-name-${apiKey.id}`}
-                name="name"
-                defaultValue={apiKey.name ?? ""}
-              />
-            </Field>
-            {updateApiKey.error && (
-              <FieldError>
-                {updateApiKey.error.error?.message ??
-                  updateApiKey.error.message}
-              </FieldError>
-            )}
-          </FieldGroup>
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-            <Button disabled={updateApiKey.isPending} type="submit">
-              {updateApiKey.isPending && <Spinner />}
-              {localization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
-        </form>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle>{labels.editApiKey}</DialogTitle>
+            </DialogHeader>
+            <FieldGroup>
+              <form.AppField name="name">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor={`api-key-name-${apiKey.id}`}>
+                      {labels.name}
+                    </FieldLabel>
+                    <Input
+                      id={`api-key-name-${apiKey.id}`}
+                      name={field.name}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                    />
+                  </Field>
+                )}
+              </form.AppField>
+              {updateApiKey.error && (
+                <FieldError>
+                  {updateApiKey.error.error?.message ??
+                    updateApiKey.error.message}
+                </FieldError>
+              )}
+            </FieldGroup>
+            <DialogFooter>
+              <DialogClose
+                className={buttonVariants({ variant: "outline" })}
+                type="button"
+              >
+                {localization.settings.cancel}
+              </DialogClose>
+              <form.AuthFormSubmitButton disabled={updateApiKey.isPending}>
+                {updateApiKey.isPending && <Spinner />}
+                {localization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/apps/docs/src/components/auth/delete-user/delete-account.tsx
+++ b/apps/docs/src/components/auth/delete-user/delete-account.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { authQueryKeys } from "@better-auth-ui/core"
+import { authQueryKeys, validateStringLength } from "@better-auth-ui/core"
 import {
   useAuth,
   useAuthPlugin,
@@ -9,7 +9,7 @@ import {
 } from "@better-auth-ui/react"
 import { useQueryClient } from "@tanstack/react-query"
 import { Eye, EyeOff, TriangleAlert } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 import {
   AlertDialog,
@@ -22,9 +22,9 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger
 } from "@/components/ui/alert-dialog"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import {
   InputGroup,
   InputGroupAddon,
@@ -34,6 +34,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { deleteUserPlugin } from "@/lib/auth/delete-user-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 
 export type DeleteAccountProps = {
   className?: string
@@ -55,7 +56,6 @@ export function DeleteAccount({ className }: DeleteAccountProps) {
   const queryClient = useQueryClient()
 
   const [confirmOpen, setConfirmOpen] = useState(false)
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
 
   const hasCredentialAccount = accounts?.some(
@@ -65,36 +65,33 @@ export function DeleteAccount({ className }: DeleteAccountProps) {
 
   const { mutate: deleteUser, isPending } = useDeleteUser(authClient)
 
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) => {
+      deleteUser(needsPassword ? { password: value.password } : {}, {
+        onSuccess: () => {
+          setConfirmOpen(false)
+          form.reset()
+
+          if (sendDeleteAccountVerification) {
+            toast.success(deleteUserLocalization.deleteUserVerificationSent)
+          } else {
+            toast.success(deleteUserLocalization.deleteUserSuccess)
+            queryClient.removeQueries({ queryKey: authQueryKeys.all })
+            navigate({
+              to: `${basePaths.auth}/${viewPaths.auth.signIn}`,
+              replace: true
+            })
+          }
+        }
+      })
+    }
+  })
+
   const handleDialogOpenChange = (open: boolean) => {
     setConfirmOpen(open)
-    setPassword("")
+    form.reset()
     setIsPasswordVisible(false)
-  }
-
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const params = {
-      ...(needsPassword ? { password } : {})
-    }
-
-    deleteUser(params, {
-      onSuccess: () => {
-        setConfirmOpen(false)
-        setPassword("")
-
-        if (sendDeleteAccountVerification) {
-          toast.success(deleteUserLocalization.deleteUserVerificationSent)
-        } else {
-          toast.success(deleteUserLocalization.deleteUserSuccess)
-          queryClient.removeQueries({ queryKey: authQueryKeys.all })
-          navigate({
-            to: `${basePaths.auth}/${viewPaths.auth.signIn}`,
-            replace: true
-          })
-        }
-      }
-    })
   }
 
   return (
@@ -121,82 +118,103 @@ export function DeleteAccount({ className }: DeleteAccountProps) {
           </AlertDialogTrigger>
 
           <AlertDialogContent>
-            <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-              <AlertDialogHeader>
-                <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
-                  <TriangleAlert />
-                </AlertDialogMedia>
+            <form.AppForm>
+              <form.AuthFormRoot className="flex flex-col gap-6">
+                <AlertDialogHeader>
+                  <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
+                    <TriangleAlert />
+                  </AlertDialogMedia>
 
-                <AlertDialogTitle>
-                  {deleteUserLocalization.deleteAccount}
-                </AlertDialogTitle>
+                  <AlertDialogTitle>
+                    {deleteUserLocalization.deleteAccount}
+                  </AlertDialogTitle>
 
-                <AlertDialogDescription>
-                  {deleteUserLocalization.deleteAccountDescription}
-                </AlertDialogDescription>
-              </AlertDialogHeader>
+                  <AlertDialogDescription>
+                    {deleteUserLocalization.deleteAccountDescription}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
 
-              {needsPassword && (
-                <Field>
-                  <FieldLabel htmlFor="delete-password">
-                    {localization.auth.password}
-                  </FieldLabel>
+                {needsPassword && (
+                  <form.AppField
+                    name="password"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          requiredMessage: localization.auth.fieldRequired
+                        })
+                    }}
+                  >
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="delete-password">
+                            {localization.auth.password}
+                          </FieldLabel>
 
-                  <InputGroup>
-                    <InputGroupInput
-                      id="delete-password"
-                      name="password"
-                      type={isPasswordVisible ? "text" : "password"}
-                      autoComplete="current-password"
-                      placeholder={localization.auth.passwordPlaceholder}
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      disabled={isPending}
-                      required
-                    />
+                          <InputGroup>
+                            <InputGroupInput
+                              id="delete-password"
+                              name={field.name}
+                              type={isPasswordVisible ? "text" : "password"}
+                              autoComplete="current-password"
+                              placeholder={
+                                localization.auth.passwordPlaceholder
+                              }
+                              value={field.state.value}
+                              onBlur={field.handleBlur}
+                              onChange={(event) =>
+                                field.handleChange(event.target.value)
+                              }
+                              disabled={isPending}
+                              required
+                            />
 
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        title={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() => {
-                          setIsPasswordVisible((visible) => !visible)
-                        }}
-                      >
-                        {isPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                size="icon-xs"
+                                aria-label={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                title={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                onClick={() => {
+                                  setIsPasswordVisible((visible) => !visible)
+                                }}
+                              >
+                                {isPasswordVisible ? <EyeOff /> : <Eye />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
 
-                  <FieldError />
-                </Field>
-              )}
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
+                )}
 
-              <AlertDialogFooter>
-                <AlertDialogCancel disabled={isPending}>
-                  {localization.settings.cancel}
-                </AlertDialogCancel>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={isPending}>
+                    {localization.settings.cancel}
+                  </AlertDialogCancel>
 
-                <Button
-                  type="submit"
-                  variant="destructive"
-                  disabled={isPending}
-                >
-                  {isPending && <Spinner />}
+                  <form.AuthFormSubmitButton
+                    variant="destructive"
+                    disabled={isPending}
+                  >
+                    {isPending && <Spinner />}
 
-                  {deleteUserLocalization.deleteAccount}
-                </Button>
-              </AlertDialogFooter>
-            </form>
+                    {deleteUserLocalization.deleteAccount}
+                  </form.AuthFormSubmitButton>
+                </AlertDialogFooter>
+              </form.AuthFormRoot>
+            </form.AppForm>
           </AlertDialogContent>
         </AlertDialog>
       </CardContent>

--- a/apps/docs/src/components/auth/device-authorization/device-authorization.tsx
+++ b/apps/docs/src/components/auth/device-authorization/device-authorization.tsx
@@ -13,7 +13,6 @@ import {
 import { REGEXP_ONLY_DIGITS_AND_CHARS } from "input-otp"
 import { CheckIcon, CircleCheckIcon, CircleXIcon, XIcon } from "lucide-react"
 import {
-  type FormEvent,
   type ReactNode,
   useCallback,
   useEffect,
@@ -47,6 +46,7 @@ import { Separator } from "@/components/ui/separator"
 import { Spinner } from "@/components/ui/spinner"
 import { deviceAuthorizationPlugin } from "@/lib/auth/device-authorization-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 
 type DeviceAuthorizationStep = "code" | "approval" | "approved" | "denied"
 
@@ -131,7 +131,6 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
     initialDeviceAuthorizationState
   )
   const submittedCodeRef = useRef<string | null>(null)
-  const normalizedUserCode = normalizeDeviceCode(userCode)
 
   const handleAuthorizationError = () => {
     dispatch({
@@ -175,19 +174,6 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
     }
   )
 
-  const handleCodeChange = (value: string) => {
-    const nextCode = normalizeDeviceCode(value)
-      .replace(/[^A-Z0-9]/g, "")
-      .slice(0, userCodeLength)
-
-    if (nextCode !== submittedCodeRef.current) {
-      submittedCodeRef.current = null
-    }
-
-    setUserCode(nextCode)
-    dispatch({ type: "codeChanged" })
-  }
-
   const submitCode = useCallback(
     (completedCode: string) => {
       const normalizedCode = normalizeDeviceCode(completedCode)
@@ -227,22 +213,22 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
     ]
   )
 
-  useEffect(() => {
-    if (normalizedUserCode.length === userCodeLength) {
-      submitCode(normalizedUserCode)
-    }
-  }, [normalizedUserCode, submitCode, userCodeLength])
+  const handleSubmit = useCallback(
+    (code: string) => {
+      const normalizedCode = normalizeDeviceCode(code)
+      if (normalizedCode.length !== userCodeLength) {
+        dispatch({
+          type: "verificationFailed",
+          message: localization.invalidDeviceCode
+        })
+        return
+      }
+      submitCode(normalizedCode)
+    },
+    [localization.invalidDeviceCode, submitCode, userCodeLength]
+  )
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-
-    if (normalizedUserCode.length !== userCodeLength) {
-      handleAuthorizationError()
-      return
-    }
-
-    submitCode(normalizedUserCode)
-  }
+  const authorizedCode = submittedCodeRef.current ?? ""
 
   const cardClassName = cn("w-full max-w-sm", className)
 
@@ -251,12 +237,12 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
       <DeviceApproval
         className={cardClassName}
         localization={localization}
-        userCode={normalizedUserCode}
+        userCode={authorizedCode}
         user={session.user}
         isApproving={isApproving}
         isDenying={isDenying}
-        onApprove={() => approveDevice({ userCode: normalizedUserCode })}
-        onDeny={() => denyDevice({ userCode: normalizedUserCode })}
+        onApprove={() => approveDevice({ userCode: authorizedCode })}
+        onDeny={() => denyDevice({ userCode: authorizedCode })}
       />
     )
   }
@@ -286,10 +272,10 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
       isSessionPending={isSessionPending}
       isVerifying={isVerifying}
       localization={localization}
-      userCode={userCode}
+      initialUserCode={userCode}
       userCodeLength={userCodeLength}
-      onCodeChange={handleCodeChange}
-      onSubmit={handleSubmit}
+      onCodeChange={() => dispatch({ type: "codeChanged" })}
+      onSubmitCode={handleSubmit}
     />
   )
 }
@@ -300,10 +286,10 @@ type DeviceCodeFormProps = {
   isSessionPending: boolean
   isVerifying: boolean
   localization: DeviceAuthorizationLocalization
-  userCode: string
+  initialUserCode: string
   userCodeLength: number
   onCodeChange: (value: string) => void
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void
+  onSubmitCode: (code: string) => void
 }
 
 function DeviceCodeForm({
@@ -312,16 +298,27 @@ function DeviceCodeForm({
   isSessionPending,
   isVerifying,
   localization,
-  userCode,
+  initialUserCode,
   userCodeLength,
   onCodeChange,
-  onSubmit
+  onSubmitCode
 }: DeviceCodeFormProps) {
   const slots = createDeviceCodeSlots(userCodeLength)
   const groupBreak = Math.ceil(userCodeLength / 2)
   const firstGroup = slots.slice(0, groupBreak)
   const secondGroup = slots.slice(groupBreak)
   const errorId = "device-code-error"
+  const form = useAuthForm({
+    defaultValues: { userCode: initialUserCode },
+    onSubmit: ({ value }) => onSubmitCode(value.userCode)
+  })
+
+  useEffect(() => {
+    form.setFieldValue("userCode", initialUserCode)
+    if (initialUserCode.length === userCodeLength) {
+      onSubmitCode(initialUserCode)
+    }
+  }, [form.setFieldValue, initialUserCode, onSubmitCode, userCodeLength])
 
   return (
     <Card className={className}>
@@ -335,63 +332,77 @@ function DeviceCodeForm({
       </CardHeader>
 
       <CardContent>
-        <form aria-label={localization.deviceAuthorization} onSubmit={onSubmit}>
-          <FieldGroup>
-            <Field data-invalid={Boolean(codeError)}>
-              <FieldLabel htmlFor="device-code">
-                {localization.deviceCode}
-              </FieldLabel>
+        <form.AppForm>
+          <form.AuthFormRoot aria-label={localization.deviceAuthorization}>
+            <FieldGroup>
+              <form.AppField name="userCode">
+                {(field) => (
+                  <Field data-invalid={Boolean(codeError)}>
+                    <FieldLabel htmlFor="device-code">
+                      {localization.deviceCode}
+                    </FieldLabel>
 
-              <InputOTP
-                id="device-code"
-                aria-describedby={codeError ? errorId : undefined}
-                aria-invalid={Boolean(codeError)}
-                autoComplete="one-time-code"
-                containerClassName="w-full justify-center"
-                disabled={isVerifying}
-                inputMode="text"
-                maxLength={userCodeLength}
-                name="userCode"
-                pasteTransformer={normalizeDeviceCode}
-                pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
-                value={userCode}
-                onChange={onCodeChange}
+                    <InputOTP
+                      id="device-code"
+                      aria-describedby={codeError ? errorId : undefined}
+                      aria-invalid={Boolean(codeError)}
+                      autoComplete="one-time-code"
+                      containerClassName="w-full justify-center"
+                      disabled={isVerifying}
+                      inputMode="text"
+                      maxLength={userCodeLength}
+                      name={field.name}
+                      pasteTransformer={normalizeDeviceCode}
+                      pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+                      value={field.state.value}
+                      onChange={(value) => {
+                        const nextCode = normalizeDeviceCode(value)
+                          .replace(/[^A-Z0-9]/g, "")
+                          .slice(0, userCodeLength)
+                        field.handleChange(nextCode)
+                        onCodeChange(nextCode)
+                        if (nextCode.length === userCodeLength)
+                          onSubmitCode(nextCode)
+                      }}
+                    >
+                      <InputOTPGroup>
+                        {firstGroup.map((slot) => (
+                          <InputOTPSlot key={slot.id} index={slot.index} />
+                        ))}
+                      </InputOTPGroup>
+
+                      {secondGroup.length > 0 ? (
+                        <>
+                          <InputOTPSeparator />
+                          <InputOTPGroup>
+                            {secondGroup.map((slot) => (
+                              <InputOTPSlot key={slot.id} index={slot.index} />
+                            ))}
+                          </InputOTPGroup>
+                        </>
+                      ) : null}
+                    </InputOTP>
+
+                    <FieldError id={errorId}>{codeError}</FieldError>
+                  </Field>
+                )}
+              </form.AppField>
+
+              <form.AuthFormSubmitButton
+                className="w-full"
+                disabled={
+                  form.state.values.userCode.length !== userCodeLength ||
+                  isSessionPending ||
+                  isVerifying
+                }
+                type="submit"
               >
-                <InputOTPGroup>
-                  {firstGroup.map((slot) => (
-                    <InputOTPSlot key={slot.id} index={slot.index} />
-                  ))}
-                </InputOTPGroup>
-
-                {secondGroup.length > 0 ? (
-                  <>
-                    <InputOTPSeparator />
-                    <InputOTPGroup>
-                      {secondGroup.map((slot) => (
-                        <InputOTPSlot key={slot.id} index={slot.index} />
-                      ))}
-                    </InputOTPGroup>
-                  </>
-                ) : null}
-              </InputOTP>
-
-              <FieldError id={errorId}>{codeError}</FieldError>
-            </Field>
-
-            <Button
-              className="w-full"
-              disabled={
-                userCode.length !== userCodeLength ||
-                isSessionPending ||
-                isVerifying
-              }
-              type="submit"
-            >
-              {isVerifying ? <Spinner data-icon="inline-start" /> : null}
-              {localization.continue}
-            </Button>
-          </FieldGroup>
-        </form>
+                {isVerifying ? <Spinner data-icon="inline-start" /> : null}
+                {localization.continue}
+              </form.AuthFormSubmitButton>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
     </Card>
   )

--- a/apps/docs/src/components/auth/email-otp/change-email-otp.tsx
+++ b/apps/docs/src/components/auth/email-otp/change-email-otp.tsx
@@ -7,17 +7,18 @@ import {
   useRequestEmailChangeOtp,
   useSendVerificationOtp
 } from "@better-auth-ui/react/plugins/email-otp"
-import { type SyntheticEvent, useReducer, useState } from "react"
+import { useEffect, useReducer } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 
@@ -84,14 +85,6 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
     changeEmailReducer,
     initialChangeEmailState
   )
-  const [code, setCode] = useState("")
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({})
-
-  const resetFlow = () => {
-    setCode("")
-    dispatch({ type: "restarted" })
-  }
-
   // The step transition is attached per call: the code goes to the current
   // address while the pending change targets the new one, so the address to
   // remember isn't in this mutation's variables.
@@ -100,9 +93,9 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
 
   const { mutate: requestEmailChangeOtp, isPending: isRequesting } =
     useRequestEmailChangeOtp(otpClient, {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: (_data, { newEmail }) => {
-        setCode("")
+        form.setFieldValue("code", "")
         dispatch({ type: "changeRequested", newEmail })
       }
     })
@@ -110,7 +103,7 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
   const { mutate: changeEmailOtp, isPending: isChanging } = useChangeEmailOtp(
     otpClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
         toast.success(localization.settings.changeEmailSuccess)
         resetFlow()
@@ -134,30 +127,39 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
     changeEmailOtp({ newEmail: state.newEmail, otp: completedCode })
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useAuthForm({
+    defaultValues: { code: "", email: "" },
+    onSubmit: ({ value }) => {
+      if (state.step === "email") {
+        const newEmail = value.email
 
-    if (state.step === "email") {
-      const formData = new FormData(e.currentTarget)
-      const newEmail = formData.get("email") as string
+        if (verifyCurrentEmail && currentEmail) {
+          sendVerificationOtp(
+            { email: currentEmail, type: "change-email" },
+            {
+              onSuccess: () =>
+                dispatch({ type: "currentEmailChallenged", newEmail })
+            }
+          )
+          return
+        }
 
-      if (verifyCurrentEmail && currentEmail) {
-        sendVerificationOtp(
-          { email: currentEmail, type: "change-email" },
-          {
-            onSuccess: () =>
-              dispatch({ type: "currentEmailChallenged", newEmail })
-          }
-        )
+        requestEmailChangeOtp({ newEmail })
         return
       }
-
-      requestEmailChangeOtp({ newEmail })
-      return
+      submitCode(value.code)
     }
+  })
 
-    submitCode(code)
+  const resetFlow = () => {
+    form.reset()
+    if (currentEmail) form.setFieldValue("email", currentEmail)
+    dispatch({ type: "restarted" })
   }
+
+  useEffect(() => {
+    if (currentEmail) form.setFieldValue("email", currentEmail)
+  }, [currentEmail, form])
 
   const codeTarget =
     state.step === "currentCode" ? currentEmail : state.newEmail
@@ -168,109 +170,111 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
         {localization.settings.changeEmail}
       </h2>
 
-      <form onSubmit={handleSubmit}>
-        <Card className={cn(className)}>
-          <CardContent className="flex flex-col gap-6">
-            {state.step === "email" ? (
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="email">
-                  {localization.auth.email}
-                </FieldLabel>
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card className={cn(className)}>
+            <CardContent className="flex flex-col gap-6">
+              {state.step === "email" ? (
+                <form.AppField name="email">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
 
-                {session ? (
-                  <Input
-                    key={currentEmail}
-                    id="email"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    defaultValue={currentEmail}
-                    placeholder={localization.auth.emailPlaceholder}
-                    disabled={isPending}
-                    required
-                    onChange={() =>
-                      setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                    }
-                    onInvalid={(e) => {
-                      e.preventDefault()
+                      {session ? (
+                        <Input
+                          key={currentEmail}
+                          id="email"
+                          name="email"
+                          type="email"
+                          autoComplete="email"
+                          value={field.state.value}
+                          placeholder={localization.auth.emailPlaceholder}
+                          disabled={isPending}
+                          required
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                        />
+                      ) : (
+                        <Skeleton>
+                          <Input className="invisible" />
+                        </Skeleton>
+                      )}
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: (e.target as HTMLInputElement).validationMessage
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
-                ) : (
-                  <Skeleton>
-                    <Input className="invisible" />
-                  </Skeleton>
-                )}
-
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
-            ) : (
-              <div className="flex flex-col gap-3">
-                <p className="text-muted-foreground text-sm">
-                  {emailOtpLocalization.confirmEmailDescription.replace(
-                    "{{email}}",
-                    codeTarget ?? ""
+                      <field.AuthFormFieldError />
+                    </Field>
                   )}
-                </p>
+                </form.AppField>
+              ) : (
+                <div className="flex flex-col gap-3">
+                  <p className="text-muted-foreground text-sm">
+                    {emailOtpLocalization.confirmEmailDescription.replace(
+                      "{{email}}",
+                      codeTarget ?? ""
+                    )}
+                  </p>
 
-                <OtpField
-                  autoFocus
+                  <form.AppField name="code">
+                    {(field) => (
+                      <OtpField
+                        autoFocus
+                        disabled={isPending}
+                        label={
+                          state.step === "currentCode"
+                            ? emailOtpLocalization.confirmCurrentEmail
+                            : emailOtpLocalization.confirmNewEmail
+                        }
+                        length={otpLength}
+                        name="otp"
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        onComplete={submitCode}
+                      />
+                    )}
+                  </form.AppField>
+
+                  {codeTarget && (
+                    <OpenEmailButton email={codeTarget} variant="secondary" />
+                  )}
+                </div>
+              )}
+            </CardContent>
+
+            <CardFooter className="gap-3">
+              {state.step !== "email" && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
                   disabled={isPending}
-                  label={
-                    state.step === "currentCode"
-                      ? emailOtpLocalization.confirmCurrentEmail
-                      : emailOtpLocalization.confirmNewEmail
-                  }
-                  length={otpLength}
-                  name="otp"
-                  value={code}
-                  onChange={setCode}
-                  onComplete={submitCode}
-                />
+                  onClick={resetFlow}
+                >
+                  {localization.settings.cancel}
+                </Button>
+              )}
 
-                {codeTarget && (
-                  <OpenEmailButton email={codeTarget} variant="secondary" />
-                )}
-              </div>
-            )}
-          </CardContent>
-
-          <CardFooter className="gap-3">
-            {state.step !== "email" && (
-              <Button
-                type="button"
+              <form.AuthFormSubmitButton
                 size="sm"
-                variant="outline"
-                disabled={isPending}
-                onClick={resetFlow}
+                disabled={
+                  isPending ||
+                  !session ||
+                  (state.step !== "email" &&
+                    form.state.values.code.length !== otpLength)
+                }
               >
-                {localization.settings.cancel}
-              </Button>
-            )}
+                {isPending && <Spinner />}
 
-            <Button
-              type="submit"
-              size="sm"
-              disabled={
-                isPending ||
-                !session ||
-                (state.step !== "email" && code.length !== otpLength)
-              }
-            >
-              {isPending && <Spinner />}
-
-              {state.step === "email"
-                ? localization.settings.updateEmail
-                : emailOtpLocalization.verifyCode}
-            </Button>
-          </CardFooter>
-        </Card>
-      </form>
+                {state.step === "email"
+                  ? localization.settings.updateEmail
+                  : emailOtpLocalization.verifyCode}
+              </form.AuthFormSubmitButton>
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/apps/docs/src/components/auth/email-otp/email-otp.tsx
+++ b/apps/docs/src/components/auth/email-otp/email-otp.tsx
@@ -9,7 +9,7 @@ import {
   useSignInEmailOtp
 } from "@better-auth-ui/react/plugins/email-otp"
 import { useIsMutating } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -22,7 +22,6 @@ import {
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -33,6 +32,7 @@ import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { useResendCooldown } from "@/lib/auth/use-resend-cooldown"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
@@ -75,10 +75,7 @@ export function EmailOtp({
   const continueSignIn = useSignInContinuation()
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
 
-  const [email, setEmail] = useState(getSsoFallbackEmail)
-  const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({})
 
   const { mutate: sendVerificationOtp, isPending: isSending } =
     useSendVerificationOtp(otpClient, {
@@ -91,7 +88,7 @@ export function EmailOtp({
   const { mutate: signInEmailOtp, isPending: isSigningIn } = useSignInEmailOtp(
     otpClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: (data) => continueSignIn(data)
     }
   )
@@ -104,23 +101,28 @@ export function EmailOtp({
   })
   const isPending = signInMutating + signUpMutating > 0 || isSending
 
-  const sendCode = () => sendVerificationOtp({ email, type: "sign-in" })
+  const sendCode = () =>
+    sendVerificationOtp({
+      email: form.state.values.email,
+      type: "sign-in"
+    })
   const verifyCode = (completedCode: string) => {
     if (isPending || isSigningIn) return
 
-    signInEmailOtp({ email, otp: completedCode })
+    signInEmailOtp({ email: form.state.values.email, otp: completedCode })
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useAuthForm({
+    defaultValues: { code: "", email: getSsoFallbackEmail() },
+    onSubmit: ({ value }) => {
+      if (!codeSent) {
+        sendVerificationOtp({ email: value.email, type: "sign-in" })
+        return
+      }
 
-    if (!codeSent) {
-      sendCode()
-      return
+      verifyCode(value.code)
     }
-
-    verifyCode(code)
-  }
+  })
 
   const showSeparator = socialProviders && socialProviders.length > 0
 
@@ -131,7 +133,10 @@ export function EmailOtp({
 
         {codeSent && (
           <CardDescription>
-            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
+            {emailOtpLocalization.codeSentTo.replace(
+              "{{email}}",
+              form.state.values.email
+            )}
           </CardDescription>
         )}
       </CardHeader>
@@ -152,112 +157,113 @@ export function EmailOtp({
             </>
           )}
 
-          <form onSubmit={handleSubmit}>
-            <FieldGroup>
-              {codeSent ? (
-                <OtpField
-                  autoFocus
-                  disabled={isPending || isSigningIn}
-                  label={emailOtpLocalization.code}
-                  length={otpLength}
-                  name="otp"
-                  value={code}
-                  onChange={setCode}
-                  onComplete={verifyCode}
-                />
-              ) : (
-                <Field data-invalid={!!fieldErrors.email}>
-                  <FieldLabel htmlFor="email">
-                    {localization.auth.email}
-                  </FieldLabel>
-
-                  <Input
-                    id="email"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    value={email}
-                    onChange={(e) => {
-                      setEmail(e.target.value)
-                      setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                    }}
-                    placeholder={localization.auth.emailPlaceholder}
-                    required
-                    disabled={isPending}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: (e.target as HTMLInputElement).validationMessage
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
-
-                  <FieldError>{fieldErrors.email}</FieldError>
-                </Field>
-              )}
-
-              <div className="flex flex-col gap-3">
-                <Button
-                  type="submit"
-                  disabled={
-                    isPending ||
-                    isSigningIn ||
-                    (codeSent && code.length !== otpLength)
-                  }
-                >
-                  {(isSending || isSigningIn) && <Spinner />}
-
-                  {codeSent
-                    ? emailOtpLocalization.verifyCode
-                    : emailOtpLocalization.sendCode}
-                </Button>
-
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <FieldGroup>
                 {codeSent ? (
-                  <>
-                    <OpenEmailButton email={email} variant="secondary" />
-
-                    <Button
-                      type="button"
-                      variant="outline"
-                      disabled={isPending || isSigningIn || isCoolingDown}
-                      onClick={sendCode}
-                    >
-                      {isCoolingDown
-                        ? localization.auth.resendIn.replace(
-                            "{{seconds}}",
-                            String(cooldown)
-                          )
-                        : localization.auth.resend}
-                    </Button>
-
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      disabled={isPending || isSigningIn}
-                      onClick={() => {
-                        setCodeSent(false)
-                        setCode("")
-                      }}
-                    >
-                      {emailOtpLocalization.useDifferentEmail}
-                    </Button>
-                  </>
-                ) : (
-                  plugins.flatMap((plugin) =>
-                    (plugin.authButtons ?? []).map((AuthButton, index) => (
-                      <AuthButton
-                        key={`${plugin.id}-${index.toString()}`}
-                        view="emailOtp"
+                  <form.AppField name="code">
+                    {(field) => (
+                      <OtpField
+                        autoFocus
+                        disabled={isPending || isSigningIn}
+                        label={emailOtpLocalization.code}
+                        length={otpLength}
+                        name={field.name}
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        onComplete={verifyCode}
                       />
-                    ))
-                  )
+                    )}
+                  </form.AppField>
+                ) : (
+                  <form.AppField name="email">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel htmlFor="email">
+                          {localization.auth.email}
+                        </FieldLabel>
+                        <Input
+                          id="email"
+                          name={field.name}
+                          type="email"
+                          autoComplete="email"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          placeholder={localization.auth.emailPlaceholder}
+                          required
+                          disabled={isPending}
+                        />
+                        <field.AuthFormFieldError />
+                      </Field>
+                    )}
+                  </form.AppField>
                 )}
-              </div>
-            </FieldGroup>
-          </form>
+
+                <div className="flex flex-col gap-3">
+                  <form.AuthFormSubmitButton
+                    disabled={
+                      isPending ||
+                      isSigningIn ||
+                      (codeSent && form.state.values.code.length !== otpLength)
+                    }
+                  >
+                    {(isSending || isSigningIn) && <Spinner />}
+
+                    {codeSent
+                      ? emailOtpLocalization.verifyCode
+                      : emailOtpLocalization.sendCode}
+                  </form.AuthFormSubmitButton>
+
+                  {codeSent ? (
+                    <>
+                      <OpenEmailButton
+                        email={form.state.values.email}
+                        variant="secondary"
+                      />
+
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isPending || isSigningIn || isCoolingDown}
+                        onClick={sendCode}
+                      >
+                        {isCoolingDown
+                          ? localization.auth.resendIn.replace(
+                              "{{seconds}}",
+                              String(cooldown)
+                            )
+                          : localization.auth.resend}
+                      </Button>
+
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        disabled={isPending || isSigningIn}
+                        onClick={() => {
+                          setCodeSent(false)
+                          form.setFieldValue("code", "")
+                        }}
+                      >
+                        {emailOtpLocalization.useDifferentEmail}
+                      </Button>
+                    </>
+                  ) : (
+                    plugins.flatMap((plugin) =>
+                      (plugin.authButtons ?? []).map((AuthButton, index) => (
+                        <AuthButton
+                          key={`${plugin.id}-${index.toString()}`}
+                          view="emailOtp"
+                        />
+                      ))
+                    )
+                  )}
+                </div>
+              </FieldGroup>
+            </form.AuthFormRoot>
+          </form.AppForm>
 
           {socialPosition === "bottom" && !codeSent && (
             <>

--- a/apps/docs/src/components/auth/email-otp/forgot-password-otp.tsx
+++ b/apps/docs/src/components/auth/email-otp/forgot-password-otp.tsx
@@ -1,17 +1,14 @@
 "use client"
 
-import { getAuthLinkURL } from "@better-auth-ui/core"
+import { getAuthLinkURL, validateEmailAddress } from "@better-auth-ui/core"
 import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin, useFetchOptions } from "@better-auth-ui/react"
 import { useRequestPasswordResetOtp } from "@better-auth-ui/react/plugins/email-otp"
-import { type SyntheticEvent, useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel
 } from "@/components/ui/field"
@@ -19,6 +16,7 @@ import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 
 /** `sessionStorage` key the reset-code form reads the pending address from. */
 export const RESET_PASSWORD_OTP_STORAGE_KEY =
@@ -52,7 +50,6 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
   const { localization: emailOtpLocalization } = useAuthPlugin(emailOtpPlugin)
 
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({})
 
   const { mutate: requestPasswordResetOtp, isPending } =
     useRequestPasswordResetOtp(authClient as EmailOtpAuthClient, {
@@ -63,15 +60,11 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
       }
     })
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    requestPasswordResetOtp({
-      email: formData.get("email") as string,
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) =>
+      requestPasswordResetOtp({ email: value.email, fetchOptions })
+  })
 
   const Captcha = plugins.find(
     (plugin) => plugin.captchaComponent
@@ -86,45 +79,57 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            <Field data-invalid={!!fieldErrors.email}>
-              <FieldLabel htmlFor="email">{localization.auth.email}</FieldLabel>
-
-              <Input
-                id="email"
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              <form.AppField
                 name="email"
-                type="email"
-                autoComplete="email"
-                placeholder={localization.auth.emailPlaceholder}
-                required
-                disabled={isPending}
-                onChange={() =>
-                  setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                }
-                onInvalid={(e) => {
-                  e.preventDefault()
-
-                  setFieldErrors((prev) => ({
-                    ...prev,
-                    email: (e.target as HTMLInputElement).validationMessage
-                  }))
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
                 }}
-                aria-invalid={!!fieldErrors.email}
-              />
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        aria-invalid={isInvalid}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
 
-              <FieldError>{fieldErrors.email}</FieldError>
-            </Field>
+              {Captcha && <div className="flex justify-center">{Captcha}</div>}
 
-            {Captcha && <div className="flex justify-center">{Captcha}</div>}
+              <form.AuthFormSubmitButton disabled={isPending}>
+                {isPending && <Spinner />}
 
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Spinner />}
-
-              {emailOtpLocalization.sendCode}
-            </Button>
-          </FieldGroup>
-        </form>
+                {emailOtpLocalization.sendCode}
+              </form.AuthFormSubmitButton>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/apps/docs/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/apps/docs/src/components/auth/email-otp/reset-password-otp.tsx
@@ -8,10 +8,9 @@ import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPasswordOtp } from "@better-auth-ui/react/plugins/email-otp"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -36,6 +35,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 import { PasswordStrengthMeter } from "../password-strength-meter"
@@ -74,24 +74,9 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
   const isHydrated = useIsHydrated()
   const initialEmail =
     (isHydrated && sessionStorage.getItem(RESET_PASSWORD_OTP_STORAGE_KEY)) || ""
-  const [email, setEmail] = useState(initialEmail)
   const [hasStoredEmail, setHasStoredEmail] = useState(Boolean(initialEmail))
-  const [code, setCode] = useState("")
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-  const formRef = useRef<HTMLFormElement>(null)
-  const submissionLockedRef = useRef(false)
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-    password?: string
-  }>({})
-
-  useEffect(() => {
-    const storedEmail =
-      sessionStorage.getItem(RESET_PASSWORD_OTP_STORAGE_KEY) ?? ""
-    setEmail(storedEmail)
-    setHasStoredEmail(Boolean(storedEmail))
-  }, [])
+  const [passwordError, setPasswordError] = useState("")
 
   const { mutate: resetPasswordOtp, isPending } = useResetPasswordOtp(
     authClient as EmailOtpAuthClient,
@@ -100,14 +85,9 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
         // The haveIBeenPwned plugin rejects on the password itself, so it
         // belongs against the field rather than in a toast.
         if (isPasswordCompromisedError(error)) {
-          setFieldErrors((prev) => ({
-            ...prev,
-            password: localization.auth.passwordCompromised
-          }))
+          setPasswordError(localization.auth.passwordCompromised)
         }
-
-        submissionLockedRef.current = false
-        setCode("")
+        form.setFieldValue("code", "")
       },
       onSuccess: () => {
         sessionStorage.removeItem(RESET_PASSWORD_OTP_STORAGE_KEY)
@@ -117,58 +97,44 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
     }
   )
 
-  const submitReset = (
-    form: HTMLFormElement,
-    submittedCode: string,
-    reportErrors: boolean
-  ) => {
-    if (isPending || submissionLockedRef.current) return
-
-    const formData = new FormData(form)
-    const password = formData.get("password") as string
-    const confirmPassword = formData.get("confirmPassword") as string
-    const submittedEmail = hasStoredEmail
-      ? email
-      : (formData.get("email") as string)
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      if (reportErrors) {
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      confirmPassword: "",
+      email: initialEmail,
+      password: ""
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
         toast.error(localization.auth.passwordsDoNotMatch)
+        return
       }
-      return
-    }
-
-    if (submittedCode.length !== otpLength) {
-      if (reportErrors) {
+      if (value.code.length !== otpLength) {
         toast.error(
           emailOtpLocalization.codeLengthMismatch.replace(
             "{{length}}",
             String(otpLength)
           )
         )
+        return
       }
-      return
+      resetPasswordOtp({
+        email: value.email,
+        otp: value.code,
+        password: value.password
+      })
     }
+  })
 
-    submissionLockedRef.current = true
-    resetPasswordOtp({ email: submittedEmail, otp: submittedCode, password })
-  }
-
-  const tryAutoSubmit = (completedCode?: string) => {
-    const form = formRef.current
-
-    if (!form?.matches(":valid")) return
-
-    const formData = new FormData(form)
-    const submittedCode = completedCode ?? String(formData.get("otp") ?? "")
-
-    submitReset(form, submittedCode, false)
-  }
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    submitReset(e.currentTarget, code, true)
-  }
+  useEffect(() => {
+    const storedEmail =
+      sessionStorage.getItem(RESET_PASSWORD_OTP_STORAGE_KEY) ?? ""
+    form.setFieldValue("email", storedEmail)
+    setHasStoredEmail(Boolean(storedEmail))
+  }, [form.setFieldValue])
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -177,160 +143,171 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
           {localization.auth.resetPassword}
         </CardTitle>
 
-        {hasStoredEmail && email && (
+        {hasStoredEmail && form.state.values.email && (
           <CardDescription>
-            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
+            {emailOtpLocalization.codeSentTo.replace(
+              "{{email}}",
+              form.state.values.email
+            )}
           </CardDescription>
         )}
       </CardHeader>
 
       <CardContent>
-        <form ref={formRef} onSubmit={handleSubmit}>
-          <FieldGroup>
-            {!hasStoredEmail && (
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="email">
-                  {localization.auth.email}
-                </FieldLabel>
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              {!hasStoredEmail && (
+                <form.AppField name="email">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
 
-                <Input
-                  id="email"
-                  name="email"
-                  type="email"
-                  autoComplete="email"
-                  value={email}
-                  placeholder={localization.auth.emailPlaceholder}
-                  required
-                  disabled={isPending}
-                  onChange={(event) => {
-                    setEmail(event.target.value)
-                    setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        value={field.state.value}
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: (e.target as HTMLInputElement).validationMessage
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.email}
-                />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
-            )}
+              <form.AppField name="code">
+                {(field) => (
+                  <OtpField
+                    autoFocus={hasStoredEmail}
+                    disabled={isPending}
+                    label={emailOtpLocalization.code}
+                    length={otpLength}
+                    name="otp"
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                    onComplete={(code) => {
+                      field.handleChange(code)
+                      if (form.state.values.password) void form.handleSubmit()
+                    }}
+                  />
+                )}
+              </form.AppField>
 
-            <OtpField
-              autoFocus={hasStoredEmail}
-              disabled={isPending}
-              label={emailOtpLocalization.code}
-              length={otpLength}
-              name="otp"
-              value={code}
-              onChange={setCode}
-              onComplete={tryAutoSubmit}
-            />
+              <form.AppField name="password">
+                {(field) => (
+                  <Field data-invalid={Boolean(passwordError)}>
+                    <FieldLabel htmlFor="password">
+                      {localization.auth.newPassword}
+                    </FieldLabel>
 
-            <Field data-invalid={!!fieldErrors.password}>
-              <FieldLabel htmlFor="password">
-                {localization.auth.newPassword}
-              </FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        id="password"
+                        name={field.name}
+                        type={isPasswordVisible ? "text" : "password"}
+                        autoComplete="new-password"
+                        placeholder={localization.auth.newPasswordPlaceholder}
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => {
+                          setPasswordError("")
+                          field.handleChange(event.target.value)
+                        }}
+                        aria-invalid={Boolean(passwordError)}
+                      />
 
-              <InputGroup>
-                <InputGroupInput
-                  id="password"
-                  name="password"
-                  type={isPasswordVisible ? "text" : "password"}
-                  autoComplete="new-password"
-                  placeholder={localization.auth.newPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                  onChange={(e) => {
-                    setPassword(e.target.value)
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={
+                            isPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          title={
+                            isPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() =>
+                            setIsPasswordVisible((visible) => !visible)
+                          }
+                        >
+                          {isPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
 
-                    setFieldErrors((prev) => ({ ...prev, password: undefined }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
-                    const el = e.target as HTMLInputElement
-                    const min = emailAndPassword?.minPasswordLength
-                    const max = emailAndPassword?.maxPasswordLength
-                    const msg = el.validity.valueMissing
-                      ? localization.auth.fieldRequired
-                      : el.validity.tooShort
-                        ? localization.auth.tooShort.replace(
-                            "{{min}}",
-                            String(min)
-                          )
-                        : localization.auth.tooLong.replace(
-                            "{{max}}",
-                            String(max)
-                          )
+                    {passwordError && <FieldError>{passwordError}</FieldError>}
 
-                    setFieldErrors((prev) => ({ ...prev, password: msg }))
-                  }}
-                  aria-invalid={!!fieldErrors.password}
-                />
+                    <PasswordStrengthMeter password={field.state.value} />
+                  </Field>
+                )}
+              </form.AppField>
 
-                <InputGroupAddon align="inline-end">
-                  <InputGroupButton
-                    size="icon-xs"
-                    aria-label={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    title={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    onClick={() => setIsPasswordVisible((visible) => !visible)}
-                  >
-                    {isPasswordVisible ? <EyeOff /> : <Eye />}
-                  </InputGroupButton>
-                </InputGroupAddon>
-              </InputGroup>
+              {emailAndPassword?.confirmPassword && (
+                <form.AppField name="confirmPassword">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="confirmPassword">
+                        {localization.auth.confirmPassword}
+                      </FieldLabel>
 
-              <FieldError>{fieldErrors.password}</FieldError>
+                      <Input
+                        id="confirmPassword"
+                        name={field.name}
+                        type="password"
+                        autoComplete="new-password"
+                        placeholder={
+                          localization.auth.confirmPasswordPlaceholder
+                        }
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-              <PasswordStrengthMeter password={password} />
-            </Field>
+              <div className="flex flex-col gap-3">
+                <form.AuthFormSubmitButton disabled={isPending}>
+                  {isPending && <Spinner />}
 
-            {emailAndPassword?.confirmPassword && (
-              <Field>
-                <FieldLabel htmlFor="confirmPassword">
-                  {localization.auth.confirmPassword}
-                </FieldLabel>
+                  {localization.auth.resetPassword}
+                </form.AuthFormSubmitButton>
 
-                <Input
-                  id="confirmPassword"
-                  name="confirmPassword"
-                  type="password"
-                  autoComplete="new-password"
-                  placeholder={localization.auth.confirmPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                />
-              </Field>
-            )}
-
-            <div className="flex flex-col gap-3">
-              <Button type="submit" disabled={isPending}>
-                {isPending && <Spinner />}
-
-                {localization.auth.resetPassword}
-              </Button>
-
-              {email && <OpenEmailButton email={email} variant="secondary" />}
-            </div>
-          </FieldGroup>
-        </form>
+                {form.state.values.email && (
+                  <OpenEmailButton
+                    email={form.state.values.email}
+                    variant="secondary"
+                  />
+                )}
+              </div>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/apps/docs/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/apps/docs/src/components/auth/email-otp/verify-email-otp.tsx
@@ -7,7 +7,7 @@ import {
   useSendVerificationOtp,
   useVerifyEmailOtp
 } from "@better-auth-ui/react/plugins/email-otp"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -21,7 +21,6 @@ import {
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel
 } from "@/components/ui/field"
@@ -33,6 +32,7 @@ import {
   useResendCooldown
 } from "@/lib/auth/use-resend-cooldown"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 import { useIsHydrated } from "../use-is-hydrated"
@@ -74,8 +74,6 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
   const [email, setEmail] = useState(
     (isHydrated && sessionStorage.getItem(VERIFY_EMAIL_STORAGE_KEY)) || ""
   )
-  const [code, setCode] = useState("")
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({})
 
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
 
@@ -102,7 +100,7 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
   const { mutate: verifyEmailOtp, isPending: isVerifying } = useVerifyEmailOtp(
     otpClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
         sessionStorage.removeItem(VERIFY_EMAIL_STORAGE_KEY)
         toast.success(emailOtpLocalization.emailVerified)
@@ -119,20 +117,19 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
     verifyEmailOtp({ email, otp: completedCode })
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (!email) {
-      const formData = new FormData(e.currentTarget)
-      sendVerificationOtp({
-        email: formData.get("email") as string,
-        type: "email-verification"
-      })
-      return
+  const form = useAuthForm({
+    defaultValues: { code: "", email: "" },
+    onSubmit: ({ value }) => {
+      if (!email) {
+        sendVerificationOtp({
+          email: value.email,
+          type: "email-verification"
+        })
+        return
+      }
+      verifyCode(value.code)
     }
-
-    verifyCode(code)
-  }
+  })
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -149,87 +146,91 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            {email ? (
-              <OtpField
-                autoFocus
-                disabled={isPending}
-                label={emailOtpLocalization.code}
-                length={otpLength}
-                name="otp"
-                value={code}
-                onChange={setCode}
-                onComplete={verifyCode}
-              />
-            ) : (
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="email">
-                  {localization.auth.email}
-                </FieldLabel>
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              {email ? (
+                <form.AppField name="code">
+                  {(field) => (
+                    <OtpField
+                      autoFocus
+                      disabled={isPending}
+                      label={emailOtpLocalization.code}
+                      length={otpLength}
+                      name="otp"
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      onComplete={verifyCode}
+                    />
+                  )}
+                </form.AppField>
+              ) : (
+                <form.AppField name="email">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
 
-                <Input
-                  id="email"
-                  name="email"
-                  type="email"
-                  autoComplete="email"
-                  placeholder={localization.auth.emailPlaceholder}
-                  required
-                  disabled={isPending}
-                  onChange={() =>
-                    setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                  }
-                  onInvalid={(e) => {
-                    e.preventDefault()
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: (e.target as HTMLInputElement).validationMessage
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.email}
-                />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
-            )}
-
-            <div className="flex flex-col gap-3">
-              <Button
-                type="submit"
-                disabled={
-                  isPending || (Boolean(email) && code.length !== otpLength)
-                }
-              >
-                {isPending && <Spinner />}
-
-                {email
-                  ? emailOtpLocalization.verifyCode
-                  : emailOtpLocalization.sendCode}
-              </Button>
-
-              {email && <OpenEmailButton email={email} variant="secondary" />}
-
-              {email && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={isPending || isCoolingDown}
-                  onClick={() =>
-                    sendVerificationOtp({ email, type: "email-verification" })
+              <div className="flex flex-col gap-3">
+                <form.AuthFormSubmitButton
+                  disabled={
+                    isPending ||
+                    (Boolean(email) &&
+                      form.state.values.code.length !== otpLength)
                   }
                 >
-                  {isCoolingDown
-                    ? localization.auth.resendIn.replace(
-                        "{{seconds}}",
-                        String(cooldown)
-                      )
-                    : localization.auth.resend}
-                </Button>
-              )}
-            </div>
-          </FieldGroup>
-        </form>
+                  {isPending && <Spinner />}
+
+                  {email
+                    ? emailOtpLocalization.verifyCode
+                    : emailOtpLocalization.sendCode}
+                </form.AuthFormSubmitButton>
+
+                {email && <OpenEmailButton email={email} variant="secondary" />}
+
+                {email && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={isPending || isCoolingDown}
+                    onClick={() =>
+                      sendVerificationOtp({ email, type: "email-verification" })
+                    }
+                  >
+                    {isCoolingDown
+                      ? localization.auth.resendIn.replace(
+                          "{{seconds}}",
+                          String(cooldown)
+                        )
+                      : localization.auth.resend}
+                  </Button>
+                )}
+              </div>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/apps/docs/src/components/auth/forgot-password.tsx
+++ b/apps/docs/src/components/auth/forgot-password.tsx
@@ -1,25 +1,23 @@
 "use client"
 
-import { getViewURL } from "@better-auth-ui/core"
+import { getViewURL, validateEmailAddress } from "@better-auth-ui/core"
 import {
   useAuth,
   useFetchOptions,
   useRequestPasswordReset
 } from "@better-auth-ui/react"
-import { type SyntheticEvent, useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel
 } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
 import { RESET_LINK_SENT_STORAGE_KEY } from "./reset-link-sent"
 
 export type ForgotPasswordProps = {
@@ -64,27 +62,23 @@ export function ForgotPassword({ className }: ForgotPasswordProps) {
     }
   )
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    const formData = new FormData(e.currentTarget)
-    requestPasswordReset({
-      email: formData.get("email") as string,
-      redirectTo: getViewURL(
-        baseURL,
-        basePaths.auth,
-        viewPaths.auth.resetPassword
-      ),
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) =>
+      requestPasswordReset({
+        email: value.email,
+        redirectTo: getViewURL(
+          baseURL,
+          basePaths.auth,
+          viewPaths.auth.resetPassword
+        ),
+        fetchOptions
+      })
+  })
 
   const Captcha = plugins.find(
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
-
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-  }>({})
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -95,54 +89,58 @@ export function ForgotPassword({ className }: ForgotPasswordProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            <Field data-invalid={!!fieldErrors.email}>
-              <FieldLabel htmlFor="email">{localization.auth.email}</FieldLabel>
-
-              <Input
-                id="email"
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              <form.AppField
                 name="email"
-                type="email"
-                autoComplete="email"
-                placeholder={localization.auth.emailPlaceholder}
-                required
-                disabled={isPending}
-                onChange={() => {
-                  setFieldErrors((prev) => ({
-                    ...prev,
-                    email: undefined
-                  }))
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
                 }}
-                onInvalid={(e) => {
-                  e.preventDefault()
-                  const el = e.target as HTMLInputElement
-                  const msg = el.validity.valueMissing
-                    ? localization.auth.fieldRequired
-                    : localization.auth.invalidEmail
-
-                  setFieldErrors((prev) => ({
-                    ...prev,
-                    email: msg
-                  }))
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        aria-invalid={isInvalid}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
                 }}
-                aria-invalid={!!fieldErrors.email}
-              />
+              </form.AppField>
 
-              <FieldError>{fieldErrors.email}</FieldError>
-            </Field>
+              {Captcha && <div className="flex justify-center">{Captcha}</div>}
 
-            {Captcha && <div className="flex justify-center">{Captcha}</div>}
-
-            <div className="flex flex-col gap-3">
-              <Button type="submit" disabled={isPending}>
-                {isPending && <Spinner />}
-
-                {localization.auth.sendResetLink}
-              </Button>
-            </div>
-          </FieldGroup>
-        </form>
+              <div className="flex flex-col gap-3">
+                <form.AuthFormSubmitButton disabled={isPending}>
+                  {isPending && <Spinner />}
+                  {localization.auth.sendResetLink}
+                </form.AuthFormSubmitButton>
+              </div>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/apps/docs/src/components/auth/magic-link.tsx
+++ b/apps/docs/src/components/auth/magic-link.tsx
@@ -1,19 +1,16 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import { authMutationKeys, validateEmailAddress } from "@better-auth-ui/core"
 import type { MagicLinkAuthClient } from "@better-auth-ui/core/plugins/magic-link"
 import { getSsoFallbackEmail } from "@better-auth-ui/core/plugins/sso"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useSignInMagicLink } from "@better-auth-ui/react/plugins/magic-link"
 import { useIsMutating } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -22,6 +19,7 @@ import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { magicLinkPlugin } from "@/lib/auth/magic-link-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
 import { MAGIC_LINK_SENT_STORAGE_KEY } from "./magic-link-sent"
 import { ProviderButtons, type SocialLayout } from "./provider-buttons"
 
@@ -60,8 +58,6 @@ export function MagicLink({
   const { localization: magicLinkLocalization, viewPaths: magicLinkViewPaths } =
     useAuthPlugin(magicLinkPlugin)
 
-  const [email, setEmail] = useState(getSsoFallbackEmail)
-
   const { mutate: signInMagicLink, isPending: signInMagicLinkPending } =
     useSignInMagicLink(authClient, {
       onSuccess: (_data, variables) => {
@@ -80,14 +76,14 @@ export function MagicLink({
   })
   const isPending = signInMutating + signUpMutating > 0
 
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-  }>({})
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    signInMagicLink({ email, callbackURL: `${baseURL}${redirectTo}` })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: getSsoFallbackEmail() },
+    onSubmit: ({ value }) =>
+      signInMagicLink({
+        callbackURL: `${baseURL}${redirectTo}`,
+        email: value.email
+      })
+  })
 
   const showSeparator = socialProviders && socialProviders.length > 0
 
@@ -113,62 +109,65 @@ export function MagicLink({
             </>
           )}
 
-          <form onSubmit={handleSubmit}>
-            <FieldGroup>
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="email">
-                  {localization.auth.email}
-                </FieldLabel>
-
-                <Input
-                  id="email"
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <FieldGroup>
+                <form.AppField
                   name="email"
-                  type="email"
-                  autoComplete="email"
-                  value={email}
-                  onChange={(e) => {
-                    setEmail(e.target.value)
-
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: undefined
-                    }))
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateEmailAddress(value, {
+                        invalidMessage: localization.auth.invalidEmail,
+                        requiredMessage: localization.auth.fieldRequired
+                      })
                   }}
-                  placeholder={localization.auth.emailPlaceholder}
-                  required
-                  disabled={isPending}
-                  onInvalid={(e) => {
-                    e.preventDefault()
-
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: (e.target as HTMLInputElement).validationMessage
-                    }))
+                >
+                  {(field) => {
+                    const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                    return (
+                      <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor="email">
+                          {localization.auth.email}
+                        </FieldLabel>
+                        <Input
+                          id="email"
+                          name={field.name}
+                          type="email"
+                          autoComplete="email"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          placeholder={localization.auth.emailPlaceholder}
+                          required
+                          disabled={isPending}
+                          aria-invalid={isInvalid}
+                        />
+                        <field.AuthFormFieldError />
+                      </Field>
+                    )
                   }}
-                  aria-invalid={!!fieldErrors.email}
-                />
+                </form.AppField>
 
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
+                <div className="flex flex-col gap-3">
+                  <form.AuthFormSubmitButton disabled={isPending}>
+                    {signInMagicLinkPending && <Spinner />}
+                    {magicLinkLocalization.sendMagicLink}
+                  </form.AuthFormSubmitButton>
 
-              <div className="flex flex-col gap-3">
-                <Button type="submit" disabled={isPending}>
-                  {signInMagicLinkPending && <Spinner />}
-
-                  {magicLinkLocalization.sendMagicLink}
-                </Button>
-
-                {plugins.flatMap((plugin) =>
-                  (plugin.authButtons ?? []).map((AuthButton, index) => (
-                    <AuthButton
-                      key={`${plugin.id}-${index.toString()}`}
-                      view="magicLink"
-                    />
-                  ))
-                )}
-              </div>
-            </FieldGroup>
-          </form>
+                  {plugins.flatMap((plugin) =>
+                    (plugin.authButtons ?? []).map((AuthButton, index) => (
+                      <AuthButton
+                        key={`${plugin.id}-${index.toString()}`}
+                        view="magicLink"
+                      />
+                    ))
+                  )}
+                </div>
+              </FieldGroup>
+            </form.AuthFormRoot>
+          </form.AppForm>
 
           {socialPosition === "bottom" && (
             <>

--- a/apps/docs/src/components/auth/organization/delete-organization-dialog.tsx
+++ b/apps/docs/src/components/auth/organization/delete-organization-dialog.tsx
@@ -5,7 +5,6 @@ import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useDeleteOrganization } from "@better-auth-ui/react/plugins/organization"
 import type { Organization } from "better-auth/client"
 import { TriangleAlert } from "lucide-react"
-import type { SyntheticEvent } from "react"
 import { toast } from "sonner"
 
 import {
@@ -18,10 +17,10 @@ import {
   AlertDialogMedia,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
+import { useAuthForm } from "../auth-form"
 import { OrganizationView } from "./organization-view"
 
 export type DeleteOrganizationDialogProps = {
@@ -57,47 +56,52 @@ export function DeleteOrganizationDialog({
     }
   )
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    deleteOrganization({ organizationId: organization.id })
-  }
+  const form = useAuthForm({
+    defaultValues: {},
+    onSubmit: () => deleteOrganization({ organizationId: organization.id })
+  })
 
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <AlertDialogHeader>
-            <AlertDialogMedia className="bg-destructive/10 text-destructive">
-              <TriangleAlert />
-            </AlertDialogMedia>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <AlertDialogHeader>
+              <AlertDialogMedia className="bg-destructive/10 text-destructive">
+                <TriangleAlert />
+              </AlertDialogMedia>
 
-            <AlertDialogTitle>
-              {organizationLocalization.deleteOrganization}
-            </AlertDialogTitle>
+              <AlertDialogTitle>
+                {organizationLocalization.deleteOrganization}
+              </AlertDialogTitle>
 
-            <AlertDialogDescription>
-              {organizationLocalization.deleteOrganizationDescription}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+              <AlertDialogDescription>
+                {organizationLocalization.deleteOrganizationDescription}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
 
-          <Card>
-            <CardContent>
-              <OrganizationView organization={organization} hideRole />
-            </CardContent>
-          </Card>
+            <Card>
+              <CardContent>
+                <OrganizationView organization={organization} hideRole />
+              </CardContent>
+            </Card>
 
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>
-              {localization.settings.cancel}
-            </AlertDialogCancel>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isPending}>
+                {localization.settings.cancel}
+              </AlertDialogCancel>
 
-            <Button type="submit" variant="destructive" disabled={isPending}>
-              {isPending && <Spinner />}
+              <form.AuthFormSubmitButton
+                variant="destructive"
+                disabled={isPending}
+              >
+                {isPending && <Spinner />}
 
-              {organizationLocalization.deleteOrganization}
-            </Button>
-          </AlertDialogFooter>
-        </form>
+                {organizationLocalization.deleteOrganization}
+              </form.AuthFormSubmitButton>
+            </AlertDialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </AlertDialogContent>
     </AlertDialog>
   )

--- a/apps/docs/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/apps/docs/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -8,8 +8,8 @@ import type {
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useAddPasskey } from "@better-auth-ui/react/plugins/passkey"
 import { Fingerprint } from "lucide-react"
-import { type SyntheticEvent, useRef } from "react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useRef } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -23,6 +23,7 @@ import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
+import { useAuthForm } from "../auth-form"
 import { FreshSessionPrompt } from "../settings/security/fresh-session-prompt"
 
 export type AddPasskeyDialogProps = {
@@ -41,14 +42,6 @@ export function AddPasskeyDialog({
   const addPasskey = useAddPasskey(authClient)
   const pendingRequest = useRef<AddPasskeyParams<PasskeyAuthClient>>(undefined)
 
-  const handleOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen) {
-      addPasskey.reset()
-      pendingRequest.current = undefined
-    }
-    onOpenChange(nextOpen)
-  }
-
   const submitRequest = (request: AddPasskeyParams<PasskeyAuthClient>) => {
     const requestWithCallbacks = {
       ...request,
@@ -61,16 +54,24 @@ export function AddPasskeyDialog({
     addPasskey.mutate(requestWithCallbacks)
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useAuthForm({
+    defaultValues: { name: "" },
+    onSubmit: ({ value }) => {
+      const name = value.name.trim()
+      submitRequest({
+        ...(name ? { name } : {}),
+        ...(authenticatorAttachment ? { authenticatorAttachment } : {})
+      } as AddPasskeyParams<PasskeyAuthClient>)
+    }
+  })
 
-    const formData = new FormData(e.target as HTMLFormElement)
-    const name = (formData.get("name") as string)?.trim()
-
-    submitRequest({
-      ...(name ? { name } : {}),
-      ...(authenticatorAttachment ? { authenticatorAttachment } : {})
-    } as AddPasskeyParams<PasskeyAuthClient>)
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      addPasskey.reset()
+      form.reset()
+      pendingRequest.current = undefined
+    }
+    onOpenChange(nextOpen)
   }
 
   const needsFreshSession = isSessionNotFreshError(addPasskey.error)
@@ -93,55 +94,65 @@ export function AddPasskeyDialog({
             />
           </>
         ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <Fingerprint />
-                {passkeyLocalization.addPasskey}
-              </DialogTitle>
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-6">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <Fingerprint />
+                  {passkeyLocalization.addPasskey}
+                </DialogTitle>
 
-              <DialogDescription>
-                {passkeyLocalization.passkeysDescription}
-              </DialogDescription>
-            </DialogHeader>
+                <DialogDescription>
+                  {passkeyLocalization.passkeysDescription}
+                </DialogDescription>
+              </DialogHeader>
 
-            <Field data-invalid={addPasskey.isError}>
-              <FieldLabel htmlFor="passkey-name">
-                {passkeyLocalization.name}
-              </FieldLabel>
+              <form.AppField name="name">
+                {(field) => (
+                  <Field data-invalid={addPasskey.isError}>
+                    <FieldLabel htmlFor="passkey-name">
+                      {passkeyLocalization.name}
+                    </FieldLabel>
+                    <Input
+                      id="passkey-name"
+                      name={field.name}
+                      autoFocus
+                      placeholder={localization.settings.optional}
+                      disabled={addPasskey.isPending}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      aria-invalid={addPasskey.isError}
+                    />
+                    {addPasskey.error && (
+                      <FieldError>
+                        {addPasskey.error.error?.message ??
+                          addPasskey.error.message}
+                      </FieldError>
+                    )}
+                  </Field>
+                )}
+              </form.AppField>
 
-              <Input
-                id="passkey-name"
-                name="name"
-                autoFocus
-                placeholder={localization.settings.optional}
-                disabled={addPasskey.isPending}
-                aria-invalid={addPasskey.isError}
-              />
+              <DialogFooter>
+                <DialogClose
+                  className={buttonVariants({ variant: "outline" })}
+                  disabled={addPasskey.isPending}
+                  type="button"
+                >
+                  {localization.settings.cancel}
+                </DialogClose>
 
-              {addPasskey.error && (
-                <FieldError>
-                  {addPasskey.error.error?.message ?? addPasskey.error.message}
-                </FieldError>
-              )}
-            </Field>
+                <form.AuthFormSubmitButton disabled={addPasskey.isPending}>
+                  {addPasskey.isPending && <Spinner />}
 
-            <DialogFooter>
-              <DialogClose
-                className={buttonVariants({ variant: "outline" })}
-                disabled={addPasskey.isPending}
-                type="button"
-              >
-                {localization.settings.cancel}
-              </DialogClose>
-
-              <Button type="submit" disabled={addPasskey.isPending}>
-                {addPasskey.isPending && <Spinner />}
-
-                {passkeyLocalization.addPasskey}
-              </Button>
-            </DialogFooter>
-          </form>
+                  {passkeyLocalization.addPasskey}
+                </form.AuthFormSubmitButton>
+              </DialogFooter>
+            </form.AuthFormRoot>
+          </form.AppForm>
         )}
       </DialogContent>
     </Dialog>

--- a/apps/docs/src/components/auth/passkey/rename-passkey-dialog.tsx
+++ b/apps/docs/src/components/auth/passkey/rename-passkey-dialog.tsx
@@ -3,8 +3,8 @@
 import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useUpdatePasskey } from "@better-auth-ui/react/plugins/passkey"
-import { type FormEvent, useEffect, useState } from "react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useEffect } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -17,6 +17,7 @@ import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
+import { useAuthForm } from "../auth-form"
 import type { ListedPasskey } from "./delete-passkey-dialog"
 
 export function RenamePasskeyDialog({
@@ -30,56 +31,61 @@ export function RenamePasskeyDialog({
 }) {
   const { authClient, localization } = useAuth<PasskeyAuthClient>()
   const { localization: labels } = useAuthPlugin(passkeyPlugin)
-  const [name, setName] = useState(passkey.name ?? "")
-
-  useEffect(() => {
-    if (open) setName(passkey.name ?? "")
-  }, [open, passkey.name])
-
   const updatePasskey = useUpdatePasskey(authClient, {
     onSuccess: () => onOpenChange(false)
   })
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const nextName = name.trim()
-    if (nextName) updatePasskey.mutate({ id: passkey.id, name: nextName })
-  }
+  const form = useAuthForm({
+    defaultValues: { name: passkey.name ?? "" },
+    onSubmit: ({ value }) => {
+      const name = value.name.trim()
+      if (name) updatePasskey.mutate({ id: passkey.id, name })
+    }
+  })
+
+  useEffect(() => {
+    if (open) form.reset({ name: passkey.name ?? "" })
+  }, [form, open, passkey.name])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form className="flex flex-col gap-6" onSubmit={submit}>
-          <DialogHeader>
-            <DialogTitle>{labels.renamePasskey}</DialogTitle>
-          </DialogHeader>
-          <Field>
-            <FieldLabel htmlFor={`passkey-name-${passkey.id}`}>
-              {labels.name}
-            </FieldLabel>
-            <Input
-              id={`passkey-name-${passkey.id}`}
-              autoFocus
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              required
-            />
-          </Field>
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-            <Button
-              disabled={!name.trim() || updatePasskey.isPending}
-              type="submit"
-            >
-              {updatePasskey.isPending && <Spinner />}
-              {localization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
-        </form>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle>{labels.renamePasskey}</DialogTitle>
+            </DialogHeader>
+            <form.AppField name="name">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor={`passkey-name-${passkey.id}`}>
+                    {labels.name}
+                  </FieldLabel>
+                  <Input
+                    id={`passkey-name-${passkey.id}`}
+                    name={field.name}
+                    autoFocus
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(event) => field.handleChange(event.target.value)}
+                    required
+                  />
+                </Field>
+              )}
+            </form.AppField>
+            <DialogFooter>
+              <DialogClose
+                className={buttonVariants({ variant: "outline" })}
+                type="button"
+              >
+                {localization.settings.cancel}
+              </DialogClose>
+              <form.AuthFormSubmitButton disabled={updatePasskey.isPending}>
+                {updatePasskey.isPending && <Spinner />}
+                {localization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/apps/docs/src/components/auth/phone-number/change-phone-number.tsx
+++ b/apps/docs/src/components/auth/phone-number/change-phone-number.tsx
@@ -14,7 +14,7 @@ import {
   useSendPhoneNumberOtp,
   useVerifyPhoneNumber
 } from "@better-auth-ui/react/plugins/phone-number"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -24,6 +24,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { InternationalPhoneField } from "./international-phone-field"
 import { RemovePhoneNumberDialog } from "./remove-phone-number-dialog"
@@ -51,20 +52,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
   const { data: session } = useSession(phoneClient)
   const currentPhoneNumber =
     (session?.user as PhoneNumberUser | undefined)?.phoneNumber ?? ""
-  const [phoneNumber, setPhoneNumber] = useState(() =>
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
-  const [fieldError, setFieldError] = useState<string>()
-
-  useEffect(() => {
-    if (session) {
-      setPhoneNumber(
-        createPhoneNumberValue(currentPhoneNumber, defaultCountry, adapter)
-      )
-    }
-  }, [adapter, currentPhoneNumber, defaultCountry, session])
 
   const { mutate: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
     phoneClient,
@@ -73,9 +61,9 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
   const { mutate: verify, isPending: isVerifying } = useVerifyPhoneNumber(
     phoneClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
-        setCode("")
+        form.setFieldValue("code", "")
         setCodeSent(false)
         toast.success(localization.phoneNumberUpdated)
       }
@@ -85,26 +73,43 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
     phoneClient,
     {
       onSuccess: () => {
-        setPhoneNumber(createPhoneNumberValue("", defaultCountry, adapter))
+        form.setFieldValue(
+          "phoneNumber",
+          createPhoneNumberValue("", defaultCountry, adapter)
+        )
         toast.success(localization.phoneNumberRemoved)
       }
     }
   )
   const isPending = isSending || isVerifying || isRemoving
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!phoneNumber.e164) {
-      setFieldError(localization.invalidPhoneNumber)
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter)
+    },
+    onSubmit: ({ value }) => {
+      if (!value.phoneNumber.e164) return
+      if (!codeSent) {
+        sendOtp({ phoneNumber: value.phoneNumber.e164 })
+        return
+      }
+      verify({
+        phoneNumber: value.phoneNumber.e164,
+        code: value.code,
+        updatePhoneNumber: true
+      })
     }
-    if (!codeSent) {
-      sendOtp({ phoneNumber: phoneNumber.e164 })
-      return
-    }
+  })
 
-    verify({ phoneNumber: phoneNumber.e164, code, updatePhoneNumber: true })
-  }
+  useEffect(() => {
+    if (session) {
+      form.setFieldValue(
+        "phoneNumber",
+        createPhoneNumberValue(currentPhoneNumber, defaultCountry, adapter)
+      )
+    }
+  }, [adapter, currentPhoneNumber, defaultCountry, form.setFieldValue, session])
   const removePhoneNumber = () =>
     updateUser({
       phoneNumber: null
@@ -115,94 +120,109 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
       <h2 className="mb-3 text-sm font-semibold">
         {localization.changePhoneNumber}
       </h2>
-      <form onSubmit={handleSubmit}>
-        <Card className={cn(className)}>
-          <CardContent className="flex flex-col gap-6">
-            {codeSent ? (
-              <>
-                <FieldDescription>
-                  {localization.codeSentTo.replace(
-                    "{{phoneNumber}}",
-                    phoneNumber.display
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card className={cn(className)}>
+            <CardContent className="flex flex-col gap-6">
+              {codeSent ? (
+                <>
+                  <FieldDescription>
+                    {localization.codeSentTo.replace(
+                      "{{phoneNumber}}",
+                      form.state.values.phoneNumber.display
+                    )}
+                  </FieldDescription>
+                  <form.AppField name="code">
+                    {(field) => (
+                      <OtpField
+                        autoFocus
+                        disabled={isPending}
+                        label={localization.phoneCode}
+                        length={otpLength}
+                        name="otp"
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                      />
+                    )}
+                  </form.AppField>
+                </>
+              ) : session ? (
+                <form.AppField
+                  name="phoneNumber"
+                  validators={{
+                    onChange: ({ value }) =>
+                      value.e164 ? undefined : localization.invalidPhoneNumber
+                  }}
+                >
+                  {(field) => (
+                    <InternationalPhoneField
+                      adapter={adapter}
+                      countryCodes={countries}
+                      countryLabel={localization.country}
+                      disabled={isPending}
+                      error={field.state.meta.errors[0]?.toString()}
+                      locale={locale}
+                      phoneLabel={localization.phoneNumber}
+                      placeholder={localization.phoneNumberPlaceholder}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                    />
                   )}
-                </FieldDescription>
-                <OtpField
-                  autoFocus
+                </form.AppField>
+              ) : (
+                <Skeleton className="h-14 w-full" />
+              )}
+            </CardContent>
+            <CardFooter className="gap-3">
+              {codeSent && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
                   disabled={isPending}
-                  label={localization.phoneCode}
-                  length={otpLength}
-                  name="otp"
-                  value={code}
-                  onChange={setCode}
-                />
-              </>
-            ) : session ? (
-              <InternationalPhoneField
-                adapter={adapter}
-                countryCodes={countries}
-                countryLabel={localization.country}
-                disabled={isPending}
-                error={fieldError}
-                locale={locale}
-                phoneLabel={localization.phoneNumber}
-                placeholder={localization.phoneNumberPlaceholder}
-                value={phoneNumber}
-                onChange={(value) => {
-                  setPhoneNumber(value)
-                  setFieldError(undefined)
-                }}
-              />
-            ) : (
-              <Skeleton className="h-14 w-full" />
-            )}
-          </CardContent>
-          <CardFooter className="gap-3">
-            {codeSent && (
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                disabled={isPending}
-                onClick={() => {
-                  setCode("")
-                  setCodeSent(false)
-                  setPhoneNumber(
-                    createPhoneNumberValue(
-                      currentPhoneNumber,
-                      defaultCountry,
-                      adapter
+                  onClick={() => {
+                    form.setFieldValue("code", "")
+                    setCodeSent(false)
+                    form.setFieldValue(
+                      "phoneNumber",
+                      createPhoneNumberValue(
+                        currentPhoneNumber,
+                        defaultCountry,
+                        adapter
+                      )
                     )
-                  )
-                }}
+                  }}
+                >
+                  {localization.cancel}
+                </Button>
+              )}
+              <form.AuthFormSubmitButton
+                size="sm"
+                disabled={
+                  isPending ||
+                  !session ||
+                  (codeSent && form.state.values.code.length !== otpLength)
+                }
               >
-                {localization.cancel}
-              </Button>
-            )}
-            <Button
-              type="submit"
-              size="sm"
-              disabled={
-                isPending || !session || (codeSent && code.length !== otpLength)
-              }
-            >
-              {(isSending || isVerifying) && <Spinner />}
-              {codeSent
-                ? localization.verifyCode
-                : localization.updatePhoneNumber}
-            </Button>
-            {!codeSent && currentPhoneNumber && (
-              <RemovePhoneNumberDialog
-                cancelLabel={localization.cancel}
-                description={localization.removePhoneNumberDescription}
-                isPending={isRemoving}
-                label={localization.removePhoneNumber}
-                title={localization.removePhoneNumberTitle}
-                onConfirm={removePhoneNumber}
-              />
-            )}
-          </CardFooter>
-        </Card>
-      </form>
+                {(isSending || isVerifying) && <Spinner />}
+                {codeSent
+                  ? localization.verifyCode
+                  : localization.updatePhoneNumber}
+              </form.AuthFormSubmitButton>
+              {!codeSent && currentPhoneNumber && (
+                <RemovePhoneNumberDialog
+                  cancelLabel={localization.cancel}
+                  description={localization.removePhoneNumberDescription}
+                  isPending={isRemoving}
+                  label={localization.removePhoneNumber}
+                  title={localization.removePhoneNumberTitle}
+                  onConfirm={removePhoneNumber}
+                />
+              )}
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/apps/docs/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/apps/docs/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -6,14 +6,13 @@ import {
 } from "@better-auth-ui/core/plugins/phone-number"
 import { useAuth, useAuthPlugin, useFetchOptions } from "@better-auth-ui/react"
 import { useRequestPhoneNumberPasswordReset } from "@better-auth-ui/react/plugins/phone-number"
-import { type SyntheticEvent, useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { FieldDescription, FieldGroup } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { InternationalPhoneField } from "./international-phone-field"
 
 export const PHONE_NUMBER_RESET_STORAGE_KEY =
@@ -38,10 +37,6 @@ export function ForgotPhoneNumberPassword({
     viewPaths: phoneNumberViewPaths
   } = useAuthPlugin(phoneNumberPlugin)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
-  const [phoneNumber, setPhoneNumber] = useState(() =>
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [fieldError, setFieldError] = useState<string>()
   const { mutate: requestReset, isPending } =
     useRequestPhoneNumberPasswordReset(authClient as PhoneNumberAuthClient, {
       onError: () => resetFetchOptions(),
@@ -56,17 +51,15 @@ export function ForgotPhoneNumberPassword({
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!phoneNumber.e164) {
-      setFieldError(phoneLocalization.invalidPhoneNumber)
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter)
+    },
+    onSubmit: ({ value }) => {
+      if (!value.phoneNumber.e164) return
+      requestReset({ phoneNumber: value.phoneNumber.e164, fetchOptions })
     }
-    requestReset({
-      phoneNumber: phoneNumber.e164,
-      fetchOptions
-    })
-  }
+  })
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -76,30 +69,41 @@ export function ForgotPhoneNumberPassword({
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            <InternationalPhoneField
-              adapter={adapter}
-              countryCodes={countries}
-              countryLabel={phoneLocalization.country}
-              disabled={isPending}
-              error={fieldError}
-              locale={locale}
-              phoneLabel={phoneLocalization.phoneNumber}
-              placeholder={phoneLocalization.phoneNumberPlaceholder}
-              value={phoneNumber}
-              onChange={(value) => {
-                setPhoneNumber(value)
-                setFieldError(undefined)
-              }}
-            />
-            {Captcha && <div className="flex justify-center">{Captcha}</div>}
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Spinner />}
-              {phoneLocalization.sendCode}
-            </Button>
-          </FieldGroup>
-        </form>
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              <form.AppField
+                name="phoneNumber"
+                validators={{
+                  onChange: ({ value }) =>
+                    value.e164
+                      ? undefined
+                      : phoneLocalization.invalidPhoneNumber
+                }}
+              >
+                {(field) => (
+                  <InternationalPhoneField
+                    adapter={adapter}
+                    countryCodes={countries}
+                    countryLabel={phoneLocalization.country}
+                    disabled={isPending}
+                    error={field.state.meta.errors[0]?.toString()}
+                    locale={locale}
+                    phoneLabel={phoneLocalization.phoneNumber}
+                    placeholder={phoneLocalization.phoneNumberPlaceholder}
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                  />
+                )}
+              </form.AppField>
+              {Captcha && <div className="flex justify-center">{Captcha}</div>}
+              <form.AuthFormSubmitButton disabled={isPending}>
+                {isPending && <Spinner />}
+                {phoneLocalization.sendCode}
+              </form.AuthFormSubmitButton>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
         <FieldDescription className="mt-4 text-center">
           {localization.auth.rememberYourPassword}{" "}
           <Link

--- a/apps/docs/src/components/auth/phone-number/phone-number.tsx
+++ b/apps/docs/src/components/auth/phone-number/phone-number.tsx
@@ -18,7 +18,7 @@ import {
 } from "@better-auth-ui/react/plugins/phone-number"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -32,7 +32,6 @@ import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -48,6 +47,7 @@ import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { useResendCooldown } from "@/lib/auth/use-resend-cooldown"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
 import { InternationalPhoneField } from "./international-phone-field"
@@ -95,17 +95,8 @@ export function PhoneNumber({
   const [mode, setMode] = useState<PhoneNumberMode>(
     signIn ? "code" : "password"
   )
-  const [phoneNumber, setPhoneNumber] = useState(() =>
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [password, setPassword] = useState("")
-  const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-  const [fieldErrors, setFieldErrors] = useState<{
-    phoneNumber?: string
-    password?: string
-  }>({})
 
   const { mutate: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
     phoneClient,
@@ -120,14 +111,14 @@ export function PhoneNumber({
   const { mutate: verify, isPending: isVerifying } = useVerifyPhoneNumber(
     phoneClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: (data) => continueSignIn(data)
     }
   )
   const { mutate: signInWithPassword, isPending: isPasswordPending } =
     useSignInPhoneNumber(phoneClient, {
       onError: (error) => {
-        setPassword("")
+        form.setFieldValue("password", "")
         resetFetchOptions()
 
         if (signIn && error.error?.code === "PHONE_NUMBER_NOT_VERIFIED") {
@@ -159,15 +150,8 @@ export function PhoneNumber({
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
 
-  const getPhoneNumber = () => {
-    if (phoneNumber.e164) return phoneNumber.e164
-    setFieldErrors((current) => ({
-      ...current,
-      phoneNumber: phoneLocalization.invalidPhoneNumber
-    }))
-  }
   const sendCode = () => {
-    const normalizedPhoneNumber = getPhoneNumber()
+    const normalizedPhoneNumber = form.state.values.phoneNumber.e164
     if (!normalizedPhoneNumber) return
     sendOtp({
       phoneNumber: normalizedPhoneNumber,
@@ -177,41 +161,49 @@ export function PhoneNumber({
   const verifyCode = (completedCode: string) => {
     if (isPending || completedCode.length !== otpLength) return
 
-    if (!phoneNumber.e164) return
-    verify({ phoneNumber: phoneNumber.e164, code: completedCode })
+    if (!form.state.values.phoneNumber.e164) return
+    verify({
+      phoneNumber: form.state.values.phoneNumber.e164,
+      code: completedCode
+    })
   }
   const switchMode = () => {
     setMode((current) => (current === "code" ? "password" : "code"))
-    setCode("")
+    form.setFieldValue("code", "")
     setCodeSent(false)
-    setPassword("")
+    form.setFieldValue("password", "")
   }
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      password: "",
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter),
+      rememberMe: false
+    },
+    onSubmit: ({ value }) => {
+      if (mode === "password") {
+        const normalizedPhoneNumber = value.phoneNumber.e164
+        if (!normalizedPhoneNumber) return
+        signInWithPassword({
+          phoneNumber: normalizedPhoneNumber,
+          password: value.password,
+          ...(emailAndPassword?.rememberMe
+            ? { rememberMe: value.rememberMe }
+            : {}),
+          fetchOptions
+        })
+        return
+      }
 
-    if (mode === "password") {
-      const normalizedPhoneNumber = getPhoneNumber()
-      if (!normalizedPhoneNumber) return
-      const formData = new FormData(event.currentTarget)
-      signInWithPassword({
-        phoneNumber: normalizedPhoneNumber,
-        password,
-        ...(emailAndPassword?.rememberMe
-          ? { rememberMe: formData.get("rememberMe") === "on" }
-          : {}),
-        fetchOptions
-      })
-      return
+      if (!codeSent) {
+        sendCode()
+        return
+      }
+
+      verifyCode(value.code)
     }
-
-    if (!codeSent) {
-      sendCode()
-      return
-    }
-
-    verifyCode(code)
-  }
+  })
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -225,7 +217,7 @@ export function PhoneNumber({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              phoneNumber.display
+              form.state.values.phoneNumber.display
             )}
           </CardDescription>
         )}
@@ -244,192 +236,207 @@ export function PhoneNumber({
             </>
           )}
 
-          <form onSubmit={handleSubmit}>
-            <FieldGroup>
-              {codeSent ? (
-                <OtpField
-                  autoFocus
-                  disabled={isPending}
-                  label={phoneLocalization.phoneCode}
-                  length={otpLength}
-                  name="otp"
-                  value={code}
-                  onChange={setCode}
-                  onComplete={verifyCode}
-                />
-              ) : (
-                <>
-                  <InternationalPhoneField
-                    adapter={adapter}
-                    countryCodes={countries}
-                    countryLabel={phoneLocalization.country}
-                    disabled={isPending}
-                    error={fieldErrors.phoneNumber}
-                    locale={locale}
-                    phoneLabel={phoneLocalization.phoneNumber}
-                    placeholder={phoneLocalization.phoneNumberPlaceholder}
-                    value={phoneNumber}
-                    onChange={(value) => {
-                      setPhoneNumber(value)
-                      setFieldErrors((current) => ({
-                        ...current,
-                        phoneNumber: undefined
-                      }))
-                    }}
-                  />
-
-                  {mode === "password" && (
-                    <Field data-invalid={Boolean(fieldErrors.password)}>
-                      <FieldLabel htmlFor="phoneNumberPassword">
-                        {localization.auth.password}
-                      </FieldLabel>
-                      <InputGroup>
-                        <InputGroupInput
-                          id="phoneNumberPassword"
-                          name="password"
-                          type={isPasswordVisible ? "text" : "password"}
-                          autoComplete="current-password"
-                          value={password}
-                          placeholder={localization.auth.passwordPlaceholder}
-                          required
-                          minLength={emailAndPassword?.minPasswordLength}
-                          maxLength={emailAndPassword?.maxPasswordLength}
-                          disabled={isPending}
-                          onChange={(event) => {
-                            setPassword(event.target.value)
-                            setFieldErrors((current) => ({
-                              ...current,
-                              password: undefined
-                            }))
-                          }}
-                          onInvalid={(event) => {
-                            event.preventDefault()
-                            setFieldErrors((current) => ({
-                              ...current,
-                              password: event.currentTarget.validationMessage
-                            }))
-                          }}
-                          aria-invalid={Boolean(fieldErrors.password)}
-                        />
-                        <InputGroupAddon align="inline-end">
-                          <InputGroupButton
-                            type="button"
-                            size="icon-xs"
-                            aria-label={
-                              isPasswordVisible
-                                ? localization.auth.hidePassword
-                                : localization.auth.showPassword
-                            }
-                            title={
-                              isPasswordVisible
-                                ? localization.auth.hidePassword
-                                : localization.auth.showPassword
-                            }
-                            onClick={() =>
-                              setIsPasswordVisible((visible) => !visible)
-                            }
-                          >
-                            {isPasswordVisible ? <EyeOff /> : <Eye />}
-                          </InputGroupButton>
-                        </InputGroupAddon>
-                      </InputGroup>
-                      <FieldError>{fieldErrors.password}</FieldError>
-                    </Field>
-                  )}
-
-                  {mode === "password" && emailAndPassword?.rememberMe && (
-                    <Field orientation="horizontal">
-                      <Checkbox
-                        id="phoneNumberRememberMe"
-                        name="rememberMe"
-                        disabled={isPending}
-                      />
-                      <FieldLabel
-                        htmlFor="phoneNumberRememberMe"
-                        className="cursor-pointer font-normal"
-                      >
-                        {localization.auth.rememberMe}
-                      </FieldLabel>
-                    </Field>
-                  )}
-
-                  {Captcha && (
-                    <div className="flex justify-center">{Captcha}</div>
-                  )}
-                </>
-              )}
-
-              <div className="flex flex-col gap-3">
-                <Button
-                  type="submit"
-                  disabled={
-                    isPending || (codeSent && code.length !== otpLength)
-                  }
-                >
-                  {(isSending || isVerifying || isPasswordPending) && (
-                    <Spinner />
-                  )}
-                  {mode === "password"
-                    ? localization.auth.signIn
-                    : codeSent
-                      ? phoneLocalization.verifyCode
-                      : phoneLocalization.sendCode}
-                </Button>
-
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <FieldGroup>
                 {codeSent ? (
-                  <>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      disabled={isPending || isCoolingDown}
-                      onClick={sendCode}
-                    >
-                      {isCoolingDown
-                        ? localization.auth.resendIn.replace(
-                            "{{seconds}}",
-                            String(cooldown)
-                          )
-                        : localization.auth.resend}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      disabled={isPending}
-                      onClick={() => {
-                        setCode("")
-                        setCodeSent(false)
-                      }}
-                    >
-                      {phoneLocalization.useDifferentPhoneNumber}
-                    </Button>
-                  </>
+                  <form.AppField name="code">
+                    {(field) => (
+                      <OtpField
+                        autoFocus
+                        disabled={isPending}
+                        label={phoneLocalization.phoneCode}
+                        length={otpLength}
+                        name="otp"
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        onComplete={verifyCode}
+                      />
+                    )}
+                  </form.AppField>
                 ) : (
                   <>
-                    {canSwitchMode && (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        disabled={isPending}
-                        onClick={switchMode}
-                      >
-                        {mode === "code"
-                          ? phoneLocalization.usePassword
-                          : phoneLocalization.useVerificationCode}
-                      </Button>
-                    )}
-                    {plugins.flatMap((plugin) =>
-                      (plugin.authButtons ?? []).map((AuthButton) => (
-                        <AuthButton
-                          key={`${plugin.id}-${AuthButton.displayName ?? AuthButton.name}`}
-                          view="phoneNumber"
+                    <form.AppField
+                      name="phoneNumber"
+                      validators={{
+                        onChange: ({ value }) =>
+                          value.e164
+                            ? undefined
+                            : phoneLocalization.invalidPhoneNumber
+                      }}
+                    >
+                      {(field) => (
+                        <InternationalPhoneField
+                          adapter={adapter}
+                          countryCodes={countries}
+                          countryLabel={phoneLocalization.country}
+                          disabled={isPending}
+                          error={field.state.meta.errors[0]?.toString()}
+                          locale={locale}
+                          phoneLabel={phoneLocalization.phoneNumber}
+                          placeholder={phoneLocalization.phoneNumberPlaceholder}
+                          value={field.state.value}
+                          onChange={field.handleChange}
                         />
-                      ))
+                      )}
+                    </form.AppField>
+
+                    {mode === "password" && (
+                      <form.AppField name="password">
+                        {(field) => (
+                          <Field>
+                            <FieldLabel htmlFor="phoneNumberPassword">
+                              {localization.auth.password}
+                            </FieldLabel>
+                            <InputGroup>
+                              <InputGroupInput
+                                id="phoneNumberPassword"
+                                name={field.name}
+                                type={isPasswordVisible ? "text" : "password"}
+                                autoComplete="current-password"
+                                value={field.state.value}
+                                placeholder={
+                                  localization.auth.passwordPlaceholder
+                                }
+                                required
+                                minLength={emailAndPassword?.minPasswordLength}
+                                maxLength={emailAndPassword?.maxPasswordLength}
+                                disabled={isPending}
+                                onBlur={field.handleBlur}
+                                onChange={(event) =>
+                                  field.handleChange(event.target.value)
+                                }
+                              />
+                              <InputGroupAddon align="inline-end">
+                                <InputGroupButton
+                                  type="button"
+                                  size="icon-xs"
+                                  aria-label={
+                                    isPasswordVisible
+                                      ? localization.auth.hidePassword
+                                      : localization.auth.showPassword
+                                  }
+                                  title={
+                                    isPasswordVisible
+                                      ? localization.auth.hidePassword
+                                      : localization.auth.showPassword
+                                  }
+                                  onClick={() =>
+                                    setIsPasswordVisible((visible) => !visible)
+                                  }
+                                >
+                                  {isPasswordVisible ? <EyeOff /> : <Eye />}
+                                </InputGroupButton>
+                              </InputGroupAddon>
+                            </InputGroup>
+                            <field.AuthFormFieldError />
+                          </Field>
+                        )}
+                      </form.AppField>
+                    )}
+
+                    {mode === "password" && emailAndPassword?.rememberMe && (
+                      <form.AppField name="rememberMe">
+                        {(field) => (
+                          <Field orientation="horizontal">
+                            <Checkbox
+                              id="phoneNumberRememberMe"
+                              name={field.name}
+                              disabled={isPending}
+                              checked={field.state.value}
+                              onCheckedChange={(checked) =>
+                                field.handleChange(checked === true)
+                              }
+                            />
+                            <FieldLabel
+                              htmlFor="phoneNumberRememberMe"
+                              className="cursor-pointer font-normal"
+                            >
+                              {localization.auth.rememberMe}
+                            </FieldLabel>
+                          </Field>
+                        )}
+                      </form.AppField>
+                    )}
+
+                    {Captcha && (
+                      <div className="flex justify-center">{Captcha}</div>
                     )}
                   </>
                 )}
-              </div>
-            </FieldGroup>
-          </form>
+
+                <div className="flex flex-col gap-3">
+                  <form.AuthFormSubmitButton
+                    disabled={
+                      isPending ||
+                      (codeSent && form.state.values.code.length !== otpLength)
+                    }
+                  >
+                    {(isSending || isVerifying || isPasswordPending) && (
+                      <Spinner />
+                    )}
+                    {mode === "password"
+                      ? localization.auth.signIn
+                      : codeSent
+                        ? phoneLocalization.verifyCode
+                        : phoneLocalization.sendCode}
+                  </form.AuthFormSubmitButton>
+
+                  {codeSent ? (
+                    <>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isPending || isCoolingDown}
+                        onClick={sendCode}
+                      >
+                        {isCoolingDown
+                          ? localization.auth.resendIn.replace(
+                              "{{seconds}}",
+                              String(cooldown)
+                            )
+                          : localization.auth.resend}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        disabled={isPending}
+                        onClick={() => {
+                          form.setFieldValue("code", "")
+                          setCodeSent(false)
+                        }}
+                      >
+                        {phoneLocalization.useDifferentPhoneNumber}
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      {canSwitchMode && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          disabled={isPending}
+                          onClick={switchMode}
+                        >
+                          {mode === "code"
+                            ? phoneLocalization.usePassword
+                            : phoneLocalization.useVerificationCode}
+                        </Button>
+                      )}
+                      {plugins.flatMap((plugin) =>
+                        (plugin.authButtons ?? []).map((AuthButton) => (
+                          <AuthButton
+                            key={`${plugin.id}-${AuthButton.displayName ?? AuthButton.name}`}
+                            view="phoneNumber"
+                          />
+                        ))
+                      )}
+                    </>
+                  )}
+                </div>
+              </FieldGroup>
+            </form.AuthFormRoot>
+          </form.AppForm>
 
           {socialPosition === "bottom" && showProviders && (
             <>

--- a/apps/docs/src/components/auth/phone-number/reset-phone-number-password.tsx
+++ b/apps/docs/src/components/auth/phone-number/reset-phone-number-password.tsx
@@ -5,10 +5,9 @@ import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-n
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPhoneNumberPassword } from "@better-auth-ui/react/plugins/phone-number"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -32,6 +31,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { PasswordStrengthMeter } from "../password-strength-meter"
 import { useIsHydrated } from "../use-is-hydrated"
@@ -55,23 +55,11 @@ export function ResetPhoneNumberPassword({
   const isHydrated = useIsHydrated()
   const initialPhoneNumber =
     (isHydrated && sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY)) || ""
-  const [phoneNumber, setPhoneNumber] = useState(initialPhoneNumber)
   const [hasStoredPhoneNumber, setHasStoredPhoneNumber] = useState(
     Boolean(initialPhoneNumber)
   )
-  const [code, setCode] = useState("")
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-  const [fieldErrors, setFieldErrors] = useState<{
-    phoneNumber?: string
-    password?: string
-  }>({})
-
-  useEffect(() => {
-    const stored = sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY) ?? ""
-    setPhoneNumber(stored)
-    setHasStoredPhoneNumber(Boolean(stored))
-  }, [])
+  const [passwordError, setPasswordError] = useState("")
 
   const { mutate: resetPassword, isPending } = useResetPhoneNumberPassword(
     authClient as PhoneNumberAuthClient,
@@ -80,13 +68,10 @@ export function ResetPhoneNumberPassword({
         // The haveIBeenPwned plugin rejects on the password itself, so it
         // belongs against the field rather than in a toast.
         if (isPasswordCompromisedError(error)) {
-          setFieldErrors((prev) => ({
-            ...prev,
-            password: localization.auth.passwordCompromised
-          }))
+          setPasswordError(localization.auth.passwordCompromised)
         }
 
-        setCode("")
+        form.setFieldValue("code", "")
       },
       onSuccess: () => {
         sessionStorage.removeItem(PHONE_NUMBER_RESET_STORAGE_KEY)
@@ -98,31 +83,44 @@ export function ResetPhoneNumberPassword({
     }
   )
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    const confirmPassword = String(formData.get("confirmPassword") ?? "")
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      toast.error(localization.auth.passwordsDoNotMatch)
-      return
-    }
-    if (code.length !== otpLength) {
-      toast.error(
-        phoneLocalization.codeLengthMismatch.replace(
-          "{{length}}",
-          String(otpLength)
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      confirmPassword: "",
+      password: "",
+      phoneNumber: initialPhoneNumber
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
+        toast.error(localization.auth.passwordsDoNotMatch)
+        return
+      }
+      if (value.code.length !== otpLength) {
+        toast.error(
+          phoneLocalization.codeLengthMismatch.replace(
+            "{{length}}",
+            String(otpLength)
+          )
         )
-      )
-      return
-    }
+        return
+      }
 
-    resetPassword({
-      phoneNumber,
-      otp: code,
-      newPassword: password
-    })
-  }
+      resetPassword({
+        phoneNumber: value.phoneNumber,
+        otp: value.code,
+        newPassword: value.password
+      })
+    }
+  })
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY) ?? ""
+    form.setFieldValue("phoneNumber", stored)
+    setHasStoredPhoneNumber(Boolean(stored))
+  }, [form.setFieldValue])
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -134,139 +132,146 @@ export function ResetPhoneNumberPassword({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              phoneNumber
+              form.state.values.phoneNumber
             )}
           </CardDescription>
         )}
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            {!hasStoredPhoneNumber && (
-              <Field data-invalid={Boolean(fieldErrors.phoneNumber)}>
-                <FieldLabel htmlFor="passwordResetPhoneNumber">
-                  {phoneLocalization.phoneNumber}
-                </FieldLabel>
-                <Input
-                  id="passwordResetPhoneNumber"
-                  name="phoneNumber"
-                  type="tel"
-                  autoComplete="tel"
-                  inputMode="tel"
-                  value={phoneNumber}
-                  placeholder={phoneLocalization.phoneNumberPlaceholder}
-                  required
-                  disabled={isPending}
-                  onChange={(event) => {
-                    setPhoneNumber(event.target.value)
-                    setFieldErrors((current) => ({
-                      ...current,
-                      phoneNumber: undefined
-                    }))
-                  }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    setFieldErrors((current) => ({
-                      ...current,
-                      phoneNumber: event.currentTarget.validationMessage
-                    }))
-                  }}
-                  aria-invalid={Boolean(fieldErrors.phoneNumber)}
-                />
-                <FieldError>{fieldErrors.phoneNumber}</FieldError>
-              </Field>
-            )}
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              {!hasStoredPhoneNumber && (
+                <form.AppField name="phoneNumber">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="passwordResetPhoneNumber">
+                        {phoneLocalization.phoneNumber}
+                      </FieldLabel>
+                      <Input
+                        id="passwordResetPhoneNumber"
+                        name={field.name}
+                        type="tel"
+                        autoComplete="tel"
+                        inputMode="tel"
+                        value={field.state.value}
+                        placeholder={phoneLocalization.phoneNumberPlaceholder}
+                        required
+                        disabled={isPending}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-            <OtpField
-              autoFocus={hasStoredPhoneNumber}
-              disabled={isPending}
-              label={phoneLocalization.phoneCode}
-              length={otpLength}
-              name="otp"
-              value={code}
-              onChange={setCode}
-            />
+              <form.AppField name="code">
+                {(field) => (
+                  <OtpField
+                    autoFocus={hasStoredPhoneNumber}
+                    disabled={isPending}
+                    label={phoneLocalization.phoneCode}
+                    length={otpLength}
+                    name="otp"
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                  />
+                )}
+              </form.AppField>
 
-            <Field data-invalid={Boolean(fieldErrors.password)}>
-              <FieldLabel htmlFor="phoneNumberNewPassword">
-                {localization.auth.newPassword}
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupInput
-                  id="phoneNumberNewPassword"
-                  name="password"
-                  type={isPasswordVisible ? "text" : "password"}
-                  autoComplete="new-password"
-                  value={password}
-                  placeholder={localization.auth.newPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                  onChange={(event) => {
-                    setPassword(event.target.value)
-                    setFieldErrors((current) => ({
-                      ...current,
-                      password: undefined
-                    }))
-                  }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    setFieldErrors((current) => ({
-                      ...current,
-                      password: event.currentTarget.validationMessage
-                    }))
-                  }}
-                  aria-invalid={Boolean(fieldErrors.password)}
-                />
-                <InputGroupAddon align="inline-end">
-                  <InputGroupButton
-                    type="button"
-                    size="icon-xs"
-                    aria-label={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    onClick={() => setIsPasswordVisible((visible) => !visible)}
-                  >
-                    {isPasswordVisible ? <EyeOff /> : <Eye />}
-                  </InputGroupButton>
-                </InputGroupAddon>
-              </InputGroup>
-              <FieldError>{fieldErrors.password}</FieldError>
+              <form.AppField name="password">
+                {(field) => (
+                  <Field data-invalid={Boolean(passwordError)}>
+                    <FieldLabel htmlFor="phoneNumberNewPassword">
+                      {localization.auth.newPassword}
+                    </FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        id="phoneNumberNewPassword"
+                        name={field.name}
+                        type={isPasswordVisible ? "text" : "password"}
+                        autoComplete="new-password"
+                        value={field.state.value}
+                        placeholder={localization.auth.newPasswordPlaceholder}
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        onChange={(event) => {
+                          setPasswordError("")
+                          field.handleChange(event.target.value)
+                        }}
+                        aria-invalid={Boolean(passwordError)}
+                      />
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          type="button"
+                          size="icon-xs"
+                          aria-label={
+                            isPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() =>
+                            setIsPasswordVisible((visible) => !visible)
+                          }
+                        >
+                          {isPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                    {passwordError && <FieldError>{passwordError}</FieldError>}
 
-              <PasswordStrengthMeter password={password} />
-            </Field>
+                    <PasswordStrengthMeter password={field.state.value} />
+                  </Field>
+                )}
+              </form.AppField>
 
-            {emailAndPassword?.confirmPassword && (
-              <Field>
-                <FieldLabel htmlFor="phoneNumberConfirmPassword">
-                  {localization.auth.confirmPassword}
-                </FieldLabel>
-                <Input
-                  id="phoneNumberConfirmPassword"
-                  name="confirmPassword"
-                  type="password"
-                  autoComplete="new-password"
-                  placeholder={localization.auth.confirmPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                />
-              </Field>
-            )}
+              {emailAndPassword?.confirmPassword && (
+                <form.AppField name="confirmPassword">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="phoneNumberConfirmPassword">
+                        {localization.auth.confirmPassword}
+                      </FieldLabel>
+                      <Input
+                        id="phoneNumberConfirmPassword"
+                        name={field.name}
+                        type="password"
+                        autoComplete="new-password"
+                        placeholder={
+                          localization.auth.confirmPasswordPlaceholder
+                        }
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-            <Button
-              type="submit"
-              disabled={isPending || code.length !== otpLength}
-            >
-              {isPending && <Spinner />}
-              {phoneLocalization.resetPassword}
-            </Button>
-          </FieldGroup>
-        </form>
+              <form.AuthFormSubmitButton
+                disabled={
+                  isPending || form.state.values.code.length !== otpLength
+                }
+              >
+                {isPending && <Spinner />}
+                {phoneLocalization.resetPassword}
+              </form.AuthFormSubmitButton>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
     </Card>
   )

--- a/apps/docs/src/components/auth/settings/account/change-email.tsx
+++ b/apps/docs/src/components/auth/settings/account/change-email.tsx
@@ -1,17 +1,17 @@
 "use client"
 
-import { getViewURL } from "@better-auth-ui/core"
+import { getViewURL, validateEmailAddress } from "@better-auth-ui/core"
 import { useAuth, useChangeEmail, useSession } from "@better-auth-ui/react"
-import { type SyntheticEvent, useState } from "react"
+import { useEffect } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../../auth-form"
 
 export type ChangeEmailProps = {
   className?: string
@@ -34,23 +34,22 @@ export function ChangeEmail({ className }: ChangeEmailProps) {
     onSuccess: () => toast.success(localization.settings.changeEmailSuccess)
   })
 
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-  }>({})
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) =>
+      changeEmail({
+        callbackURL: getViewURL(
+          baseURL,
+          basePaths.settings,
+          viewPaths.settings.account
+        ),
+        newEmail: value.email
+      })
+  })
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    changeEmail({
-      newEmail: formData.get("email") as string,
-      callbackURL: getViewURL(
-        baseURL,
-        basePaths.settings,
-        viewPaths.settings.account
-      )
-    })
-  }
+  useEffect(() => {
+    if (session) form.reset({ email: session.user.email })
+  }, [form, session])
 
   return (
     <div>
@@ -58,57 +57,68 @@ export function ChangeEmail({ className }: ChangeEmailProps) {
         {localization.settings.changeEmail}
       </h2>
 
-      <form onSubmit={handleSubmit}>
-        <Card className={cn(className)}>
-          <CardContent className="flex flex-col gap-6">
-            <Field data-invalid={!!fieldErrors.email}>
-              <FieldLabel htmlFor="email">{localization.auth.email}</FieldLabel>
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card className={cn(className)}>
+            <CardContent className="flex flex-col gap-6">
+              <form.AppField
+                name="email"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
+                }}
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
+                      {session ? (
+                        <Input
+                          id="email"
+                          name={field.name}
+                          type="email"
+                          autoComplete="email"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          placeholder={localization.auth.emailPlaceholder}
+                          disabled={isPending}
+                          required
+                          aria-invalid={isInvalid}
+                        />
+                      ) : (
+                        <Skeleton>
+                          <Input className="invisible" />
+                        </Skeleton>
+                      )}
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+            </CardContent>
 
-              {session ? (
-                <Input
-                  key={session?.user.email}
-                  id="email"
-                  name="email"
-                  type="email"
-                  autoComplete="email"
-                  defaultValue={session?.user.email}
-                  placeholder={localization.auth.emailPlaceholder}
-                  disabled={isPending}
-                  required
-                  onChange={() => {
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: undefined
-                    }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: (e.target as HTMLInputElement).validationMessage
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.email}
-                />
-              ) : (
-                <Skeleton>
-                  <Input className="invisible" />
-                </Skeleton>
-              )}
+            <CardFooter>
+              <form.AuthFormSubmitButton
+                size="sm"
+                disabled={isPending || !session}
+              >
+                {isPending && <Spinner />}
 
-              <FieldError>{fieldErrors.email}</FieldError>
-            </Field>
-          </CardContent>
-
-          <CardFooter>
-            <Button type="submit" size="sm" disabled={isPending || !session}>
-              {isPending && <Spinner />}
-
-              {localization.settings.updateEmail}
-            </Button>
-          </CardFooter>
-        </Card>
-      </form>
+                {localization.settings.updateEmail}
+              </form.AuthFormSubmitButton>
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/apps/docs/src/components/auth/settings/security/fresh-session-prompt.tsx
+++ b/apps/docs/src/components/auth/settings/security/fresh-session-prompt.tsx
@@ -2,7 +2,6 @@
 
 import { isTwoFactorRedirect } from "@better-auth-ui/core/plugins/two-factor"
 import { useAuth, useSession, useSignInEmail } from "@better-auth-ui/react"
-import { type FormEvent, useState } from "react"
 import { Button } from "@/components/ui/button"
 import {
   Field,
@@ -14,6 +13,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
+import { useAuthForm } from "../../auth-form"
 
 export interface FreshSessionPromptProps {
   onFresh: () => unknown | Promise<unknown>
@@ -23,26 +23,25 @@ export function FreshSessionPrompt({ onFresh }: FreshSessionPromptProps) {
   const auth = useAuth()
   const session = useSession(auth.authClient)
   const continueSignIn = useSignInContinuation()
-  const [password, setPassword] = useState("")
   const signIn = useSignInEmail(auth.authClient, {
     meta: { errorPresentation: "inline" },
-    onError: () => setPassword(""),
+    onError: () => form.reset(),
     onSuccess: async (data) => {
       if (isTwoFactorRedirect(data)) {
         continueSignIn(data)
         return
       }
-      setPassword("")
+      form.reset()
       await onFresh()
     }
   })
-
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const email = session.data?.user.email
-    if (!email) return
-    signIn.mutate({ email, password })
-  }
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) => {
+      const email = session.data?.user.email
+      if (email) signIn.mutate({ email, password: value.password })
+    }
+  })
 
   return (
     <div className="p-4">
@@ -56,31 +55,41 @@ export function FreshSessionPrompt({ onFresh }: FreshSessionPromptProps) {
           </FieldDescription>
         </div>
         {auth.emailAndPassword?.enabled ? (
-          <form className="flex flex-col gap-3" onSubmit={submit}>
-            <Field data-invalid={signIn.isError}>
-              <FieldLabel htmlFor="fresh-session-password">
-                {auth.localization.auth.password}
-              </FieldLabel>
-              <Input
-                id="fresh-session-password"
-                autoComplete="current-password"
-                disabled={signIn.isPending}
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                type="password"
-                required
-              />
-              {signIn.error && (
-                <FieldError>
-                  {signIn.error.error?.message ?? signIn.error.message}
-                </FieldError>
-              )}
-            </Field>
-            <Button disabled={!password || signIn.isPending} type="submit">
-              {signIn.isPending && <Spinner />}
-              {auth.localization.settings.freshSessionSubmit}
-            </Button>
-          </form>
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-3">
+              <form.AppField name="password">
+                {(field) => (
+                  <Field data-invalid={signIn.isError}>
+                    <FieldLabel htmlFor="fresh-session-password">
+                      {auth.localization.auth.password}
+                    </FieldLabel>
+                    <Input
+                      id="fresh-session-password"
+                      autoComplete="current-password"
+                      disabled={signIn.isPending}
+                      name={field.name}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      type="password"
+                      required
+                    />
+                    {signIn.error && (
+                      <FieldError>
+                        {signIn.error.error?.message ?? signIn.error.message}
+                      </FieldError>
+                    )}
+                  </Field>
+                )}
+              </form.AppField>
+              <form.AuthFormSubmitButton disabled={signIn.isPending}>
+                {signIn.isPending && <Spinner />}
+                {auth.localization.settings.freshSessionSubmit}
+              </form.AuthFormSubmitButton>
+            </form.AuthFormRoot>
+          </form.AppForm>
         ) : (
           <Button
             onClick={() =>

--- a/apps/docs/src/components/auth/sign-in.tsx
+++ b/apps/docs/src/components/auth/sign-in.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import {
+  authMutationKeys,
+  validateEmailAddress,
+  validateStringLength
+} from "@better-auth-ui/core"
 import {
   isPasskeyAutoFillEnabled,
   withPasskeyAutoFill
@@ -13,15 +17,13 @@ import {
 } from "@better-auth-ui/react"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -36,6 +38,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
 import { LastUsedBadge } from "./last-login-method/last-used-badge"
 import { ProviderButtons, type SocialLayout } from "./provider-buttons"
 
@@ -73,13 +76,11 @@ export function SignIn({
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
   const continueSignIn = useSignInContinuation()
 
-  const [password, setPassword] = useState("")
-
   const { mutate: signInEmail, isPending: signInEmailPending } = useSignInEmail(
     authClient,
     {
       onError: (error, { email }) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
           sessionStorage.setItem("better-auth-ui.verify-email", email)
@@ -109,26 +110,18 @@ export function SignIn({
   const passkeyAutoFill = isPasskeyAutoFillEnabled(plugins)
 
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-    password?: string
-  }>({})
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const email = formData.get("email") as string
-    const rememberMe = formData.get("rememberMe") === "on"
-
-    signInEmail({
-      email,
-      password,
-      ...(emailAndPassword?.rememberMe ? { rememberMe } : {}),
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "", password: "", rememberMe: false },
+    onSubmit: ({ value }) =>
+      signInEmail({
+        email: value.email,
+        password: value.password,
+        ...(emailAndPassword?.rememberMe
+          ? { rememberMe: value.rememberMe }
+          : {}),
+        fetchOptions
+      })
+  })
 
   const showSeparator =
     emailAndPassword?.enabled && socialProviders && socialProviders.length > 0
@@ -159,170 +152,185 @@ export function SignIn({
           )}
 
           {emailAndPassword?.enabled && (
-            <form onSubmit={handleSubmit}>
-              <FieldGroup>
-                <Field data-invalid={!!fieldErrors.email}>
-                  <FieldLabel htmlFor="email">
-                    {localization.auth.email}
-                  </FieldLabel>
-
-                  <Input
-                    id="email"
+            <form.AppForm>
+              <form.AuthFormRoot>
+                <FieldGroup>
+                  <form.AppField
                     name="email"
-                    type="email"
-                    autoComplete={withPasskeyAutoFill("email", passkeyAutoFill)}
-                    placeholder={localization.auth.emailPlaceholder}
-                    required
-                    disabled={isPending}
-                    onChange={() => {
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: undefined
-                      }))
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateEmailAddress(value, {
+                          invalidMessage: localization.auth.invalidEmail,
+                          requiredMessage: localization.auth.fieldRequired
+                        })
                     }}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-                      const el = e.target as HTMLInputElement
-                      const msg = el.validity.valueMissing
-                        ? localization.auth.fieldRequired
-                        : localization.auth.invalidEmail
-
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: msg
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
-
-                  <FieldError>{fieldErrors.email}</FieldError>
-                </Field>
-
-                <Field data-invalid={!!fieldErrors.password}>
-                  <FieldLabel htmlFor="password">
-                    {localization.auth.password}
-                  </FieldLabel>
-
-                  <InputGroup>
-                    <InputGroupInput
-                      id="password"
-                      name="password"
-                      type={isPasswordVisible ? "text" : "password"}
-                      autoComplete={withPasskeyAutoFill(
-                        "current-password",
-                        passkeyAutoFill
-                      )}
-                      value={password}
-                      onChange={(e) => {
-                        setPassword(e.target.value)
-
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: undefined
-                        }))
-                      }}
-                      placeholder={localization.auth.passwordPlaceholder}
-                      required
-                      minLength={emailAndPassword?.minPasswordLength}
-                      maxLength={emailAndPassword?.maxPasswordLength}
-                      disabled={isPending}
-                      onInvalid={(e) => {
-                        e.preventDefault()
-                        const el = e.target as HTMLInputElement
-                        const min = emailAndPassword?.minPasswordLength
-                        const max = emailAndPassword?.maxPasswordLength
-                        const msg = el.validity.valueMissing
-                          ? localization.auth.fieldRequired
-                          : el.validity.tooShort
-                            ? localization.auth.tooShort.replace(
-                                "{{min}}",
-                                String(min)
-                              )
-                            : localization.auth.tooLong.replace(
-                                "{{max}}",
-                                String(max)
-                              )
-
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: msg
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.password}
-                    />
-
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        title={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() => {
-                          setIsPasswordVisible((visible) => !visible)
-                        }}
-                      >
-                        {isPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-
-                  <FieldError>{fieldErrors.password}</FieldError>
-                </Field>
-
-                {emailAndPassword.rememberMe && (
-                  <Field className="my-1">
-                    <div className="flex items-center gap-3">
-                      <Checkbox
-                        id="rememberMe"
-                        name="rememberMe"
-                        disabled={isPending}
-                      />
-
-                      <FieldLabel
-                        htmlFor="rememberMe"
-                        className="cursor-pointer text-sm font-normal"
-                      >
-                        {localization.auth.rememberMe}
-                      </FieldLabel>
-                    </div>
-                  </Field>
-                )}
-
-                {Captcha && (
-                  <div className="flex justify-center">{Captcha}</div>
-                )}
-
-                <div className="flex flex-col gap-3">
-                  <Button
-                    type="submit"
-                    className="relative overflow-visible"
-                    disabled={isPending}
                   >
-                    {signInEmailPending && <Spinner />}
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="email">
+                            {localization.auth.email}
+                          </FieldLabel>
 
-                    {localization.auth.signIn}
+                          <Input
+                            id="email"
+                            name={field.name}
+                            type="email"
+                            autoComplete={withPasskeyAutoFill(
+                              "email",
+                              passkeyAutoFill
+                            )}
+                            placeholder={localization.auth.emailPlaceholder}
+                            required
+                            disabled={isPending}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) =>
+                              field.handleChange(event.target.value)
+                            }
+                            aria-invalid={isInvalid}
+                          />
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
 
-                    <LastUsedBadge method="email" floating />
-                  </Button>
+                  <form.AppField
+                    name="password"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          maxLength: emailAndPassword?.maxPasswordLength,
+                          maxLengthMessage: localization.auth.tooLong.replace(
+                            "{{max}}",
+                            String(emailAndPassword?.maxPasswordLength)
+                          ),
+                          minLength: emailAndPassword?.minPasswordLength,
+                          minLengthMessage: localization.auth.tooShort.replace(
+                            "{{min}}",
+                            String(emailAndPassword?.minPasswordLength)
+                          ),
+                          requiredMessage: localization.auth.fieldRequired
+                        })
+                    }}
+                  >
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="password">
+                            {localization.auth.password}
+                          </FieldLabel>
 
-                  {plugins.flatMap((plugin) =>
-                    (plugin.authButtons ?? []).map((AuthButton, index) => (
-                      <AuthButton
-                        key={`${plugin.id}-${index.toString()}`}
-                        view="signIn"
-                      />
-                    ))
+                          <InputGroup>
+                            <InputGroupInput
+                              id="password"
+                              name={field.name}
+                              type={isPasswordVisible ? "text" : "password"}
+                              autoComplete={withPasskeyAutoFill(
+                                "current-password",
+                                passkeyAutoFill
+                              )}
+                              value={field.state.value}
+                              onBlur={field.handleBlur}
+                              onChange={(event) =>
+                                field.handleChange(event.target.value)
+                              }
+                              placeholder={
+                                localization.auth.passwordPlaceholder
+                              }
+                              required
+                              minLength={emailAndPassword?.minPasswordLength}
+                              maxLength={emailAndPassword?.maxPasswordLength}
+                              disabled={isPending}
+                              aria-invalid={isInvalid}
+                            />
+
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                size="icon-xs"
+                                aria-label={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                title={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                onClick={() => {
+                                  setIsPasswordVisible((visible) => !visible)
+                                }}
+                              >
+                                {isPasswordVisible ? <EyeOff /> : <Eye />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
+
+                  {emailAndPassword.rememberMe && (
+                    <form.AppField name="rememberMe">
+                      {(field) => (
+                        <Field className="my-1">
+                          <div className="flex items-center gap-3">
+                            <Checkbox
+                              id="rememberMe"
+                              name={field.name}
+                              checked={field.state.value}
+                              disabled={isPending}
+                              onCheckedChange={(checked) =>
+                                field.handleChange(checked === true)
+                              }
+                            />
+
+                            <FieldLabel
+                              htmlFor="rememberMe"
+                              className="cursor-pointer text-sm font-normal"
+                            >
+                              {localization.auth.rememberMe}
+                            </FieldLabel>
+                          </div>
+                        </Field>
+                      )}
+                    </form.AppField>
                   )}
-                </div>
-              </FieldGroup>
-            </form>
+
+                  {Captcha && (
+                    <div className="flex justify-center">{Captcha}</div>
+                  )}
+
+                  <div className="flex flex-col gap-3">
+                    <form.AuthFormSubmitButton
+                      className="relative overflow-visible"
+                      disabled={isPending}
+                    >
+                      {signInEmailPending && <Spinner />}
+
+                      {localization.auth.signIn}
+
+                      <LastUsedBadge method="email" floating />
+                    </form.AuthFormSubmitButton>
+
+                    {plugins.flatMap((plugin) =>
+                      (plugin.authButtons ?? []).map((AuthButton, index) => (
+                        <AuthButton
+                          key={`${plugin.id}-${index.toString()}`}
+                          view="signIn"
+                        />
+                      ))
+                    )}
+                  </div>
+                </FieldGroup>
+              </form.AuthFormRoot>
+            </form.AppForm>
           )}
 
           {socialPosition === "bottom" && (

--- a/apps/docs/src/components/auth/siwe/sign-in-ethereum-button.tsx
+++ b/apps/docs/src/components/auth/siwe/sign-in-ethereum-button.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { type AuthView, authMutationKeys } from "@better-auth-ui/core"
+import {
+  type AuthView,
+  authMutationKeys,
+  validateEmailAddress
+} from "@better-auth-ui/core"
 import {
   type SiweAuthClient,
   siweMutationKeys
@@ -9,7 +13,7 @@ import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useSignInSiwe } from "@better-auth-ui/react/plugins/siwe"
 import { useIsMutating } from "@tanstack/react-query"
 import { Wallet } from "lucide-react"
-import { type FormEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -20,16 +24,12 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel
-} from "@/components/ui/field"
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { siwePlugin } from "@/lib/auth/siwe-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 
 export type SignInEthereumButtonProps = { view?: AuthView }
 
@@ -50,8 +50,6 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
       useIsMutating({ mutationKey: siweMutationKeys.all }) >
     0
 
-  if (view === "signUp") return null
-
   const complete = (email?: string) => {
     signIn.mutate(email ? { email } : undefined, {
       onSuccess: () => {
@@ -61,13 +59,12 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
     })
   }
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const email = String(
-      new FormData(event.currentTarget).get("email") ?? ""
-    ).trim()
-    complete(email || undefined)
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) => complete(value.email.trim() || undefined)
+  })
+
+  if (view === "signUp") return null
 
   return (
     <>
@@ -84,50 +81,77 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <Wallet />
-                {plugin.localization.continueWithEthereum}
-              </DialogTitle>
-              <DialogDescription>
-                {plugin.localization.emailDescription}
-              </DialogDescription>
-            </DialogHeader>
-            <Field>
-              <FieldLabel htmlFor="siwe-email">
-                {plugin.email === "required"
-                  ? plugin.localization.email
-                  : plugin.localization.emailOptional}
-              </FieldLabel>
-              <Input
-                id="siwe-email"
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-4">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <Wallet />
+                  {plugin.localization.continueWithEthereum}
+                </DialogTitle>
+                <DialogDescription>
+                  {plugin.localization.emailDescription}
+                </DialogDescription>
+              </DialogHeader>
+              <form.AppField
                 name="email"
-                type="email"
-                autoComplete="email"
-                required={plugin.email === "required"}
-                disabled={signIn.isPending}
-              />
-              <FieldDescription>
-                {plugin.localization.emailDescription}
-              </FieldDescription>
-              <FieldError />
-            </Field>
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                disabled={signIn.isPending}
-                onClick={() => setOpen(false)}
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage:
+                        plugin.email === "required"
+                          ? localization.auth.fieldRequired
+                          : undefined
+                    })
+                }}
               >
-                {localization.settings.cancel}
-              </Button>
-              <Button type="submit" disabled={signIn.isPending}>
-                {signIn.isPending && <Spinner />}
-                {plugin.localization.signMessage}
-              </Button>
-            </DialogFooter>
-          </form>
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="siwe-email">
+                        {plugin.email === "required"
+                          ? plugin.localization.email
+                          : plugin.localization.emailOptional}
+                      </FieldLabel>
+                      <Input
+                        id="siwe-email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        required={plugin.email === "required"}
+                        disabled={signIn.isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        aria-invalid={isInvalid}
+                      />
+                      <FieldDescription>
+                        {plugin.localization.emailDescription}
+                      </FieldDescription>
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={signIn.isPending}
+                  onClick={() => setOpen(false)}
+                >
+                  {localization.settings.cancel}
+                </Button>
+                <form.AuthFormSubmitButton disabled={signIn.isPending}>
+                  {signIn.isPending && <Spinner />}
+                  {plugin.localization.signMessage}
+                </form.AuthFormSubmitButton>
+              </DialogFooter>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </DialogContent>
       </Dialog>
     </>

--- a/apps/docs/src/components/auth/sso/email-first-sign-in.tsx
+++ b/apps/docs/src/components/auth/sso/email-first-sign-in.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import {
+  authMutationKeys,
+  validateEmailAddress,
+  validateStringLength
+} from "@better-auth-ui/core"
 import {
   isPasskeyAutoFillEnabled,
   withPasskeyAutoFill
@@ -20,7 +24,7 @@ import {
 import { useSignInSso } from "@better-auth-ui/react/plugins/sso"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -35,7 +39,6 @@ import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -51,6 +54,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { ssoPlugin } from "@/lib/auth/sso-plugin"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 import { ProviderButtons } from "../provider-buttons"
 
 export type EmailFirstSignInProps = {
@@ -83,21 +87,15 @@ export function EmailFirstSignIn({
   const continueSignIn = useSignInContinuation()
 
   const [step, setStep] = useState<"email" | "fallback">("email")
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
   const [discoveryError, setDiscoveryError] = useState("")
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-    password?: string
-  }>({})
 
   const { mutate: signInSso, isPending: isDiscovering } = useSignInSso(
     authClient as SsoAuthClient,
     {
       onError: (error) => {
         if (error.status === 404) {
-          setSsoFallbackEmail(email)
+          setSsoFallbackEmail(form.state.values.email)
           setDiscoveryError(ssoLocalization.noProvider)
           setStep("fallback")
           return
@@ -112,10 +110,13 @@ export function EmailFirstSignIn({
     authClient,
     {
       onError: (error) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
-          sessionStorage.setItem("better-auth-ui.verify-email", email)
+          sessionStorage.setItem(
+            "better-auth-ui.verify-email",
+            form.state.values.email
+          )
           navigate({
             to: `${basePaths.auth}/${viewPaths.auth.verifyEmail}`
           })
@@ -139,33 +140,33 @@ export function EmailFirstSignIn({
   const showSocialSeparator =
     emailAndPassword.enabled && !!socialProviders?.length
 
-  const submitEmail = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setDiscoveryError("")
-    setSsoFallbackEmail(email)
-    signInSso({
-      email,
-      callbackURL: `${baseURL}${redirectTo}`,
-      loginHint: email
-    })
-  }
-
-  const submitPassword = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    signInEmail({
-      email,
-      password,
-      ...(emailAndPassword.rememberMe
-        ? { rememberMe: formData.get("rememberMe") === "on" }
-        : {}),
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "", password: "", rememberMe: false },
+    onSubmit: ({ value }) => {
+      if (step === "email") {
+        setDiscoveryError("")
+        setSsoFallbackEmail(value.email)
+        signInSso({
+          callbackURL: `${baseURL}${redirectTo}`,
+          email: value.email,
+          loginHint: value.email
+        })
+        return
+      }
+      signInEmail({
+        email: value.email,
+        password: value.password,
+        ...(emailAndPassword.rememberMe
+          ? { rememberMe: value.rememberMe }
+          : {}),
+        fetchOptions
+      })
+    }
+  })
 
   const startOver = () => {
     setStep("email")
-    setPassword("")
+    form.setFieldValue("password", "")
     setDiscoveryError("")
   }
 
@@ -177,207 +178,238 @@ export function EmailFirstSignIn({
           {localization.auth.signIn}
         </CardTitle>
         <CardDescription>
-          {step === "email" ? ssoLocalization.emailFirstDescription : email}
+          {step === "email"
+            ? ssoLocalization.emailFirstDescription
+            : form.state.values.email}
         </CardDescription>
       </CardHeader>
 
       <CardContent>
-        {step === "email" ? (
-          <form onSubmit={submitEmail}>
-            <FieldGroup>
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="sso-email">
-                  {localization.auth.email}
-                </FieldLabel>
-                <Input
-                  id="sso-email"
+        <form.AppForm>
+          {step === "email" ? (
+            <form.AuthFormRoot>
+              <FieldGroup>
+                <form.AppField
                   name="email"
-                  type="email"
-                  autoComplete={withPasskeyAutoFill("email", passkeyAutoFill)}
-                  autoFocus
-                  value={email}
-                  onChange={(event) => {
-                    setEmail(event.target.value)
-                    setFieldErrors((current) => ({
-                      ...current,
-                      email: undefined
-                    }))
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateEmailAddress(value, {
+                        invalidMessage: localization.auth.invalidEmail,
+                        requiredMessage: localization.auth.fieldRequired
+                      })
                   }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    const element = event.currentTarget
-                    setFieldErrors((current) => ({
-                      ...current,
-                      email: element.validity.valueMissing
-                        ? localization.auth.fieldRequired
-                        : localization.auth.invalidEmail
-                    }))
+                >
+                  {(field) => {
+                    const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                    return (
+                      <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor="sso-email">
+                          {localization.auth.email}
+                        </FieldLabel>
+                        <Input
+                          id="sso-email"
+                          name={field.name}
+                          type="email"
+                          autoComplete={withPasskeyAutoFill(
+                            "email",
+                            passkeyAutoFill
+                          )}
+                          autoFocus
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          placeholder={localization.auth.emailPlaceholder}
+                          required
+                          disabled={isPending}
+                          aria-invalid={isInvalid}
+                        />
+                        <field.AuthFormFieldError />
+                      </Field>
+                    )
                   }}
-                  placeholder={localization.auth.emailPlaceholder}
-                  required
-                  disabled={isPending}
-                  aria-invalid={!!fieldErrors.email}
-                />
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
+                </form.AppField>
+
+                {discoveryError && (
+                  <FieldDescription role="alert" className="text-destructive">
+                    {discoveryError}
+                  </FieldDescription>
+                )}
+
+                <form.AuthFormSubmitButton disabled={isPending}>
+                  {isDiscovering && <Spinner data-icon="inline-start" />}
+                  {ssoLocalization.continueWithEmail}
+                </form.AuthFormSubmitButton>
+              </FieldGroup>
+            </form.AuthFormRoot>
+          ) : (
+            <div className="flex flex-col gap-4">
+              {socialPosition === "top" && (
+                <>
+                  {!!socialProviders?.length && (
+                    <ProviderButtons
+                      socialLayout={socialLayout}
+                      view="signIn"
+                    />
+                  )}
+                  {showSocialSeparator && (
+                    <FieldSeparator>{localization.auth.or}</FieldSeparator>
+                  )}
+                </>
+              )}
 
               {discoveryError && (
-                <FieldDescription role="alert" className="text-destructive">
+                <FieldDescription role="status">
                   {discoveryError}
                 </FieldDescription>
               )}
 
-              <Button type="submit" disabled={isPending}>
-                {isDiscovering && <Spinner data-icon="inline-start" />}
-                {ssoLocalization.continueWithEmail}
-              </Button>
-            </FieldGroup>
-          </form>
-        ) : (
-          <div className="flex flex-col gap-4">
-            {socialPosition === "top" && (
-              <>
-                {!!socialProviders?.length && (
-                  <ProviderButtons socialLayout={socialLayout} view="signIn" />
-                )}
-                {showSocialSeparator && (
-                  <FieldSeparator>{localization.auth.or}</FieldSeparator>
-                )}
-              </>
-            )}
+              {emailAndPassword.enabled && (
+                <form.AuthFormRoot>
+                  <FieldGroup>
+                    <form.AppField
+                      name="password"
+                      validators={{
+                        onChange: ({ value }) =>
+                          validateStringLength(value, {
+                            maxLength: emailAndPassword.maxPasswordLength,
+                            maxLengthMessage: localization.auth.tooLong.replace(
+                              "{{max}}",
+                              String(emailAndPassword.maxPasswordLength)
+                            ),
+                            minLength: emailAndPassword.minPasswordLength,
+                            minLengthMessage:
+                              localization.auth.tooShort.replace(
+                                "{{min}}",
+                                String(emailAndPassword.minPasswordLength)
+                              ),
+                            requiredMessage: localization.auth.fieldRequired
+                          })
+                      }}
+                    >
+                      {(field) => {
+                        const isInvalid = isAuthFormFieldInvalid(
+                          field.state.meta
+                        )
+                        return (
+                          <Field data-invalid={isInvalid}>
+                            <FieldLabel htmlFor="sso-password">
+                              {localization.auth.password}
+                            </FieldLabel>
+                            <InputGroup>
+                              <InputGroupInput
+                                id="sso-password"
+                                name={field.name}
+                                type={isPasswordVisible ? "text" : "password"}
+                                autoComplete={withPasskeyAutoFill(
+                                  "current-password",
+                                  passkeyAutoFill
+                                )}
+                                autoFocus
+                                value={field.state.value}
+                                onBlur={field.handleBlur}
+                                onChange={(event) =>
+                                  field.handleChange(event.target.value)
+                                }
+                                placeholder={
+                                  localization.auth.passwordPlaceholder
+                                }
+                                minLength={emailAndPassword.minPasswordLength}
+                                maxLength={emailAndPassword.maxPasswordLength}
+                                required
+                                disabled={isPending}
+                                aria-invalid={isInvalid}
+                              />
+                              <InputGroupAddon align="inline-end">
+                                <InputGroupButton
+                                  size="icon-xs"
+                                  aria-label={
+                                    isPasswordVisible
+                                      ? localization.auth.hidePassword
+                                      : localization.auth.showPassword
+                                  }
+                                  onClick={() =>
+                                    setIsPasswordVisible((visible) => !visible)
+                                  }
+                                >
+                                  {isPasswordVisible ? <EyeOff /> : <Eye />}
+                                </InputGroupButton>
+                              </InputGroupAddon>
+                            </InputGroup>
+                            <field.AuthFormFieldError />
+                          </Field>
+                        )
+                      }}
+                    </form.AppField>
 
-            {discoveryError && (
-              <FieldDescription role="status">
-                {discoveryError}
-              </FieldDescription>
-            )}
-
-            {emailAndPassword.enabled && (
-              <form onSubmit={submitPassword}>
-                <FieldGroup>
-                  <Field data-invalid={!!fieldErrors.password}>
-                    <FieldLabel htmlFor="sso-password">
-                      {localization.auth.password}
-                    </FieldLabel>
-                    <InputGroup>
-                      <InputGroupInput
-                        id="sso-password"
-                        name="password"
-                        type={isPasswordVisible ? "text" : "password"}
-                        autoComplete={withPasskeyAutoFill(
-                          "current-password",
-                          passkeyAutoFill
+                    {emailAndPassword.rememberMe && (
+                      <form.AppField name="rememberMe">
+                        {(field) => (
+                          <Field>
+                            <div className="flex items-center gap-3">
+                              <Checkbox
+                                id="sso-remember-me"
+                                name={field.name}
+                                checked={field.state.value}
+                                disabled={isPending}
+                                onCheckedChange={(checked) =>
+                                  field.handleChange(checked === true)
+                                }
+                              />
+                              <FieldLabel
+                                htmlFor="sso-remember-me"
+                                className="cursor-pointer text-sm font-normal"
+                              >
+                                {localization.auth.rememberMe}
+                              </FieldLabel>
+                            </div>
+                          </Field>
                         )}
-                        autoFocus
-                        value={password}
-                        onChange={(event) => {
-                          setPassword(event.target.value)
-                          setFieldErrors((current) => ({
-                            ...current,
-                            password: undefined
-                          }))
-                        }}
-                        onInvalid={(event) => {
-                          event.preventDefault()
-                          const element = event.currentTarget
-                          const message = element.validity.valueMissing
-                            ? localization.auth.fieldRequired
-                            : element.validity.tooShort
-                              ? localization.auth.tooShort.replace(
-                                  "{{min}}",
-                                  String(emailAndPassword.minPasswordLength)
-                                )
-                              : localization.auth.tooLong.replace(
-                                  "{{max}}",
-                                  String(emailAndPassword.maxPasswordLength)
-                                )
+                      </form.AppField>
+                    )}
 
-                          setFieldErrors((current) => ({
-                            ...current,
-                            password: message
-                          }))
-                        }}
-                        placeholder={localization.auth.passwordPlaceholder}
-                        minLength={emailAndPassword.minPasswordLength}
-                        maxLength={emailAndPassword.maxPasswordLength}
-                        required
-                        disabled={isPending}
-                        aria-invalid={!!fieldErrors.password}
-                      />
-                      <InputGroupAddon align="inline-end">
-                        <InputGroupButton
-                          size="icon-xs"
-                          aria-label={
-                            isPasswordVisible
-                              ? localization.auth.hidePassword
-                              : localization.auth.showPassword
-                          }
-                          onClick={() =>
-                            setIsPasswordVisible((visible) => !visible)
-                          }
-                        >
-                          {isPasswordVisible ? <EyeOff /> : <Eye />}
-                        </InputGroupButton>
-                      </InputGroupAddon>
-                    </InputGroup>
-                    <FieldError>{fieldErrors.password}</FieldError>
-                  </Field>
+                    {Captcha && (
+                      <div className="flex justify-center">{Captcha}</div>
+                    )}
 
-                  {emailAndPassword.rememberMe && (
-                    <Field>
-                      <div className="flex items-center gap-3">
-                        <Checkbox
-                          id="sso-remember-me"
-                          name="rememberMe"
-                          disabled={isPending}
-                        />
-                        <FieldLabel
-                          htmlFor="sso-remember-me"
-                          className="cursor-pointer text-sm font-normal"
-                        >
-                          {localization.auth.rememberMe}
-                        </FieldLabel>
-                      </div>
-                    </Field>
+                    <form.AuthFormSubmitButton disabled={isPending}>
+                      {isSigningIn && <Spinner data-icon="inline-start" />}
+                      {localization.auth.signIn}
+                    </form.AuthFormSubmitButton>
+                  </FieldGroup>
+                </form.AuthFormRoot>
+              )}
+
+              {plugins.flatMap((plugin) =>
+                (plugin.authButtons ?? []).map((AuthButton) => (
+                  <AuthButton
+                    key={getAuthButtonKey(plugin.id, AuthButton)}
+                    view="signIn"
+                  />
+                ))
+              )}
+
+              {socialPosition === "bottom" && (
+                <>
+                  {showSocialSeparator && (
+                    <FieldSeparator>{localization.auth.or}</FieldSeparator>
                   )}
-
-                  {Captcha && (
-                    <div className="flex justify-center">{Captcha}</div>
+                  {!!socialProviders?.length && (
+                    <ProviderButtons
+                      socialLayout={socialLayout}
+                      view="signIn"
+                    />
                   )}
+                </>
+              )}
 
-                  <Button type="submit" disabled={isPending}>
-                    {isSigningIn && <Spinner data-icon="inline-start" />}
-                    {localization.auth.signIn}
-                  </Button>
-                </FieldGroup>
-              </form>
-            )}
-
-            {plugins.flatMap((plugin) =>
-              (plugin.authButtons ?? []).map((AuthButton) => (
-                <AuthButton
-                  key={getAuthButtonKey(plugin.id, AuthButton)}
-                  view="signIn"
-                />
-              ))
-            )}
-
-            {socialPosition === "bottom" && (
-              <>
-                {showSocialSeparator && (
-                  <FieldSeparator>{localization.auth.or}</FieldSeparator>
-                )}
-                {!!socialProviders?.length && (
-                  <ProviderButtons socialLayout={socialLayout} view="signIn" />
-                )}
-              </>
-            )}
-
-            <Button variant="ghost" onClick={startOver}>
-              {ssoLocalization.useDifferentEmail}
-            </Button>
-          </div>
-        )}
+              <Button variant="ghost" onClick={startOver}>
+                {ssoLocalization.useDifferentEmail}
+              </Button>
+            </div>
+          )}
+        </form.AppForm>
       </CardContent>
 
       {emailAndPassword.enabled && (

--- a/apps/docs/src/components/auth/sso/sso-domain-verification.tsx
+++ b/apps/docs/src/components/auth/sso/sso-domain-verification.tsx
@@ -12,7 +12,7 @@ import {
 } from "@better-auth-ui/react/plugins/sso"
 import type { BetterFetchError } from "better-auth/client"
 import { CheckIcon, CopyIcon } from "lucide-react"
-import { type FormEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -39,6 +39,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { ssoPlugin } from "@/lib/auth/sso-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 
 export type SsoDomainVerificationProps = {
   className?: string
@@ -61,7 +62,6 @@ export function SsoDomainVerification({
 }: SsoDomainVerificationProps) {
   const { authClient } = useAuth()
   const { localization } = useAuthPlugin(ssoPlugin)
-  const [providerId, setProviderId] = useState(defaultProviderId)
   const [token, setToken] = useState(defaultToken)
   const [verified, setVerified] = useState(false)
   const [copyError, setCopyError] = useState("")
@@ -74,7 +74,6 @@ export function SsoDomainVerification({
   const verify = useVerifySsoDomain(authClient as SsoAuthClient, {
     onSuccess: () => setVerified(true)
   })
-  const host = providerId ? `_${tokenPrefix}-${providerId}` : ""
   const hostCopy = useCopyToClipboard({
     onError: (error) =>
       setCopyError(error instanceof Error ? error.message : String(error))
@@ -88,12 +87,14 @@ export function SsoDomainVerification({
       ? requestToken.error
       : verify.error
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setCopyError("")
-    setVerified(false)
-    verify.mutate({ providerId })
-  }
+  const form = useAuthForm({
+    defaultValues: { providerId: defaultProviderId },
+    onSubmit: ({ value }) => {
+      setCopyError("")
+      setVerified(false)
+      verify.mutate({ providerId: value.providerId })
+    }
+  })
 
   return (
     <Card className={cn("w-full max-w-xl", className)}>
@@ -104,120 +105,144 @@ export function SsoDomainVerification({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="sso-verification-provider-id">
-                {localization.providerId}
-              </FieldLabel>
-              <Input
-                id="sso-verification-provider-id"
-                name="providerId"
-                value={providerId}
-                onChange={(event) => {
-                  setProviderId(event.target.value.trim())
-                  setToken("")
-                  setVerified(false)
-                }}
-                required
-              />
-            </Field>
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <form.Subscribe selector={(state) => state.values.providerId}>
+              {(providerId) => {
+                const host = providerId ? `_${tokenPrefix}-${providerId}` : ""
+                return (
+                  <FieldGroup>
+                    <form.AppField name="providerId">
+                      {(field) => (
+                        <Field>
+                          <FieldLabel htmlFor="sso-verification-provider-id">
+                            {localization.providerId}
+                          </FieldLabel>
+                          <Input
+                            id="sso-verification-provider-id"
+                            name={field.name}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              field.handleChange(event.target.value.trim())
+                              setToken("")
+                              setVerified(false)
+                            }}
+                            required
+                          />
+                        </Field>
+                      )}
+                    </form.AppField>
 
-            {token ? (
-              <div className="grid gap-3 rounded-lg border p-3">
-                <Field>
-                  <FieldLabel htmlFor="sso-dns-host">
-                    {localization.txtRecordHost}
-                  </FieldLabel>
-                  <InputGroup>
-                    <InputGroupInput
-                      className="font-mono text-xs"
-                      id="sso-dns-host"
-                      readOnly
-                      value={host}
-                    />
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        aria-label={localization.copyDnsHost}
-                        size="icon-xs"
+                    {token ? (
+                      <div className="grid gap-3 rounded-lg border p-3">
+                        <Field>
+                          <FieldLabel htmlFor="sso-dns-host">
+                            {localization.txtRecordHost}
+                          </FieldLabel>
+                          <InputGroup>
+                            <InputGroupInput
+                              className="font-mono text-xs"
+                              id="sso-dns-host"
+                              readOnly
+                              value={host}
+                            />
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                aria-label={localization.copyDnsHost}
+                                size="icon-xs"
+                                onClick={() => {
+                                  setCopyError("")
+                                  void hostCopy.copy(host)
+                                }}
+                              >
+                                {hostCopy.copied ? <CheckIcon /> : <CopyIcon />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+                        </Field>
+                        <Field>
+                          <FieldLabel htmlFor="sso-dns-value">
+                            {localization.txtRecordValue}
+                          </FieldLabel>
+                          <InputGroup>
+                            <InputGroupInput
+                              className="font-mono text-xs"
+                              id="sso-dns-value"
+                              readOnly
+                              value={token}
+                            />
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                aria-label={localization.copyDnsValue}
+                                size="icon-xs"
+                                onClick={() => {
+                                  setCopyError("")
+                                  void tokenCopy.copy(token)
+                                }}
+                              >
+                                {tokenCopy.copied ? (
+                                  <CheckIcon />
+                                ) : (
+                                  <CopyIcon />
+                                )}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+                        </Field>
+                      </div>
+                    ) : null}
+
+                    {error ? (
+                      <FieldError>{getErrorMessage(error)}</FieldError>
+                    ) : null}
+                    {copyError ? <FieldError>{copyError}</FieldError> : null}
+                    {verified ? (
+                      <FieldDescription
+                        role="status"
+                        className="text-foreground"
+                      >
+                        {localization.domainVerified}
+                      </FieldDescription>
+                    ) : null}
+
+                    <div className="flex flex-wrap justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={!providerId || verify.isPending}
                         onClick={() => {
                           setCopyError("")
-                          void hostCopy.copy(host)
+                          setVerified(false)
+                          requestToken.mutate({ providerId })
                         }}
                       >
-                        {hostCopy.copied ? <CheckIcon /> : <CopyIcon />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                </Field>
-                <Field>
-                  <FieldLabel htmlFor="sso-dns-value">
-                    {localization.txtRecordValue}
-                  </FieldLabel>
-                  <InputGroup>
-                    <InputGroupInput
-                      className="font-mono text-xs"
-                      id="sso-dns-value"
-                      readOnly
-                      value={token}
-                    />
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        aria-label={localization.copyDnsValue}
-                        size="icon-xs"
-                        onClick={() => {
-                          setCopyError("")
-                          void tokenCopy.copy(token)
-                        }}
+                        {requestToken.isPending ? (
+                          <Spinner data-icon="inline-start" />
+                        ) : null}
+                        {localization.requestNewToken}
+                      </Button>
+                      <form.AuthFormSubmitButton
+                        disabled={!providerId || requestToken.isPending}
                       >
-                        {tokenCopy.copied ? <CheckIcon /> : <CopyIcon />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                </Field>
-              </div>
-            ) : null}
+                        {verify.isPending ? (
+                          <Spinner data-icon="inline-start" />
+                        ) : null}
+                        {localization.verifyDomain}
+                      </form.AuthFormSubmitButton>
+                    </div>
 
-            {error ? <FieldError>{getErrorMessage(error)}</FieldError> : null}
-            {copyError ? <FieldError>{copyError}</FieldError> : null}
-            {verified ? (
-              <FieldDescription role="status" className="text-foreground">
-                {localization.domainVerified}
-              </FieldDescription>
-            ) : null}
-
-            <div className="flex flex-wrap justify-end gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                disabled={!providerId || verify.isPending}
-                onClick={() => {
-                  setCopyError("")
-                  setVerified(false)
-                  requestToken.mutate({ providerId })
-                }}
-              >
-                {requestToken.isPending ? (
-                  <Spinner data-icon="inline-start" />
-                ) : null}
-                {localization.requestNewToken}
-              </Button>
-              <Button
-                type="submit"
-                disabled={!providerId || requestToken.isPending}
-              >
-                {verify.isPending ? <Spinner data-icon="inline-start" /> : null}
-                {localization.verifyDomain}
-              </Button>
-            </div>
-
-            <span className="sr-only" aria-live="polite">
-              {token && !verified
-                ? localization.domainVerificationRequested
-                : ""}
-            </span>
-          </FieldGroup>
-        </form>
+                    <span className="sr-only" aria-live="polite">
+                      {token && !verified
+                        ? localization.domainVerificationRequested
+                        : ""}
+                    </span>
+                  </FieldGroup>
+                )
+              }}
+            </form.Subscribe>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
     </Card>
   )

--- a/apps/docs/src/components/auth/two-factor/disable-two-factor-dialog.tsx
+++ b/apps/docs/src/components/auth/two-factor/disable-two-factor-dialog.tsx
@@ -4,7 +4,6 @@ import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-facto
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useDisableTwoFactor } from "@better-auth-ui/react/plugins/two-factor"
 import { ShieldAlert } from "lucide-react"
-import type { SyntheticEvent } from "react"
 import { toast } from "sonner"
 
 import {
@@ -17,12 +16,12 @@ import {
   AlertDialogMedia,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
-import { Button } from "@/components/ui/button"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
+import { useAuthForm } from "../auth-form"
 
 export type DisableTwoFactorDialogProps = {
   open: boolean
@@ -54,68 +53,79 @@ export function DisableTwoFactorDialog({
 
   const isPending = isDisabling || isResolvingPasswordRequirement
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-
-    disableTwoFactor(requiresPassword ? { password } : {})
-  }
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) =>
+      disableTwoFactor(requiresPassword ? { password: value.password } : {})
+  })
 
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <AlertDialogHeader>
-            <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
-              <ShieldAlert />
-            </AlertDialogMedia>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <AlertDialogHeader>
+              <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
+                <ShieldAlert />
+              </AlertDialogMedia>
 
-            <AlertDialogTitle>
-              {twoFactorLocalization.disableTwoFactor}
-            </AlertDialogTitle>
+              <AlertDialogTitle>
+                {twoFactorLocalization.disableTwoFactor}
+              </AlertDialogTitle>
 
-            <AlertDialogDescription>
-              {requiresPassword
-                ? twoFactorLocalization.passwordConfirmation
-                : twoFactorLocalization.twoFactorDescription}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+              <AlertDialogDescription>
+                {requiresPassword
+                  ? twoFactorLocalization.passwordConfirmation
+                  : twoFactorLocalization.twoFactorDescription}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
 
-          {requiresPassword && (
-            <Field>
-              <FieldLabel htmlFor="disable-two-factor-password">
-                {localization.auth.password}
-              </FieldLabel>
+            {requiresPassword && (
+              <form.AppField name="password">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="disable-two-factor-password">
+                      {localization.auth.password}
+                    </FieldLabel>
 
-              <Input
-                id="disable-two-factor-password"
-                name="password"
-                type="password"
-                autoComplete="current-password"
-                autoFocus
-                required
-                placeholder={localization.auth.passwordPlaceholder}
+                    <Input
+                      id="disable-two-factor-password"
+                      name={field.name}
+                      type="password"
+                      autoComplete="current-password"
+                      autoFocus
+                      required
+                      placeholder={localization.auth.passwordPlaceholder}
+                      disabled={isPending}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                    />
+
+                    <FieldError />
+                  </Field>
+                )}
+              </form.AppField>
+            )}
+
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isPending}>
+                {localization.settings.cancel}
+              </AlertDialogCancel>
+
+              <form.AuthFormSubmitButton
+                variant="destructive"
                 disabled={isPending}
-              />
+              >
+                {isPending && <Spinner />}
 
-              <FieldError />
-            </Field>
-          )}
-
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>
-              {localization.settings.cancel}
-            </AlertDialogCancel>
-
-            <Button type="submit" variant="destructive" disabled={isPending}>
-              {isPending && <Spinner />}
-
-              {twoFactorLocalization.disableTwoFactor}
-            </Button>
-          </AlertDialogFooter>
-        </form>
+                {twoFactorLocalization.disableTwoFactor}
+              </form.AuthFormSubmitButton>
+            </AlertDialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </AlertDialogContent>
     </AlertDialog>
   )

--- a/apps/docs/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/apps/docs/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -15,9 +15,9 @@ import {
   useVerifyTotp
 } from "@better-auth-ui/react/plugins/two-factor"
 import { Check, Copy, ShieldCheck } from "lucide-react"
-import { type SyntheticEvent, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -39,6 +39,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { BackupCodes } from "./backup-codes"
 
@@ -79,7 +80,6 @@ export function EnableTwoFactorDialog({
   )
   const [totpUri, setTotpUri] = useState("")
   const [backupCodes, setBackupCodes] = useState<string[]>([])
-  const [code, setCode] = useState("")
   const {
     copied: setupKeyCopied,
     copy: copySetupKeyValue,
@@ -132,7 +132,7 @@ export function EnableTwoFactorDialog({
   const { mutate: verifyTotp, isPending: isVerifying } = useVerifyTotp(
     twoFactorClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
         toast.success(twoFactorLocalization.twoFactorEnabled)
         setStep("backupCodes")
@@ -141,6 +141,23 @@ export function EnableTwoFactorDialog({
   )
 
   const isPending = isEnabling || isVerifying || isResolvingPasswordRequirement
+
+  const form = useAuthForm({
+    defaultValues: { code: "", password: "" },
+    onSubmit: ({ value }) => {
+      if (step === "backupCodes") {
+        handleOpenChange(false)
+        return
+      }
+      if (step === "verify") {
+        verifyCode(value.code)
+        return
+      }
+      enableTwoFactor(
+        requiresPassword ? { method, password: value.password } : { method }
+      )
+    }
+  })
 
   const verifyCode = (completedCode: string) => {
     if (isPending || step !== "verify" || completedCode.length !== codeLength) {
@@ -158,30 +175,11 @@ export function EnableTwoFactorDialog({
       setMethod(enrollmentMethods[0] ?? "totp")
       setTotpUri("")
       setBackupCodes([])
-      setCode("")
+      form.reset()
       resetSetupKeyCopy()
       // Clears the resolved TOTP URI and backup codes from the mutation cache.
       resetEnrollment()
     }
-  }
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (step === "backupCodes") {
-      handleOpenChange(false)
-      return
-    }
-
-    if (step === "verify") {
-      verifyCode(code)
-      return
-    }
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-
-    enableTwoFactor(requiresPassword ? { method, password } : { method })
   }
 
   const submitLabel =
@@ -194,169 +192,189 @@ export function EnableTwoFactorDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <ShieldCheck />
-              {twoFactorLocalization.twoFactor}
-            </DialogTitle>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <ShieldCheck />
+                {twoFactorLocalization.twoFactor}
+              </DialogTitle>
 
-            <DialogDescription>
-              {step === "password" && requiresPassword
-                ? twoFactorLocalization.passwordConfirmation
-                : step === "verify"
-                  ? twoFactorLocalization.scanQrCode
-                  : twoFactorLocalization.twoFactorDescription}
-            </DialogDescription>
-          </DialogHeader>
+              <DialogDescription>
+                {step === "password" && requiresPassword
+                  ? twoFactorLocalization.passwordConfirmation
+                  : step === "verify"
+                    ? twoFactorLocalization.scanQrCode
+                    : twoFactorLocalization.twoFactorDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          {step === "password" && (
-            <div className="flex flex-col gap-4">
-              {enrollmentMethods.length > 1 && (
-                <Tabs
-                  value={method}
-                  onValueChange={(value) => setMethod(value as TwoFactorMethod)}
-                >
-                  <TabsList
-                    aria-label={twoFactorLocalization.chooseEnrollmentMethod}
-                    className="w-full"
+            {step === "password" && (
+              <div className="flex flex-col gap-4">
+                {enrollmentMethods.length > 1 && (
+                  <Tabs
+                    value={method}
+                    onValueChange={(value) =>
+                      setMethod(value as TwoFactorMethod)
+                    }
                   >
-                    {enrollmentMethods.includes("totp") && (
-                      <TabsTrigger value="totp">
-                        {twoFactorLocalization.authenticatorApp}
-                      </TabsTrigger>
+                    <TabsList
+                      aria-label={twoFactorLocalization.chooseEnrollmentMethod}
+                      className="w-full"
+                    >
+                      {enrollmentMethods.includes("totp") && (
+                        <TabsTrigger value="totp">
+                          {twoFactorLocalization.authenticatorApp}
+                        </TabsTrigger>
+                      )}
+                      {enrollmentMethods.includes("otp") && (
+                        <TabsTrigger value="otp">
+                          {twoFactorLocalization.deliveredCode}
+                        </TabsTrigger>
+                      )}
+                    </TabsList>
+                  </Tabs>
+                )}
+
+                <p className="text-muted-foreground text-sm">
+                  {method === "totp"
+                    ? twoFactorLocalization.authenticatorAppDescription
+                    : twoFactorLocalization.deliveredCodeDescription}
+                </p>
+
+                {requiresPassword && (
+                  <form.AppField name="password">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel htmlFor="two-factor-password">
+                          {localization.auth.password}
+                        </FieldLabel>
+
+                        <Input
+                          id="two-factor-password"
+                          name={field.name}
+                          type="password"
+                          autoComplete="current-password"
+                          autoFocus
+                          required
+                          placeholder={localization.auth.passwordPlaceholder}
+                          disabled={isPending}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                        />
+
+                        <FieldError />
+                      </Field>
                     )}
-                    {enrollmentMethods.includes("otp") && (
-                      <TabsTrigger value="otp">
-                        {twoFactorLocalization.deliveredCode}
-                      </TabsTrigger>
-                    )}
-                  </TabsList>
-                </Tabs>
-              )}
-
-              <p className="text-muted-foreground text-sm">
-                {method === "totp"
-                  ? twoFactorLocalization.authenticatorAppDescription
-                  : twoFactorLocalization.deliveredCodeDescription}
-              </p>
-
-              {requiresPassword && (
-                <Field>
-                  <FieldLabel htmlFor="two-factor-password">
-                    {localization.auth.password}
-                  </FieldLabel>
-
-                  <Input
-                    id="two-factor-password"
-                    name="password"
-                    type="password"
-                    autoComplete="current-password"
-                    autoFocus
-                    required
-                    placeholder={localization.auth.passwordPlaceholder}
-                    disabled={isPending}
-                  />
-
-                  <FieldError />
-                </Field>
-              )}
-            </div>
-          )}
-
-          {step === "verify" && (
-            <div className="flex flex-col items-center gap-4">
-              {qrCode && (
-                <svg
-                  aria-hidden="true"
-                  className="size-44 rounded-md border"
-                  viewBox={`0 0 ${qrCode.size} ${qrCode.size}`}
-                >
-                  <path
-                    fill="white"
-                    d={`M0 0h${qrCode.size}v${qrCode.size}H0z`}
-                  />
-                  <path
-                    fill="black"
-                    d={qrCode.path}
-                    shapeRendering="crispEdges"
-                  />
-                </svg>
-              )}
-
-              {setupKey && (
-                <Field className="w-full gap-1">
-                  <FieldLabel
-                    className="text-muted-foreground text-xs"
-                    htmlFor="two-factor-setup-key"
-                  >
-                    {twoFactorLocalization.setupKey}
-                  </FieldLabel>
-
-                  <InputGroup>
-                    <InputGroupInput
-                      className="font-mono text-xs"
-                      id="two-factor-setup-key"
-                      readOnly
-                      value={setupKey}
-                    />
-
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        aria-label={
-                          setupKeyCopied
-                            ? twoFactorLocalization.setupKeyCopied
-                            : localization.settings.copyToClipboard
-                        }
-                        onClick={copySetupKey}
-                        size="icon-xs"
-                      >
-                        {setupKeyCopied ? <Check /> : <Copy />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                </Field>
-              )}
-
-              <OtpField
-                autoFocus
-                className="w-full"
-                disabled={isPending}
-                label={twoFactorLocalization.authenticatorCode}
-                length={codeLength}
-                name="code"
-                value={code}
-                onChange={setCode}
-                onComplete={verifyCode}
-              />
-            </div>
-          )}
-
-          {step === "backupCodes" && <BackupCodes codes={backupCodes} />}
-
-          <DialogFooter>
-            {step !== "backupCodes" && (
-              <DialogClose
-                className={buttonVariants({ variant: "outline" })}
-                disabled={isPending}
-                type="button"
-              >
-                {localization.settings.cancel}
-              </DialogClose>
+                  </form.AppField>
+                )}
+              </div>
             )}
 
-            <Button
-              type="submit"
-              disabled={
-                isPending || (step === "verify" && code.length !== codeLength)
-              }
-            >
-              {isPending && <Spinner />}
+            {step === "verify" && (
+              <div className="flex flex-col items-center gap-4">
+                {qrCode && (
+                  <svg
+                    aria-hidden="true"
+                    className="size-44 rounded-md border"
+                    viewBox={`0 0 ${qrCode.size} ${qrCode.size}`}
+                  >
+                    <path
+                      fill="white"
+                      d={`M0 0h${qrCode.size}v${qrCode.size}H0z`}
+                    />
+                    <path
+                      fill="black"
+                      d={qrCode.path}
+                      shapeRendering="crispEdges"
+                    />
+                  </svg>
+                )}
 
-              {submitLabel}
-            </Button>
-          </DialogFooter>
-        </form>
+                {setupKey && (
+                  <Field className="w-full gap-1">
+                    <FieldLabel
+                      className="text-muted-foreground text-xs"
+                      htmlFor="two-factor-setup-key"
+                    >
+                      {twoFactorLocalization.setupKey}
+                    </FieldLabel>
+
+                    <InputGroup>
+                      <InputGroupInput
+                        className="font-mono text-xs"
+                        id="two-factor-setup-key"
+                        readOnly
+                        value={setupKey}
+                      />
+
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          aria-label={
+                            setupKeyCopied
+                              ? twoFactorLocalization.setupKeyCopied
+                              : localization.settings.copyToClipboard
+                          }
+                          onClick={copySetupKey}
+                          size="icon-xs"
+                        >
+                          {setupKeyCopied ? <Check /> : <Copy />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  </Field>
+                )}
+
+                <form.AppField name="code">
+                  {(field) => (
+                    <OtpField
+                      autoFocus
+                      className="w-full"
+                      disabled={isPending}
+                      label={twoFactorLocalization.authenticatorCode}
+                      length={codeLength}
+                      name={field.name}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      onComplete={verifyCode}
+                    />
+                  )}
+                </form.AppField>
+              </div>
+            )}
+
+            {step === "backupCodes" && <BackupCodes codes={backupCodes} />}
+
+            <DialogFooter>
+              {step !== "backupCodes" && (
+                <DialogClose
+                  className={buttonVariants({ variant: "outline" })}
+                  disabled={isPending}
+                  type="button"
+                >
+                  {localization.settings.cancel}
+                </DialogClose>
+              )}
+
+              <form.Subscribe selector={(state) => state.values.code}>
+                {(code) => (
+                  <form.AuthFormSubmitButton
+                    disabled={
+                      isPending ||
+                      (step === "verify" && code.length !== codeLength)
+                    }
+                  >
+                    {isPending && <Spinner />}
+                    {submitLabel}
+                  </form.AuthFormSubmitButton>
+                )}
+              </form.Subscribe>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/apps/docs/src/components/auth/two-factor/regenerate-backup-codes-dialog.tsx
+++ b/apps/docs/src/components/auth/two-factor/regenerate-backup-codes-dialog.tsx
@@ -4,7 +4,7 @@ import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-facto
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useGenerateBackupCodes } from "@better-auth-ui/react/plugins/two-factor"
 import { KeyRound } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -17,12 +17,12 @@ import {
   AlertDialogMedia,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
-import { Button } from "@/components/ui/button"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
+import { useAuthForm } from "../auth-form"
 import { BackupCodes } from "./backup-codes"
 
 export type RegenerateBackupCodesDialogProps = {
@@ -63,91 +63,100 @@ export function RegenerateBackupCodesDialog({
 
   const isPending = isGenerating || isResolvingPasswordRequirement
 
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) => {
+      if (codes.length) {
+        handleOpenChange(false)
+        return
+      }
+      generateBackupCodes(requiresPassword ? { password: value.password } : {})
+    }
+  })
+
   const handleOpenChange = (nextOpen: boolean) => {
     onOpenChange(nextOpen)
 
     if (!nextOpen) {
       setCodes([])
+      form.reset()
       // Clears the resolved backup codes from the mutation cache.
       resetGeneration()
     }
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (codes.length) {
-      handleOpenChange(false)
-      return
-    }
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-
-    generateBackupCodes(requiresPassword ? { password } : {})
-  }
-
   return (
     <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <AlertDialogHeader>
-            <AlertDialogMedia>
-              <KeyRound />
-            </AlertDialogMedia>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <AlertDialogHeader>
+              <AlertDialogMedia>
+                <KeyRound />
+              </AlertDialogMedia>
 
-            <AlertDialogTitle>
-              {twoFactorLocalization.backupCodes}
-            </AlertDialogTitle>
+              <AlertDialogTitle>
+                {twoFactorLocalization.backupCodes}
+              </AlertDialogTitle>
 
-            <AlertDialogDescription>
-              {codes.length || !requiresPassword
-                ? twoFactorLocalization.backupCodesDescription
-                : twoFactorLocalization.passwordConfirmation}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+              <AlertDialogDescription>
+                {codes.length || !requiresPassword
+                  ? twoFactorLocalization.backupCodesDescription
+                  : twoFactorLocalization.passwordConfirmation}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
 
-          {codes.length ? (
-            <BackupCodes codes={codes} />
-          ) : (
-            requiresPassword && (
-              <Field>
-                <FieldLabel htmlFor="regenerate-backup-codes-password">
-                  {localization.auth.password}
-                </FieldLabel>
+            {codes.length ? (
+              <BackupCodes codes={codes} />
+            ) : (
+              requiresPassword && (
+                <form.AppField name="password">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="regenerate-backup-codes-password">
+                        {localization.auth.password}
+                      </FieldLabel>
 
-                <Input
-                  id="regenerate-backup-codes-password"
-                  name="password"
-                  type="password"
-                  autoComplete="current-password"
-                  autoFocus
-                  required
-                  placeholder={localization.auth.passwordPlaceholder}
-                  disabled={isPending}
-                />
+                      <Input
+                        id="regenerate-backup-codes-password"
+                        name={field.name}
+                        type="password"
+                        autoComplete="current-password"
+                        autoFocus
+                        required
+                        placeholder={localization.auth.passwordPlaceholder}
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
 
-                <FieldError />
-              </Field>
-            )
-          )}
-
-          <AlertDialogFooter>
-            {!codes.length && (
-              <AlertDialogCancel disabled={isPending}>
-                {localization.settings.cancel}
-              </AlertDialogCancel>
+                      <FieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              )
             )}
 
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Spinner />}
+            <AlertDialogFooter>
+              {!codes.length && (
+                <AlertDialogCancel disabled={isPending}>
+                  {localization.settings.cancel}
+                </AlertDialogCancel>
+              )}
 
-              {codes.length
-                ? twoFactorLocalization.done
-                : twoFactorLocalization.regenerateBackupCodes}
-            </Button>
-          </AlertDialogFooter>
-        </form>
+              <form.AuthFormSubmitButton disabled={isPending}>
+                {isPending && <Spinner />}
+
+                {codes.length
+                  ? twoFactorLocalization.done
+                  : twoFactorLocalization.regenerateBackupCodes}
+              </form.AuthFormSubmitButton>
+            </AlertDialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </AlertDialogContent>
     </AlertDialog>
   )

--- a/apps/docs/src/components/auth/two-factor/two-factor-challenge.tsx
+++ b/apps/docs/src/components/auth/two-factor/two-factor-challenge.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { authQueryKeys } from "@better-auth-ui/core"
+import { authQueryKeys, validateStringLength } from "@better-auth-ui/core"
 import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-factor"
 import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
 import {
@@ -10,7 +10,7 @@ import {
   useVerifyTwoFactorOtp
 } from "@better-auth-ui/react/plugins/two-factor"
 import { useQueryClient } from "@tanstack/react-query"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -40,6 +40,7 @@ import {
   useResendCooldown
 } from "@/lib/auth/use-resend-cooldown"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { useIsHydrated } from "../use-is-hydrated"
 
@@ -88,8 +89,6 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
   const [method, setMethod] = useState<ChallengeMethod>(
     () => methods[0] ?? "totp"
   )
-  const [code, setCode] = useState("")
-  const [trustDevice, setTrustDevice] = useState(false)
   const [otpRequested, setOtpRequested] = useState(false)
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
 
@@ -117,12 +116,15 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
 
   const { mutate: verifyTotp, isPending: isVerifyingTotp } = useVerifyTotp(
     twoFactorClient,
-    { onError: () => setCode(""), onSuccess: onVerified }
+    {
+      onError: () => form.setFieldValue("code", ""),
+      onSuccess: onVerified
+    }
   )
 
   const { mutate: verifyTwoFactorOtp, isPending: isVerifyingOtp } =
     useVerifyTwoFactorOtp(twoFactorClient, {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: onVerified
     })
 
@@ -133,8 +135,21 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
     isSendingOtp || isVerifyingTotp || isVerifyingOtp || isVerifyingBackupCode
   const needsOtpRequest = method === "otp" && !otpRequested
 
+  const form = useAuthForm({
+    defaultValues: { backupCode: "", code: "", trustDevice: false },
+    onSubmit: ({ value }) => {
+      const trust = trustDeviceEnabled ? { trustDevice: value.trustDevice } : {}
+      if (method === "backup") {
+        verifyBackupCode({ code: value.backupCode.trim(), ...trust })
+        return
+      }
+      verifyCode(value.code)
+    }
+  })
+
   const switchMethod = (next: ChallengeMethod) => {
-    setCode("")
+    form.setFieldValue("code", "")
+    form.setFieldValue("backupCode", "")
     setMethod(next)
   }
 
@@ -148,7 +163,9 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
       return
     }
 
-    const trust = trustDeviceEnabled ? { trustDevice } : {}
+    const trust = trustDeviceEnabled
+      ? { trustDevice: form.state.values.trustDevice }
+      : {}
 
     if (method === "otp") {
       verifyTwoFactorOtp({ code: completedCode, ...trust })
@@ -156,23 +173,6 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
     }
 
     verifyTotp({ code: completedCode, ...trust })
-  }
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const trust = trustDeviceEnabled ? { trustDevice } : {}
-
-    if (method === "backup") {
-      const formData = new FormData(e.currentTarget)
-      verifyBackupCode({
-        code: (formData.get("backupCode") as string).trim(),
-        ...trust
-      })
-      return
-    }
-
-    verifyCode(code)
   }
 
   const description =
@@ -210,113 +210,143 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            {method === "backup" ? (
-              <Field>
-                <FieldLabel htmlFor="backupCode">
-                  {twoFactorLocalization.backupCode}
-                </FieldLabel>
-
-                <Input
-                  id="backupCode"
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              {method === "backup" ? (
+                <form.AppField
                   name="backupCode"
-                  autoComplete="one-time-code"
-                  autoFocus
-                  required
-                  disabled={isPending}
-                />
-              </Field>
-            ) : (
-              <OtpField
-                autoFocus
-                disabled={isPending || needsOtpRequest}
-                label={
-                  method === "otp"
-                    ? twoFactorLocalization.emailedCode
-                    : twoFactorLocalization.authenticatorCode
-                }
-                length={codeLength}
-                name="code"
-                value={code}
-                onChange={setCode}
-                onComplete={verifyCode}
-              />
-            )}
-
-            {trustDeviceEnabled && (
-              <Field orientation="horizontal">
-                <Checkbox
-                  id="trustDevice"
-                  name="trustDevice"
-                  checked={trustDevice}
-                  disabled={isPending}
-                  onCheckedChange={(checked) =>
-                    setTrustDevice(checked === true)
-                  }
-                />
-
-                <FieldLabel htmlFor="trustDevice" className="font-normal">
-                  {twoFactorLocalization.trustDevice}
-                </FieldLabel>
-              </Field>
-            )}
-
-            <div className="flex flex-col gap-3">
-              {needsOtpRequest ? (
-                <Button
-                  type="button"
-                  disabled={isSendingOtp}
-                  onClick={() => sendTwoFactorOtp()}
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateStringLength(value, {
+                        requiredMessage: localization.auth.fieldRequired,
+                        trim: true
+                      })
+                  }}
                 >
-                  {isSendingOtp && <Spinner />}
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="backupCode">
+                        {twoFactorLocalization.backupCode}
+                      </FieldLabel>
 
-                  {twoFactorLocalization.sendEmailCode}
-                </Button>
+                      <Input
+                        id="backupCode"
+                        name={field.name}
+                        autoComplete="one-time-code"
+                        autoFocus
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                    </Field>
+                  )}
+                </form.AppField>
               ) : (
-                <Button
-                  type="submit"
-                  disabled={
-                    isPending ||
-                    (method !== "backup" && code.length !== codeLength)
-                  }
-                >
-                  {isPending && <Spinner />}
-
-                  {twoFactorLocalization.verify}
-                </Button>
+                <form.AppField name="code">
+                  {(field) => (
+                    <OtpField
+                      autoFocus
+                      disabled={isPending || needsOtpRequest}
+                      label={
+                        method === "otp"
+                          ? twoFactorLocalization.emailedCode
+                          : twoFactorLocalization.authenticatorCode
+                      }
+                      length={codeLength}
+                      name={field.name}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      onComplete={verifyCode}
+                    />
+                  )}
+                </form.AppField>
               )}
 
-              {method === "otp" && otpRequested && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={isPending || isCoolingDown}
-                  onClick={() => sendTwoFactorOtp()}
-                >
-                  {isCoolingDown
-                    ? localization.auth.resendIn.replace(
-                        "{{seconds}}",
-                        String(cooldown)
-                      )
-                    : localization.auth.resend}
-                </Button>
+              {trustDeviceEnabled && (
+                <form.AppField name="trustDevice">
+                  {(field) => (
+                    <Field orientation="horizontal">
+                      <Checkbox
+                        id="trustDevice"
+                        name={field.name}
+                        checked={field.state.value}
+                        disabled={isPending}
+                        onCheckedChange={(checked) =>
+                          field.handleChange(checked === true)
+                        }
+                      />
+
+                      <FieldLabel htmlFor="trustDevice" className="font-normal">
+                        {twoFactorLocalization.trustDevice}
+                      </FieldLabel>
+                    </Field>
+                  )}
+                </form.AppField>
               )}
 
-              {alternatives.map((alternative) => (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  key={alternative.key}
-                  disabled={isPending}
-                  onClick={() => switchMethod(alternative.key)}
-                >
-                  {alternative.label}
-                </Button>
-              ))}
-            </div>
-          </FieldGroup>
-        </form>
+              <div className="flex flex-col gap-3">
+                {needsOtpRequest ? (
+                  <Button
+                    type="button"
+                    disabled={isSendingOtp}
+                    onClick={() => sendTwoFactorOtp()}
+                  >
+                    {isSendingOtp && <Spinner />}
+
+                    {twoFactorLocalization.sendEmailCode}
+                  </Button>
+                ) : (
+                  <form.Subscribe selector={(state) => state.values.code}>
+                    {(code) => (
+                      <form.AuthFormSubmitButton
+                        disabled={
+                          isPending ||
+                          (method !== "backup" && code.length !== codeLength)
+                        }
+                      >
+                        {isPending && <Spinner />}
+                        {twoFactorLocalization.verify}
+                      </form.AuthFormSubmitButton>
+                    )}
+                  </form.Subscribe>
+                )}
+
+                {method === "otp" && otpRequested && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={isPending || isCoolingDown}
+                    onClick={() => sendTwoFactorOtp()}
+                  >
+                    {isCoolingDown
+                      ? localization.auth.resendIn.replace(
+                          "{{seconds}}",
+                          String(cooldown)
+                        )
+                      : localization.auth.resend}
+                  </Button>
+                )}
+
+                {alternatives.map((alternative) => (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    key={alternative.key}
+                    disabled={isPending}
+                    onClick={() => switchMethod(alternative.key)}
+                  >
+                    {alternative.label}
+                  </Button>
+                ))}
+              </div>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/apps/docs/src/components/auth/username/sign-in-username.tsx
+++ b/apps/docs/src/components/auth/username/sign-in-username.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import { authMutationKeys, validateStringLength } from "@better-auth-ui/core"
 import {
   isPasskeyAutoFillEnabled,
   withPasskeyAutoFill
@@ -16,18 +16,16 @@ import {
 import { useSignInUsername } from "@better-auth-ui/react/plugins/username"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import {
   ProviderButtons,
   type SocialLayout
 } from "@/components/auth/provider-buttons"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -43,6 +41,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { usernamePlugin } from "@/lib/auth/username-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 import { LastUsedBadge } from "../last-login-method/last-used-badge"
 
 export type SignInUsernameProps = {
@@ -82,12 +81,10 @@ export function SignInUsername({
 
   const { localization: usernameLocalization } = useAuthPlugin(usernamePlugin)
 
-  const [password, setPassword] = useState("")
-
   const { mutate: signInEmail, isPending: isSignInEmailPending } =
     useSignInEmail(authClient, {
       onError: (error, { email }) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
           sessionStorage.setItem("better-auth-ui.verify-email", email)
@@ -107,7 +104,7 @@ export function SignInUsername({
   const { mutate: signInUsername, isPending: isSignInUsernamePending } =
     useSignInUsername(authClient, {
       onError: (error) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
           sessionStorage.removeItem("better-auth-ui.verify-email")
@@ -141,35 +138,30 @@ export function SignInUsername({
   const passkeyAutoFill = isPasskeyAutoFillEnabled(plugins)
 
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-    password?: string
-  }>({})
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const email = formData.get("email") as string
-    const rememberMe = formData.get("rememberMe") === "on"
-
-    if (isEmail(email)) {
-      signInEmail({
-        email,
-        password,
-        ...(emailAndPassword?.rememberMe ? { rememberMe } : {}),
-        fetchOptions
-      })
-    } else {
-      signInUsername({
-        username: email,
-        password,
-        ...(emailAndPassword?.rememberMe ? { rememberMe } : {}),
-        fetchOptions
-      })
+  const form = useAuthForm({
+    defaultValues: { identifier: "", password: "", rememberMe: false },
+    onSubmit: ({ value }) => {
+      if (isEmail(value.identifier)) {
+        signInEmail({
+          email: value.identifier,
+          password: value.password,
+          ...(emailAndPassword?.rememberMe
+            ? { rememberMe: value.rememberMe }
+            : {}),
+          fetchOptions
+        })
+      } else {
+        signInUsername({
+          username: value.identifier,
+          password: value.password,
+          ...(emailAndPassword?.rememberMe
+            ? { rememberMe: value.rememberMe }
+            : {}),
+          fetchOptions
+        })
+      }
     }
-  }
+  })
 
   const showSeparator =
     emailAndPassword?.enabled && socialProviders && socialProviders.length > 0
@@ -200,171 +192,187 @@ export function SignInUsername({
           )}
 
           {emailAndPassword?.enabled && (
-            <form onSubmit={handleSubmit}>
-              <FieldGroup>
-                <Field data-invalid={!!fieldErrors.email}>
-                  <FieldLabel htmlFor="email">
-                    {usernameLocalization.username}
-                  </FieldLabel>
-
-                  <Input
-                    id="email"
-                    name="email"
-                    type="text"
-                    autoComplete={withPasskeyAutoFill(
-                      "username",
-                      passkeyAutoFill
-                    )}
-                    placeholder={
-                      usernameLocalization.usernameOrEmailPlaceholder
-                    }
-                    required
-                    disabled={isPending}
-                    onChange={() => {
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: undefined
-                      }))
+            <form.AppForm>
+              <form.AuthFormRoot>
+                <FieldGroup>
+                  <form.AppField
+                    name="identifier"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          requiredMessage: localization.auth.fieldRequired,
+                          trim: true
+                        })
                     }}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: localization.auth.fieldRequired
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
-
-                  <FieldError>{fieldErrors.email}</FieldError>
-                </Field>
-
-                <Field data-invalid={!!fieldErrors.password}>
-                  <FieldLabel htmlFor="password">
-                    {localization.auth.password}
-                  </FieldLabel>
-
-                  <InputGroup>
-                    <InputGroupInput
-                      id="password"
-                      name="password"
-                      type={isPasswordVisible ? "text" : "password"}
-                      autoComplete={withPasskeyAutoFill(
-                        "current-password",
-                        passkeyAutoFill
-                      )}
-                      value={password}
-                      onChange={(e) => {
-                        setPassword(e.target.value)
-
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: undefined
-                        }))
-                      }}
-                      placeholder={localization.auth.passwordPlaceholder}
-                      required
-                      minLength={emailAndPassword?.minPasswordLength}
-                      maxLength={emailAndPassword?.maxPasswordLength}
-                      disabled={isPending}
-                      onInvalid={(e) => {
-                        e.preventDefault()
-                        const el = e.target as HTMLInputElement
-                        const min = emailAndPassword?.minPasswordLength
-                        const max = emailAndPassword?.maxPasswordLength
-                        const msg = el.validity.valueMissing
-                          ? localization.auth.fieldRequired
-                          : el.validity.tooShort
-                            ? localization.auth.tooShort.replace(
-                                "{{min}}",
-                                String(min)
-                              )
-                            : localization.auth.tooLong.replace(
-                                "{{max}}",
-                                String(max)
-                              )
-
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: msg
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.password}
-                    />
-
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        title={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() => {
-                          setIsPasswordVisible((visible) => !visible)
-                        }}
-                      >
-                        {isPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-
-                  <FieldError>{fieldErrors.password}</FieldError>
-                </Field>
-
-                {emailAndPassword.rememberMe && (
-                  <Field className="my-1">
-                    <div className="flex items-center gap-3">
-                      <Checkbox
-                        id="rememberMe"
-                        name="rememberMe"
-                        disabled={isPending}
-                      />
-
-                      <FieldLabel
-                        htmlFor="rememberMe"
-                        className="cursor-pointer text-sm font-normal"
-                      >
-                        {localization.auth.rememberMe}
-                      </FieldLabel>
-                    </div>
-                  </Field>
-                )}
-
-                {Captcha && (
-                  <div className="flex justify-center">{Captcha}</div>
-                )}
-
-                <div className="flex flex-col gap-3">
-                  <Button
-                    type="submit"
-                    className="relative overflow-visible"
-                    disabled={isPending}
                   >
-                    {isSignInPending && <Spinner />}
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="email">
+                            {usernameLocalization.username}
+                          </FieldLabel>
 
-                    {localization.auth.signIn}
+                          <Input
+                            id="email"
+                            name={field.name}
+                            type="text"
+                            autoComplete={withPasskeyAutoFill(
+                              "username",
+                              passkeyAutoFill
+                            )}
+                            placeholder={
+                              usernameLocalization.usernameOrEmailPlaceholder
+                            }
+                            required
+                            disabled={isPending}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) =>
+                              field.handleChange(event.target.value)
+                            }
+                            aria-invalid={isInvalid}
+                          />
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
 
-                    <LastUsedBadge method={["email", "username"]} floating />
-                  </Button>
+                  <form.AppField
+                    name="password"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          maxLength: emailAndPassword?.maxPasswordLength,
+                          maxLengthMessage: localization.auth.tooLong.replace(
+                            "{{max}}",
+                            String(emailAndPassword?.maxPasswordLength)
+                          ),
+                          minLength: emailAndPassword?.minPasswordLength,
+                          minLengthMessage: localization.auth.tooShort.replace(
+                            "{{min}}",
+                            String(emailAndPassword?.minPasswordLength)
+                          ),
+                          requiredMessage: localization.auth.fieldRequired
+                        })
+                    }}
+                  >
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="password">
+                            {localization.auth.password}
+                          </FieldLabel>
 
-                  {plugins.flatMap((plugin) =>
-                    (plugin.authButtons ?? []).map((AuthButton, index) => (
-                      <AuthButton
-                        key={`${plugin.id}-${index.toString()}`}
-                        view="signIn"
-                      />
-                    ))
+                          <InputGroup>
+                            <InputGroupInput
+                              id="password"
+                              name={field.name}
+                              type={isPasswordVisible ? "text" : "password"}
+                              autoComplete={withPasskeyAutoFill(
+                                "current-password",
+                                passkeyAutoFill
+                              )}
+                              value={field.state.value}
+                              onBlur={field.handleBlur}
+                              onChange={(event) =>
+                                field.handleChange(event.target.value)
+                              }
+                              placeholder={
+                                localization.auth.passwordPlaceholder
+                              }
+                              required
+                              minLength={emailAndPassword?.minPasswordLength}
+                              maxLength={emailAndPassword?.maxPasswordLength}
+                              disabled={isPending}
+                              aria-invalid={isInvalid}
+                            />
+
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                size="icon-xs"
+                                aria-label={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                title={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                onClick={() => {
+                                  setIsPasswordVisible((visible) => !visible)
+                                }}
+                              >
+                                {isPasswordVisible ? <EyeOff /> : <Eye />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
+
+                  {emailAndPassword.rememberMe && (
+                    <form.AppField name="rememberMe">
+                      {(field) => (
+                        <Field className="my-1">
+                          <div className="flex items-center gap-3">
+                            <Checkbox
+                              id="rememberMe"
+                              name={field.name}
+                              checked={field.state.value}
+                              disabled={isPending}
+                              onCheckedChange={(checked) =>
+                                field.handleChange(checked === true)
+                              }
+                            />
+
+                            <FieldLabel
+                              htmlFor="rememberMe"
+                              className="cursor-pointer text-sm font-normal"
+                            >
+                              {localization.auth.rememberMe}
+                            </FieldLabel>
+                          </div>
+                        </Field>
+                      )}
+                    </form.AppField>
                   )}
-                </div>
-              </FieldGroup>
-            </form>
+
+                  {Captcha && (
+                    <div className="flex justify-center">{Captcha}</div>
+                  )}
+
+                  <div className="flex flex-col gap-3">
+                    <form.AuthFormSubmitButton
+                      className="relative overflow-visible"
+                      disabled={isPending}
+                    >
+                      {isSignInPending && <Spinner />}
+
+                      {localization.auth.signIn}
+
+                      <LastUsedBadge method={["email", "username"]} floating />
+                    </form.AuthFormSubmitButton>
+
+                    {plugins.flatMap((plugin) =>
+                      (plugin.authButtons ?? []).map((AuthButton, index) => (
+                        <AuthButton
+                          key={`${plugin.id}-${index.toString()}`}
+                          view="signIn"
+                        />
+                      ))
+                    )}
+                  </div>
+                </FieldGroup>
+              </form.AuthFormRoot>
+            </form.AppForm>
           )}
 
           {socialPosition === "bottom" && (

--- a/examples/next-shadcn-example/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -7,8 +7,8 @@ import {
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useCreateApiKey } from "@better-auth-ui/react/plugins/api-key"
 import { Key } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useState } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -35,6 +35,7 @@ import {
 } from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
+import { useAuthForm } from "../auth-form"
 import { NewApiKeyDialog } from "./new-api-key-dialog"
 
 export type CreateApiKeyDialogProps = {
@@ -66,10 +67,47 @@ export function CreateApiKeyDialog({
     (configuration) => configuration.organization === Boolean(organizationId)
   )
 
+  const form = useAuthForm({
+    defaultValues: {
+      configId: availableConfigurations[0]?.id ?? "",
+      expiration:
+        keyExpiration && keyExpiration.defaultInterval === null
+          ? "never"
+          : String((keyExpiration && keyExpiration.defaultInterval) ?? "never"),
+      name: ""
+    },
+    onSubmit: ({ value }) => {
+      const name = value.name.trim()
+      const expirationDays =
+        value.expiration !== "never" ? Number(value.expiration) : undefined
+      const expiresIn = expirationDays
+        ? apiKeyExpirationDaysToSeconds(expirationDays)
+        : undefined
+      const configId = value.configId.trim()
+      const resolvedConfigId =
+        configId || (organizationId ? "organization" : undefined)
+      const payload = {
+        ...(name ? { name } : {}),
+        ...(expiresIn ? { expiresIn } : {}),
+        ...(resolvedConfigId ? { configId: resolvedConfigId } : {}),
+        ...(organizationId ? { organizationId } : {})
+      }
+      createApiKey(Object.keys(payload).length > 0 ? payload : undefined, {
+        onSuccess: (result) => {
+          handleOpenChange(false)
+          setKeyName(name)
+          setSecretKey(result.key)
+          setIsNewKeyDialogOpen(true)
+        }
+      })
+    }
+  })
+
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {
       setKeyName(null)
       setSecretKey(null)
+      form.reset()
     }
 
     onOpenChange(nextOpen)
@@ -84,163 +122,149 @@ export function CreateApiKeyDialog({
     }
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.target as HTMLFormElement)
-    const name = (formData.get("name") as string).trim()
-    const expiration = formData.get("expiration")
-    const expirationDays =
-      typeof expiration === "string" && expiration !== "never"
-        ? Number(expiration)
-        : undefined
-    const expiresIn = expirationDays
-      ? apiKeyExpirationDaysToSeconds(expirationDays)
-      : undefined
-
-    const configId = String(formData.get("configId") ?? "").trim()
-    const resolvedConfigId =
-      configId || (organizationId ? "organization" : undefined)
-    const payload = {
-      ...(name ? { name } : {}),
-      ...(expiresIn ? { expiresIn } : {}),
-      ...(resolvedConfigId ? { configId: resolvedConfigId } : {}),
-      ...(organizationId ? { organizationId } : {})
-    }
-
-    createApiKey(Object.keys(payload).length > 0 ? payload : undefined, {
-      onSuccess: (result) => {
-        handleOpenChange(false)
-        setKeyName(name)
-        setSecretKey(result.key)
-        setIsNewKeyDialogOpen(true)
-      }
-    })
-  }
-
   return (
     <>
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <Key />
-                {apiKeyLocalization.createApiKey}
-              </DialogTitle>
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-6">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <Key />
+                  {apiKeyLocalization.createApiKey}
+                </DialogTitle>
 
-              <DialogDescription>
-                {apiKeyLocalization.apiKeysDescription}
-              </DialogDescription>
-            </DialogHeader>
+                <DialogDescription>
+                  {apiKeyLocalization.apiKeysDescription}
+                </DialogDescription>
+              </DialogHeader>
 
-            <FieldGroup>
-              <Field>
-                <FieldLabel htmlFor="api-key-name">
-                  {apiKeyLocalization.name}
-                </FieldLabel>
+              <FieldGroup>
+                <form.AppField name="name">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="api-key-name">
+                        {apiKeyLocalization.name}
+                      </FieldLabel>
 
-                <Input
-                  id="api-key-name"
-                  name="name"
-                  autoFocus
-                  placeholder={localization.settings.optional}
-                  disabled={isCreating}
-                />
+                      <Input
+                        id="api-key-name"
+                        name={field.name}
+                        autoFocus
+                        placeholder={localization.settings.optional}
+                        disabled={isCreating}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
 
-                <FieldError />
-              </Field>
+                      <FieldError />
+                    </Field>
+                  )}
+                </form.AppField>
 
-              {availableConfigurations.length > 0 && (
-                <Field>
-                  <FieldLabel htmlFor="api-key-configuration">
-                    {apiKeyLocalization.configuration}
-                  </FieldLabel>
-                  <Select
-                    name="configId"
-                    defaultValue={availableConfigurations[0]?.id}
-                    disabled={isCreating}
-                  >
-                    <SelectTrigger
-                      id="api-key-configuration"
-                      className="w-full"
-                    >
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        {availableConfigurations.map((configuration) => (
-                          <SelectItem
-                            key={configuration.id}
-                            value={configuration.id}
+                {availableConfigurations.length > 0 && (
+                  <form.AppField name="configId">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel htmlFor="api-key-configuration">
+                          {apiKeyLocalization.configuration}
+                        </FieldLabel>
+                        <Select
+                          name={field.name}
+                          value={field.state.value}
+                          onValueChange={(value) => field.handleChange(value)}
+                          disabled={isCreating}
+                        >
+                          <SelectTrigger
+                            id="api-key-configuration"
+                            className="w-full"
                           >
-                            {configuration.label}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </Field>
-              )}
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              {availableConfigurations.map((configuration) => (
+                                <SelectItem
+                                  key={configuration.id}
+                                  value={configuration.id}
+                                >
+                                  {configuration.label}
+                                </SelectItem>
+                              ))}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      </Field>
+                    )}
+                  </form.AppField>
+                )}
 
-              {keyExpiration ? (
-                <Field>
-                  <FieldLabel htmlFor="api-key-expiration">
-                    {apiKeyLocalization.expiration}
-                  </FieldLabel>
+                {keyExpiration ? (
+                  <form.AppField name="expiration">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel htmlFor="api-key-expiration">
+                          {apiKeyLocalization.expiration}
+                        </FieldLabel>
 
-                  <Select
-                    name="expiration"
-                    defaultValue={
-                      keyExpiration.defaultInterval === null
-                        ? "never"
-                        : String(keyExpiration.defaultInterval)
-                    }
-                    disabled={isCreating}
-                  >
-                    <SelectTrigger id="api-key-expiration" className="w-full">
-                      <SelectValue />
-                    </SelectTrigger>
+                        <Select
+                          name={field.name}
+                          value={field.state.value}
+                          onValueChange={(value) => field.handleChange(value)}
+                          disabled={isCreating}
+                        >
+                          <SelectTrigger
+                            id="api-key-expiration"
+                            className="w-full"
+                          >
+                            <SelectValue />
+                          </SelectTrigger>
 
-                    <SelectContent>
-                      <SelectGroup>
-                        {keyExpiration.intervals.map((days) => (
-                          <SelectItem key={days} value={String(days)}>
-                            {days.toLocaleString()}{" "}
-                            {days === 1
-                              ? apiKeyLocalization.day
-                              : apiKeyLocalization.days}
-                          </SelectItem>
-                        ))}
+                          <SelectContent>
+                            <SelectGroup>
+                              {keyExpiration.intervals.map((days) => (
+                                <SelectItem key={days} value={String(days)}>
+                                  {days.toLocaleString()}{" "}
+                                  {days === 1
+                                    ? apiKeyLocalization.day
+                                    : apiKeyLocalization.days}
+                                </SelectItem>
+                              ))}
 
-                        {keyExpiration.allowNever ? (
-                          <SelectItem value="never">
-                            {apiKeyLocalization.never}
-                          </SelectItem>
-                        ) : null}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </Field>
-              ) : null}
-            </FieldGroup>
+                              {keyExpiration.allowNever ? (
+                                <SelectItem value="never">
+                                  {apiKeyLocalization.never}
+                                </SelectItem>
+                              ) : null}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      </Field>
+                    )}
+                  </form.AppField>
+                ) : null}
+              </FieldGroup>
 
-            <DialogFooter>
-              <DialogClose
-                className={buttonVariants({ variant: "outline" })}
-                disabled={isCreating}
-                type="button"
-              >
-                {localization.settings.cancel}
-              </DialogClose>
+              <DialogFooter>
+                <DialogClose
+                  className={buttonVariants({ variant: "outline" })}
+                  disabled={isCreating}
+                  type="button"
+                >
+                  {localization.settings.cancel}
+                </DialogClose>
 
-              <Button type="submit" disabled={isCreating}>
-                {isCreating && <Spinner />}
+                <form.AuthFormSubmitButton disabled={isCreating}>
+                  {isCreating && <Spinner />}
 
-                {apiKeyLocalization.createApiKey}
-              </Button>
-            </DialogFooter>
-          </form>
+                  {apiKeyLocalization.createApiKey}
+                </form.AuthFormSubmitButton>
+              </DialogFooter>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </DialogContent>
       </Dialog>
 

--- a/examples/next-shadcn-example/src/components/auth/api-key/edit-api-key-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/api-key/edit-api-key-dialog.tsx
@@ -6,8 +6,8 @@ import type {
 } from "@better-auth-ui/core/plugins/api-key"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useUpdateApiKey } from "@better-auth-ui/react/plugins/api-key"
-import type { FormEvent } from "react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useEffect } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -25,6 +25,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
+import { useAuthForm } from "../auth-form"
 
 export function EditApiKeyDialog({
   apiKey,
@@ -41,53 +42,66 @@ export function EditApiKeyDialog({
   const updateApiKey = useUpdateApiKey(authClient, {
     onSuccess: () => onOpenChange(false)
   })
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    updateApiKey.mutate({
-      keyId: apiKey.id,
-      configId: apiKey.configId,
-      name: String(formData.get("name") ?? "").trim()
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { name: apiKey.name ?? "" },
+    onSubmit: ({ value }) =>
+      updateApiKey.mutate({
+        configId: apiKey.configId,
+        keyId: apiKey.id,
+        name: value.name.trim()
+      })
+  })
+  useEffect(() => {
+    if (open) form.reset({ name: apiKey.name ?? "" })
+  }, [apiKey.name, form, open])
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form className="flex flex-col gap-6" onSubmit={submit}>
-          <DialogHeader>
-            <DialogTitle>{labels.editApiKey}</DialogTitle>
-          </DialogHeader>
-          <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor={`api-key-name-${apiKey.id}`}>
-                {labels.name}
-              </FieldLabel>
-              <Input
-                id={`api-key-name-${apiKey.id}`}
-                name="name"
-                defaultValue={apiKey.name ?? ""}
-              />
-            </Field>
-            {updateApiKey.error && (
-              <FieldError>
-                {updateApiKey.error.error?.message ??
-                  updateApiKey.error.message}
-              </FieldError>
-            )}
-          </FieldGroup>
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-            <Button disabled={updateApiKey.isPending} type="submit">
-              {updateApiKey.isPending && <Spinner />}
-              {localization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
-        </form>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle>{labels.editApiKey}</DialogTitle>
+            </DialogHeader>
+            <FieldGroup>
+              <form.AppField name="name">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor={`api-key-name-${apiKey.id}`}>
+                      {labels.name}
+                    </FieldLabel>
+                    <Input
+                      id={`api-key-name-${apiKey.id}`}
+                      name={field.name}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                    />
+                  </Field>
+                )}
+              </form.AppField>
+              {updateApiKey.error && (
+                <FieldError>
+                  {updateApiKey.error.error?.message ??
+                    updateApiKey.error.message}
+                </FieldError>
+              )}
+            </FieldGroup>
+            <DialogFooter>
+              <DialogClose
+                className={buttonVariants({ variant: "outline" })}
+                type="button"
+              >
+                {localization.settings.cancel}
+              </DialogClose>
+              <form.AuthFormSubmitButton disabled={updateApiKey.isPending}>
+                {updateApiKey.isPending && <Spinner />}
+                {localization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/next-shadcn-example/src/components/auth/delete-user/delete-account.tsx
+++ b/examples/next-shadcn-example/src/components/auth/delete-user/delete-account.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { authQueryKeys } from "@better-auth-ui/core"
+import { authQueryKeys, validateStringLength } from "@better-auth-ui/core"
 import {
   useAuth,
   useAuthPlugin,
@@ -9,7 +9,7 @@ import {
 } from "@better-auth-ui/react"
 import { useQueryClient } from "@tanstack/react-query"
 import { Eye, EyeOff, TriangleAlert } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 import {
   AlertDialog,
@@ -22,9 +22,9 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger
 } from "@/components/ui/alert-dialog"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import {
   InputGroup,
   InputGroupAddon,
@@ -34,6 +34,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { deleteUserPlugin } from "@/lib/auth/delete-user-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 
 export type DeleteAccountProps = {
   className?: string
@@ -55,7 +56,6 @@ export function DeleteAccount({ className }: DeleteAccountProps) {
   const queryClient = useQueryClient()
 
   const [confirmOpen, setConfirmOpen] = useState(false)
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
 
   const hasCredentialAccount = accounts?.some(
@@ -65,36 +65,33 @@ export function DeleteAccount({ className }: DeleteAccountProps) {
 
   const { mutate: deleteUser, isPending } = useDeleteUser(authClient)
 
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) => {
+      deleteUser(needsPassword ? { password: value.password } : {}, {
+        onSuccess: () => {
+          setConfirmOpen(false)
+          form.reset()
+
+          if (sendDeleteAccountVerification) {
+            toast.success(deleteUserLocalization.deleteUserVerificationSent)
+          } else {
+            toast.success(deleteUserLocalization.deleteUserSuccess)
+            queryClient.removeQueries({ queryKey: authQueryKeys.all })
+            navigate({
+              to: `${basePaths.auth}/${viewPaths.auth.signIn}`,
+              replace: true
+            })
+          }
+        }
+      })
+    }
+  })
+
   const handleDialogOpenChange = (open: boolean) => {
     setConfirmOpen(open)
-    setPassword("")
+    form.reset()
     setIsPasswordVisible(false)
-  }
-
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const params = {
-      ...(needsPassword ? { password } : {})
-    }
-
-    deleteUser(params, {
-      onSuccess: () => {
-        setConfirmOpen(false)
-        setPassword("")
-
-        if (sendDeleteAccountVerification) {
-          toast.success(deleteUserLocalization.deleteUserVerificationSent)
-        } else {
-          toast.success(deleteUserLocalization.deleteUserSuccess)
-          queryClient.removeQueries({ queryKey: authQueryKeys.all })
-          navigate({
-            to: `${basePaths.auth}/${viewPaths.auth.signIn}`,
-            replace: true
-          })
-        }
-      }
-    })
   }
 
   return (
@@ -121,82 +118,103 @@ export function DeleteAccount({ className }: DeleteAccountProps) {
           </AlertDialogTrigger>
 
           <AlertDialogContent>
-            <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-              <AlertDialogHeader>
-                <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
-                  <TriangleAlert />
-                </AlertDialogMedia>
+            <form.AppForm>
+              <form.AuthFormRoot className="flex flex-col gap-6">
+                <AlertDialogHeader>
+                  <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
+                    <TriangleAlert />
+                  </AlertDialogMedia>
 
-                <AlertDialogTitle>
-                  {deleteUserLocalization.deleteAccount}
-                </AlertDialogTitle>
+                  <AlertDialogTitle>
+                    {deleteUserLocalization.deleteAccount}
+                  </AlertDialogTitle>
 
-                <AlertDialogDescription>
-                  {deleteUserLocalization.deleteAccountDescription}
-                </AlertDialogDescription>
-              </AlertDialogHeader>
+                  <AlertDialogDescription>
+                    {deleteUserLocalization.deleteAccountDescription}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
 
-              {needsPassword && (
-                <Field>
-                  <FieldLabel htmlFor="delete-password">
-                    {localization.auth.password}
-                  </FieldLabel>
+                {needsPassword && (
+                  <form.AppField
+                    name="password"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          requiredMessage: localization.auth.fieldRequired
+                        })
+                    }}
+                  >
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="delete-password">
+                            {localization.auth.password}
+                          </FieldLabel>
 
-                  <InputGroup>
-                    <InputGroupInput
-                      id="delete-password"
-                      name="password"
-                      type={isPasswordVisible ? "text" : "password"}
-                      autoComplete="current-password"
-                      placeholder={localization.auth.passwordPlaceholder}
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      disabled={isPending}
-                      required
-                    />
+                          <InputGroup>
+                            <InputGroupInput
+                              id="delete-password"
+                              name={field.name}
+                              type={isPasswordVisible ? "text" : "password"}
+                              autoComplete="current-password"
+                              placeholder={
+                                localization.auth.passwordPlaceholder
+                              }
+                              value={field.state.value}
+                              onBlur={field.handleBlur}
+                              onChange={(event) =>
+                                field.handleChange(event.target.value)
+                              }
+                              disabled={isPending}
+                              required
+                            />
 
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        title={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() => {
-                          setIsPasswordVisible((visible) => !visible)
-                        }}
-                      >
-                        {isPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                size="icon-xs"
+                                aria-label={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                title={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                onClick={() => {
+                                  setIsPasswordVisible((visible) => !visible)
+                                }}
+                              >
+                                {isPasswordVisible ? <EyeOff /> : <Eye />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
 
-                  <FieldError />
-                </Field>
-              )}
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
+                )}
 
-              <AlertDialogFooter>
-                <AlertDialogCancel disabled={isPending}>
-                  {localization.settings.cancel}
-                </AlertDialogCancel>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={isPending}>
+                    {localization.settings.cancel}
+                  </AlertDialogCancel>
 
-                <Button
-                  type="submit"
-                  variant="destructive"
-                  disabled={isPending}
-                >
-                  {isPending && <Spinner />}
+                  <form.AuthFormSubmitButton
+                    variant="destructive"
+                    disabled={isPending}
+                  >
+                    {isPending && <Spinner />}
 
-                  {deleteUserLocalization.deleteAccount}
-                </Button>
-              </AlertDialogFooter>
-            </form>
+                    {deleteUserLocalization.deleteAccount}
+                  </form.AuthFormSubmitButton>
+                </AlertDialogFooter>
+              </form.AuthFormRoot>
+            </form.AppForm>
           </AlertDialogContent>
         </AlertDialog>
       </CardContent>

--- a/examples/next-shadcn-example/src/components/auth/device-authorization/device-authorization.tsx
+++ b/examples/next-shadcn-example/src/components/auth/device-authorization/device-authorization.tsx
@@ -13,7 +13,6 @@ import {
 import { REGEXP_ONLY_DIGITS_AND_CHARS } from "input-otp"
 import { CheckIcon, CircleCheckIcon, CircleXIcon, XIcon } from "lucide-react"
 import {
-  type FormEvent,
   type ReactNode,
   useCallback,
   useEffect,
@@ -47,6 +46,7 @@ import { Separator } from "@/components/ui/separator"
 import { Spinner } from "@/components/ui/spinner"
 import { deviceAuthorizationPlugin } from "@/lib/auth/device-authorization-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 
 type DeviceAuthorizationStep = "code" | "approval" | "approved" | "denied"
 
@@ -131,7 +131,6 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
     initialDeviceAuthorizationState
   )
   const submittedCodeRef = useRef<string | null>(null)
-  const normalizedUserCode = normalizeDeviceCode(userCode)
 
   const handleAuthorizationError = () => {
     dispatch({
@@ -175,19 +174,6 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
     }
   )
 
-  const handleCodeChange = (value: string) => {
-    const nextCode = normalizeDeviceCode(value)
-      .replace(/[^A-Z0-9]/g, "")
-      .slice(0, userCodeLength)
-
-    if (nextCode !== submittedCodeRef.current) {
-      submittedCodeRef.current = null
-    }
-
-    setUserCode(nextCode)
-    dispatch({ type: "codeChanged" })
-  }
-
   const submitCode = useCallback(
     (completedCode: string) => {
       const normalizedCode = normalizeDeviceCode(completedCode)
@@ -227,22 +213,22 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
     ]
   )
 
-  useEffect(() => {
-    if (normalizedUserCode.length === userCodeLength) {
-      submitCode(normalizedUserCode)
-    }
-  }, [normalizedUserCode, submitCode, userCodeLength])
+  const handleSubmit = useCallback(
+    (code: string) => {
+      const normalizedCode = normalizeDeviceCode(code)
+      if (normalizedCode.length !== userCodeLength) {
+        dispatch({
+          type: "verificationFailed",
+          message: localization.invalidDeviceCode
+        })
+        return
+      }
+      submitCode(normalizedCode)
+    },
+    [localization.invalidDeviceCode, submitCode, userCodeLength]
+  )
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-
-    if (normalizedUserCode.length !== userCodeLength) {
-      handleAuthorizationError()
-      return
-    }
-
-    submitCode(normalizedUserCode)
-  }
+  const authorizedCode = submittedCodeRef.current ?? ""
 
   const cardClassName = cn("w-full max-w-sm", className)
 
@@ -251,12 +237,12 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
       <DeviceApproval
         className={cardClassName}
         localization={localization}
-        userCode={normalizedUserCode}
+        userCode={authorizedCode}
         user={session.user}
         isApproving={isApproving}
         isDenying={isDenying}
-        onApprove={() => approveDevice({ userCode: normalizedUserCode })}
-        onDeny={() => denyDevice({ userCode: normalizedUserCode })}
+        onApprove={() => approveDevice({ userCode: authorizedCode })}
+        onDeny={() => denyDevice({ userCode: authorizedCode })}
       />
     )
   }
@@ -286,10 +272,10 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
       isSessionPending={isSessionPending}
       isVerifying={isVerifying}
       localization={localization}
-      userCode={userCode}
+      initialUserCode={userCode}
       userCodeLength={userCodeLength}
-      onCodeChange={handleCodeChange}
-      onSubmit={handleSubmit}
+      onCodeChange={() => dispatch({ type: "codeChanged" })}
+      onSubmitCode={handleSubmit}
     />
   )
 }
@@ -300,10 +286,10 @@ type DeviceCodeFormProps = {
   isSessionPending: boolean
   isVerifying: boolean
   localization: DeviceAuthorizationLocalization
-  userCode: string
+  initialUserCode: string
   userCodeLength: number
   onCodeChange: (value: string) => void
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void
+  onSubmitCode: (code: string) => void
 }
 
 function DeviceCodeForm({
@@ -312,16 +298,27 @@ function DeviceCodeForm({
   isSessionPending,
   isVerifying,
   localization,
-  userCode,
+  initialUserCode,
   userCodeLength,
   onCodeChange,
-  onSubmit
+  onSubmitCode
 }: DeviceCodeFormProps) {
   const slots = createDeviceCodeSlots(userCodeLength)
   const groupBreak = Math.ceil(userCodeLength / 2)
   const firstGroup = slots.slice(0, groupBreak)
   const secondGroup = slots.slice(groupBreak)
   const errorId = "device-code-error"
+  const form = useAuthForm({
+    defaultValues: { userCode: initialUserCode },
+    onSubmit: ({ value }) => onSubmitCode(value.userCode)
+  })
+
+  useEffect(() => {
+    form.setFieldValue("userCode", initialUserCode)
+    if (initialUserCode.length === userCodeLength) {
+      onSubmitCode(initialUserCode)
+    }
+  }, [form.setFieldValue, initialUserCode, onSubmitCode, userCodeLength])
 
   return (
     <Card className={className}>
@@ -335,63 +332,77 @@ function DeviceCodeForm({
       </CardHeader>
 
       <CardContent>
-        <form aria-label={localization.deviceAuthorization} onSubmit={onSubmit}>
-          <FieldGroup>
-            <Field data-invalid={Boolean(codeError)}>
-              <FieldLabel htmlFor="device-code">
-                {localization.deviceCode}
-              </FieldLabel>
+        <form.AppForm>
+          <form.AuthFormRoot aria-label={localization.deviceAuthorization}>
+            <FieldGroup>
+              <form.AppField name="userCode">
+                {(field) => (
+                  <Field data-invalid={Boolean(codeError)}>
+                    <FieldLabel htmlFor="device-code">
+                      {localization.deviceCode}
+                    </FieldLabel>
 
-              <InputOTP
-                id="device-code"
-                aria-describedby={codeError ? errorId : undefined}
-                aria-invalid={Boolean(codeError)}
-                autoComplete="one-time-code"
-                containerClassName="w-full justify-center"
-                disabled={isVerifying}
-                inputMode="text"
-                maxLength={userCodeLength}
-                name="userCode"
-                pasteTransformer={normalizeDeviceCode}
-                pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
-                value={userCode}
-                onChange={onCodeChange}
+                    <InputOTP
+                      id="device-code"
+                      aria-describedby={codeError ? errorId : undefined}
+                      aria-invalid={Boolean(codeError)}
+                      autoComplete="one-time-code"
+                      containerClassName="w-full justify-center"
+                      disabled={isVerifying}
+                      inputMode="text"
+                      maxLength={userCodeLength}
+                      name={field.name}
+                      pasteTransformer={normalizeDeviceCode}
+                      pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+                      value={field.state.value}
+                      onChange={(value) => {
+                        const nextCode = normalizeDeviceCode(value)
+                          .replace(/[^A-Z0-9]/g, "")
+                          .slice(0, userCodeLength)
+                        field.handleChange(nextCode)
+                        onCodeChange(nextCode)
+                        if (nextCode.length === userCodeLength)
+                          onSubmitCode(nextCode)
+                      }}
+                    >
+                      <InputOTPGroup>
+                        {firstGroup.map((slot) => (
+                          <InputOTPSlot key={slot.id} index={slot.index} />
+                        ))}
+                      </InputOTPGroup>
+
+                      {secondGroup.length > 0 ? (
+                        <>
+                          <InputOTPSeparator />
+                          <InputOTPGroup>
+                            {secondGroup.map((slot) => (
+                              <InputOTPSlot key={slot.id} index={slot.index} />
+                            ))}
+                          </InputOTPGroup>
+                        </>
+                      ) : null}
+                    </InputOTP>
+
+                    <FieldError id={errorId}>{codeError}</FieldError>
+                  </Field>
+                )}
+              </form.AppField>
+
+              <form.AuthFormSubmitButton
+                className="w-full"
+                disabled={
+                  form.state.values.userCode.length !== userCodeLength ||
+                  isSessionPending ||
+                  isVerifying
+                }
+                type="submit"
               >
-                <InputOTPGroup>
-                  {firstGroup.map((slot) => (
-                    <InputOTPSlot key={slot.id} index={slot.index} />
-                  ))}
-                </InputOTPGroup>
-
-                {secondGroup.length > 0 ? (
-                  <>
-                    <InputOTPSeparator />
-                    <InputOTPGroup>
-                      {secondGroup.map((slot) => (
-                        <InputOTPSlot key={slot.id} index={slot.index} />
-                      ))}
-                    </InputOTPGroup>
-                  </>
-                ) : null}
-              </InputOTP>
-
-              <FieldError id={errorId}>{codeError}</FieldError>
-            </Field>
-
-            <Button
-              className="w-full"
-              disabled={
-                userCode.length !== userCodeLength ||
-                isSessionPending ||
-                isVerifying
-              }
-              type="submit"
-            >
-              {isVerifying ? <Spinner data-icon="inline-start" /> : null}
-              {localization.continue}
-            </Button>
-          </FieldGroup>
-        </form>
+                {isVerifying ? <Spinner data-icon="inline-start" /> : null}
+                {localization.continue}
+              </form.AuthFormSubmitButton>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
     </Card>
   )

--- a/examples/next-shadcn-example/src/components/auth/email-otp/change-email-otp.tsx
+++ b/examples/next-shadcn-example/src/components/auth/email-otp/change-email-otp.tsx
@@ -7,17 +7,18 @@ import {
   useRequestEmailChangeOtp,
   useSendVerificationOtp
 } from "@better-auth-ui/react/plugins/email-otp"
-import { type SyntheticEvent, useReducer, useState } from "react"
+import { useEffect, useReducer } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 
@@ -84,14 +85,6 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
     changeEmailReducer,
     initialChangeEmailState
   )
-  const [code, setCode] = useState("")
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({})
-
-  const resetFlow = () => {
-    setCode("")
-    dispatch({ type: "restarted" })
-  }
-
   // The step transition is attached per call: the code goes to the current
   // address while the pending change targets the new one, so the address to
   // remember isn't in this mutation's variables.
@@ -100,9 +93,9 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
 
   const { mutate: requestEmailChangeOtp, isPending: isRequesting } =
     useRequestEmailChangeOtp(otpClient, {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: (_data, { newEmail }) => {
-        setCode("")
+        form.setFieldValue("code", "")
         dispatch({ type: "changeRequested", newEmail })
       }
     })
@@ -110,7 +103,7 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
   const { mutate: changeEmailOtp, isPending: isChanging } = useChangeEmailOtp(
     otpClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
         toast.success(localization.settings.changeEmailSuccess)
         resetFlow()
@@ -134,30 +127,39 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
     changeEmailOtp({ newEmail: state.newEmail, otp: completedCode })
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useAuthForm({
+    defaultValues: { code: "", email: "" },
+    onSubmit: ({ value }) => {
+      if (state.step === "email") {
+        const newEmail = value.email
 
-    if (state.step === "email") {
-      const formData = new FormData(e.currentTarget)
-      const newEmail = formData.get("email") as string
+        if (verifyCurrentEmail && currentEmail) {
+          sendVerificationOtp(
+            { email: currentEmail, type: "change-email" },
+            {
+              onSuccess: () =>
+                dispatch({ type: "currentEmailChallenged", newEmail })
+            }
+          )
+          return
+        }
 
-      if (verifyCurrentEmail && currentEmail) {
-        sendVerificationOtp(
-          { email: currentEmail, type: "change-email" },
-          {
-            onSuccess: () =>
-              dispatch({ type: "currentEmailChallenged", newEmail })
-          }
-        )
+        requestEmailChangeOtp({ newEmail })
         return
       }
-
-      requestEmailChangeOtp({ newEmail })
-      return
+      submitCode(value.code)
     }
+  })
 
-    submitCode(code)
+  const resetFlow = () => {
+    form.reset()
+    if (currentEmail) form.setFieldValue("email", currentEmail)
+    dispatch({ type: "restarted" })
   }
+
+  useEffect(() => {
+    if (currentEmail) form.setFieldValue("email", currentEmail)
+  }, [currentEmail, form])
 
   const codeTarget =
     state.step === "currentCode" ? currentEmail : state.newEmail
@@ -168,109 +170,111 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
         {localization.settings.changeEmail}
       </h2>
 
-      <form onSubmit={handleSubmit}>
-        <Card className={cn(className)}>
-          <CardContent className="flex flex-col gap-6">
-            {state.step === "email" ? (
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="email">
-                  {localization.auth.email}
-                </FieldLabel>
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card className={cn(className)}>
+            <CardContent className="flex flex-col gap-6">
+              {state.step === "email" ? (
+                <form.AppField name="email">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
 
-                {session ? (
-                  <Input
-                    key={currentEmail}
-                    id="email"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    defaultValue={currentEmail}
-                    placeholder={localization.auth.emailPlaceholder}
-                    disabled={isPending}
-                    required
-                    onChange={() =>
-                      setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                    }
-                    onInvalid={(e) => {
-                      e.preventDefault()
+                      {session ? (
+                        <Input
+                          key={currentEmail}
+                          id="email"
+                          name="email"
+                          type="email"
+                          autoComplete="email"
+                          value={field.state.value}
+                          placeholder={localization.auth.emailPlaceholder}
+                          disabled={isPending}
+                          required
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                        />
+                      ) : (
+                        <Skeleton>
+                          <Input className="invisible" />
+                        </Skeleton>
+                      )}
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: (e.target as HTMLInputElement).validationMessage
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
-                ) : (
-                  <Skeleton>
-                    <Input className="invisible" />
-                  </Skeleton>
-                )}
-
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
-            ) : (
-              <div className="flex flex-col gap-3">
-                <p className="text-muted-foreground text-sm">
-                  {emailOtpLocalization.confirmEmailDescription.replace(
-                    "{{email}}",
-                    codeTarget ?? ""
+                      <field.AuthFormFieldError />
+                    </Field>
                   )}
-                </p>
+                </form.AppField>
+              ) : (
+                <div className="flex flex-col gap-3">
+                  <p className="text-muted-foreground text-sm">
+                    {emailOtpLocalization.confirmEmailDescription.replace(
+                      "{{email}}",
+                      codeTarget ?? ""
+                    )}
+                  </p>
 
-                <OtpField
-                  autoFocus
+                  <form.AppField name="code">
+                    {(field) => (
+                      <OtpField
+                        autoFocus
+                        disabled={isPending}
+                        label={
+                          state.step === "currentCode"
+                            ? emailOtpLocalization.confirmCurrentEmail
+                            : emailOtpLocalization.confirmNewEmail
+                        }
+                        length={otpLength}
+                        name="otp"
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        onComplete={submitCode}
+                      />
+                    )}
+                  </form.AppField>
+
+                  {codeTarget && (
+                    <OpenEmailButton email={codeTarget} variant="secondary" />
+                  )}
+                </div>
+              )}
+            </CardContent>
+
+            <CardFooter className="gap-3">
+              {state.step !== "email" && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
                   disabled={isPending}
-                  label={
-                    state.step === "currentCode"
-                      ? emailOtpLocalization.confirmCurrentEmail
-                      : emailOtpLocalization.confirmNewEmail
-                  }
-                  length={otpLength}
-                  name="otp"
-                  value={code}
-                  onChange={setCode}
-                  onComplete={submitCode}
-                />
+                  onClick={resetFlow}
+                >
+                  {localization.settings.cancel}
+                </Button>
+              )}
 
-                {codeTarget && (
-                  <OpenEmailButton email={codeTarget} variant="secondary" />
-                )}
-              </div>
-            )}
-          </CardContent>
-
-          <CardFooter className="gap-3">
-            {state.step !== "email" && (
-              <Button
-                type="button"
+              <form.AuthFormSubmitButton
                 size="sm"
-                variant="outline"
-                disabled={isPending}
-                onClick={resetFlow}
+                disabled={
+                  isPending ||
+                  !session ||
+                  (state.step !== "email" &&
+                    form.state.values.code.length !== otpLength)
+                }
               >
-                {localization.settings.cancel}
-              </Button>
-            )}
+                {isPending && <Spinner />}
 
-            <Button
-              type="submit"
-              size="sm"
-              disabled={
-                isPending ||
-                !session ||
-                (state.step !== "email" && code.length !== otpLength)
-              }
-            >
-              {isPending && <Spinner />}
-
-              {state.step === "email"
-                ? localization.settings.updateEmail
-                : emailOtpLocalization.verifyCode}
-            </Button>
-          </CardFooter>
-        </Card>
-      </form>
+                {state.step === "email"
+                  ? localization.settings.updateEmail
+                  : emailOtpLocalization.verifyCode}
+              </form.AuthFormSubmitButton>
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/examples/next-shadcn-example/src/components/auth/email-otp/email-otp.tsx
+++ b/examples/next-shadcn-example/src/components/auth/email-otp/email-otp.tsx
@@ -9,7 +9,7 @@ import {
   useSignInEmailOtp
 } from "@better-auth-ui/react/plugins/email-otp"
 import { useIsMutating } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -22,7 +22,6 @@ import {
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -33,6 +32,7 @@ import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { useResendCooldown } from "@/lib/auth/use-resend-cooldown"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
@@ -75,10 +75,7 @@ export function EmailOtp({
   const continueSignIn = useSignInContinuation()
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
 
-  const [email, setEmail] = useState(getSsoFallbackEmail)
-  const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({})
 
   const { mutate: sendVerificationOtp, isPending: isSending } =
     useSendVerificationOtp(otpClient, {
@@ -91,7 +88,7 @@ export function EmailOtp({
   const { mutate: signInEmailOtp, isPending: isSigningIn } = useSignInEmailOtp(
     otpClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: (data) => continueSignIn(data)
     }
   )
@@ -104,23 +101,28 @@ export function EmailOtp({
   })
   const isPending = signInMutating + signUpMutating > 0 || isSending
 
-  const sendCode = () => sendVerificationOtp({ email, type: "sign-in" })
+  const sendCode = () =>
+    sendVerificationOtp({
+      email: form.state.values.email,
+      type: "sign-in"
+    })
   const verifyCode = (completedCode: string) => {
     if (isPending || isSigningIn) return
 
-    signInEmailOtp({ email, otp: completedCode })
+    signInEmailOtp({ email: form.state.values.email, otp: completedCode })
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useAuthForm({
+    defaultValues: { code: "", email: getSsoFallbackEmail() },
+    onSubmit: ({ value }) => {
+      if (!codeSent) {
+        sendVerificationOtp({ email: value.email, type: "sign-in" })
+        return
+      }
 
-    if (!codeSent) {
-      sendCode()
-      return
+      verifyCode(value.code)
     }
-
-    verifyCode(code)
-  }
+  })
 
   const showSeparator = socialProviders && socialProviders.length > 0
 
@@ -131,7 +133,10 @@ export function EmailOtp({
 
         {codeSent && (
           <CardDescription>
-            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
+            {emailOtpLocalization.codeSentTo.replace(
+              "{{email}}",
+              form.state.values.email
+            )}
           </CardDescription>
         )}
       </CardHeader>
@@ -152,112 +157,113 @@ export function EmailOtp({
             </>
           )}
 
-          <form onSubmit={handleSubmit}>
-            <FieldGroup>
-              {codeSent ? (
-                <OtpField
-                  autoFocus
-                  disabled={isPending || isSigningIn}
-                  label={emailOtpLocalization.code}
-                  length={otpLength}
-                  name="otp"
-                  value={code}
-                  onChange={setCode}
-                  onComplete={verifyCode}
-                />
-              ) : (
-                <Field data-invalid={!!fieldErrors.email}>
-                  <FieldLabel htmlFor="email">
-                    {localization.auth.email}
-                  </FieldLabel>
-
-                  <Input
-                    id="email"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    value={email}
-                    onChange={(e) => {
-                      setEmail(e.target.value)
-                      setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                    }}
-                    placeholder={localization.auth.emailPlaceholder}
-                    required
-                    disabled={isPending}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: (e.target as HTMLInputElement).validationMessage
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
-
-                  <FieldError>{fieldErrors.email}</FieldError>
-                </Field>
-              )}
-
-              <div className="flex flex-col gap-3">
-                <Button
-                  type="submit"
-                  disabled={
-                    isPending ||
-                    isSigningIn ||
-                    (codeSent && code.length !== otpLength)
-                  }
-                >
-                  {(isSending || isSigningIn) && <Spinner />}
-
-                  {codeSent
-                    ? emailOtpLocalization.verifyCode
-                    : emailOtpLocalization.sendCode}
-                </Button>
-
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <FieldGroup>
                 {codeSent ? (
-                  <>
-                    <OpenEmailButton email={email} variant="secondary" />
-
-                    <Button
-                      type="button"
-                      variant="outline"
-                      disabled={isPending || isSigningIn || isCoolingDown}
-                      onClick={sendCode}
-                    >
-                      {isCoolingDown
-                        ? localization.auth.resendIn.replace(
-                            "{{seconds}}",
-                            String(cooldown)
-                          )
-                        : localization.auth.resend}
-                    </Button>
-
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      disabled={isPending || isSigningIn}
-                      onClick={() => {
-                        setCodeSent(false)
-                        setCode("")
-                      }}
-                    >
-                      {emailOtpLocalization.useDifferentEmail}
-                    </Button>
-                  </>
-                ) : (
-                  plugins.flatMap((plugin) =>
-                    (plugin.authButtons ?? []).map((AuthButton, index) => (
-                      <AuthButton
-                        key={`${plugin.id}-${index.toString()}`}
-                        view="emailOtp"
+                  <form.AppField name="code">
+                    {(field) => (
+                      <OtpField
+                        autoFocus
+                        disabled={isPending || isSigningIn}
+                        label={emailOtpLocalization.code}
+                        length={otpLength}
+                        name={field.name}
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        onComplete={verifyCode}
                       />
-                    ))
-                  )
+                    )}
+                  </form.AppField>
+                ) : (
+                  <form.AppField name="email">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel htmlFor="email">
+                          {localization.auth.email}
+                        </FieldLabel>
+                        <Input
+                          id="email"
+                          name={field.name}
+                          type="email"
+                          autoComplete="email"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          placeholder={localization.auth.emailPlaceholder}
+                          required
+                          disabled={isPending}
+                        />
+                        <field.AuthFormFieldError />
+                      </Field>
+                    )}
+                  </form.AppField>
                 )}
-              </div>
-            </FieldGroup>
-          </form>
+
+                <div className="flex flex-col gap-3">
+                  <form.AuthFormSubmitButton
+                    disabled={
+                      isPending ||
+                      isSigningIn ||
+                      (codeSent && form.state.values.code.length !== otpLength)
+                    }
+                  >
+                    {(isSending || isSigningIn) && <Spinner />}
+
+                    {codeSent
+                      ? emailOtpLocalization.verifyCode
+                      : emailOtpLocalization.sendCode}
+                  </form.AuthFormSubmitButton>
+
+                  {codeSent ? (
+                    <>
+                      <OpenEmailButton
+                        email={form.state.values.email}
+                        variant="secondary"
+                      />
+
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isPending || isSigningIn || isCoolingDown}
+                        onClick={sendCode}
+                      >
+                        {isCoolingDown
+                          ? localization.auth.resendIn.replace(
+                              "{{seconds}}",
+                              String(cooldown)
+                            )
+                          : localization.auth.resend}
+                      </Button>
+
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        disabled={isPending || isSigningIn}
+                        onClick={() => {
+                          setCodeSent(false)
+                          form.setFieldValue("code", "")
+                        }}
+                      >
+                        {emailOtpLocalization.useDifferentEmail}
+                      </Button>
+                    </>
+                  ) : (
+                    plugins.flatMap((plugin) =>
+                      (plugin.authButtons ?? []).map((AuthButton, index) => (
+                        <AuthButton
+                          key={`${plugin.id}-${index.toString()}`}
+                          view="emailOtp"
+                        />
+                      ))
+                    )
+                  )}
+                </div>
+              </FieldGroup>
+            </form.AuthFormRoot>
+          </form.AppForm>
 
           {socialPosition === "bottom" && !codeSent && (
             <>

--- a/examples/next-shadcn-example/src/components/auth/email-otp/forgot-password-otp.tsx
+++ b/examples/next-shadcn-example/src/components/auth/email-otp/forgot-password-otp.tsx
@@ -1,17 +1,14 @@
 "use client"
 
-import { getAuthLinkURL } from "@better-auth-ui/core"
+import { getAuthLinkURL, validateEmailAddress } from "@better-auth-ui/core"
 import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin, useFetchOptions } from "@better-auth-ui/react"
 import { useRequestPasswordResetOtp } from "@better-auth-ui/react/plugins/email-otp"
-import { type SyntheticEvent, useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel
 } from "@/components/ui/field"
@@ -19,6 +16,7 @@ import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 
 /** `sessionStorage` key the reset-code form reads the pending address from. */
 export const RESET_PASSWORD_OTP_STORAGE_KEY =
@@ -52,7 +50,6 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
   const { localization: emailOtpLocalization } = useAuthPlugin(emailOtpPlugin)
 
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({})
 
   const { mutate: requestPasswordResetOtp, isPending } =
     useRequestPasswordResetOtp(authClient as EmailOtpAuthClient, {
@@ -63,15 +60,11 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
       }
     })
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    requestPasswordResetOtp({
-      email: formData.get("email") as string,
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) =>
+      requestPasswordResetOtp({ email: value.email, fetchOptions })
+  })
 
   const Captcha = plugins.find(
     (plugin) => plugin.captchaComponent
@@ -86,45 +79,57 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            <Field data-invalid={!!fieldErrors.email}>
-              <FieldLabel htmlFor="email">{localization.auth.email}</FieldLabel>
-
-              <Input
-                id="email"
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              <form.AppField
                 name="email"
-                type="email"
-                autoComplete="email"
-                placeholder={localization.auth.emailPlaceholder}
-                required
-                disabled={isPending}
-                onChange={() =>
-                  setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                }
-                onInvalid={(e) => {
-                  e.preventDefault()
-
-                  setFieldErrors((prev) => ({
-                    ...prev,
-                    email: (e.target as HTMLInputElement).validationMessage
-                  }))
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
                 }}
-                aria-invalid={!!fieldErrors.email}
-              />
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        aria-invalid={isInvalid}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
 
-              <FieldError>{fieldErrors.email}</FieldError>
-            </Field>
+              {Captcha && <div className="flex justify-center">{Captcha}</div>}
 
-            {Captcha && <div className="flex justify-center">{Captcha}</div>}
+              <form.AuthFormSubmitButton disabled={isPending}>
+                {isPending && <Spinner />}
 
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Spinner />}
-
-              {emailOtpLocalization.sendCode}
-            </Button>
-          </FieldGroup>
-        </form>
+                {emailOtpLocalization.sendCode}
+              </form.AuthFormSubmitButton>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/examples/next-shadcn-example/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/examples/next-shadcn-example/src/components/auth/email-otp/reset-password-otp.tsx
@@ -8,10 +8,9 @@ import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPasswordOtp } from "@better-auth-ui/react/plugins/email-otp"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -36,6 +35,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 import { PasswordStrengthMeter } from "../password-strength-meter"
@@ -74,24 +74,9 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
   const isHydrated = useIsHydrated()
   const initialEmail =
     (isHydrated && sessionStorage.getItem(RESET_PASSWORD_OTP_STORAGE_KEY)) || ""
-  const [email, setEmail] = useState(initialEmail)
   const [hasStoredEmail, setHasStoredEmail] = useState(Boolean(initialEmail))
-  const [code, setCode] = useState("")
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-  const formRef = useRef<HTMLFormElement>(null)
-  const submissionLockedRef = useRef(false)
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-    password?: string
-  }>({})
-
-  useEffect(() => {
-    const storedEmail =
-      sessionStorage.getItem(RESET_PASSWORD_OTP_STORAGE_KEY) ?? ""
-    setEmail(storedEmail)
-    setHasStoredEmail(Boolean(storedEmail))
-  }, [])
+  const [passwordError, setPasswordError] = useState("")
 
   const { mutate: resetPasswordOtp, isPending } = useResetPasswordOtp(
     authClient as EmailOtpAuthClient,
@@ -100,14 +85,9 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
         // The haveIBeenPwned plugin rejects on the password itself, so it
         // belongs against the field rather than in a toast.
         if (isPasswordCompromisedError(error)) {
-          setFieldErrors((prev) => ({
-            ...prev,
-            password: localization.auth.passwordCompromised
-          }))
+          setPasswordError(localization.auth.passwordCompromised)
         }
-
-        submissionLockedRef.current = false
-        setCode("")
+        form.setFieldValue("code", "")
       },
       onSuccess: () => {
         sessionStorage.removeItem(RESET_PASSWORD_OTP_STORAGE_KEY)
@@ -117,58 +97,44 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
     }
   )
 
-  const submitReset = (
-    form: HTMLFormElement,
-    submittedCode: string,
-    reportErrors: boolean
-  ) => {
-    if (isPending || submissionLockedRef.current) return
-
-    const formData = new FormData(form)
-    const password = formData.get("password") as string
-    const confirmPassword = formData.get("confirmPassword") as string
-    const submittedEmail = hasStoredEmail
-      ? email
-      : (formData.get("email") as string)
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      if (reportErrors) {
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      confirmPassword: "",
+      email: initialEmail,
+      password: ""
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
         toast.error(localization.auth.passwordsDoNotMatch)
+        return
       }
-      return
-    }
-
-    if (submittedCode.length !== otpLength) {
-      if (reportErrors) {
+      if (value.code.length !== otpLength) {
         toast.error(
           emailOtpLocalization.codeLengthMismatch.replace(
             "{{length}}",
             String(otpLength)
           )
         )
+        return
       }
-      return
+      resetPasswordOtp({
+        email: value.email,
+        otp: value.code,
+        password: value.password
+      })
     }
+  })
 
-    submissionLockedRef.current = true
-    resetPasswordOtp({ email: submittedEmail, otp: submittedCode, password })
-  }
-
-  const tryAutoSubmit = (completedCode?: string) => {
-    const form = formRef.current
-
-    if (!form?.matches(":valid")) return
-
-    const formData = new FormData(form)
-    const submittedCode = completedCode ?? String(formData.get("otp") ?? "")
-
-    submitReset(form, submittedCode, false)
-  }
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    submitReset(e.currentTarget, code, true)
-  }
+  useEffect(() => {
+    const storedEmail =
+      sessionStorage.getItem(RESET_PASSWORD_OTP_STORAGE_KEY) ?? ""
+    form.setFieldValue("email", storedEmail)
+    setHasStoredEmail(Boolean(storedEmail))
+  }, [form.setFieldValue])
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -177,160 +143,171 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
           {localization.auth.resetPassword}
         </CardTitle>
 
-        {hasStoredEmail && email && (
+        {hasStoredEmail && form.state.values.email && (
           <CardDescription>
-            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
+            {emailOtpLocalization.codeSentTo.replace(
+              "{{email}}",
+              form.state.values.email
+            )}
           </CardDescription>
         )}
       </CardHeader>
 
       <CardContent>
-        <form ref={formRef} onSubmit={handleSubmit}>
-          <FieldGroup>
-            {!hasStoredEmail && (
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="email">
-                  {localization.auth.email}
-                </FieldLabel>
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              {!hasStoredEmail && (
+                <form.AppField name="email">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
 
-                <Input
-                  id="email"
-                  name="email"
-                  type="email"
-                  autoComplete="email"
-                  value={email}
-                  placeholder={localization.auth.emailPlaceholder}
-                  required
-                  disabled={isPending}
-                  onChange={(event) => {
-                    setEmail(event.target.value)
-                    setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        value={field.state.value}
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: (e.target as HTMLInputElement).validationMessage
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.email}
-                />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
-            )}
+              <form.AppField name="code">
+                {(field) => (
+                  <OtpField
+                    autoFocus={hasStoredEmail}
+                    disabled={isPending}
+                    label={emailOtpLocalization.code}
+                    length={otpLength}
+                    name="otp"
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                    onComplete={(code) => {
+                      field.handleChange(code)
+                      if (form.state.values.password) void form.handleSubmit()
+                    }}
+                  />
+                )}
+              </form.AppField>
 
-            <OtpField
-              autoFocus={hasStoredEmail}
-              disabled={isPending}
-              label={emailOtpLocalization.code}
-              length={otpLength}
-              name="otp"
-              value={code}
-              onChange={setCode}
-              onComplete={tryAutoSubmit}
-            />
+              <form.AppField name="password">
+                {(field) => (
+                  <Field data-invalid={Boolean(passwordError)}>
+                    <FieldLabel htmlFor="password">
+                      {localization.auth.newPassword}
+                    </FieldLabel>
 
-            <Field data-invalid={!!fieldErrors.password}>
-              <FieldLabel htmlFor="password">
-                {localization.auth.newPassword}
-              </FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        id="password"
+                        name={field.name}
+                        type={isPasswordVisible ? "text" : "password"}
+                        autoComplete="new-password"
+                        placeholder={localization.auth.newPasswordPlaceholder}
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => {
+                          setPasswordError("")
+                          field.handleChange(event.target.value)
+                        }}
+                        aria-invalid={Boolean(passwordError)}
+                      />
 
-              <InputGroup>
-                <InputGroupInput
-                  id="password"
-                  name="password"
-                  type={isPasswordVisible ? "text" : "password"}
-                  autoComplete="new-password"
-                  placeholder={localization.auth.newPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                  onChange={(e) => {
-                    setPassword(e.target.value)
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={
+                            isPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          title={
+                            isPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() =>
+                            setIsPasswordVisible((visible) => !visible)
+                          }
+                        >
+                          {isPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
 
-                    setFieldErrors((prev) => ({ ...prev, password: undefined }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
-                    const el = e.target as HTMLInputElement
-                    const min = emailAndPassword?.minPasswordLength
-                    const max = emailAndPassword?.maxPasswordLength
-                    const msg = el.validity.valueMissing
-                      ? localization.auth.fieldRequired
-                      : el.validity.tooShort
-                        ? localization.auth.tooShort.replace(
-                            "{{min}}",
-                            String(min)
-                          )
-                        : localization.auth.tooLong.replace(
-                            "{{max}}",
-                            String(max)
-                          )
+                    {passwordError && <FieldError>{passwordError}</FieldError>}
 
-                    setFieldErrors((prev) => ({ ...prev, password: msg }))
-                  }}
-                  aria-invalid={!!fieldErrors.password}
-                />
+                    <PasswordStrengthMeter password={field.state.value} />
+                  </Field>
+                )}
+              </form.AppField>
 
-                <InputGroupAddon align="inline-end">
-                  <InputGroupButton
-                    size="icon-xs"
-                    aria-label={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    title={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    onClick={() => setIsPasswordVisible((visible) => !visible)}
-                  >
-                    {isPasswordVisible ? <EyeOff /> : <Eye />}
-                  </InputGroupButton>
-                </InputGroupAddon>
-              </InputGroup>
+              {emailAndPassword?.confirmPassword && (
+                <form.AppField name="confirmPassword">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="confirmPassword">
+                        {localization.auth.confirmPassword}
+                      </FieldLabel>
 
-              <FieldError>{fieldErrors.password}</FieldError>
+                      <Input
+                        id="confirmPassword"
+                        name={field.name}
+                        type="password"
+                        autoComplete="new-password"
+                        placeholder={
+                          localization.auth.confirmPasswordPlaceholder
+                        }
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-              <PasswordStrengthMeter password={password} />
-            </Field>
+              <div className="flex flex-col gap-3">
+                <form.AuthFormSubmitButton disabled={isPending}>
+                  {isPending && <Spinner />}
 
-            {emailAndPassword?.confirmPassword && (
-              <Field>
-                <FieldLabel htmlFor="confirmPassword">
-                  {localization.auth.confirmPassword}
-                </FieldLabel>
+                  {localization.auth.resetPassword}
+                </form.AuthFormSubmitButton>
 
-                <Input
-                  id="confirmPassword"
-                  name="confirmPassword"
-                  type="password"
-                  autoComplete="new-password"
-                  placeholder={localization.auth.confirmPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                />
-              </Field>
-            )}
-
-            <div className="flex flex-col gap-3">
-              <Button type="submit" disabled={isPending}>
-                {isPending && <Spinner />}
-
-                {localization.auth.resetPassword}
-              </Button>
-
-              {email && <OpenEmailButton email={email} variant="secondary" />}
-            </div>
-          </FieldGroup>
-        </form>
+                {form.state.values.email && (
+                  <OpenEmailButton
+                    email={form.state.values.email}
+                    variant="secondary"
+                  />
+                )}
+              </div>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/examples/next-shadcn-example/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/examples/next-shadcn-example/src/components/auth/email-otp/verify-email-otp.tsx
@@ -7,7 +7,7 @@ import {
   useSendVerificationOtp,
   useVerifyEmailOtp
 } from "@better-auth-ui/react/plugins/email-otp"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -21,7 +21,6 @@ import {
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel
 } from "@/components/ui/field"
@@ -33,6 +32,7 @@ import {
   useResendCooldown
 } from "@/lib/auth/use-resend-cooldown"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 import { useIsHydrated } from "../use-is-hydrated"
@@ -74,8 +74,6 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
   const [email, setEmail] = useState(
     (isHydrated && sessionStorage.getItem(VERIFY_EMAIL_STORAGE_KEY)) || ""
   )
-  const [code, setCode] = useState("")
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({})
 
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
 
@@ -102,7 +100,7 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
   const { mutate: verifyEmailOtp, isPending: isVerifying } = useVerifyEmailOtp(
     otpClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
         sessionStorage.removeItem(VERIFY_EMAIL_STORAGE_KEY)
         toast.success(emailOtpLocalization.emailVerified)
@@ -119,20 +117,19 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
     verifyEmailOtp({ email, otp: completedCode })
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (!email) {
-      const formData = new FormData(e.currentTarget)
-      sendVerificationOtp({
-        email: formData.get("email") as string,
-        type: "email-verification"
-      })
-      return
+  const form = useAuthForm({
+    defaultValues: { code: "", email: "" },
+    onSubmit: ({ value }) => {
+      if (!email) {
+        sendVerificationOtp({
+          email: value.email,
+          type: "email-verification"
+        })
+        return
+      }
+      verifyCode(value.code)
     }
-
-    verifyCode(code)
-  }
+  })
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -149,87 +146,91 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            {email ? (
-              <OtpField
-                autoFocus
-                disabled={isPending}
-                label={emailOtpLocalization.code}
-                length={otpLength}
-                name="otp"
-                value={code}
-                onChange={setCode}
-                onComplete={verifyCode}
-              />
-            ) : (
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="email">
-                  {localization.auth.email}
-                </FieldLabel>
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              {email ? (
+                <form.AppField name="code">
+                  {(field) => (
+                    <OtpField
+                      autoFocus
+                      disabled={isPending}
+                      label={emailOtpLocalization.code}
+                      length={otpLength}
+                      name="otp"
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      onComplete={verifyCode}
+                    />
+                  )}
+                </form.AppField>
+              ) : (
+                <form.AppField name="email">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
 
-                <Input
-                  id="email"
-                  name="email"
-                  type="email"
-                  autoComplete="email"
-                  placeholder={localization.auth.emailPlaceholder}
-                  required
-                  disabled={isPending}
-                  onChange={() =>
-                    setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                  }
-                  onInvalid={(e) => {
-                    e.preventDefault()
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: (e.target as HTMLInputElement).validationMessage
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.email}
-                />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
-            )}
-
-            <div className="flex flex-col gap-3">
-              <Button
-                type="submit"
-                disabled={
-                  isPending || (Boolean(email) && code.length !== otpLength)
-                }
-              >
-                {isPending && <Spinner />}
-
-                {email
-                  ? emailOtpLocalization.verifyCode
-                  : emailOtpLocalization.sendCode}
-              </Button>
-
-              {email && <OpenEmailButton email={email} variant="secondary" />}
-
-              {email && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={isPending || isCoolingDown}
-                  onClick={() =>
-                    sendVerificationOtp({ email, type: "email-verification" })
+              <div className="flex flex-col gap-3">
+                <form.AuthFormSubmitButton
+                  disabled={
+                    isPending ||
+                    (Boolean(email) &&
+                      form.state.values.code.length !== otpLength)
                   }
                 >
-                  {isCoolingDown
-                    ? localization.auth.resendIn.replace(
-                        "{{seconds}}",
-                        String(cooldown)
-                      )
-                    : localization.auth.resend}
-                </Button>
-              )}
-            </div>
-          </FieldGroup>
-        </form>
+                  {isPending && <Spinner />}
+
+                  {email
+                    ? emailOtpLocalization.verifyCode
+                    : emailOtpLocalization.sendCode}
+                </form.AuthFormSubmitButton>
+
+                {email && <OpenEmailButton email={email} variant="secondary" />}
+
+                {email && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={isPending || isCoolingDown}
+                    onClick={() =>
+                      sendVerificationOtp({ email, type: "email-verification" })
+                    }
+                  >
+                    {isCoolingDown
+                      ? localization.auth.resendIn.replace(
+                          "{{seconds}}",
+                          String(cooldown)
+                        )
+                      : localization.auth.resend}
+                  </Button>
+                )}
+              </div>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/examples/next-shadcn-example/src/components/auth/forgot-password.tsx
+++ b/examples/next-shadcn-example/src/components/auth/forgot-password.tsx
@@ -1,25 +1,23 @@
 "use client"
 
-import { getViewURL } from "@better-auth-ui/core"
+import { getViewURL, validateEmailAddress } from "@better-auth-ui/core"
 import {
   useAuth,
   useFetchOptions,
   useRequestPasswordReset
 } from "@better-auth-ui/react"
-import { type SyntheticEvent, useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel
 } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
 import { RESET_LINK_SENT_STORAGE_KEY } from "./reset-link-sent"
 
 export type ForgotPasswordProps = {
@@ -64,27 +62,23 @@ export function ForgotPassword({ className }: ForgotPasswordProps) {
     }
   )
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    const formData = new FormData(e.currentTarget)
-    requestPasswordReset({
-      email: formData.get("email") as string,
-      redirectTo: getViewURL(
-        baseURL,
-        basePaths.auth,
-        viewPaths.auth.resetPassword
-      ),
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) =>
+      requestPasswordReset({
+        email: value.email,
+        redirectTo: getViewURL(
+          baseURL,
+          basePaths.auth,
+          viewPaths.auth.resetPassword
+        ),
+        fetchOptions
+      })
+  })
 
   const Captcha = plugins.find(
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
-
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-  }>({})
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -95,54 +89,58 @@ export function ForgotPassword({ className }: ForgotPasswordProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            <Field data-invalid={!!fieldErrors.email}>
-              <FieldLabel htmlFor="email">{localization.auth.email}</FieldLabel>
-
-              <Input
-                id="email"
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              <form.AppField
                 name="email"
-                type="email"
-                autoComplete="email"
-                placeholder={localization.auth.emailPlaceholder}
-                required
-                disabled={isPending}
-                onChange={() => {
-                  setFieldErrors((prev) => ({
-                    ...prev,
-                    email: undefined
-                  }))
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
                 }}
-                onInvalid={(e) => {
-                  e.preventDefault()
-                  const el = e.target as HTMLInputElement
-                  const msg = el.validity.valueMissing
-                    ? localization.auth.fieldRequired
-                    : localization.auth.invalidEmail
-
-                  setFieldErrors((prev) => ({
-                    ...prev,
-                    email: msg
-                  }))
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        aria-invalid={isInvalid}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
                 }}
-                aria-invalid={!!fieldErrors.email}
-              />
+              </form.AppField>
 
-              <FieldError>{fieldErrors.email}</FieldError>
-            </Field>
+              {Captcha && <div className="flex justify-center">{Captcha}</div>}
 
-            {Captcha && <div className="flex justify-center">{Captcha}</div>}
-
-            <div className="flex flex-col gap-3">
-              <Button type="submit" disabled={isPending}>
-                {isPending && <Spinner />}
-
-                {localization.auth.sendResetLink}
-              </Button>
-            </div>
-          </FieldGroup>
-        </form>
+              <div className="flex flex-col gap-3">
+                <form.AuthFormSubmitButton disabled={isPending}>
+                  {isPending && <Spinner />}
+                  {localization.auth.sendResetLink}
+                </form.AuthFormSubmitButton>
+              </div>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/examples/next-shadcn-example/src/components/auth/magic-link.tsx
+++ b/examples/next-shadcn-example/src/components/auth/magic-link.tsx
@@ -1,19 +1,16 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import { authMutationKeys, validateEmailAddress } from "@better-auth-ui/core"
 import type { MagicLinkAuthClient } from "@better-auth-ui/core/plugins/magic-link"
 import { getSsoFallbackEmail } from "@better-auth-ui/core/plugins/sso"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useSignInMagicLink } from "@better-auth-ui/react/plugins/magic-link"
 import { useIsMutating } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -22,6 +19,7 @@ import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { magicLinkPlugin } from "@/lib/auth/magic-link-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
 import { MAGIC_LINK_SENT_STORAGE_KEY } from "./magic-link-sent"
 import { ProviderButtons, type SocialLayout } from "./provider-buttons"
 
@@ -60,8 +58,6 @@ export function MagicLink({
   const { localization: magicLinkLocalization, viewPaths: magicLinkViewPaths } =
     useAuthPlugin(magicLinkPlugin)
 
-  const [email, setEmail] = useState(getSsoFallbackEmail)
-
   const { mutate: signInMagicLink, isPending: signInMagicLinkPending } =
     useSignInMagicLink(authClient, {
       onSuccess: (_data, variables) => {
@@ -80,14 +76,14 @@ export function MagicLink({
   })
   const isPending = signInMutating + signUpMutating > 0
 
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-  }>({})
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    signInMagicLink({ email, callbackURL: `${baseURL}${redirectTo}` })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: getSsoFallbackEmail() },
+    onSubmit: ({ value }) =>
+      signInMagicLink({
+        callbackURL: `${baseURL}${redirectTo}`,
+        email: value.email
+      })
+  })
 
   const showSeparator = socialProviders && socialProviders.length > 0
 
@@ -113,62 +109,65 @@ export function MagicLink({
             </>
           )}
 
-          <form onSubmit={handleSubmit}>
-            <FieldGroup>
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="email">
-                  {localization.auth.email}
-                </FieldLabel>
-
-                <Input
-                  id="email"
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <FieldGroup>
+                <form.AppField
                   name="email"
-                  type="email"
-                  autoComplete="email"
-                  value={email}
-                  onChange={(e) => {
-                    setEmail(e.target.value)
-
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: undefined
-                    }))
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateEmailAddress(value, {
+                        invalidMessage: localization.auth.invalidEmail,
+                        requiredMessage: localization.auth.fieldRequired
+                      })
                   }}
-                  placeholder={localization.auth.emailPlaceholder}
-                  required
-                  disabled={isPending}
-                  onInvalid={(e) => {
-                    e.preventDefault()
-
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: (e.target as HTMLInputElement).validationMessage
-                    }))
+                >
+                  {(field) => {
+                    const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                    return (
+                      <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor="email">
+                          {localization.auth.email}
+                        </FieldLabel>
+                        <Input
+                          id="email"
+                          name={field.name}
+                          type="email"
+                          autoComplete="email"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          placeholder={localization.auth.emailPlaceholder}
+                          required
+                          disabled={isPending}
+                          aria-invalid={isInvalid}
+                        />
+                        <field.AuthFormFieldError />
+                      </Field>
+                    )
                   }}
-                  aria-invalid={!!fieldErrors.email}
-                />
+                </form.AppField>
 
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
+                <div className="flex flex-col gap-3">
+                  <form.AuthFormSubmitButton disabled={isPending}>
+                    {signInMagicLinkPending && <Spinner />}
+                    {magicLinkLocalization.sendMagicLink}
+                  </form.AuthFormSubmitButton>
 
-              <div className="flex flex-col gap-3">
-                <Button type="submit" disabled={isPending}>
-                  {signInMagicLinkPending && <Spinner />}
-
-                  {magicLinkLocalization.sendMagicLink}
-                </Button>
-
-                {plugins.flatMap((plugin) =>
-                  (plugin.authButtons ?? []).map((AuthButton, index) => (
-                    <AuthButton
-                      key={`${plugin.id}-${index.toString()}`}
-                      view="magicLink"
-                    />
-                  ))
-                )}
-              </div>
-            </FieldGroup>
-          </form>
+                  {plugins.flatMap((plugin) =>
+                    (plugin.authButtons ?? []).map((AuthButton, index) => (
+                      <AuthButton
+                        key={`${plugin.id}-${index.toString()}`}
+                        view="magicLink"
+                      />
+                    ))
+                  )}
+                </div>
+              </FieldGroup>
+            </form.AuthFormRoot>
+          </form.AppForm>
 
           {socialPosition === "bottom" && (
             <>

--- a/examples/next-shadcn-example/src/components/auth/organization/delete-organization-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/delete-organization-dialog.tsx
@@ -5,7 +5,6 @@ import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useDeleteOrganization } from "@better-auth-ui/react/plugins/organization"
 import type { Organization } from "better-auth/client"
 import { TriangleAlert } from "lucide-react"
-import type { SyntheticEvent } from "react"
 import { toast } from "sonner"
 
 import {
@@ -18,10 +17,10 @@ import {
   AlertDialogMedia,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
+import { useAuthForm } from "../auth-form"
 import { OrganizationView } from "./organization-view"
 
 export type DeleteOrganizationDialogProps = {
@@ -57,47 +56,52 @@ export function DeleteOrganizationDialog({
     }
   )
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    deleteOrganization({ organizationId: organization.id })
-  }
+  const form = useAuthForm({
+    defaultValues: {},
+    onSubmit: () => deleteOrganization({ organizationId: organization.id })
+  })
 
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <AlertDialogHeader>
-            <AlertDialogMedia className="bg-destructive/10 text-destructive">
-              <TriangleAlert />
-            </AlertDialogMedia>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <AlertDialogHeader>
+              <AlertDialogMedia className="bg-destructive/10 text-destructive">
+                <TriangleAlert />
+              </AlertDialogMedia>
 
-            <AlertDialogTitle>
-              {organizationLocalization.deleteOrganization}
-            </AlertDialogTitle>
+              <AlertDialogTitle>
+                {organizationLocalization.deleteOrganization}
+              </AlertDialogTitle>
 
-            <AlertDialogDescription>
-              {organizationLocalization.deleteOrganizationDescription}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+              <AlertDialogDescription>
+                {organizationLocalization.deleteOrganizationDescription}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
 
-          <Card>
-            <CardContent>
-              <OrganizationView organization={organization} hideRole />
-            </CardContent>
-          </Card>
+            <Card>
+              <CardContent>
+                <OrganizationView organization={organization} hideRole />
+              </CardContent>
+            </Card>
 
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>
-              {localization.settings.cancel}
-            </AlertDialogCancel>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isPending}>
+                {localization.settings.cancel}
+              </AlertDialogCancel>
 
-            <Button type="submit" variant="destructive" disabled={isPending}>
-              {isPending && <Spinner />}
+              <form.AuthFormSubmitButton
+                variant="destructive"
+                disabled={isPending}
+              >
+                {isPending && <Spinner />}
 
-              {organizationLocalization.deleteOrganization}
-            </Button>
-          </AlertDialogFooter>
-        </form>
+                {organizationLocalization.deleteOrganization}
+              </form.AuthFormSubmitButton>
+            </AlertDialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </AlertDialogContent>
     </AlertDialog>
   )

--- a/examples/next-shadcn-example/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -8,8 +8,8 @@ import type {
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useAddPasskey } from "@better-auth-ui/react/plugins/passkey"
 import { Fingerprint } from "lucide-react"
-import { type SyntheticEvent, useRef } from "react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useRef } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -23,6 +23,7 @@ import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
+import { useAuthForm } from "../auth-form"
 import { FreshSessionPrompt } from "../settings/security/fresh-session-prompt"
 
 export type AddPasskeyDialogProps = {
@@ -41,14 +42,6 @@ export function AddPasskeyDialog({
   const addPasskey = useAddPasskey(authClient)
   const pendingRequest = useRef<AddPasskeyParams<PasskeyAuthClient>>(undefined)
 
-  const handleOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen) {
-      addPasskey.reset()
-      pendingRequest.current = undefined
-    }
-    onOpenChange(nextOpen)
-  }
-
   const submitRequest = (request: AddPasskeyParams<PasskeyAuthClient>) => {
     const requestWithCallbacks = {
       ...request,
@@ -61,16 +54,24 @@ export function AddPasskeyDialog({
     addPasskey.mutate(requestWithCallbacks)
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useAuthForm({
+    defaultValues: { name: "" },
+    onSubmit: ({ value }) => {
+      const name = value.name.trim()
+      submitRequest({
+        ...(name ? { name } : {}),
+        ...(authenticatorAttachment ? { authenticatorAttachment } : {})
+      } as AddPasskeyParams<PasskeyAuthClient>)
+    }
+  })
 
-    const formData = new FormData(e.target as HTMLFormElement)
-    const name = (formData.get("name") as string)?.trim()
-
-    submitRequest({
-      ...(name ? { name } : {}),
-      ...(authenticatorAttachment ? { authenticatorAttachment } : {})
-    } as AddPasskeyParams<PasskeyAuthClient>)
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      addPasskey.reset()
+      form.reset()
+      pendingRequest.current = undefined
+    }
+    onOpenChange(nextOpen)
   }
 
   const needsFreshSession = isSessionNotFreshError(addPasskey.error)
@@ -93,55 +94,65 @@ export function AddPasskeyDialog({
             />
           </>
         ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <Fingerprint />
-                {passkeyLocalization.addPasskey}
-              </DialogTitle>
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-6">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <Fingerprint />
+                  {passkeyLocalization.addPasskey}
+                </DialogTitle>
 
-              <DialogDescription>
-                {passkeyLocalization.passkeysDescription}
-              </DialogDescription>
-            </DialogHeader>
+                <DialogDescription>
+                  {passkeyLocalization.passkeysDescription}
+                </DialogDescription>
+              </DialogHeader>
 
-            <Field data-invalid={addPasskey.isError}>
-              <FieldLabel htmlFor="passkey-name">
-                {passkeyLocalization.name}
-              </FieldLabel>
+              <form.AppField name="name">
+                {(field) => (
+                  <Field data-invalid={addPasskey.isError}>
+                    <FieldLabel htmlFor="passkey-name">
+                      {passkeyLocalization.name}
+                    </FieldLabel>
+                    <Input
+                      id="passkey-name"
+                      name={field.name}
+                      autoFocus
+                      placeholder={localization.settings.optional}
+                      disabled={addPasskey.isPending}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      aria-invalid={addPasskey.isError}
+                    />
+                    {addPasskey.error && (
+                      <FieldError>
+                        {addPasskey.error.error?.message ??
+                          addPasskey.error.message}
+                      </FieldError>
+                    )}
+                  </Field>
+                )}
+              </form.AppField>
 
-              <Input
-                id="passkey-name"
-                name="name"
-                autoFocus
-                placeholder={localization.settings.optional}
-                disabled={addPasskey.isPending}
-                aria-invalid={addPasskey.isError}
-              />
+              <DialogFooter>
+                <DialogClose
+                  className={buttonVariants({ variant: "outline" })}
+                  disabled={addPasskey.isPending}
+                  type="button"
+                >
+                  {localization.settings.cancel}
+                </DialogClose>
 
-              {addPasskey.error && (
-                <FieldError>
-                  {addPasskey.error.error?.message ?? addPasskey.error.message}
-                </FieldError>
-              )}
-            </Field>
+                <form.AuthFormSubmitButton disabled={addPasskey.isPending}>
+                  {addPasskey.isPending && <Spinner />}
 
-            <DialogFooter>
-              <DialogClose
-                className={buttonVariants({ variant: "outline" })}
-                disabled={addPasskey.isPending}
-                type="button"
-              >
-                {localization.settings.cancel}
-              </DialogClose>
-
-              <Button type="submit" disabled={addPasskey.isPending}>
-                {addPasskey.isPending && <Spinner />}
-
-                {passkeyLocalization.addPasskey}
-              </Button>
-            </DialogFooter>
-          </form>
+                  {passkeyLocalization.addPasskey}
+                </form.AuthFormSubmitButton>
+              </DialogFooter>
+            </form.AuthFormRoot>
+          </form.AppForm>
         )}
       </DialogContent>
     </Dialog>

--- a/examples/next-shadcn-example/src/components/auth/passkey/rename-passkey-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/passkey/rename-passkey-dialog.tsx
@@ -3,8 +3,8 @@
 import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useUpdatePasskey } from "@better-auth-ui/react/plugins/passkey"
-import { type FormEvent, useEffect, useState } from "react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useEffect } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -17,6 +17,7 @@ import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
+import { useAuthForm } from "../auth-form"
 import type { ListedPasskey } from "./delete-passkey-dialog"
 
 export function RenamePasskeyDialog({
@@ -30,56 +31,61 @@ export function RenamePasskeyDialog({
 }) {
   const { authClient, localization } = useAuth<PasskeyAuthClient>()
   const { localization: labels } = useAuthPlugin(passkeyPlugin)
-  const [name, setName] = useState(passkey.name ?? "")
-
-  useEffect(() => {
-    if (open) setName(passkey.name ?? "")
-  }, [open, passkey.name])
-
   const updatePasskey = useUpdatePasskey(authClient, {
     onSuccess: () => onOpenChange(false)
   })
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const nextName = name.trim()
-    if (nextName) updatePasskey.mutate({ id: passkey.id, name: nextName })
-  }
+  const form = useAuthForm({
+    defaultValues: { name: passkey.name ?? "" },
+    onSubmit: ({ value }) => {
+      const name = value.name.trim()
+      if (name) updatePasskey.mutate({ id: passkey.id, name })
+    }
+  })
+
+  useEffect(() => {
+    if (open) form.reset({ name: passkey.name ?? "" })
+  }, [form, open, passkey.name])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form className="flex flex-col gap-6" onSubmit={submit}>
-          <DialogHeader>
-            <DialogTitle>{labels.renamePasskey}</DialogTitle>
-          </DialogHeader>
-          <Field>
-            <FieldLabel htmlFor={`passkey-name-${passkey.id}`}>
-              {labels.name}
-            </FieldLabel>
-            <Input
-              id={`passkey-name-${passkey.id}`}
-              autoFocus
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              required
-            />
-          </Field>
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-            <Button
-              disabled={!name.trim() || updatePasskey.isPending}
-              type="submit"
-            >
-              {updatePasskey.isPending && <Spinner />}
-              {localization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
-        </form>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle>{labels.renamePasskey}</DialogTitle>
+            </DialogHeader>
+            <form.AppField name="name">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor={`passkey-name-${passkey.id}`}>
+                    {labels.name}
+                  </FieldLabel>
+                  <Input
+                    id={`passkey-name-${passkey.id}`}
+                    name={field.name}
+                    autoFocus
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(event) => field.handleChange(event.target.value)}
+                    required
+                  />
+                </Field>
+              )}
+            </form.AppField>
+            <DialogFooter>
+              <DialogClose
+                className={buttonVariants({ variant: "outline" })}
+                type="button"
+              >
+                {localization.settings.cancel}
+              </DialogClose>
+              <form.AuthFormSubmitButton disabled={updatePasskey.isPending}>
+                {updatePasskey.isPending && <Spinner />}
+                {localization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/next-shadcn-example/src/components/auth/phone-number/change-phone-number.tsx
+++ b/examples/next-shadcn-example/src/components/auth/phone-number/change-phone-number.tsx
@@ -14,7 +14,7 @@ import {
   useSendPhoneNumberOtp,
   useVerifyPhoneNumber
 } from "@better-auth-ui/react/plugins/phone-number"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -24,6 +24,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { InternationalPhoneField } from "./international-phone-field"
 import { RemovePhoneNumberDialog } from "./remove-phone-number-dialog"
@@ -51,20 +52,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
   const { data: session } = useSession(phoneClient)
   const currentPhoneNumber =
     (session?.user as PhoneNumberUser | undefined)?.phoneNumber ?? ""
-  const [phoneNumber, setPhoneNumber] = useState(() =>
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
-  const [fieldError, setFieldError] = useState<string>()
-
-  useEffect(() => {
-    if (session) {
-      setPhoneNumber(
-        createPhoneNumberValue(currentPhoneNumber, defaultCountry, adapter)
-      )
-    }
-  }, [adapter, currentPhoneNumber, defaultCountry, session])
 
   const { mutate: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
     phoneClient,
@@ -73,9 +61,9 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
   const { mutate: verify, isPending: isVerifying } = useVerifyPhoneNumber(
     phoneClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
-        setCode("")
+        form.setFieldValue("code", "")
         setCodeSent(false)
         toast.success(localization.phoneNumberUpdated)
       }
@@ -85,26 +73,43 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
     phoneClient,
     {
       onSuccess: () => {
-        setPhoneNumber(createPhoneNumberValue("", defaultCountry, adapter))
+        form.setFieldValue(
+          "phoneNumber",
+          createPhoneNumberValue("", defaultCountry, adapter)
+        )
         toast.success(localization.phoneNumberRemoved)
       }
     }
   )
   const isPending = isSending || isVerifying || isRemoving
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!phoneNumber.e164) {
-      setFieldError(localization.invalidPhoneNumber)
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter)
+    },
+    onSubmit: ({ value }) => {
+      if (!value.phoneNumber.e164) return
+      if (!codeSent) {
+        sendOtp({ phoneNumber: value.phoneNumber.e164 })
+        return
+      }
+      verify({
+        phoneNumber: value.phoneNumber.e164,
+        code: value.code,
+        updatePhoneNumber: true
+      })
     }
-    if (!codeSent) {
-      sendOtp({ phoneNumber: phoneNumber.e164 })
-      return
-    }
+  })
 
-    verify({ phoneNumber: phoneNumber.e164, code, updatePhoneNumber: true })
-  }
+  useEffect(() => {
+    if (session) {
+      form.setFieldValue(
+        "phoneNumber",
+        createPhoneNumberValue(currentPhoneNumber, defaultCountry, adapter)
+      )
+    }
+  }, [adapter, currentPhoneNumber, defaultCountry, form.setFieldValue, session])
   const removePhoneNumber = () =>
     updateUser({
       phoneNumber: null
@@ -115,94 +120,109 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
       <h2 className="mb-3 text-sm font-semibold">
         {localization.changePhoneNumber}
       </h2>
-      <form onSubmit={handleSubmit}>
-        <Card className={cn(className)}>
-          <CardContent className="flex flex-col gap-6">
-            {codeSent ? (
-              <>
-                <FieldDescription>
-                  {localization.codeSentTo.replace(
-                    "{{phoneNumber}}",
-                    phoneNumber.display
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card className={cn(className)}>
+            <CardContent className="flex flex-col gap-6">
+              {codeSent ? (
+                <>
+                  <FieldDescription>
+                    {localization.codeSentTo.replace(
+                      "{{phoneNumber}}",
+                      form.state.values.phoneNumber.display
+                    )}
+                  </FieldDescription>
+                  <form.AppField name="code">
+                    {(field) => (
+                      <OtpField
+                        autoFocus
+                        disabled={isPending}
+                        label={localization.phoneCode}
+                        length={otpLength}
+                        name="otp"
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                      />
+                    )}
+                  </form.AppField>
+                </>
+              ) : session ? (
+                <form.AppField
+                  name="phoneNumber"
+                  validators={{
+                    onChange: ({ value }) =>
+                      value.e164 ? undefined : localization.invalidPhoneNumber
+                  }}
+                >
+                  {(field) => (
+                    <InternationalPhoneField
+                      adapter={adapter}
+                      countryCodes={countries}
+                      countryLabel={localization.country}
+                      disabled={isPending}
+                      error={field.state.meta.errors[0]?.toString()}
+                      locale={locale}
+                      phoneLabel={localization.phoneNumber}
+                      placeholder={localization.phoneNumberPlaceholder}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                    />
                   )}
-                </FieldDescription>
-                <OtpField
-                  autoFocus
+                </form.AppField>
+              ) : (
+                <Skeleton className="h-14 w-full" />
+              )}
+            </CardContent>
+            <CardFooter className="gap-3">
+              {codeSent && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
                   disabled={isPending}
-                  label={localization.phoneCode}
-                  length={otpLength}
-                  name="otp"
-                  value={code}
-                  onChange={setCode}
-                />
-              </>
-            ) : session ? (
-              <InternationalPhoneField
-                adapter={adapter}
-                countryCodes={countries}
-                countryLabel={localization.country}
-                disabled={isPending}
-                error={fieldError}
-                locale={locale}
-                phoneLabel={localization.phoneNumber}
-                placeholder={localization.phoneNumberPlaceholder}
-                value={phoneNumber}
-                onChange={(value) => {
-                  setPhoneNumber(value)
-                  setFieldError(undefined)
-                }}
-              />
-            ) : (
-              <Skeleton className="h-14 w-full" />
-            )}
-          </CardContent>
-          <CardFooter className="gap-3">
-            {codeSent && (
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                disabled={isPending}
-                onClick={() => {
-                  setCode("")
-                  setCodeSent(false)
-                  setPhoneNumber(
-                    createPhoneNumberValue(
-                      currentPhoneNumber,
-                      defaultCountry,
-                      adapter
+                  onClick={() => {
+                    form.setFieldValue("code", "")
+                    setCodeSent(false)
+                    form.setFieldValue(
+                      "phoneNumber",
+                      createPhoneNumberValue(
+                        currentPhoneNumber,
+                        defaultCountry,
+                        adapter
+                      )
                     )
-                  )
-                }}
+                  }}
+                >
+                  {localization.cancel}
+                </Button>
+              )}
+              <form.AuthFormSubmitButton
+                size="sm"
+                disabled={
+                  isPending ||
+                  !session ||
+                  (codeSent && form.state.values.code.length !== otpLength)
+                }
               >
-                {localization.cancel}
-              </Button>
-            )}
-            <Button
-              type="submit"
-              size="sm"
-              disabled={
-                isPending || !session || (codeSent && code.length !== otpLength)
-              }
-            >
-              {(isSending || isVerifying) && <Spinner />}
-              {codeSent
-                ? localization.verifyCode
-                : localization.updatePhoneNumber}
-            </Button>
-            {!codeSent && currentPhoneNumber && (
-              <RemovePhoneNumberDialog
-                cancelLabel={localization.cancel}
-                description={localization.removePhoneNumberDescription}
-                isPending={isRemoving}
-                label={localization.removePhoneNumber}
-                title={localization.removePhoneNumberTitle}
-                onConfirm={removePhoneNumber}
-              />
-            )}
-          </CardFooter>
-        </Card>
-      </form>
+                {(isSending || isVerifying) && <Spinner />}
+                {codeSent
+                  ? localization.verifyCode
+                  : localization.updatePhoneNumber}
+              </form.AuthFormSubmitButton>
+              {!codeSent && currentPhoneNumber && (
+                <RemovePhoneNumberDialog
+                  cancelLabel={localization.cancel}
+                  description={localization.removePhoneNumberDescription}
+                  isPending={isRemoving}
+                  label={localization.removePhoneNumber}
+                  title={localization.removePhoneNumberTitle}
+                  onConfirm={removePhoneNumber}
+                />
+              )}
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/examples/next-shadcn-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/examples/next-shadcn-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -6,14 +6,13 @@ import {
 } from "@better-auth-ui/core/plugins/phone-number"
 import { useAuth, useAuthPlugin, useFetchOptions } from "@better-auth-ui/react"
 import { useRequestPhoneNumberPasswordReset } from "@better-auth-ui/react/plugins/phone-number"
-import { type SyntheticEvent, useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { FieldDescription, FieldGroup } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { InternationalPhoneField } from "./international-phone-field"
 
 export const PHONE_NUMBER_RESET_STORAGE_KEY =
@@ -38,10 +37,6 @@ export function ForgotPhoneNumberPassword({
     viewPaths: phoneNumberViewPaths
   } = useAuthPlugin(phoneNumberPlugin)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
-  const [phoneNumber, setPhoneNumber] = useState(() =>
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [fieldError, setFieldError] = useState<string>()
   const { mutate: requestReset, isPending } =
     useRequestPhoneNumberPasswordReset(authClient as PhoneNumberAuthClient, {
       onError: () => resetFetchOptions(),
@@ -56,17 +51,15 @@ export function ForgotPhoneNumberPassword({
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!phoneNumber.e164) {
-      setFieldError(phoneLocalization.invalidPhoneNumber)
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter)
+    },
+    onSubmit: ({ value }) => {
+      if (!value.phoneNumber.e164) return
+      requestReset({ phoneNumber: value.phoneNumber.e164, fetchOptions })
     }
-    requestReset({
-      phoneNumber: phoneNumber.e164,
-      fetchOptions
-    })
-  }
+  })
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -76,30 +69,41 @@ export function ForgotPhoneNumberPassword({
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            <InternationalPhoneField
-              adapter={adapter}
-              countryCodes={countries}
-              countryLabel={phoneLocalization.country}
-              disabled={isPending}
-              error={fieldError}
-              locale={locale}
-              phoneLabel={phoneLocalization.phoneNumber}
-              placeholder={phoneLocalization.phoneNumberPlaceholder}
-              value={phoneNumber}
-              onChange={(value) => {
-                setPhoneNumber(value)
-                setFieldError(undefined)
-              }}
-            />
-            {Captcha && <div className="flex justify-center">{Captcha}</div>}
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Spinner />}
-              {phoneLocalization.sendCode}
-            </Button>
-          </FieldGroup>
-        </form>
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              <form.AppField
+                name="phoneNumber"
+                validators={{
+                  onChange: ({ value }) =>
+                    value.e164
+                      ? undefined
+                      : phoneLocalization.invalidPhoneNumber
+                }}
+              >
+                {(field) => (
+                  <InternationalPhoneField
+                    adapter={adapter}
+                    countryCodes={countries}
+                    countryLabel={phoneLocalization.country}
+                    disabled={isPending}
+                    error={field.state.meta.errors[0]?.toString()}
+                    locale={locale}
+                    phoneLabel={phoneLocalization.phoneNumber}
+                    placeholder={phoneLocalization.phoneNumberPlaceholder}
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                  />
+                )}
+              </form.AppField>
+              {Captcha && <div className="flex justify-center">{Captcha}</div>}
+              <form.AuthFormSubmitButton disabled={isPending}>
+                {isPending && <Spinner />}
+                {phoneLocalization.sendCode}
+              </form.AuthFormSubmitButton>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
         <FieldDescription className="mt-4 text-center">
           {localization.auth.rememberYourPassword}{" "}
           <Link

--- a/examples/next-shadcn-example/src/components/auth/phone-number/phone-number.tsx
+++ b/examples/next-shadcn-example/src/components/auth/phone-number/phone-number.tsx
@@ -18,7 +18,7 @@ import {
 } from "@better-auth-ui/react/plugins/phone-number"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -32,7 +32,6 @@ import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -48,6 +47,7 @@ import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { useResendCooldown } from "@/lib/auth/use-resend-cooldown"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
 import { InternationalPhoneField } from "./international-phone-field"
@@ -95,17 +95,8 @@ export function PhoneNumber({
   const [mode, setMode] = useState<PhoneNumberMode>(
     signIn ? "code" : "password"
   )
-  const [phoneNumber, setPhoneNumber] = useState(() =>
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [password, setPassword] = useState("")
-  const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-  const [fieldErrors, setFieldErrors] = useState<{
-    phoneNumber?: string
-    password?: string
-  }>({})
 
   const { mutate: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
     phoneClient,
@@ -120,14 +111,14 @@ export function PhoneNumber({
   const { mutate: verify, isPending: isVerifying } = useVerifyPhoneNumber(
     phoneClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: (data) => continueSignIn(data)
     }
   )
   const { mutate: signInWithPassword, isPending: isPasswordPending } =
     useSignInPhoneNumber(phoneClient, {
       onError: (error) => {
-        setPassword("")
+        form.setFieldValue("password", "")
         resetFetchOptions()
 
         if (signIn && error.error?.code === "PHONE_NUMBER_NOT_VERIFIED") {
@@ -159,15 +150,8 @@ export function PhoneNumber({
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
 
-  const getPhoneNumber = () => {
-    if (phoneNumber.e164) return phoneNumber.e164
-    setFieldErrors((current) => ({
-      ...current,
-      phoneNumber: phoneLocalization.invalidPhoneNumber
-    }))
-  }
   const sendCode = () => {
-    const normalizedPhoneNumber = getPhoneNumber()
+    const normalizedPhoneNumber = form.state.values.phoneNumber.e164
     if (!normalizedPhoneNumber) return
     sendOtp({
       phoneNumber: normalizedPhoneNumber,
@@ -177,41 +161,49 @@ export function PhoneNumber({
   const verifyCode = (completedCode: string) => {
     if (isPending || completedCode.length !== otpLength) return
 
-    if (!phoneNumber.e164) return
-    verify({ phoneNumber: phoneNumber.e164, code: completedCode })
+    if (!form.state.values.phoneNumber.e164) return
+    verify({
+      phoneNumber: form.state.values.phoneNumber.e164,
+      code: completedCode
+    })
   }
   const switchMode = () => {
     setMode((current) => (current === "code" ? "password" : "code"))
-    setCode("")
+    form.setFieldValue("code", "")
     setCodeSent(false)
-    setPassword("")
+    form.setFieldValue("password", "")
   }
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      password: "",
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter),
+      rememberMe: false
+    },
+    onSubmit: ({ value }) => {
+      if (mode === "password") {
+        const normalizedPhoneNumber = value.phoneNumber.e164
+        if (!normalizedPhoneNumber) return
+        signInWithPassword({
+          phoneNumber: normalizedPhoneNumber,
+          password: value.password,
+          ...(emailAndPassword?.rememberMe
+            ? { rememberMe: value.rememberMe }
+            : {}),
+          fetchOptions
+        })
+        return
+      }
 
-    if (mode === "password") {
-      const normalizedPhoneNumber = getPhoneNumber()
-      if (!normalizedPhoneNumber) return
-      const formData = new FormData(event.currentTarget)
-      signInWithPassword({
-        phoneNumber: normalizedPhoneNumber,
-        password,
-        ...(emailAndPassword?.rememberMe
-          ? { rememberMe: formData.get("rememberMe") === "on" }
-          : {}),
-        fetchOptions
-      })
-      return
+      if (!codeSent) {
+        sendCode()
+        return
+      }
+
+      verifyCode(value.code)
     }
-
-    if (!codeSent) {
-      sendCode()
-      return
-    }
-
-    verifyCode(code)
-  }
+  })
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -225,7 +217,7 @@ export function PhoneNumber({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              phoneNumber.display
+              form.state.values.phoneNumber.display
             )}
           </CardDescription>
         )}
@@ -244,192 +236,207 @@ export function PhoneNumber({
             </>
           )}
 
-          <form onSubmit={handleSubmit}>
-            <FieldGroup>
-              {codeSent ? (
-                <OtpField
-                  autoFocus
-                  disabled={isPending}
-                  label={phoneLocalization.phoneCode}
-                  length={otpLength}
-                  name="otp"
-                  value={code}
-                  onChange={setCode}
-                  onComplete={verifyCode}
-                />
-              ) : (
-                <>
-                  <InternationalPhoneField
-                    adapter={adapter}
-                    countryCodes={countries}
-                    countryLabel={phoneLocalization.country}
-                    disabled={isPending}
-                    error={fieldErrors.phoneNumber}
-                    locale={locale}
-                    phoneLabel={phoneLocalization.phoneNumber}
-                    placeholder={phoneLocalization.phoneNumberPlaceholder}
-                    value={phoneNumber}
-                    onChange={(value) => {
-                      setPhoneNumber(value)
-                      setFieldErrors((current) => ({
-                        ...current,
-                        phoneNumber: undefined
-                      }))
-                    }}
-                  />
-
-                  {mode === "password" && (
-                    <Field data-invalid={Boolean(fieldErrors.password)}>
-                      <FieldLabel htmlFor="phoneNumberPassword">
-                        {localization.auth.password}
-                      </FieldLabel>
-                      <InputGroup>
-                        <InputGroupInput
-                          id="phoneNumberPassword"
-                          name="password"
-                          type={isPasswordVisible ? "text" : "password"}
-                          autoComplete="current-password"
-                          value={password}
-                          placeholder={localization.auth.passwordPlaceholder}
-                          required
-                          minLength={emailAndPassword?.minPasswordLength}
-                          maxLength={emailAndPassword?.maxPasswordLength}
-                          disabled={isPending}
-                          onChange={(event) => {
-                            setPassword(event.target.value)
-                            setFieldErrors((current) => ({
-                              ...current,
-                              password: undefined
-                            }))
-                          }}
-                          onInvalid={(event) => {
-                            event.preventDefault()
-                            setFieldErrors((current) => ({
-                              ...current,
-                              password: event.currentTarget.validationMessage
-                            }))
-                          }}
-                          aria-invalid={Boolean(fieldErrors.password)}
-                        />
-                        <InputGroupAddon align="inline-end">
-                          <InputGroupButton
-                            type="button"
-                            size="icon-xs"
-                            aria-label={
-                              isPasswordVisible
-                                ? localization.auth.hidePassword
-                                : localization.auth.showPassword
-                            }
-                            title={
-                              isPasswordVisible
-                                ? localization.auth.hidePassword
-                                : localization.auth.showPassword
-                            }
-                            onClick={() =>
-                              setIsPasswordVisible((visible) => !visible)
-                            }
-                          >
-                            {isPasswordVisible ? <EyeOff /> : <Eye />}
-                          </InputGroupButton>
-                        </InputGroupAddon>
-                      </InputGroup>
-                      <FieldError>{fieldErrors.password}</FieldError>
-                    </Field>
-                  )}
-
-                  {mode === "password" && emailAndPassword?.rememberMe && (
-                    <Field orientation="horizontal">
-                      <Checkbox
-                        id="phoneNumberRememberMe"
-                        name="rememberMe"
-                        disabled={isPending}
-                      />
-                      <FieldLabel
-                        htmlFor="phoneNumberRememberMe"
-                        className="cursor-pointer font-normal"
-                      >
-                        {localization.auth.rememberMe}
-                      </FieldLabel>
-                    </Field>
-                  )}
-
-                  {Captcha && (
-                    <div className="flex justify-center">{Captcha}</div>
-                  )}
-                </>
-              )}
-
-              <div className="flex flex-col gap-3">
-                <Button
-                  type="submit"
-                  disabled={
-                    isPending || (codeSent && code.length !== otpLength)
-                  }
-                >
-                  {(isSending || isVerifying || isPasswordPending) && (
-                    <Spinner />
-                  )}
-                  {mode === "password"
-                    ? localization.auth.signIn
-                    : codeSent
-                      ? phoneLocalization.verifyCode
-                      : phoneLocalization.sendCode}
-                </Button>
-
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <FieldGroup>
                 {codeSent ? (
-                  <>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      disabled={isPending || isCoolingDown}
-                      onClick={sendCode}
-                    >
-                      {isCoolingDown
-                        ? localization.auth.resendIn.replace(
-                            "{{seconds}}",
-                            String(cooldown)
-                          )
-                        : localization.auth.resend}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      disabled={isPending}
-                      onClick={() => {
-                        setCode("")
-                        setCodeSent(false)
-                      }}
-                    >
-                      {phoneLocalization.useDifferentPhoneNumber}
-                    </Button>
-                  </>
+                  <form.AppField name="code">
+                    {(field) => (
+                      <OtpField
+                        autoFocus
+                        disabled={isPending}
+                        label={phoneLocalization.phoneCode}
+                        length={otpLength}
+                        name="otp"
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        onComplete={verifyCode}
+                      />
+                    )}
+                  </form.AppField>
                 ) : (
                   <>
-                    {canSwitchMode && (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        disabled={isPending}
-                        onClick={switchMode}
-                      >
-                        {mode === "code"
-                          ? phoneLocalization.usePassword
-                          : phoneLocalization.useVerificationCode}
-                      </Button>
-                    )}
-                    {plugins.flatMap((plugin) =>
-                      (plugin.authButtons ?? []).map((AuthButton) => (
-                        <AuthButton
-                          key={`${plugin.id}-${AuthButton.displayName ?? AuthButton.name}`}
-                          view="phoneNumber"
+                    <form.AppField
+                      name="phoneNumber"
+                      validators={{
+                        onChange: ({ value }) =>
+                          value.e164
+                            ? undefined
+                            : phoneLocalization.invalidPhoneNumber
+                      }}
+                    >
+                      {(field) => (
+                        <InternationalPhoneField
+                          adapter={adapter}
+                          countryCodes={countries}
+                          countryLabel={phoneLocalization.country}
+                          disabled={isPending}
+                          error={field.state.meta.errors[0]?.toString()}
+                          locale={locale}
+                          phoneLabel={phoneLocalization.phoneNumber}
+                          placeholder={phoneLocalization.phoneNumberPlaceholder}
+                          value={field.state.value}
+                          onChange={field.handleChange}
                         />
-                      ))
+                      )}
+                    </form.AppField>
+
+                    {mode === "password" && (
+                      <form.AppField name="password">
+                        {(field) => (
+                          <Field>
+                            <FieldLabel htmlFor="phoneNumberPassword">
+                              {localization.auth.password}
+                            </FieldLabel>
+                            <InputGroup>
+                              <InputGroupInput
+                                id="phoneNumberPassword"
+                                name={field.name}
+                                type={isPasswordVisible ? "text" : "password"}
+                                autoComplete="current-password"
+                                value={field.state.value}
+                                placeholder={
+                                  localization.auth.passwordPlaceholder
+                                }
+                                required
+                                minLength={emailAndPassword?.minPasswordLength}
+                                maxLength={emailAndPassword?.maxPasswordLength}
+                                disabled={isPending}
+                                onBlur={field.handleBlur}
+                                onChange={(event) =>
+                                  field.handleChange(event.target.value)
+                                }
+                              />
+                              <InputGroupAddon align="inline-end">
+                                <InputGroupButton
+                                  type="button"
+                                  size="icon-xs"
+                                  aria-label={
+                                    isPasswordVisible
+                                      ? localization.auth.hidePassword
+                                      : localization.auth.showPassword
+                                  }
+                                  title={
+                                    isPasswordVisible
+                                      ? localization.auth.hidePassword
+                                      : localization.auth.showPassword
+                                  }
+                                  onClick={() =>
+                                    setIsPasswordVisible((visible) => !visible)
+                                  }
+                                >
+                                  {isPasswordVisible ? <EyeOff /> : <Eye />}
+                                </InputGroupButton>
+                              </InputGroupAddon>
+                            </InputGroup>
+                            <field.AuthFormFieldError />
+                          </Field>
+                        )}
+                      </form.AppField>
+                    )}
+
+                    {mode === "password" && emailAndPassword?.rememberMe && (
+                      <form.AppField name="rememberMe">
+                        {(field) => (
+                          <Field orientation="horizontal">
+                            <Checkbox
+                              id="phoneNumberRememberMe"
+                              name={field.name}
+                              disabled={isPending}
+                              checked={field.state.value}
+                              onCheckedChange={(checked) =>
+                                field.handleChange(checked === true)
+                              }
+                            />
+                            <FieldLabel
+                              htmlFor="phoneNumberRememberMe"
+                              className="cursor-pointer font-normal"
+                            >
+                              {localization.auth.rememberMe}
+                            </FieldLabel>
+                          </Field>
+                        )}
+                      </form.AppField>
+                    )}
+
+                    {Captcha && (
+                      <div className="flex justify-center">{Captcha}</div>
                     )}
                   </>
                 )}
-              </div>
-            </FieldGroup>
-          </form>
+
+                <div className="flex flex-col gap-3">
+                  <form.AuthFormSubmitButton
+                    disabled={
+                      isPending ||
+                      (codeSent && form.state.values.code.length !== otpLength)
+                    }
+                  >
+                    {(isSending || isVerifying || isPasswordPending) && (
+                      <Spinner />
+                    )}
+                    {mode === "password"
+                      ? localization.auth.signIn
+                      : codeSent
+                        ? phoneLocalization.verifyCode
+                        : phoneLocalization.sendCode}
+                  </form.AuthFormSubmitButton>
+
+                  {codeSent ? (
+                    <>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isPending || isCoolingDown}
+                        onClick={sendCode}
+                      >
+                        {isCoolingDown
+                          ? localization.auth.resendIn.replace(
+                              "{{seconds}}",
+                              String(cooldown)
+                            )
+                          : localization.auth.resend}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        disabled={isPending}
+                        onClick={() => {
+                          form.setFieldValue("code", "")
+                          setCodeSent(false)
+                        }}
+                      >
+                        {phoneLocalization.useDifferentPhoneNumber}
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      {canSwitchMode && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          disabled={isPending}
+                          onClick={switchMode}
+                        >
+                          {mode === "code"
+                            ? phoneLocalization.usePassword
+                            : phoneLocalization.useVerificationCode}
+                        </Button>
+                      )}
+                      {plugins.flatMap((plugin) =>
+                        (plugin.authButtons ?? []).map((AuthButton) => (
+                          <AuthButton
+                            key={`${plugin.id}-${AuthButton.displayName ?? AuthButton.name}`}
+                            view="phoneNumber"
+                          />
+                        ))
+                      )}
+                    </>
+                  )}
+                </div>
+              </FieldGroup>
+            </form.AuthFormRoot>
+          </form.AppForm>
 
           {socialPosition === "bottom" && showProviders && (
             <>

--- a/examples/next-shadcn-example/src/components/auth/phone-number/reset-phone-number-password.tsx
+++ b/examples/next-shadcn-example/src/components/auth/phone-number/reset-phone-number-password.tsx
@@ -5,10 +5,9 @@ import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-n
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPhoneNumberPassword } from "@better-auth-ui/react/plugins/phone-number"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -32,6 +31,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { PasswordStrengthMeter } from "../password-strength-meter"
 import { useIsHydrated } from "../use-is-hydrated"
@@ -55,23 +55,11 @@ export function ResetPhoneNumberPassword({
   const isHydrated = useIsHydrated()
   const initialPhoneNumber =
     (isHydrated && sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY)) || ""
-  const [phoneNumber, setPhoneNumber] = useState(initialPhoneNumber)
   const [hasStoredPhoneNumber, setHasStoredPhoneNumber] = useState(
     Boolean(initialPhoneNumber)
   )
-  const [code, setCode] = useState("")
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-  const [fieldErrors, setFieldErrors] = useState<{
-    phoneNumber?: string
-    password?: string
-  }>({})
-
-  useEffect(() => {
-    const stored = sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY) ?? ""
-    setPhoneNumber(stored)
-    setHasStoredPhoneNumber(Boolean(stored))
-  }, [])
+  const [passwordError, setPasswordError] = useState("")
 
   const { mutate: resetPassword, isPending } = useResetPhoneNumberPassword(
     authClient as PhoneNumberAuthClient,
@@ -80,13 +68,10 @@ export function ResetPhoneNumberPassword({
         // The haveIBeenPwned plugin rejects on the password itself, so it
         // belongs against the field rather than in a toast.
         if (isPasswordCompromisedError(error)) {
-          setFieldErrors((prev) => ({
-            ...prev,
-            password: localization.auth.passwordCompromised
-          }))
+          setPasswordError(localization.auth.passwordCompromised)
         }
 
-        setCode("")
+        form.setFieldValue("code", "")
       },
       onSuccess: () => {
         sessionStorage.removeItem(PHONE_NUMBER_RESET_STORAGE_KEY)
@@ -98,31 +83,44 @@ export function ResetPhoneNumberPassword({
     }
   )
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    const confirmPassword = String(formData.get("confirmPassword") ?? "")
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      toast.error(localization.auth.passwordsDoNotMatch)
-      return
-    }
-    if (code.length !== otpLength) {
-      toast.error(
-        phoneLocalization.codeLengthMismatch.replace(
-          "{{length}}",
-          String(otpLength)
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      confirmPassword: "",
+      password: "",
+      phoneNumber: initialPhoneNumber
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
+        toast.error(localization.auth.passwordsDoNotMatch)
+        return
+      }
+      if (value.code.length !== otpLength) {
+        toast.error(
+          phoneLocalization.codeLengthMismatch.replace(
+            "{{length}}",
+            String(otpLength)
+          )
         )
-      )
-      return
-    }
+        return
+      }
 
-    resetPassword({
-      phoneNumber,
-      otp: code,
-      newPassword: password
-    })
-  }
+      resetPassword({
+        phoneNumber: value.phoneNumber,
+        otp: value.code,
+        newPassword: value.password
+      })
+    }
+  })
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY) ?? ""
+    form.setFieldValue("phoneNumber", stored)
+    setHasStoredPhoneNumber(Boolean(stored))
+  }, [form.setFieldValue])
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -134,139 +132,146 @@ export function ResetPhoneNumberPassword({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              phoneNumber
+              form.state.values.phoneNumber
             )}
           </CardDescription>
         )}
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            {!hasStoredPhoneNumber && (
-              <Field data-invalid={Boolean(fieldErrors.phoneNumber)}>
-                <FieldLabel htmlFor="passwordResetPhoneNumber">
-                  {phoneLocalization.phoneNumber}
-                </FieldLabel>
-                <Input
-                  id="passwordResetPhoneNumber"
-                  name="phoneNumber"
-                  type="tel"
-                  autoComplete="tel"
-                  inputMode="tel"
-                  value={phoneNumber}
-                  placeholder={phoneLocalization.phoneNumberPlaceholder}
-                  required
-                  disabled={isPending}
-                  onChange={(event) => {
-                    setPhoneNumber(event.target.value)
-                    setFieldErrors((current) => ({
-                      ...current,
-                      phoneNumber: undefined
-                    }))
-                  }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    setFieldErrors((current) => ({
-                      ...current,
-                      phoneNumber: event.currentTarget.validationMessage
-                    }))
-                  }}
-                  aria-invalid={Boolean(fieldErrors.phoneNumber)}
-                />
-                <FieldError>{fieldErrors.phoneNumber}</FieldError>
-              </Field>
-            )}
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              {!hasStoredPhoneNumber && (
+                <form.AppField name="phoneNumber">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="passwordResetPhoneNumber">
+                        {phoneLocalization.phoneNumber}
+                      </FieldLabel>
+                      <Input
+                        id="passwordResetPhoneNumber"
+                        name={field.name}
+                        type="tel"
+                        autoComplete="tel"
+                        inputMode="tel"
+                        value={field.state.value}
+                        placeholder={phoneLocalization.phoneNumberPlaceholder}
+                        required
+                        disabled={isPending}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-            <OtpField
-              autoFocus={hasStoredPhoneNumber}
-              disabled={isPending}
-              label={phoneLocalization.phoneCode}
-              length={otpLength}
-              name="otp"
-              value={code}
-              onChange={setCode}
-            />
+              <form.AppField name="code">
+                {(field) => (
+                  <OtpField
+                    autoFocus={hasStoredPhoneNumber}
+                    disabled={isPending}
+                    label={phoneLocalization.phoneCode}
+                    length={otpLength}
+                    name="otp"
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                  />
+                )}
+              </form.AppField>
 
-            <Field data-invalid={Boolean(fieldErrors.password)}>
-              <FieldLabel htmlFor="phoneNumberNewPassword">
-                {localization.auth.newPassword}
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupInput
-                  id="phoneNumberNewPassword"
-                  name="password"
-                  type={isPasswordVisible ? "text" : "password"}
-                  autoComplete="new-password"
-                  value={password}
-                  placeholder={localization.auth.newPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                  onChange={(event) => {
-                    setPassword(event.target.value)
-                    setFieldErrors((current) => ({
-                      ...current,
-                      password: undefined
-                    }))
-                  }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    setFieldErrors((current) => ({
-                      ...current,
-                      password: event.currentTarget.validationMessage
-                    }))
-                  }}
-                  aria-invalid={Boolean(fieldErrors.password)}
-                />
-                <InputGroupAddon align="inline-end">
-                  <InputGroupButton
-                    type="button"
-                    size="icon-xs"
-                    aria-label={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    onClick={() => setIsPasswordVisible((visible) => !visible)}
-                  >
-                    {isPasswordVisible ? <EyeOff /> : <Eye />}
-                  </InputGroupButton>
-                </InputGroupAddon>
-              </InputGroup>
-              <FieldError>{fieldErrors.password}</FieldError>
+              <form.AppField name="password">
+                {(field) => (
+                  <Field data-invalid={Boolean(passwordError)}>
+                    <FieldLabel htmlFor="phoneNumberNewPassword">
+                      {localization.auth.newPassword}
+                    </FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        id="phoneNumberNewPassword"
+                        name={field.name}
+                        type={isPasswordVisible ? "text" : "password"}
+                        autoComplete="new-password"
+                        value={field.state.value}
+                        placeholder={localization.auth.newPasswordPlaceholder}
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        onChange={(event) => {
+                          setPasswordError("")
+                          field.handleChange(event.target.value)
+                        }}
+                        aria-invalid={Boolean(passwordError)}
+                      />
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          type="button"
+                          size="icon-xs"
+                          aria-label={
+                            isPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() =>
+                            setIsPasswordVisible((visible) => !visible)
+                          }
+                        >
+                          {isPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                    {passwordError && <FieldError>{passwordError}</FieldError>}
 
-              <PasswordStrengthMeter password={password} />
-            </Field>
+                    <PasswordStrengthMeter password={field.state.value} />
+                  </Field>
+                )}
+              </form.AppField>
 
-            {emailAndPassword?.confirmPassword && (
-              <Field>
-                <FieldLabel htmlFor="phoneNumberConfirmPassword">
-                  {localization.auth.confirmPassword}
-                </FieldLabel>
-                <Input
-                  id="phoneNumberConfirmPassword"
-                  name="confirmPassword"
-                  type="password"
-                  autoComplete="new-password"
-                  placeholder={localization.auth.confirmPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                />
-              </Field>
-            )}
+              {emailAndPassword?.confirmPassword && (
+                <form.AppField name="confirmPassword">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="phoneNumberConfirmPassword">
+                        {localization.auth.confirmPassword}
+                      </FieldLabel>
+                      <Input
+                        id="phoneNumberConfirmPassword"
+                        name={field.name}
+                        type="password"
+                        autoComplete="new-password"
+                        placeholder={
+                          localization.auth.confirmPasswordPlaceholder
+                        }
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-            <Button
-              type="submit"
-              disabled={isPending || code.length !== otpLength}
-            >
-              {isPending && <Spinner />}
-              {phoneLocalization.resetPassword}
-            </Button>
-          </FieldGroup>
-        </form>
+              <form.AuthFormSubmitButton
+                disabled={
+                  isPending || form.state.values.code.length !== otpLength
+                }
+              >
+                {isPending && <Spinner />}
+                {phoneLocalization.resetPassword}
+              </form.AuthFormSubmitButton>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
     </Card>
   )

--- a/examples/next-shadcn-example/src/components/auth/settings/account/change-email.tsx
+++ b/examples/next-shadcn-example/src/components/auth/settings/account/change-email.tsx
@@ -1,17 +1,17 @@
 "use client"
 
-import { getViewURL } from "@better-auth-ui/core"
+import { getViewURL, validateEmailAddress } from "@better-auth-ui/core"
 import { useAuth, useChangeEmail, useSession } from "@better-auth-ui/react"
-import { type SyntheticEvent, useState } from "react"
+import { useEffect } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../../auth-form"
 
 export type ChangeEmailProps = {
   className?: string
@@ -34,23 +34,22 @@ export function ChangeEmail({ className }: ChangeEmailProps) {
     onSuccess: () => toast.success(localization.settings.changeEmailSuccess)
   })
 
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-  }>({})
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) =>
+      changeEmail({
+        callbackURL: getViewURL(
+          baseURL,
+          basePaths.settings,
+          viewPaths.settings.account
+        ),
+        newEmail: value.email
+      })
+  })
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    changeEmail({
-      newEmail: formData.get("email") as string,
-      callbackURL: getViewURL(
-        baseURL,
-        basePaths.settings,
-        viewPaths.settings.account
-      )
-    })
-  }
+  useEffect(() => {
+    if (session) form.reset({ email: session.user.email })
+  }, [form, session])
 
   return (
     <div>
@@ -58,57 +57,68 @@ export function ChangeEmail({ className }: ChangeEmailProps) {
         {localization.settings.changeEmail}
       </h2>
 
-      <form onSubmit={handleSubmit}>
-        <Card className={cn(className)}>
-          <CardContent className="flex flex-col gap-6">
-            <Field data-invalid={!!fieldErrors.email}>
-              <FieldLabel htmlFor="email">{localization.auth.email}</FieldLabel>
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card className={cn(className)}>
+            <CardContent className="flex flex-col gap-6">
+              <form.AppField
+                name="email"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
+                }}
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
+                      {session ? (
+                        <Input
+                          id="email"
+                          name={field.name}
+                          type="email"
+                          autoComplete="email"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          placeholder={localization.auth.emailPlaceholder}
+                          disabled={isPending}
+                          required
+                          aria-invalid={isInvalid}
+                        />
+                      ) : (
+                        <Skeleton>
+                          <Input className="invisible" />
+                        </Skeleton>
+                      )}
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+            </CardContent>
 
-              {session ? (
-                <Input
-                  key={session?.user.email}
-                  id="email"
-                  name="email"
-                  type="email"
-                  autoComplete="email"
-                  defaultValue={session?.user.email}
-                  placeholder={localization.auth.emailPlaceholder}
-                  disabled={isPending}
-                  required
-                  onChange={() => {
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: undefined
-                    }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: (e.target as HTMLInputElement).validationMessage
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.email}
-                />
-              ) : (
-                <Skeleton>
-                  <Input className="invisible" />
-                </Skeleton>
-              )}
+            <CardFooter>
+              <form.AuthFormSubmitButton
+                size="sm"
+                disabled={isPending || !session}
+              >
+                {isPending && <Spinner />}
 
-              <FieldError>{fieldErrors.email}</FieldError>
-            </Field>
-          </CardContent>
-
-          <CardFooter>
-            <Button type="submit" size="sm" disabled={isPending || !session}>
-              {isPending && <Spinner />}
-
-              {localization.settings.updateEmail}
-            </Button>
-          </CardFooter>
-        </Card>
-      </form>
+                {localization.settings.updateEmail}
+              </form.AuthFormSubmitButton>
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/examples/next-shadcn-example/src/components/auth/settings/security/fresh-session-prompt.tsx
+++ b/examples/next-shadcn-example/src/components/auth/settings/security/fresh-session-prompt.tsx
@@ -2,7 +2,6 @@
 
 import { isTwoFactorRedirect } from "@better-auth-ui/core/plugins/two-factor"
 import { useAuth, useSession, useSignInEmail } from "@better-auth-ui/react"
-import { type FormEvent, useState } from "react"
 import { Button } from "@/components/ui/button"
 import {
   Field,
@@ -14,6 +13,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
+import { useAuthForm } from "../../auth-form"
 
 export interface FreshSessionPromptProps {
   onFresh: () => unknown | Promise<unknown>
@@ -23,26 +23,25 @@ export function FreshSessionPrompt({ onFresh }: FreshSessionPromptProps) {
   const auth = useAuth()
   const session = useSession(auth.authClient)
   const continueSignIn = useSignInContinuation()
-  const [password, setPassword] = useState("")
   const signIn = useSignInEmail(auth.authClient, {
     meta: { errorPresentation: "inline" },
-    onError: () => setPassword(""),
+    onError: () => form.reset(),
     onSuccess: async (data) => {
       if (isTwoFactorRedirect(data)) {
         continueSignIn(data)
         return
       }
-      setPassword("")
+      form.reset()
       await onFresh()
     }
   })
-
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const email = session.data?.user.email
-    if (!email) return
-    signIn.mutate({ email, password })
-  }
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) => {
+      const email = session.data?.user.email
+      if (email) signIn.mutate({ email, password: value.password })
+    }
+  })
 
   return (
     <div className="p-4">
@@ -56,31 +55,41 @@ export function FreshSessionPrompt({ onFresh }: FreshSessionPromptProps) {
           </FieldDescription>
         </div>
         {auth.emailAndPassword?.enabled ? (
-          <form className="flex flex-col gap-3" onSubmit={submit}>
-            <Field data-invalid={signIn.isError}>
-              <FieldLabel htmlFor="fresh-session-password">
-                {auth.localization.auth.password}
-              </FieldLabel>
-              <Input
-                id="fresh-session-password"
-                autoComplete="current-password"
-                disabled={signIn.isPending}
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                type="password"
-                required
-              />
-              {signIn.error && (
-                <FieldError>
-                  {signIn.error.error?.message ?? signIn.error.message}
-                </FieldError>
-              )}
-            </Field>
-            <Button disabled={!password || signIn.isPending} type="submit">
-              {signIn.isPending && <Spinner />}
-              {auth.localization.settings.freshSessionSubmit}
-            </Button>
-          </form>
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-3">
+              <form.AppField name="password">
+                {(field) => (
+                  <Field data-invalid={signIn.isError}>
+                    <FieldLabel htmlFor="fresh-session-password">
+                      {auth.localization.auth.password}
+                    </FieldLabel>
+                    <Input
+                      id="fresh-session-password"
+                      autoComplete="current-password"
+                      disabled={signIn.isPending}
+                      name={field.name}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      type="password"
+                      required
+                    />
+                    {signIn.error && (
+                      <FieldError>
+                        {signIn.error.error?.message ?? signIn.error.message}
+                      </FieldError>
+                    )}
+                  </Field>
+                )}
+              </form.AppField>
+              <form.AuthFormSubmitButton disabled={signIn.isPending}>
+                {signIn.isPending && <Spinner />}
+                {auth.localization.settings.freshSessionSubmit}
+              </form.AuthFormSubmitButton>
+            </form.AuthFormRoot>
+          </form.AppForm>
         ) : (
           <Button
             onClick={() =>

--- a/examples/next-shadcn-example/src/components/auth/sign-in.tsx
+++ b/examples/next-shadcn-example/src/components/auth/sign-in.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import {
+  authMutationKeys,
+  validateEmailAddress,
+  validateStringLength
+} from "@better-auth-ui/core"
 import {
   isPasskeyAutoFillEnabled,
   withPasskeyAutoFill
@@ -13,15 +17,13 @@ import {
 } from "@better-auth-ui/react"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -36,6 +38,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
 import { LastUsedBadge } from "./last-login-method/last-used-badge"
 import { ProviderButtons, type SocialLayout } from "./provider-buttons"
 
@@ -73,13 +76,11 @@ export function SignIn({
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
   const continueSignIn = useSignInContinuation()
 
-  const [password, setPassword] = useState("")
-
   const { mutate: signInEmail, isPending: signInEmailPending } = useSignInEmail(
     authClient,
     {
       onError: (error, { email }) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
           sessionStorage.setItem("better-auth-ui.verify-email", email)
@@ -109,26 +110,18 @@ export function SignIn({
   const passkeyAutoFill = isPasskeyAutoFillEnabled(plugins)
 
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-    password?: string
-  }>({})
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const email = formData.get("email") as string
-    const rememberMe = formData.get("rememberMe") === "on"
-
-    signInEmail({
-      email,
-      password,
-      ...(emailAndPassword?.rememberMe ? { rememberMe } : {}),
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "", password: "", rememberMe: false },
+    onSubmit: ({ value }) =>
+      signInEmail({
+        email: value.email,
+        password: value.password,
+        ...(emailAndPassword?.rememberMe
+          ? { rememberMe: value.rememberMe }
+          : {}),
+        fetchOptions
+      })
+  })
 
   const showSeparator =
     emailAndPassword?.enabled && socialProviders && socialProviders.length > 0
@@ -159,170 +152,185 @@ export function SignIn({
           )}
 
           {emailAndPassword?.enabled && (
-            <form onSubmit={handleSubmit}>
-              <FieldGroup>
-                <Field data-invalid={!!fieldErrors.email}>
-                  <FieldLabel htmlFor="email">
-                    {localization.auth.email}
-                  </FieldLabel>
-
-                  <Input
-                    id="email"
+            <form.AppForm>
+              <form.AuthFormRoot>
+                <FieldGroup>
+                  <form.AppField
                     name="email"
-                    type="email"
-                    autoComplete={withPasskeyAutoFill("email", passkeyAutoFill)}
-                    placeholder={localization.auth.emailPlaceholder}
-                    required
-                    disabled={isPending}
-                    onChange={() => {
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: undefined
-                      }))
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateEmailAddress(value, {
+                          invalidMessage: localization.auth.invalidEmail,
+                          requiredMessage: localization.auth.fieldRequired
+                        })
                     }}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-                      const el = e.target as HTMLInputElement
-                      const msg = el.validity.valueMissing
-                        ? localization.auth.fieldRequired
-                        : localization.auth.invalidEmail
-
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: msg
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
-
-                  <FieldError>{fieldErrors.email}</FieldError>
-                </Field>
-
-                <Field data-invalid={!!fieldErrors.password}>
-                  <FieldLabel htmlFor="password">
-                    {localization.auth.password}
-                  </FieldLabel>
-
-                  <InputGroup>
-                    <InputGroupInput
-                      id="password"
-                      name="password"
-                      type={isPasswordVisible ? "text" : "password"}
-                      autoComplete={withPasskeyAutoFill(
-                        "current-password",
-                        passkeyAutoFill
-                      )}
-                      value={password}
-                      onChange={(e) => {
-                        setPassword(e.target.value)
-
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: undefined
-                        }))
-                      }}
-                      placeholder={localization.auth.passwordPlaceholder}
-                      required
-                      minLength={emailAndPassword?.minPasswordLength}
-                      maxLength={emailAndPassword?.maxPasswordLength}
-                      disabled={isPending}
-                      onInvalid={(e) => {
-                        e.preventDefault()
-                        const el = e.target as HTMLInputElement
-                        const min = emailAndPassword?.minPasswordLength
-                        const max = emailAndPassword?.maxPasswordLength
-                        const msg = el.validity.valueMissing
-                          ? localization.auth.fieldRequired
-                          : el.validity.tooShort
-                            ? localization.auth.tooShort.replace(
-                                "{{min}}",
-                                String(min)
-                              )
-                            : localization.auth.tooLong.replace(
-                                "{{max}}",
-                                String(max)
-                              )
-
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: msg
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.password}
-                    />
-
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        title={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() => {
-                          setIsPasswordVisible((visible) => !visible)
-                        }}
-                      >
-                        {isPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-
-                  <FieldError>{fieldErrors.password}</FieldError>
-                </Field>
-
-                {emailAndPassword.rememberMe && (
-                  <Field className="my-1">
-                    <div className="flex items-center gap-3">
-                      <Checkbox
-                        id="rememberMe"
-                        name="rememberMe"
-                        disabled={isPending}
-                      />
-
-                      <FieldLabel
-                        htmlFor="rememberMe"
-                        className="cursor-pointer text-sm font-normal"
-                      >
-                        {localization.auth.rememberMe}
-                      </FieldLabel>
-                    </div>
-                  </Field>
-                )}
-
-                {Captcha && (
-                  <div className="flex justify-center">{Captcha}</div>
-                )}
-
-                <div className="flex flex-col gap-3">
-                  <Button
-                    type="submit"
-                    className="relative overflow-visible"
-                    disabled={isPending}
                   >
-                    {signInEmailPending && <Spinner />}
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="email">
+                            {localization.auth.email}
+                          </FieldLabel>
 
-                    {localization.auth.signIn}
+                          <Input
+                            id="email"
+                            name={field.name}
+                            type="email"
+                            autoComplete={withPasskeyAutoFill(
+                              "email",
+                              passkeyAutoFill
+                            )}
+                            placeholder={localization.auth.emailPlaceholder}
+                            required
+                            disabled={isPending}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) =>
+                              field.handleChange(event.target.value)
+                            }
+                            aria-invalid={isInvalid}
+                          />
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
 
-                    <LastUsedBadge method="email" floating />
-                  </Button>
+                  <form.AppField
+                    name="password"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          maxLength: emailAndPassword?.maxPasswordLength,
+                          maxLengthMessage: localization.auth.tooLong.replace(
+                            "{{max}}",
+                            String(emailAndPassword?.maxPasswordLength)
+                          ),
+                          minLength: emailAndPassword?.minPasswordLength,
+                          minLengthMessage: localization.auth.tooShort.replace(
+                            "{{min}}",
+                            String(emailAndPassword?.minPasswordLength)
+                          ),
+                          requiredMessage: localization.auth.fieldRequired
+                        })
+                    }}
+                  >
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="password">
+                            {localization.auth.password}
+                          </FieldLabel>
 
-                  {plugins.flatMap((plugin) =>
-                    (plugin.authButtons ?? []).map((AuthButton, index) => (
-                      <AuthButton
-                        key={`${plugin.id}-${index.toString()}`}
-                        view="signIn"
-                      />
-                    ))
+                          <InputGroup>
+                            <InputGroupInput
+                              id="password"
+                              name={field.name}
+                              type={isPasswordVisible ? "text" : "password"}
+                              autoComplete={withPasskeyAutoFill(
+                                "current-password",
+                                passkeyAutoFill
+                              )}
+                              value={field.state.value}
+                              onBlur={field.handleBlur}
+                              onChange={(event) =>
+                                field.handleChange(event.target.value)
+                              }
+                              placeholder={
+                                localization.auth.passwordPlaceholder
+                              }
+                              required
+                              minLength={emailAndPassword?.minPasswordLength}
+                              maxLength={emailAndPassword?.maxPasswordLength}
+                              disabled={isPending}
+                              aria-invalid={isInvalid}
+                            />
+
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                size="icon-xs"
+                                aria-label={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                title={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                onClick={() => {
+                                  setIsPasswordVisible((visible) => !visible)
+                                }}
+                              >
+                                {isPasswordVisible ? <EyeOff /> : <Eye />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
+
+                  {emailAndPassword.rememberMe && (
+                    <form.AppField name="rememberMe">
+                      {(field) => (
+                        <Field className="my-1">
+                          <div className="flex items-center gap-3">
+                            <Checkbox
+                              id="rememberMe"
+                              name={field.name}
+                              checked={field.state.value}
+                              disabled={isPending}
+                              onCheckedChange={(checked) =>
+                                field.handleChange(checked === true)
+                              }
+                            />
+
+                            <FieldLabel
+                              htmlFor="rememberMe"
+                              className="cursor-pointer text-sm font-normal"
+                            >
+                              {localization.auth.rememberMe}
+                            </FieldLabel>
+                          </div>
+                        </Field>
+                      )}
+                    </form.AppField>
                   )}
-                </div>
-              </FieldGroup>
-            </form>
+
+                  {Captcha && (
+                    <div className="flex justify-center">{Captcha}</div>
+                  )}
+
+                  <div className="flex flex-col gap-3">
+                    <form.AuthFormSubmitButton
+                      className="relative overflow-visible"
+                      disabled={isPending}
+                    >
+                      {signInEmailPending && <Spinner />}
+
+                      {localization.auth.signIn}
+
+                      <LastUsedBadge method="email" floating />
+                    </form.AuthFormSubmitButton>
+
+                    {plugins.flatMap((plugin) =>
+                      (plugin.authButtons ?? []).map((AuthButton, index) => (
+                        <AuthButton
+                          key={`${plugin.id}-${index.toString()}`}
+                          view="signIn"
+                        />
+                      ))
+                    )}
+                  </div>
+                </FieldGroup>
+              </form.AuthFormRoot>
+            </form.AppForm>
           )}
 
           {socialPosition === "bottom" && (

--- a/examples/next-shadcn-example/src/components/auth/siwe/sign-in-ethereum-button.tsx
+++ b/examples/next-shadcn-example/src/components/auth/siwe/sign-in-ethereum-button.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { type AuthView, authMutationKeys } from "@better-auth-ui/core"
+import {
+  type AuthView,
+  authMutationKeys,
+  validateEmailAddress
+} from "@better-auth-ui/core"
 import {
   type SiweAuthClient,
   siweMutationKeys
@@ -9,7 +13,7 @@ import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useSignInSiwe } from "@better-auth-ui/react/plugins/siwe"
 import { useIsMutating } from "@tanstack/react-query"
 import { Wallet } from "lucide-react"
-import { type FormEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -20,16 +24,12 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel
-} from "@/components/ui/field"
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { siwePlugin } from "@/lib/auth/siwe-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 
 export type SignInEthereumButtonProps = { view?: AuthView }
 
@@ -50,8 +50,6 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
       useIsMutating({ mutationKey: siweMutationKeys.all }) >
     0
 
-  if (view === "signUp") return null
-
   const complete = (email?: string) => {
     signIn.mutate(email ? { email } : undefined, {
       onSuccess: () => {
@@ -61,13 +59,12 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
     })
   }
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const email = String(
-      new FormData(event.currentTarget).get("email") ?? ""
-    ).trim()
-    complete(email || undefined)
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) => complete(value.email.trim() || undefined)
+  })
+
+  if (view === "signUp") return null
 
   return (
     <>
@@ -84,50 +81,77 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <Wallet />
-                {plugin.localization.continueWithEthereum}
-              </DialogTitle>
-              <DialogDescription>
-                {plugin.localization.emailDescription}
-              </DialogDescription>
-            </DialogHeader>
-            <Field>
-              <FieldLabel htmlFor="siwe-email">
-                {plugin.email === "required"
-                  ? plugin.localization.email
-                  : plugin.localization.emailOptional}
-              </FieldLabel>
-              <Input
-                id="siwe-email"
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-4">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <Wallet />
+                  {plugin.localization.continueWithEthereum}
+                </DialogTitle>
+                <DialogDescription>
+                  {plugin.localization.emailDescription}
+                </DialogDescription>
+              </DialogHeader>
+              <form.AppField
                 name="email"
-                type="email"
-                autoComplete="email"
-                required={plugin.email === "required"}
-                disabled={signIn.isPending}
-              />
-              <FieldDescription>
-                {plugin.localization.emailDescription}
-              </FieldDescription>
-              <FieldError />
-            </Field>
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                disabled={signIn.isPending}
-                onClick={() => setOpen(false)}
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage:
+                        plugin.email === "required"
+                          ? localization.auth.fieldRequired
+                          : undefined
+                    })
+                }}
               >
-                {localization.settings.cancel}
-              </Button>
-              <Button type="submit" disabled={signIn.isPending}>
-                {signIn.isPending && <Spinner />}
-                {plugin.localization.signMessage}
-              </Button>
-            </DialogFooter>
-          </form>
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="siwe-email">
+                        {plugin.email === "required"
+                          ? plugin.localization.email
+                          : plugin.localization.emailOptional}
+                      </FieldLabel>
+                      <Input
+                        id="siwe-email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        required={plugin.email === "required"}
+                        disabled={signIn.isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        aria-invalid={isInvalid}
+                      />
+                      <FieldDescription>
+                        {plugin.localization.emailDescription}
+                      </FieldDescription>
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={signIn.isPending}
+                  onClick={() => setOpen(false)}
+                >
+                  {localization.settings.cancel}
+                </Button>
+                <form.AuthFormSubmitButton disabled={signIn.isPending}>
+                  {signIn.isPending && <Spinner />}
+                  {plugin.localization.signMessage}
+                </form.AuthFormSubmitButton>
+              </DialogFooter>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </DialogContent>
       </Dialog>
     </>

--- a/examples/next-shadcn-example/src/components/auth/sso/email-first-sign-in.tsx
+++ b/examples/next-shadcn-example/src/components/auth/sso/email-first-sign-in.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import {
+  authMutationKeys,
+  validateEmailAddress,
+  validateStringLength
+} from "@better-auth-ui/core"
 import {
   isPasskeyAutoFillEnabled,
   withPasskeyAutoFill
@@ -20,7 +24,7 @@ import {
 import { useSignInSso } from "@better-auth-ui/react/plugins/sso"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -35,7 +39,6 @@ import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -51,6 +54,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { ssoPlugin } from "@/lib/auth/sso-plugin"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 import { ProviderButtons } from "../provider-buttons"
 
 export type EmailFirstSignInProps = {
@@ -83,21 +87,15 @@ export function EmailFirstSignIn({
   const continueSignIn = useSignInContinuation()
 
   const [step, setStep] = useState<"email" | "fallback">("email")
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
   const [discoveryError, setDiscoveryError] = useState("")
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-    password?: string
-  }>({})
 
   const { mutate: signInSso, isPending: isDiscovering } = useSignInSso(
     authClient as SsoAuthClient,
     {
       onError: (error) => {
         if (error.status === 404) {
-          setSsoFallbackEmail(email)
+          setSsoFallbackEmail(form.state.values.email)
           setDiscoveryError(ssoLocalization.noProvider)
           setStep("fallback")
           return
@@ -112,10 +110,13 @@ export function EmailFirstSignIn({
     authClient,
     {
       onError: (error) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
-          sessionStorage.setItem("better-auth-ui.verify-email", email)
+          sessionStorage.setItem(
+            "better-auth-ui.verify-email",
+            form.state.values.email
+          )
           navigate({
             to: `${basePaths.auth}/${viewPaths.auth.verifyEmail}`
           })
@@ -139,33 +140,33 @@ export function EmailFirstSignIn({
   const showSocialSeparator =
     emailAndPassword.enabled && !!socialProviders?.length
 
-  const submitEmail = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setDiscoveryError("")
-    setSsoFallbackEmail(email)
-    signInSso({
-      email,
-      callbackURL: `${baseURL}${redirectTo}`,
-      loginHint: email
-    })
-  }
-
-  const submitPassword = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    signInEmail({
-      email,
-      password,
-      ...(emailAndPassword.rememberMe
-        ? { rememberMe: formData.get("rememberMe") === "on" }
-        : {}),
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "", password: "", rememberMe: false },
+    onSubmit: ({ value }) => {
+      if (step === "email") {
+        setDiscoveryError("")
+        setSsoFallbackEmail(value.email)
+        signInSso({
+          callbackURL: `${baseURL}${redirectTo}`,
+          email: value.email,
+          loginHint: value.email
+        })
+        return
+      }
+      signInEmail({
+        email: value.email,
+        password: value.password,
+        ...(emailAndPassword.rememberMe
+          ? { rememberMe: value.rememberMe }
+          : {}),
+        fetchOptions
+      })
+    }
+  })
 
   const startOver = () => {
     setStep("email")
-    setPassword("")
+    form.setFieldValue("password", "")
     setDiscoveryError("")
   }
 
@@ -177,207 +178,238 @@ export function EmailFirstSignIn({
           {localization.auth.signIn}
         </CardTitle>
         <CardDescription>
-          {step === "email" ? ssoLocalization.emailFirstDescription : email}
+          {step === "email"
+            ? ssoLocalization.emailFirstDescription
+            : form.state.values.email}
         </CardDescription>
       </CardHeader>
 
       <CardContent>
-        {step === "email" ? (
-          <form onSubmit={submitEmail}>
-            <FieldGroup>
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="sso-email">
-                  {localization.auth.email}
-                </FieldLabel>
-                <Input
-                  id="sso-email"
+        <form.AppForm>
+          {step === "email" ? (
+            <form.AuthFormRoot>
+              <FieldGroup>
+                <form.AppField
                   name="email"
-                  type="email"
-                  autoComplete={withPasskeyAutoFill("email", passkeyAutoFill)}
-                  autoFocus
-                  value={email}
-                  onChange={(event) => {
-                    setEmail(event.target.value)
-                    setFieldErrors((current) => ({
-                      ...current,
-                      email: undefined
-                    }))
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateEmailAddress(value, {
+                        invalidMessage: localization.auth.invalidEmail,
+                        requiredMessage: localization.auth.fieldRequired
+                      })
                   }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    const element = event.currentTarget
-                    setFieldErrors((current) => ({
-                      ...current,
-                      email: element.validity.valueMissing
-                        ? localization.auth.fieldRequired
-                        : localization.auth.invalidEmail
-                    }))
+                >
+                  {(field) => {
+                    const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                    return (
+                      <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor="sso-email">
+                          {localization.auth.email}
+                        </FieldLabel>
+                        <Input
+                          id="sso-email"
+                          name={field.name}
+                          type="email"
+                          autoComplete={withPasskeyAutoFill(
+                            "email",
+                            passkeyAutoFill
+                          )}
+                          autoFocus
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          placeholder={localization.auth.emailPlaceholder}
+                          required
+                          disabled={isPending}
+                          aria-invalid={isInvalid}
+                        />
+                        <field.AuthFormFieldError />
+                      </Field>
+                    )
                   }}
-                  placeholder={localization.auth.emailPlaceholder}
-                  required
-                  disabled={isPending}
-                  aria-invalid={!!fieldErrors.email}
-                />
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
+                </form.AppField>
+
+                {discoveryError && (
+                  <FieldDescription role="alert" className="text-destructive">
+                    {discoveryError}
+                  </FieldDescription>
+                )}
+
+                <form.AuthFormSubmitButton disabled={isPending}>
+                  {isDiscovering && <Spinner data-icon="inline-start" />}
+                  {ssoLocalization.continueWithEmail}
+                </form.AuthFormSubmitButton>
+              </FieldGroup>
+            </form.AuthFormRoot>
+          ) : (
+            <div className="flex flex-col gap-4">
+              {socialPosition === "top" && (
+                <>
+                  {!!socialProviders?.length && (
+                    <ProviderButtons
+                      socialLayout={socialLayout}
+                      view="signIn"
+                    />
+                  )}
+                  {showSocialSeparator && (
+                    <FieldSeparator>{localization.auth.or}</FieldSeparator>
+                  )}
+                </>
+              )}
 
               {discoveryError && (
-                <FieldDescription role="alert" className="text-destructive">
+                <FieldDescription role="status">
                   {discoveryError}
                 </FieldDescription>
               )}
 
-              <Button type="submit" disabled={isPending}>
-                {isDiscovering && <Spinner data-icon="inline-start" />}
-                {ssoLocalization.continueWithEmail}
-              </Button>
-            </FieldGroup>
-          </form>
-        ) : (
-          <div className="flex flex-col gap-4">
-            {socialPosition === "top" && (
-              <>
-                {!!socialProviders?.length && (
-                  <ProviderButtons socialLayout={socialLayout} view="signIn" />
-                )}
-                {showSocialSeparator && (
-                  <FieldSeparator>{localization.auth.or}</FieldSeparator>
-                )}
-              </>
-            )}
+              {emailAndPassword.enabled && (
+                <form.AuthFormRoot>
+                  <FieldGroup>
+                    <form.AppField
+                      name="password"
+                      validators={{
+                        onChange: ({ value }) =>
+                          validateStringLength(value, {
+                            maxLength: emailAndPassword.maxPasswordLength,
+                            maxLengthMessage: localization.auth.tooLong.replace(
+                              "{{max}}",
+                              String(emailAndPassword.maxPasswordLength)
+                            ),
+                            minLength: emailAndPassword.minPasswordLength,
+                            minLengthMessage:
+                              localization.auth.tooShort.replace(
+                                "{{min}}",
+                                String(emailAndPassword.minPasswordLength)
+                              ),
+                            requiredMessage: localization.auth.fieldRequired
+                          })
+                      }}
+                    >
+                      {(field) => {
+                        const isInvalid = isAuthFormFieldInvalid(
+                          field.state.meta
+                        )
+                        return (
+                          <Field data-invalid={isInvalid}>
+                            <FieldLabel htmlFor="sso-password">
+                              {localization.auth.password}
+                            </FieldLabel>
+                            <InputGroup>
+                              <InputGroupInput
+                                id="sso-password"
+                                name={field.name}
+                                type={isPasswordVisible ? "text" : "password"}
+                                autoComplete={withPasskeyAutoFill(
+                                  "current-password",
+                                  passkeyAutoFill
+                                )}
+                                autoFocus
+                                value={field.state.value}
+                                onBlur={field.handleBlur}
+                                onChange={(event) =>
+                                  field.handleChange(event.target.value)
+                                }
+                                placeholder={
+                                  localization.auth.passwordPlaceholder
+                                }
+                                minLength={emailAndPassword.minPasswordLength}
+                                maxLength={emailAndPassword.maxPasswordLength}
+                                required
+                                disabled={isPending}
+                                aria-invalid={isInvalid}
+                              />
+                              <InputGroupAddon align="inline-end">
+                                <InputGroupButton
+                                  size="icon-xs"
+                                  aria-label={
+                                    isPasswordVisible
+                                      ? localization.auth.hidePassword
+                                      : localization.auth.showPassword
+                                  }
+                                  onClick={() =>
+                                    setIsPasswordVisible((visible) => !visible)
+                                  }
+                                >
+                                  {isPasswordVisible ? <EyeOff /> : <Eye />}
+                                </InputGroupButton>
+                              </InputGroupAddon>
+                            </InputGroup>
+                            <field.AuthFormFieldError />
+                          </Field>
+                        )
+                      }}
+                    </form.AppField>
 
-            {discoveryError && (
-              <FieldDescription role="status">
-                {discoveryError}
-              </FieldDescription>
-            )}
-
-            {emailAndPassword.enabled && (
-              <form onSubmit={submitPassword}>
-                <FieldGroup>
-                  <Field data-invalid={!!fieldErrors.password}>
-                    <FieldLabel htmlFor="sso-password">
-                      {localization.auth.password}
-                    </FieldLabel>
-                    <InputGroup>
-                      <InputGroupInput
-                        id="sso-password"
-                        name="password"
-                        type={isPasswordVisible ? "text" : "password"}
-                        autoComplete={withPasskeyAutoFill(
-                          "current-password",
-                          passkeyAutoFill
+                    {emailAndPassword.rememberMe && (
+                      <form.AppField name="rememberMe">
+                        {(field) => (
+                          <Field>
+                            <div className="flex items-center gap-3">
+                              <Checkbox
+                                id="sso-remember-me"
+                                name={field.name}
+                                checked={field.state.value}
+                                disabled={isPending}
+                                onCheckedChange={(checked) =>
+                                  field.handleChange(checked === true)
+                                }
+                              />
+                              <FieldLabel
+                                htmlFor="sso-remember-me"
+                                className="cursor-pointer text-sm font-normal"
+                              >
+                                {localization.auth.rememberMe}
+                              </FieldLabel>
+                            </div>
+                          </Field>
                         )}
-                        autoFocus
-                        value={password}
-                        onChange={(event) => {
-                          setPassword(event.target.value)
-                          setFieldErrors((current) => ({
-                            ...current,
-                            password: undefined
-                          }))
-                        }}
-                        onInvalid={(event) => {
-                          event.preventDefault()
-                          const element = event.currentTarget
-                          const message = element.validity.valueMissing
-                            ? localization.auth.fieldRequired
-                            : element.validity.tooShort
-                              ? localization.auth.tooShort.replace(
-                                  "{{min}}",
-                                  String(emailAndPassword.minPasswordLength)
-                                )
-                              : localization.auth.tooLong.replace(
-                                  "{{max}}",
-                                  String(emailAndPassword.maxPasswordLength)
-                                )
+                      </form.AppField>
+                    )}
 
-                          setFieldErrors((current) => ({
-                            ...current,
-                            password: message
-                          }))
-                        }}
-                        placeholder={localization.auth.passwordPlaceholder}
-                        minLength={emailAndPassword.minPasswordLength}
-                        maxLength={emailAndPassword.maxPasswordLength}
-                        required
-                        disabled={isPending}
-                        aria-invalid={!!fieldErrors.password}
-                      />
-                      <InputGroupAddon align="inline-end">
-                        <InputGroupButton
-                          size="icon-xs"
-                          aria-label={
-                            isPasswordVisible
-                              ? localization.auth.hidePassword
-                              : localization.auth.showPassword
-                          }
-                          onClick={() =>
-                            setIsPasswordVisible((visible) => !visible)
-                          }
-                        >
-                          {isPasswordVisible ? <EyeOff /> : <Eye />}
-                        </InputGroupButton>
-                      </InputGroupAddon>
-                    </InputGroup>
-                    <FieldError>{fieldErrors.password}</FieldError>
-                  </Field>
+                    {Captcha && (
+                      <div className="flex justify-center">{Captcha}</div>
+                    )}
 
-                  {emailAndPassword.rememberMe && (
-                    <Field>
-                      <div className="flex items-center gap-3">
-                        <Checkbox
-                          id="sso-remember-me"
-                          name="rememberMe"
-                          disabled={isPending}
-                        />
-                        <FieldLabel
-                          htmlFor="sso-remember-me"
-                          className="cursor-pointer text-sm font-normal"
-                        >
-                          {localization.auth.rememberMe}
-                        </FieldLabel>
-                      </div>
-                    </Field>
+                    <form.AuthFormSubmitButton disabled={isPending}>
+                      {isSigningIn && <Spinner data-icon="inline-start" />}
+                      {localization.auth.signIn}
+                    </form.AuthFormSubmitButton>
+                  </FieldGroup>
+                </form.AuthFormRoot>
+              )}
+
+              {plugins.flatMap((plugin) =>
+                (plugin.authButtons ?? []).map((AuthButton) => (
+                  <AuthButton
+                    key={getAuthButtonKey(plugin.id, AuthButton)}
+                    view="signIn"
+                  />
+                ))
+              )}
+
+              {socialPosition === "bottom" && (
+                <>
+                  {showSocialSeparator && (
+                    <FieldSeparator>{localization.auth.or}</FieldSeparator>
                   )}
-
-                  {Captcha && (
-                    <div className="flex justify-center">{Captcha}</div>
+                  {!!socialProviders?.length && (
+                    <ProviderButtons
+                      socialLayout={socialLayout}
+                      view="signIn"
+                    />
                   )}
+                </>
+              )}
 
-                  <Button type="submit" disabled={isPending}>
-                    {isSigningIn && <Spinner data-icon="inline-start" />}
-                    {localization.auth.signIn}
-                  </Button>
-                </FieldGroup>
-              </form>
-            )}
-
-            {plugins.flatMap((plugin) =>
-              (plugin.authButtons ?? []).map((AuthButton) => (
-                <AuthButton
-                  key={getAuthButtonKey(plugin.id, AuthButton)}
-                  view="signIn"
-                />
-              ))
-            )}
-
-            {socialPosition === "bottom" && (
-              <>
-                {showSocialSeparator && (
-                  <FieldSeparator>{localization.auth.or}</FieldSeparator>
-                )}
-                {!!socialProviders?.length && (
-                  <ProviderButtons socialLayout={socialLayout} view="signIn" />
-                )}
-              </>
-            )}
-
-            <Button variant="ghost" onClick={startOver}>
-              {ssoLocalization.useDifferentEmail}
-            </Button>
-          </div>
-        )}
+              <Button variant="ghost" onClick={startOver}>
+                {ssoLocalization.useDifferentEmail}
+              </Button>
+            </div>
+          )}
+        </form.AppForm>
       </CardContent>
 
       {emailAndPassword.enabled && (

--- a/examples/next-shadcn-example/src/components/auth/sso/sso-domain-verification.tsx
+++ b/examples/next-shadcn-example/src/components/auth/sso/sso-domain-verification.tsx
@@ -12,7 +12,7 @@ import {
 } from "@better-auth-ui/react/plugins/sso"
 import type { BetterFetchError } from "better-auth/client"
 import { CheckIcon, CopyIcon } from "lucide-react"
-import { type FormEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -39,6 +39,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { ssoPlugin } from "@/lib/auth/sso-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 
 export type SsoDomainVerificationProps = {
   className?: string
@@ -61,7 +62,6 @@ export function SsoDomainVerification({
 }: SsoDomainVerificationProps) {
   const { authClient } = useAuth()
   const { localization } = useAuthPlugin(ssoPlugin)
-  const [providerId, setProviderId] = useState(defaultProviderId)
   const [token, setToken] = useState(defaultToken)
   const [verified, setVerified] = useState(false)
   const [copyError, setCopyError] = useState("")
@@ -74,7 +74,6 @@ export function SsoDomainVerification({
   const verify = useVerifySsoDomain(authClient as SsoAuthClient, {
     onSuccess: () => setVerified(true)
   })
-  const host = providerId ? `_${tokenPrefix}-${providerId}` : ""
   const hostCopy = useCopyToClipboard({
     onError: (error) =>
       setCopyError(error instanceof Error ? error.message : String(error))
@@ -88,12 +87,14 @@ export function SsoDomainVerification({
       ? requestToken.error
       : verify.error
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setCopyError("")
-    setVerified(false)
-    verify.mutate({ providerId })
-  }
+  const form = useAuthForm({
+    defaultValues: { providerId: defaultProviderId },
+    onSubmit: ({ value }) => {
+      setCopyError("")
+      setVerified(false)
+      verify.mutate({ providerId: value.providerId })
+    }
+  })
 
   return (
     <Card className={cn("w-full max-w-xl", className)}>
@@ -104,120 +105,144 @@ export function SsoDomainVerification({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="sso-verification-provider-id">
-                {localization.providerId}
-              </FieldLabel>
-              <Input
-                id="sso-verification-provider-id"
-                name="providerId"
-                value={providerId}
-                onChange={(event) => {
-                  setProviderId(event.target.value.trim())
-                  setToken("")
-                  setVerified(false)
-                }}
-                required
-              />
-            </Field>
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <form.Subscribe selector={(state) => state.values.providerId}>
+              {(providerId) => {
+                const host = providerId ? `_${tokenPrefix}-${providerId}` : ""
+                return (
+                  <FieldGroup>
+                    <form.AppField name="providerId">
+                      {(field) => (
+                        <Field>
+                          <FieldLabel htmlFor="sso-verification-provider-id">
+                            {localization.providerId}
+                          </FieldLabel>
+                          <Input
+                            id="sso-verification-provider-id"
+                            name={field.name}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              field.handleChange(event.target.value.trim())
+                              setToken("")
+                              setVerified(false)
+                            }}
+                            required
+                          />
+                        </Field>
+                      )}
+                    </form.AppField>
 
-            {token ? (
-              <div className="grid gap-3 rounded-lg border p-3">
-                <Field>
-                  <FieldLabel htmlFor="sso-dns-host">
-                    {localization.txtRecordHost}
-                  </FieldLabel>
-                  <InputGroup>
-                    <InputGroupInput
-                      className="font-mono text-xs"
-                      id="sso-dns-host"
-                      readOnly
-                      value={host}
-                    />
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        aria-label={localization.copyDnsHost}
-                        size="icon-xs"
+                    {token ? (
+                      <div className="grid gap-3 rounded-lg border p-3">
+                        <Field>
+                          <FieldLabel htmlFor="sso-dns-host">
+                            {localization.txtRecordHost}
+                          </FieldLabel>
+                          <InputGroup>
+                            <InputGroupInput
+                              className="font-mono text-xs"
+                              id="sso-dns-host"
+                              readOnly
+                              value={host}
+                            />
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                aria-label={localization.copyDnsHost}
+                                size="icon-xs"
+                                onClick={() => {
+                                  setCopyError("")
+                                  void hostCopy.copy(host)
+                                }}
+                              >
+                                {hostCopy.copied ? <CheckIcon /> : <CopyIcon />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+                        </Field>
+                        <Field>
+                          <FieldLabel htmlFor="sso-dns-value">
+                            {localization.txtRecordValue}
+                          </FieldLabel>
+                          <InputGroup>
+                            <InputGroupInput
+                              className="font-mono text-xs"
+                              id="sso-dns-value"
+                              readOnly
+                              value={token}
+                            />
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                aria-label={localization.copyDnsValue}
+                                size="icon-xs"
+                                onClick={() => {
+                                  setCopyError("")
+                                  void tokenCopy.copy(token)
+                                }}
+                              >
+                                {tokenCopy.copied ? (
+                                  <CheckIcon />
+                                ) : (
+                                  <CopyIcon />
+                                )}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+                        </Field>
+                      </div>
+                    ) : null}
+
+                    {error ? (
+                      <FieldError>{getErrorMessage(error)}</FieldError>
+                    ) : null}
+                    {copyError ? <FieldError>{copyError}</FieldError> : null}
+                    {verified ? (
+                      <FieldDescription
+                        role="status"
+                        className="text-foreground"
+                      >
+                        {localization.domainVerified}
+                      </FieldDescription>
+                    ) : null}
+
+                    <div className="flex flex-wrap justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={!providerId || verify.isPending}
                         onClick={() => {
                           setCopyError("")
-                          void hostCopy.copy(host)
+                          setVerified(false)
+                          requestToken.mutate({ providerId })
                         }}
                       >
-                        {hostCopy.copied ? <CheckIcon /> : <CopyIcon />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                </Field>
-                <Field>
-                  <FieldLabel htmlFor="sso-dns-value">
-                    {localization.txtRecordValue}
-                  </FieldLabel>
-                  <InputGroup>
-                    <InputGroupInput
-                      className="font-mono text-xs"
-                      id="sso-dns-value"
-                      readOnly
-                      value={token}
-                    />
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        aria-label={localization.copyDnsValue}
-                        size="icon-xs"
-                        onClick={() => {
-                          setCopyError("")
-                          void tokenCopy.copy(token)
-                        }}
+                        {requestToken.isPending ? (
+                          <Spinner data-icon="inline-start" />
+                        ) : null}
+                        {localization.requestNewToken}
+                      </Button>
+                      <form.AuthFormSubmitButton
+                        disabled={!providerId || requestToken.isPending}
                       >
-                        {tokenCopy.copied ? <CheckIcon /> : <CopyIcon />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                </Field>
-              </div>
-            ) : null}
+                        {verify.isPending ? (
+                          <Spinner data-icon="inline-start" />
+                        ) : null}
+                        {localization.verifyDomain}
+                      </form.AuthFormSubmitButton>
+                    </div>
 
-            {error ? <FieldError>{getErrorMessage(error)}</FieldError> : null}
-            {copyError ? <FieldError>{copyError}</FieldError> : null}
-            {verified ? (
-              <FieldDescription role="status" className="text-foreground">
-                {localization.domainVerified}
-              </FieldDescription>
-            ) : null}
-
-            <div className="flex flex-wrap justify-end gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                disabled={!providerId || verify.isPending}
-                onClick={() => {
-                  setCopyError("")
-                  setVerified(false)
-                  requestToken.mutate({ providerId })
-                }}
-              >
-                {requestToken.isPending ? (
-                  <Spinner data-icon="inline-start" />
-                ) : null}
-                {localization.requestNewToken}
-              </Button>
-              <Button
-                type="submit"
-                disabled={!providerId || requestToken.isPending}
-              >
-                {verify.isPending ? <Spinner data-icon="inline-start" /> : null}
-                {localization.verifyDomain}
-              </Button>
-            </div>
-
-            <span className="sr-only" aria-live="polite">
-              {token && !verified
-                ? localization.domainVerificationRequested
-                : ""}
-            </span>
-          </FieldGroup>
-        </form>
+                    <span className="sr-only" aria-live="polite">
+                      {token && !verified
+                        ? localization.domainVerificationRequested
+                        : ""}
+                    </span>
+                  </FieldGroup>
+                )
+              }}
+            </form.Subscribe>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
     </Card>
   )

--- a/examples/next-shadcn-example/src/components/auth/two-factor/disable-two-factor-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/two-factor/disable-two-factor-dialog.tsx
@@ -4,7 +4,6 @@ import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-facto
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useDisableTwoFactor } from "@better-auth-ui/react/plugins/two-factor"
 import { ShieldAlert } from "lucide-react"
-import type { SyntheticEvent } from "react"
 import { toast } from "sonner"
 
 import {
@@ -17,12 +16,12 @@ import {
   AlertDialogMedia,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
-import { Button } from "@/components/ui/button"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
+import { useAuthForm } from "../auth-form"
 
 export type DisableTwoFactorDialogProps = {
   open: boolean
@@ -54,68 +53,79 @@ export function DisableTwoFactorDialog({
 
   const isPending = isDisabling || isResolvingPasswordRequirement
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-
-    disableTwoFactor(requiresPassword ? { password } : {})
-  }
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) =>
+      disableTwoFactor(requiresPassword ? { password: value.password } : {})
+  })
 
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <AlertDialogHeader>
-            <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
-              <ShieldAlert />
-            </AlertDialogMedia>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <AlertDialogHeader>
+              <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
+                <ShieldAlert />
+              </AlertDialogMedia>
 
-            <AlertDialogTitle>
-              {twoFactorLocalization.disableTwoFactor}
-            </AlertDialogTitle>
+              <AlertDialogTitle>
+                {twoFactorLocalization.disableTwoFactor}
+              </AlertDialogTitle>
 
-            <AlertDialogDescription>
-              {requiresPassword
-                ? twoFactorLocalization.passwordConfirmation
-                : twoFactorLocalization.twoFactorDescription}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+              <AlertDialogDescription>
+                {requiresPassword
+                  ? twoFactorLocalization.passwordConfirmation
+                  : twoFactorLocalization.twoFactorDescription}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
 
-          {requiresPassword && (
-            <Field>
-              <FieldLabel htmlFor="disable-two-factor-password">
-                {localization.auth.password}
-              </FieldLabel>
+            {requiresPassword && (
+              <form.AppField name="password">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="disable-two-factor-password">
+                      {localization.auth.password}
+                    </FieldLabel>
 
-              <Input
-                id="disable-two-factor-password"
-                name="password"
-                type="password"
-                autoComplete="current-password"
-                autoFocus
-                required
-                placeholder={localization.auth.passwordPlaceholder}
+                    <Input
+                      id="disable-two-factor-password"
+                      name={field.name}
+                      type="password"
+                      autoComplete="current-password"
+                      autoFocus
+                      required
+                      placeholder={localization.auth.passwordPlaceholder}
+                      disabled={isPending}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                    />
+
+                    <FieldError />
+                  </Field>
+                )}
+              </form.AppField>
+            )}
+
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isPending}>
+                {localization.settings.cancel}
+              </AlertDialogCancel>
+
+              <form.AuthFormSubmitButton
+                variant="destructive"
                 disabled={isPending}
-              />
+              >
+                {isPending && <Spinner />}
 
-              <FieldError />
-            </Field>
-          )}
-
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>
-              {localization.settings.cancel}
-            </AlertDialogCancel>
-
-            <Button type="submit" variant="destructive" disabled={isPending}>
-              {isPending && <Spinner />}
-
-              {twoFactorLocalization.disableTwoFactor}
-            </Button>
-          </AlertDialogFooter>
-        </form>
+                {twoFactorLocalization.disableTwoFactor}
+              </form.AuthFormSubmitButton>
+            </AlertDialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </AlertDialogContent>
     </AlertDialog>
   )

--- a/examples/next-shadcn-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -15,9 +15,9 @@ import {
   useVerifyTotp
 } from "@better-auth-ui/react/plugins/two-factor"
 import { Check, Copy, ShieldCheck } from "lucide-react"
-import { type SyntheticEvent, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -39,6 +39,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { BackupCodes } from "./backup-codes"
 
@@ -79,7 +80,6 @@ export function EnableTwoFactorDialog({
   )
   const [totpUri, setTotpUri] = useState("")
   const [backupCodes, setBackupCodes] = useState<string[]>([])
-  const [code, setCode] = useState("")
   const {
     copied: setupKeyCopied,
     copy: copySetupKeyValue,
@@ -132,7 +132,7 @@ export function EnableTwoFactorDialog({
   const { mutate: verifyTotp, isPending: isVerifying } = useVerifyTotp(
     twoFactorClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
         toast.success(twoFactorLocalization.twoFactorEnabled)
         setStep("backupCodes")
@@ -141,6 +141,23 @@ export function EnableTwoFactorDialog({
   )
 
   const isPending = isEnabling || isVerifying || isResolvingPasswordRequirement
+
+  const form = useAuthForm({
+    defaultValues: { code: "", password: "" },
+    onSubmit: ({ value }) => {
+      if (step === "backupCodes") {
+        handleOpenChange(false)
+        return
+      }
+      if (step === "verify") {
+        verifyCode(value.code)
+        return
+      }
+      enableTwoFactor(
+        requiresPassword ? { method, password: value.password } : { method }
+      )
+    }
+  })
 
   const verifyCode = (completedCode: string) => {
     if (isPending || step !== "verify" || completedCode.length !== codeLength) {
@@ -158,30 +175,11 @@ export function EnableTwoFactorDialog({
       setMethod(enrollmentMethods[0] ?? "totp")
       setTotpUri("")
       setBackupCodes([])
-      setCode("")
+      form.reset()
       resetSetupKeyCopy()
       // Clears the resolved TOTP URI and backup codes from the mutation cache.
       resetEnrollment()
     }
-  }
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (step === "backupCodes") {
-      handleOpenChange(false)
-      return
-    }
-
-    if (step === "verify") {
-      verifyCode(code)
-      return
-    }
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-
-    enableTwoFactor(requiresPassword ? { method, password } : { method })
   }
 
   const submitLabel =
@@ -194,169 +192,189 @@ export function EnableTwoFactorDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <ShieldCheck />
-              {twoFactorLocalization.twoFactor}
-            </DialogTitle>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <ShieldCheck />
+                {twoFactorLocalization.twoFactor}
+              </DialogTitle>
 
-            <DialogDescription>
-              {step === "password" && requiresPassword
-                ? twoFactorLocalization.passwordConfirmation
-                : step === "verify"
-                  ? twoFactorLocalization.scanQrCode
-                  : twoFactorLocalization.twoFactorDescription}
-            </DialogDescription>
-          </DialogHeader>
+              <DialogDescription>
+                {step === "password" && requiresPassword
+                  ? twoFactorLocalization.passwordConfirmation
+                  : step === "verify"
+                    ? twoFactorLocalization.scanQrCode
+                    : twoFactorLocalization.twoFactorDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          {step === "password" && (
-            <div className="flex flex-col gap-4">
-              {enrollmentMethods.length > 1 && (
-                <Tabs
-                  value={method}
-                  onValueChange={(value) => setMethod(value as TwoFactorMethod)}
-                >
-                  <TabsList
-                    aria-label={twoFactorLocalization.chooseEnrollmentMethod}
-                    className="w-full"
+            {step === "password" && (
+              <div className="flex flex-col gap-4">
+                {enrollmentMethods.length > 1 && (
+                  <Tabs
+                    value={method}
+                    onValueChange={(value) =>
+                      setMethod(value as TwoFactorMethod)
+                    }
                   >
-                    {enrollmentMethods.includes("totp") && (
-                      <TabsTrigger value="totp">
-                        {twoFactorLocalization.authenticatorApp}
-                      </TabsTrigger>
+                    <TabsList
+                      aria-label={twoFactorLocalization.chooseEnrollmentMethod}
+                      className="w-full"
+                    >
+                      {enrollmentMethods.includes("totp") && (
+                        <TabsTrigger value="totp">
+                          {twoFactorLocalization.authenticatorApp}
+                        </TabsTrigger>
+                      )}
+                      {enrollmentMethods.includes("otp") && (
+                        <TabsTrigger value="otp">
+                          {twoFactorLocalization.deliveredCode}
+                        </TabsTrigger>
+                      )}
+                    </TabsList>
+                  </Tabs>
+                )}
+
+                <p className="text-muted-foreground text-sm">
+                  {method === "totp"
+                    ? twoFactorLocalization.authenticatorAppDescription
+                    : twoFactorLocalization.deliveredCodeDescription}
+                </p>
+
+                {requiresPassword && (
+                  <form.AppField name="password">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel htmlFor="two-factor-password">
+                          {localization.auth.password}
+                        </FieldLabel>
+
+                        <Input
+                          id="two-factor-password"
+                          name={field.name}
+                          type="password"
+                          autoComplete="current-password"
+                          autoFocus
+                          required
+                          placeholder={localization.auth.passwordPlaceholder}
+                          disabled={isPending}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                        />
+
+                        <FieldError />
+                      </Field>
                     )}
-                    {enrollmentMethods.includes("otp") && (
-                      <TabsTrigger value="otp">
-                        {twoFactorLocalization.deliveredCode}
-                      </TabsTrigger>
-                    )}
-                  </TabsList>
-                </Tabs>
-              )}
-
-              <p className="text-muted-foreground text-sm">
-                {method === "totp"
-                  ? twoFactorLocalization.authenticatorAppDescription
-                  : twoFactorLocalization.deliveredCodeDescription}
-              </p>
-
-              {requiresPassword && (
-                <Field>
-                  <FieldLabel htmlFor="two-factor-password">
-                    {localization.auth.password}
-                  </FieldLabel>
-
-                  <Input
-                    id="two-factor-password"
-                    name="password"
-                    type="password"
-                    autoComplete="current-password"
-                    autoFocus
-                    required
-                    placeholder={localization.auth.passwordPlaceholder}
-                    disabled={isPending}
-                  />
-
-                  <FieldError />
-                </Field>
-              )}
-            </div>
-          )}
-
-          {step === "verify" && (
-            <div className="flex flex-col items-center gap-4">
-              {qrCode && (
-                <svg
-                  aria-hidden="true"
-                  className="size-44 rounded-md border"
-                  viewBox={`0 0 ${qrCode.size} ${qrCode.size}`}
-                >
-                  <path
-                    fill="white"
-                    d={`M0 0h${qrCode.size}v${qrCode.size}H0z`}
-                  />
-                  <path
-                    fill="black"
-                    d={qrCode.path}
-                    shapeRendering="crispEdges"
-                  />
-                </svg>
-              )}
-
-              {setupKey && (
-                <Field className="w-full gap-1">
-                  <FieldLabel
-                    className="text-muted-foreground text-xs"
-                    htmlFor="two-factor-setup-key"
-                  >
-                    {twoFactorLocalization.setupKey}
-                  </FieldLabel>
-
-                  <InputGroup>
-                    <InputGroupInput
-                      className="font-mono text-xs"
-                      id="two-factor-setup-key"
-                      readOnly
-                      value={setupKey}
-                    />
-
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        aria-label={
-                          setupKeyCopied
-                            ? twoFactorLocalization.setupKeyCopied
-                            : localization.settings.copyToClipboard
-                        }
-                        onClick={copySetupKey}
-                        size="icon-xs"
-                      >
-                        {setupKeyCopied ? <Check /> : <Copy />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                </Field>
-              )}
-
-              <OtpField
-                autoFocus
-                className="w-full"
-                disabled={isPending}
-                label={twoFactorLocalization.authenticatorCode}
-                length={codeLength}
-                name="code"
-                value={code}
-                onChange={setCode}
-                onComplete={verifyCode}
-              />
-            </div>
-          )}
-
-          {step === "backupCodes" && <BackupCodes codes={backupCodes} />}
-
-          <DialogFooter>
-            {step !== "backupCodes" && (
-              <DialogClose
-                className={buttonVariants({ variant: "outline" })}
-                disabled={isPending}
-                type="button"
-              >
-                {localization.settings.cancel}
-              </DialogClose>
+                  </form.AppField>
+                )}
+              </div>
             )}
 
-            <Button
-              type="submit"
-              disabled={
-                isPending || (step === "verify" && code.length !== codeLength)
-              }
-            >
-              {isPending && <Spinner />}
+            {step === "verify" && (
+              <div className="flex flex-col items-center gap-4">
+                {qrCode && (
+                  <svg
+                    aria-hidden="true"
+                    className="size-44 rounded-md border"
+                    viewBox={`0 0 ${qrCode.size} ${qrCode.size}`}
+                  >
+                    <path
+                      fill="white"
+                      d={`M0 0h${qrCode.size}v${qrCode.size}H0z`}
+                    />
+                    <path
+                      fill="black"
+                      d={qrCode.path}
+                      shapeRendering="crispEdges"
+                    />
+                  </svg>
+                )}
 
-              {submitLabel}
-            </Button>
-          </DialogFooter>
-        </form>
+                {setupKey && (
+                  <Field className="w-full gap-1">
+                    <FieldLabel
+                      className="text-muted-foreground text-xs"
+                      htmlFor="two-factor-setup-key"
+                    >
+                      {twoFactorLocalization.setupKey}
+                    </FieldLabel>
+
+                    <InputGroup>
+                      <InputGroupInput
+                        className="font-mono text-xs"
+                        id="two-factor-setup-key"
+                        readOnly
+                        value={setupKey}
+                      />
+
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          aria-label={
+                            setupKeyCopied
+                              ? twoFactorLocalization.setupKeyCopied
+                              : localization.settings.copyToClipboard
+                          }
+                          onClick={copySetupKey}
+                          size="icon-xs"
+                        >
+                          {setupKeyCopied ? <Check /> : <Copy />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  </Field>
+                )}
+
+                <form.AppField name="code">
+                  {(field) => (
+                    <OtpField
+                      autoFocus
+                      className="w-full"
+                      disabled={isPending}
+                      label={twoFactorLocalization.authenticatorCode}
+                      length={codeLength}
+                      name={field.name}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      onComplete={verifyCode}
+                    />
+                  )}
+                </form.AppField>
+              </div>
+            )}
+
+            {step === "backupCodes" && <BackupCodes codes={backupCodes} />}
+
+            <DialogFooter>
+              {step !== "backupCodes" && (
+                <DialogClose
+                  className={buttonVariants({ variant: "outline" })}
+                  disabled={isPending}
+                  type="button"
+                >
+                  {localization.settings.cancel}
+                </DialogClose>
+              )}
+
+              <form.Subscribe selector={(state) => state.values.code}>
+                {(code) => (
+                  <form.AuthFormSubmitButton
+                    disabled={
+                      isPending ||
+                      (step === "verify" && code.length !== codeLength)
+                    }
+                  >
+                    {isPending && <Spinner />}
+                    {submitLabel}
+                  </form.AuthFormSubmitButton>
+                )}
+              </form.Subscribe>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/next-shadcn-example/src/components/auth/two-factor/regenerate-backup-codes-dialog.tsx
+++ b/examples/next-shadcn-example/src/components/auth/two-factor/regenerate-backup-codes-dialog.tsx
@@ -4,7 +4,7 @@ import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-facto
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useGenerateBackupCodes } from "@better-auth-ui/react/plugins/two-factor"
 import { KeyRound } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -17,12 +17,12 @@ import {
   AlertDialogMedia,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
-import { Button } from "@/components/ui/button"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
+import { useAuthForm } from "../auth-form"
 import { BackupCodes } from "./backup-codes"
 
 export type RegenerateBackupCodesDialogProps = {
@@ -63,91 +63,100 @@ export function RegenerateBackupCodesDialog({
 
   const isPending = isGenerating || isResolvingPasswordRequirement
 
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) => {
+      if (codes.length) {
+        handleOpenChange(false)
+        return
+      }
+      generateBackupCodes(requiresPassword ? { password: value.password } : {})
+    }
+  })
+
   const handleOpenChange = (nextOpen: boolean) => {
     onOpenChange(nextOpen)
 
     if (!nextOpen) {
       setCodes([])
+      form.reset()
       // Clears the resolved backup codes from the mutation cache.
       resetGeneration()
     }
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (codes.length) {
-      handleOpenChange(false)
-      return
-    }
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-
-    generateBackupCodes(requiresPassword ? { password } : {})
-  }
-
   return (
     <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <AlertDialogHeader>
-            <AlertDialogMedia>
-              <KeyRound />
-            </AlertDialogMedia>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <AlertDialogHeader>
+              <AlertDialogMedia>
+                <KeyRound />
+              </AlertDialogMedia>
 
-            <AlertDialogTitle>
-              {twoFactorLocalization.backupCodes}
-            </AlertDialogTitle>
+              <AlertDialogTitle>
+                {twoFactorLocalization.backupCodes}
+              </AlertDialogTitle>
 
-            <AlertDialogDescription>
-              {codes.length || !requiresPassword
-                ? twoFactorLocalization.backupCodesDescription
-                : twoFactorLocalization.passwordConfirmation}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+              <AlertDialogDescription>
+                {codes.length || !requiresPassword
+                  ? twoFactorLocalization.backupCodesDescription
+                  : twoFactorLocalization.passwordConfirmation}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
 
-          {codes.length ? (
-            <BackupCodes codes={codes} />
-          ) : (
-            requiresPassword && (
-              <Field>
-                <FieldLabel htmlFor="regenerate-backup-codes-password">
-                  {localization.auth.password}
-                </FieldLabel>
+            {codes.length ? (
+              <BackupCodes codes={codes} />
+            ) : (
+              requiresPassword && (
+                <form.AppField name="password">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="regenerate-backup-codes-password">
+                        {localization.auth.password}
+                      </FieldLabel>
 
-                <Input
-                  id="regenerate-backup-codes-password"
-                  name="password"
-                  type="password"
-                  autoComplete="current-password"
-                  autoFocus
-                  required
-                  placeholder={localization.auth.passwordPlaceholder}
-                  disabled={isPending}
-                />
+                      <Input
+                        id="regenerate-backup-codes-password"
+                        name={field.name}
+                        type="password"
+                        autoComplete="current-password"
+                        autoFocus
+                        required
+                        placeholder={localization.auth.passwordPlaceholder}
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
 
-                <FieldError />
-              </Field>
-            )
-          )}
-
-          <AlertDialogFooter>
-            {!codes.length && (
-              <AlertDialogCancel disabled={isPending}>
-                {localization.settings.cancel}
-              </AlertDialogCancel>
+                      <FieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              )
             )}
 
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Spinner />}
+            <AlertDialogFooter>
+              {!codes.length && (
+                <AlertDialogCancel disabled={isPending}>
+                  {localization.settings.cancel}
+                </AlertDialogCancel>
+              )}
 
-              {codes.length
-                ? twoFactorLocalization.done
-                : twoFactorLocalization.regenerateBackupCodes}
-            </Button>
-          </AlertDialogFooter>
-        </form>
+              <form.AuthFormSubmitButton disabled={isPending}>
+                {isPending && <Spinner />}
+
+                {codes.length
+                  ? twoFactorLocalization.done
+                  : twoFactorLocalization.regenerateBackupCodes}
+              </form.AuthFormSubmitButton>
+            </AlertDialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </AlertDialogContent>
     </AlertDialog>
   )

--- a/examples/next-shadcn-example/src/components/auth/two-factor/two-factor-challenge.tsx
+++ b/examples/next-shadcn-example/src/components/auth/two-factor/two-factor-challenge.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { authQueryKeys } from "@better-auth-ui/core"
+import { authQueryKeys, validateStringLength } from "@better-auth-ui/core"
 import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-factor"
 import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
 import {
@@ -10,7 +10,7 @@ import {
   useVerifyTwoFactorOtp
 } from "@better-auth-ui/react/plugins/two-factor"
 import { useQueryClient } from "@tanstack/react-query"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -40,6 +40,7 @@ import {
   useResendCooldown
 } from "@/lib/auth/use-resend-cooldown"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { useIsHydrated } from "../use-is-hydrated"
 
@@ -88,8 +89,6 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
   const [method, setMethod] = useState<ChallengeMethod>(
     () => methods[0] ?? "totp"
   )
-  const [code, setCode] = useState("")
-  const [trustDevice, setTrustDevice] = useState(false)
   const [otpRequested, setOtpRequested] = useState(false)
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
 
@@ -117,12 +116,15 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
 
   const { mutate: verifyTotp, isPending: isVerifyingTotp } = useVerifyTotp(
     twoFactorClient,
-    { onError: () => setCode(""), onSuccess: onVerified }
+    {
+      onError: () => form.setFieldValue("code", ""),
+      onSuccess: onVerified
+    }
   )
 
   const { mutate: verifyTwoFactorOtp, isPending: isVerifyingOtp } =
     useVerifyTwoFactorOtp(twoFactorClient, {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: onVerified
     })
 
@@ -133,8 +135,21 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
     isSendingOtp || isVerifyingTotp || isVerifyingOtp || isVerifyingBackupCode
   const needsOtpRequest = method === "otp" && !otpRequested
 
+  const form = useAuthForm({
+    defaultValues: { backupCode: "", code: "", trustDevice: false },
+    onSubmit: ({ value }) => {
+      const trust = trustDeviceEnabled ? { trustDevice: value.trustDevice } : {}
+      if (method === "backup") {
+        verifyBackupCode({ code: value.backupCode.trim(), ...trust })
+        return
+      }
+      verifyCode(value.code)
+    }
+  })
+
   const switchMethod = (next: ChallengeMethod) => {
-    setCode("")
+    form.setFieldValue("code", "")
+    form.setFieldValue("backupCode", "")
     setMethod(next)
   }
 
@@ -148,7 +163,9 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
       return
     }
 
-    const trust = trustDeviceEnabled ? { trustDevice } : {}
+    const trust = trustDeviceEnabled
+      ? { trustDevice: form.state.values.trustDevice }
+      : {}
 
     if (method === "otp") {
       verifyTwoFactorOtp({ code: completedCode, ...trust })
@@ -156,23 +173,6 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
     }
 
     verifyTotp({ code: completedCode, ...trust })
-  }
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const trust = trustDeviceEnabled ? { trustDevice } : {}
-
-    if (method === "backup") {
-      const formData = new FormData(e.currentTarget)
-      verifyBackupCode({
-        code: (formData.get("backupCode") as string).trim(),
-        ...trust
-      })
-      return
-    }
-
-    verifyCode(code)
   }
 
   const description =
@@ -210,113 +210,143 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            {method === "backup" ? (
-              <Field>
-                <FieldLabel htmlFor="backupCode">
-                  {twoFactorLocalization.backupCode}
-                </FieldLabel>
-
-                <Input
-                  id="backupCode"
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              {method === "backup" ? (
+                <form.AppField
                   name="backupCode"
-                  autoComplete="one-time-code"
-                  autoFocus
-                  required
-                  disabled={isPending}
-                />
-              </Field>
-            ) : (
-              <OtpField
-                autoFocus
-                disabled={isPending || needsOtpRequest}
-                label={
-                  method === "otp"
-                    ? twoFactorLocalization.emailedCode
-                    : twoFactorLocalization.authenticatorCode
-                }
-                length={codeLength}
-                name="code"
-                value={code}
-                onChange={setCode}
-                onComplete={verifyCode}
-              />
-            )}
-
-            {trustDeviceEnabled && (
-              <Field orientation="horizontal">
-                <Checkbox
-                  id="trustDevice"
-                  name="trustDevice"
-                  checked={trustDevice}
-                  disabled={isPending}
-                  onCheckedChange={(checked) =>
-                    setTrustDevice(checked === true)
-                  }
-                />
-
-                <FieldLabel htmlFor="trustDevice" className="font-normal">
-                  {twoFactorLocalization.trustDevice}
-                </FieldLabel>
-              </Field>
-            )}
-
-            <div className="flex flex-col gap-3">
-              {needsOtpRequest ? (
-                <Button
-                  type="button"
-                  disabled={isSendingOtp}
-                  onClick={() => sendTwoFactorOtp()}
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateStringLength(value, {
+                        requiredMessage: localization.auth.fieldRequired,
+                        trim: true
+                      })
+                  }}
                 >
-                  {isSendingOtp && <Spinner />}
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="backupCode">
+                        {twoFactorLocalization.backupCode}
+                      </FieldLabel>
 
-                  {twoFactorLocalization.sendEmailCode}
-                </Button>
+                      <Input
+                        id="backupCode"
+                        name={field.name}
+                        autoComplete="one-time-code"
+                        autoFocus
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                    </Field>
+                  )}
+                </form.AppField>
               ) : (
-                <Button
-                  type="submit"
-                  disabled={
-                    isPending ||
-                    (method !== "backup" && code.length !== codeLength)
-                  }
-                >
-                  {isPending && <Spinner />}
-
-                  {twoFactorLocalization.verify}
-                </Button>
+                <form.AppField name="code">
+                  {(field) => (
+                    <OtpField
+                      autoFocus
+                      disabled={isPending || needsOtpRequest}
+                      label={
+                        method === "otp"
+                          ? twoFactorLocalization.emailedCode
+                          : twoFactorLocalization.authenticatorCode
+                      }
+                      length={codeLength}
+                      name={field.name}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      onComplete={verifyCode}
+                    />
+                  )}
+                </form.AppField>
               )}
 
-              {method === "otp" && otpRequested && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={isPending || isCoolingDown}
-                  onClick={() => sendTwoFactorOtp()}
-                >
-                  {isCoolingDown
-                    ? localization.auth.resendIn.replace(
-                        "{{seconds}}",
-                        String(cooldown)
-                      )
-                    : localization.auth.resend}
-                </Button>
+              {trustDeviceEnabled && (
+                <form.AppField name="trustDevice">
+                  {(field) => (
+                    <Field orientation="horizontal">
+                      <Checkbox
+                        id="trustDevice"
+                        name={field.name}
+                        checked={field.state.value}
+                        disabled={isPending}
+                        onCheckedChange={(checked) =>
+                          field.handleChange(checked === true)
+                        }
+                      />
+
+                      <FieldLabel htmlFor="trustDevice" className="font-normal">
+                        {twoFactorLocalization.trustDevice}
+                      </FieldLabel>
+                    </Field>
+                  )}
+                </form.AppField>
               )}
 
-              {alternatives.map((alternative) => (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  key={alternative.key}
-                  disabled={isPending}
-                  onClick={() => switchMethod(alternative.key)}
-                >
-                  {alternative.label}
-                </Button>
-              ))}
-            </div>
-          </FieldGroup>
-        </form>
+              <div className="flex flex-col gap-3">
+                {needsOtpRequest ? (
+                  <Button
+                    type="button"
+                    disabled={isSendingOtp}
+                    onClick={() => sendTwoFactorOtp()}
+                  >
+                    {isSendingOtp && <Spinner />}
+
+                    {twoFactorLocalization.sendEmailCode}
+                  </Button>
+                ) : (
+                  <form.Subscribe selector={(state) => state.values.code}>
+                    {(code) => (
+                      <form.AuthFormSubmitButton
+                        disabled={
+                          isPending ||
+                          (method !== "backup" && code.length !== codeLength)
+                        }
+                      >
+                        {isPending && <Spinner />}
+                        {twoFactorLocalization.verify}
+                      </form.AuthFormSubmitButton>
+                    )}
+                  </form.Subscribe>
+                )}
+
+                {method === "otp" && otpRequested && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={isPending || isCoolingDown}
+                    onClick={() => sendTwoFactorOtp()}
+                  >
+                    {isCoolingDown
+                      ? localization.auth.resendIn.replace(
+                          "{{seconds}}",
+                          String(cooldown)
+                        )
+                      : localization.auth.resend}
+                  </Button>
+                )}
+
+                {alternatives.map((alternative) => (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    key={alternative.key}
+                    disabled={isPending}
+                    onClick={() => switchMethod(alternative.key)}
+                  >
+                    {alternative.label}
+                  </Button>
+                ))}
+              </div>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/examples/next-shadcn-example/src/components/auth/username/sign-in-username.tsx
+++ b/examples/next-shadcn-example/src/components/auth/username/sign-in-username.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import { authMutationKeys, validateStringLength } from "@better-auth-ui/core"
 import {
   isPasskeyAutoFillEnabled,
   withPasskeyAutoFill
@@ -16,18 +16,16 @@ import {
 import { useSignInUsername } from "@better-auth-ui/react/plugins/username"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import {
   ProviderButtons,
   type SocialLayout
 } from "@/components/auth/provider-buttons"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -43,6 +41,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { usernamePlugin } from "@/lib/auth/username-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 import { LastUsedBadge } from "../last-login-method/last-used-badge"
 
 export type SignInUsernameProps = {
@@ -82,12 +81,10 @@ export function SignInUsername({
 
   const { localization: usernameLocalization } = useAuthPlugin(usernamePlugin)
 
-  const [password, setPassword] = useState("")
-
   const { mutate: signInEmail, isPending: isSignInEmailPending } =
     useSignInEmail(authClient, {
       onError: (error, { email }) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
           sessionStorage.setItem("better-auth-ui.verify-email", email)
@@ -107,7 +104,7 @@ export function SignInUsername({
   const { mutate: signInUsername, isPending: isSignInUsernamePending } =
     useSignInUsername(authClient, {
       onError: (error) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
           sessionStorage.removeItem("better-auth-ui.verify-email")
@@ -141,35 +138,30 @@ export function SignInUsername({
   const passkeyAutoFill = isPasskeyAutoFillEnabled(plugins)
 
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-    password?: string
-  }>({})
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const email = formData.get("email") as string
-    const rememberMe = formData.get("rememberMe") === "on"
-
-    if (isEmail(email)) {
-      signInEmail({
-        email,
-        password,
-        ...(emailAndPassword?.rememberMe ? { rememberMe } : {}),
-        fetchOptions
-      })
-    } else {
-      signInUsername({
-        username: email,
-        password,
-        ...(emailAndPassword?.rememberMe ? { rememberMe } : {}),
-        fetchOptions
-      })
+  const form = useAuthForm({
+    defaultValues: { identifier: "", password: "", rememberMe: false },
+    onSubmit: ({ value }) => {
+      if (isEmail(value.identifier)) {
+        signInEmail({
+          email: value.identifier,
+          password: value.password,
+          ...(emailAndPassword?.rememberMe
+            ? { rememberMe: value.rememberMe }
+            : {}),
+          fetchOptions
+        })
+      } else {
+        signInUsername({
+          username: value.identifier,
+          password: value.password,
+          ...(emailAndPassword?.rememberMe
+            ? { rememberMe: value.rememberMe }
+            : {}),
+          fetchOptions
+        })
+      }
     }
-  }
+  })
 
   const showSeparator =
     emailAndPassword?.enabled && socialProviders && socialProviders.length > 0
@@ -200,171 +192,187 @@ export function SignInUsername({
           )}
 
           {emailAndPassword?.enabled && (
-            <form onSubmit={handleSubmit}>
-              <FieldGroup>
-                <Field data-invalid={!!fieldErrors.email}>
-                  <FieldLabel htmlFor="email">
-                    {usernameLocalization.username}
-                  </FieldLabel>
-
-                  <Input
-                    id="email"
-                    name="email"
-                    type="text"
-                    autoComplete={withPasskeyAutoFill(
-                      "username",
-                      passkeyAutoFill
-                    )}
-                    placeholder={
-                      usernameLocalization.usernameOrEmailPlaceholder
-                    }
-                    required
-                    disabled={isPending}
-                    onChange={() => {
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: undefined
-                      }))
+            <form.AppForm>
+              <form.AuthFormRoot>
+                <FieldGroup>
+                  <form.AppField
+                    name="identifier"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          requiredMessage: localization.auth.fieldRequired,
+                          trim: true
+                        })
                     }}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: localization.auth.fieldRequired
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
-
-                  <FieldError>{fieldErrors.email}</FieldError>
-                </Field>
-
-                <Field data-invalid={!!fieldErrors.password}>
-                  <FieldLabel htmlFor="password">
-                    {localization.auth.password}
-                  </FieldLabel>
-
-                  <InputGroup>
-                    <InputGroupInput
-                      id="password"
-                      name="password"
-                      type={isPasswordVisible ? "text" : "password"}
-                      autoComplete={withPasskeyAutoFill(
-                        "current-password",
-                        passkeyAutoFill
-                      )}
-                      value={password}
-                      onChange={(e) => {
-                        setPassword(e.target.value)
-
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: undefined
-                        }))
-                      }}
-                      placeholder={localization.auth.passwordPlaceholder}
-                      required
-                      minLength={emailAndPassword?.minPasswordLength}
-                      maxLength={emailAndPassword?.maxPasswordLength}
-                      disabled={isPending}
-                      onInvalid={(e) => {
-                        e.preventDefault()
-                        const el = e.target as HTMLInputElement
-                        const min = emailAndPassword?.minPasswordLength
-                        const max = emailAndPassword?.maxPasswordLength
-                        const msg = el.validity.valueMissing
-                          ? localization.auth.fieldRequired
-                          : el.validity.tooShort
-                            ? localization.auth.tooShort.replace(
-                                "{{min}}",
-                                String(min)
-                              )
-                            : localization.auth.tooLong.replace(
-                                "{{max}}",
-                                String(max)
-                              )
-
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: msg
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.password}
-                    />
-
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        title={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() => {
-                          setIsPasswordVisible((visible) => !visible)
-                        }}
-                      >
-                        {isPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-
-                  <FieldError>{fieldErrors.password}</FieldError>
-                </Field>
-
-                {emailAndPassword.rememberMe && (
-                  <Field className="my-1">
-                    <div className="flex items-center gap-3">
-                      <Checkbox
-                        id="rememberMe"
-                        name="rememberMe"
-                        disabled={isPending}
-                      />
-
-                      <FieldLabel
-                        htmlFor="rememberMe"
-                        className="cursor-pointer text-sm font-normal"
-                      >
-                        {localization.auth.rememberMe}
-                      </FieldLabel>
-                    </div>
-                  </Field>
-                )}
-
-                {Captcha && (
-                  <div className="flex justify-center">{Captcha}</div>
-                )}
-
-                <div className="flex flex-col gap-3">
-                  <Button
-                    type="submit"
-                    className="relative overflow-visible"
-                    disabled={isPending}
                   >
-                    {isSignInPending && <Spinner />}
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="email">
+                            {usernameLocalization.username}
+                          </FieldLabel>
 
-                    {localization.auth.signIn}
+                          <Input
+                            id="email"
+                            name={field.name}
+                            type="text"
+                            autoComplete={withPasskeyAutoFill(
+                              "username",
+                              passkeyAutoFill
+                            )}
+                            placeholder={
+                              usernameLocalization.usernameOrEmailPlaceholder
+                            }
+                            required
+                            disabled={isPending}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) =>
+                              field.handleChange(event.target.value)
+                            }
+                            aria-invalid={isInvalid}
+                          />
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
 
-                    <LastUsedBadge method={["email", "username"]} floating />
-                  </Button>
+                  <form.AppField
+                    name="password"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          maxLength: emailAndPassword?.maxPasswordLength,
+                          maxLengthMessage: localization.auth.tooLong.replace(
+                            "{{max}}",
+                            String(emailAndPassword?.maxPasswordLength)
+                          ),
+                          minLength: emailAndPassword?.minPasswordLength,
+                          minLengthMessage: localization.auth.tooShort.replace(
+                            "{{min}}",
+                            String(emailAndPassword?.minPasswordLength)
+                          ),
+                          requiredMessage: localization.auth.fieldRequired
+                        })
+                    }}
+                  >
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="password">
+                            {localization.auth.password}
+                          </FieldLabel>
 
-                  {plugins.flatMap((plugin) =>
-                    (plugin.authButtons ?? []).map((AuthButton, index) => (
-                      <AuthButton
-                        key={`${plugin.id}-${index.toString()}`}
-                        view="signIn"
-                      />
-                    ))
+                          <InputGroup>
+                            <InputGroupInput
+                              id="password"
+                              name={field.name}
+                              type={isPasswordVisible ? "text" : "password"}
+                              autoComplete={withPasskeyAutoFill(
+                                "current-password",
+                                passkeyAutoFill
+                              )}
+                              value={field.state.value}
+                              onBlur={field.handleBlur}
+                              onChange={(event) =>
+                                field.handleChange(event.target.value)
+                              }
+                              placeholder={
+                                localization.auth.passwordPlaceholder
+                              }
+                              required
+                              minLength={emailAndPassword?.minPasswordLength}
+                              maxLength={emailAndPassword?.maxPasswordLength}
+                              disabled={isPending}
+                              aria-invalid={isInvalid}
+                            />
+
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                size="icon-xs"
+                                aria-label={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                title={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                onClick={() => {
+                                  setIsPasswordVisible((visible) => !visible)
+                                }}
+                              >
+                                {isPasswordVisible ? <EyeOff /> : <Eye />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
+
+                  {emailAndPassword.rememberMe && (
+                    <form.AppField name="rememberMe">
+                      {(field) => (
+                        <Field className="my-1">
+                          <div className="flex items-center gap-3">
+                            <Checkbox
+                              id="rememberMe"
+                              name={field.name}
+                              checked={field.state.value}
+                              disabled={isPending}
+                              onCheckedChange={(checked) =>
+                                field.handleChange(checked === true)
+                              }
+                            />
+
+                            <FieldLabel
+                              htmlFor="rememberMe"
+                              className="cursor-pointer text-sm font-normal"
+                            >
+                              {localization.auth.rememberMe}
+                            </FieldLabel>
+                          </div>
+                        </Field>
+                      )}
+                    </form.AppField>
                   )}
-                </div>
-              </FieldGroup>
-            </form>
+
+                  {Captcha && (
+                    <div className="flex justify-center">{Captcha}</div>
+                  )}
+
+                  <div className="flex flex-col gap-3">
+                    <form.AuthFormSubmitButton
+                      className="relative overflow-visible"
+                      disabled={isPending}
+                    >
+                      {isSignInPending && <Spinner />}
+
+                      {localization.auth.signIn}
+
+                      <LastUsedBadge method={["email", "username"]} floating />
+                    </form.AuthFormSubmitButton>
+
+                    {plugins.flatMap((plugin) =>
+                      (plugin.authButtons ?? []).map((AuthButton, index) => (
+                        <AuthButton
+                          key={`${plugin.id}-${index.toString()}`}
+                          view="signIn"
+                        />
+                      ))
+                    )}
+                  </div>
+                </FieldGroup>
+              </form.AuthFormRoot>
+            </form.AppForm>
           )}
 
           {socialPosition === "bottom" && (

--- a/examples/start-shadcn-baseui-example/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -7,8 +7,8 @@ import {
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useCreateApiKey } from "@better-auth-ui/react/plugins/api-key"
 import { Key } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useState } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -35,6 +35,7 @@ import {
 } from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
+import { useAuthForm } from "../auth-form"
 import { NewApiKeyDialog } from "./new-api-key-dialog"
 
 export type CreateApiKeyDialogProps = {
@@ -65,24 +66,48 @@ export function CreateApiKeyDialog({
   const availableConfigurations = configurations.filter(
     (configuration) => configuration.organization === Boolean(organizationId)
   )
-  const expirationItems = keyExpiration
-    ? [
-        ...keyExpiration.intervals.map((days) => ({
-          label: `${days.toLocaleString()} ${
-            days === 1 ? apiKeyLocalization.day : apiKeyLocalization.days
-          }`,
-          value: String(days)
-        })),
-        ...(keyExpiration.allowNever
-          ? [{ label: apiKeyLocalization.never, value: "never" }]
-          : [])
-      ]
-    : []
+
+  const form = useAuthForm({
+    defaultValues: {
+      configId: availableConfigurations[0]?.id ?? "",
+      expiration:
+        keyExpiration && keyExpiration.defaultInterval === null
+          ? "never"
+          : String((keyExpiration && keyExpiration.defaultInterval) ?? "never"),
+      name: ""
+    },
+    onSubmit: ({ value }) => {
+      const name = value.name.trim()
+      const expirationDays =
+        value.expiration !== "never" ? Number(value.expiration) : undefined
+      const expiresIn = expirationDays
+        ? apiKeyExpirationDaysToSeconds(expirationDays)
+        : undefined
+      const configId = value.configId.trim()
+      const resolvedConfigId =
+        configId || (organizationId ? "organization" : undefined)
+      const payload = {
+        ...(name ? { name } : {}),
+        ...(expiresIn ? { expiresIn } : {}),
+        ...(resolvedConfigId ? { configId: resolvedConfigId } : {}),
+        ...(organizationId ? { organizationId } : {})
+      }
+      createApiKey(Object.keys(payload).length > 0 ? payload : undefined, {
+        onSuccess: (result) => {
+          handleOpenChange(false)
+          setKeyName(name)
+          setSecretKey(result.key)
+          setIsNewKeyDialogOpen(true)
+        }
+      })
+    }
+  })
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {
       setKeyName(null)
       setSecretKey(null)
+      form.reset()
     }
 
     onOpenChange(nextOpen)
@@ -97,159 +122,177 @@ export function CreateApiKeyDialog({
     }
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.target as HTMLFormElement)
-    const name = (formData.get("name") as string).trim()
-    const expiration = formData.get("expiration")
-    const expirationDays =
-      typeof expiration === "string" && expiration !== "never"
-        ? Number(expiration)
-        : undefined
-    const expiresIn = expirationDays
-      ? apiKeyExpirationDaysToSeconds(expirationDays)
-      : undefined
-
-    const configId = String(formData.get("configId") ?? "").trim()
-    const resolvedConfigId =
-      configId || (organizationId ? "organization" : undefined)
-    const payload = {
-      ...(name ? { name } : {}),
-      ...(expiresIn ? { expiresIn } : {}),
-      ...(resolvedConfigId ? { configId: resolvedConfigId } : {}),
-      ...(organizationId ? { organizationId } : {})
-    }
-
-    createApiKey(Object.keys(payload).length > 0 ? payload : undefined, {
-      onSuccess: (result) => {
-        handleOpenChange(false)
-        setKeyName(name)
-        setSecretKey(result.key)
-        setIsNewKeyDialogOpen(true)
-      }
-    })
-  }
-
   return (
     <>
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <Key />
-                {apiKeyLocalization.createApiKey}
-              </DialogTitle>
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-6">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <Key />
+                  {apiKeyLocalization.createApiKey}
+                </DialogTitle>
 
-              <DialogDescription>
-                {apiKeyLocalization.apiKeysDescription}
-              </DialogDescription>
-            </DialogHeader>
+                <DialogDescription>
+                  {apiKeyLocalization.apiKeysDescription}
+                </DialogDescription>
+              </DialogHeader>
 
-            <FieldGroup>
-              <Field>
-                <FieldLabel htmlFor="api-key-name">
-                  {apiKeyLocalization.name}
-                </FieldLabel>
+              <FieldGroup>
+                <form.AppField name="name">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="api-key-name">
+                        {apiKeyLocalization.name}
+                      </FieldLabel>
 
-                <Input
-                  id="api-key-name"
-                  name="name"
-                  autoFocus
-                  placeholder={localization.settings.optional}
-                  disabled={isCreating}
-                />
+                      <Input
+                        id="api-key-name"
+                        name={field.name}
+                        autoFocus
+                        placeholder={localization.settings.optional}
+                        disabled={isCreating}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
 
-                <FieldError />
-              </Field>
+                      <FieldError />
+                    </Field>
+                  )}
+                </form.AppField>
 
-              {availableConfigurations.length > 0 && (
-                <Field>
-                  <FieldLabel htmlFor="api-key-configuration">
-                    {apiKeyLocalization.configuration}
-                  </FieldLabel>
-                  <Select
-                    items={availableConfigurations.map((configuration) => ({
-                      label: configuration.label,
-                      value: configuration.id
-                    }))}
-                    name="configId"
-                    defaultValue={availableConfigurations[0]?.id}
-                    disabled={isCreating}
-                  >
-                    <SelectTrigger
-                      id="api-key-configuration"
-                      className="w-full"
-                    >
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        {availableConfigurations.map((configuration) => (
-                          <SelectItem
-                            key={configuration.id}
-                            value={configuration.id}
+                {availableConfigurations.length > 0 && (
+                  <form.AppField name="configId">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel htmlFor="api-key-configuration">
+                          {apiKeyLocalization.configuration}
+                        </FieldLabel>
+                        <Select
+                          items={availableConfigurations.map(
+                            (configuration) => ({
+                              label: configuration.label,
+                              value: configuration.id
+                            })
+                          )}
+                          name={field.name}
+                          value={field.state.value}
+                          onValueChange={(value) =>
+                            field.handleChange(value ?? "")
+                          }
+                          disabled={isCreating}
+                        >
+                          <SelectTrigger
+                            id="api-key-configuration"
+                            className="w-full"
                           >
-                            {configuration.label}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </Field>
-              )}
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              {availableConfigurations.map((configuration) => (
+                                <SelectItem
+                                  key={configuration.id}
+                                  value={configuration.id}
+                                >
+                                  {configuration.label}
+                                </SelectItem>
+                              ))}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      </Field>
+                    )}
+                  </form.AppField>
+                )}
 
-              {keyExpiration ? (
-                <Field>
-                  <FieldLabel htmlFor="api-key-expiration">
-                    {apiKeyLocalization.expiration}
-                  </FieldLabel>
+                {keyExpiration ? (
+                  <form.AppField name="expiration">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel htmlFor="api-key-expiration">
+                          {apiKeyLocalization.expiration}
+                        </FieldLabel>
 
-                  <Select
-                    items={expirationItems}
-                    name="expiration"
-                    defaultValue={
-                      keyExpiration.defaultInterval === null
-                        ? "never"
-                        : String(keyExpiration.defaultInterval)
-                    }
-                    disabled={isCreating}
-                  >
-                    <SelectTrigger id="api-key-expiration" className="w-full">
-                      <SelectValue />
-                    </SelectTrigger>
+                        <Select
+                          items={[
+                            ...keyExpiration.intervals.map((days) => ({
+                              label: `${days.toLocaleString()} ${
+                                days === 1
+                                  ? apiKeyLocalization.day
+                                  : apiKeyLocalization.days
+                              }`,
+                              value: String(days)
+                            })),
+                            ...(keyExpiration.allowNever
+                              ? [
+                                  {
+                                    label: apiKeyLocalization.never,
+                                    value: "never"
+                                  }
+                                ]
+                              : [])
+                          ]}
+                          name={field.name}
+                          value={field.state.value}
+                          onValueChange={(value) =>
+                            field.handleChange(value ?? "")
+                          }
+                          disabled={isCreating}
+                        >
+                          <SelectTrigger
+                            id="api-key-expiration"
+                            className="w-full"
+                          >
+                            <SelectValue />
+                          </SelectTrigger>
 
-                    <SelectContent>
-                      <SelectGroup>
-                        {expirationItems.map((item) => (
-                          <SelectItem key={item.value} value={item.value}>
-                            {item.label}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </Field>
-              ) : null}
-            </FieldGroup>
+                          <SelectContent>
+                            <SelectGroup>
+                              {keyExpiration.intervals.map((days) => (
+                                <SelectItem key={days} value={String(days)}>
+                                  {days.toLocaleString()}{" "}
+                                  {days === 1
+                                    ? apiKeyLocalization.day
+                                    : apiKeyLocalization.days}
+                                </SelectItem>
+                              ))}
 
-            <DialogFooter>
-              <DialogClose
-                className={buttonVariants({ variant: "outline" })}
-                disabled={isCreating}
-                type="button"
-              >
-                {localization.settings.cancel}
-              </DialogClose>
+                              {keyExpiration.allowNever ? (
+                                <SelectItem value="never">
+                                  {apiKeyLocalization.never}
+                                </SelectItem>
+                              ) : null}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      </Field>
+                    )}
+                  </form.AppField>
+                ) : null}
+              </FieldGroup>
 
-              <Button type="submit" disabled={isCreating}>
-                {isCreating && <Spinner />}
+              <DialogFooter>
+                <DialogClose
+                  className={buttonVariants({ variant: "outline" })}
+                  disabled={isCreating}
+                  type="button"
+                >
+                  {localization.settings.cancel}
+                </DialogClose>
 
-                {apiKeyLocalization.createApiKey}
-              </Button>
-            </DialogFooter>
-          </form>
+                <form.AuthFormSubmitButton disabled={isCreating}>
+                  {isCreating && <Spinner />}
+
+                  {apiKeyLocalization.createApiKey}
+                </form.AuthFormSubmitButton>
+              </DialogFooter>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </DialogContent>
       </Dialog>
 

--- a/examples/start-shadcn-baseui-example/src/components/auth/api-key/edit-api-key-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/api-key/edit-api-key-dialog.tsx
@@ -6,8 +6,8 @@ import type {
 } from "@better-auth-ui/core/plugins/api-key"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useUpdateApiKey } from "@better-auth-ui/react/plugins/api-key"
-import type { FormEvent } from "react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useEffect } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -25,6 +25,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
+import { useAuthForm } from "../auth-form"
 
 export function EditApiKeyDialog({
   apiKey,
@@ -41,53 +42,66 @@ export function EditApiKeyDialog({
   const updateApiKey = useUpdateApiKey(authClient, {
     onSuccess: () => onOpenChange(false)
   })
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    updateApiKey.mutate({
-      keyId: apiKey.id,
-      configId: apiKey.configId,
-      name: String(formData.get("name") ?? "").trim()
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { name: apiKey.name ?? "" },
+    onSubmit: ({ value }) =>
+      updateApiKey.mutate({
+        configId: apiKey.configId,
+        keyId: apiKey.id,
+        name: value.name.trim()
+      })
+  })
+  useEffect(() => {
+    if (open) form.reset({ name: apiKey.name ?? "" })
+  }, [apiKey.name, form, open])
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form className="flex flex-col gap-6" onSubmit={submit}>
-          <DialogHeader>
-            <DialogTitle>{labels.editApiKey}</DialogTitle>
-          </DialogHeader>
-          <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor={`api-key-name-${apiKey.id}`}>
-                {labels.name}
-              </FieldLabel>
-              <Input
-                id={`api-key-name-${apiKey.id}`}
-                name="name"
-                defaultValue={apiKey.name ?? ""}
-              />
-            </Field>
-            {updateApiKey.error && (
-              <FieldError>
-                {updateApiKey.error.error?.message ??
-                  updateApiKey.error.message}
-              </FieldError>
-            )}
-          </FieldGroup>
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-            <Button disabled={updateApiKey.isPending} type="submit">
-              {updateApiKey.isPending && <Spinner />}
-              {localization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
-        </form>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle>{labels.editApiKey}</DialogTitle>
+            </DialogHeader>
+            <FieldGroup>
+              <form.AppField name="name">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor={`api-key-name-${apiKey.id}`}>
+                      {labels.name}
+                    </FieldLabel>
+                    <Input
+                      id={`api-key-name-${apiKey.id}`}
+                      name={field.name}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                    />
+                  </Field>
+                )}
+              </form.AppField>
+              {updateApiKey.error && (
+                <FieldError>
+                  {updateApiKey.error.error?.message ??
+                    updateApiKey.error.message}
+                </FieldError>
+              )}
+            </FieldGroup>
+            <DialogFooter>
+              <DialogClose
+                className={buttonVariants({ variant: "outline" })}
+                type="button"
+              >
+                {localization.settings.cancel}
+              </DialogClose>
+              <form.AuthFormSubmitButton disabled={updateApiKey.isPending}>
+                {updateApiKey.isPending && <Spinner />}
+                {localization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-shadcn-baseui-example/src/components/auth/delete-user/delete-account.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/delete-user/delete-account.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { authQueryKeys } from "@better-auth-ui/core"
+import { authQueryKeys, validateStringLength } from "@better-auth-ui/core"
 import {
   useAuth,
   useAuthPlugin,
@@ -9,7 +9,7 @@ import {
 } from "@better-auth-ui/react"
 import { useQueryClient } from "@tanstack/react-query"
 import { Eye, EyeOff, TriangleAlert } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 import {
   AlertDialog,
@@ -22,9 +22,9 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger
 } from "@/components/ui/alert-dialog"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import {
   InputGroup,
   InputGroupAddon,
@@ -34,6 +34,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { deleteUserPlugin } from "@/lib/auth/delete-user-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 
 export type DeleteAccountProps = {
   className?: string
@@ -55,7 +56,6 @@ export function DeleteAccount({ className }: DeleteAccountProps) {
   const queryClient = useQueryClient()
 
   const [confirmOpen, setConfirmOpen] = useState(false)
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
 
   const hasCredentialAccount = accounts?.some(
@@ -65,36 +65,33 @@ export function DeleteAccount({ className }: DeleteAccountProps) {
 
   const { mutate: deleteUser, isPending } = useDeleteUser(authClient)
 
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) => {
+      deleteUser(needsPassword ? { password: value.password } : {}, {
+        onSuccess: () => {
+          setConfirmOpen(false)
+          form.reset()
+
+          if (sendDeleteAccountVerification) {
+            toast.success(deleteUserLocalization.deleteUserVerificationSent)
+          } else {
+            toast.success(deleteUserLocalization.deleteUserSuccess)
+            queryClient.removeQueries({ queryKey: authQueryKeys.all })
+            navigate({
+              to: `${basePaths.auth}/${viewPaths.auth.signIn}`,
+              replace: true
+            })
+          }
+        }
+      })
+    }
+  })
+
   const handleDialogOpenChange = (open: boolean) => {
     setConfirmOpen(open)
-    setPassword("")
+    form.reset()
     setIsPasswordVisible(false)
-  }
-
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const params = {
-      ...(needsPassword ? { password } : {})
-    }
-
-    deleteUser(params, {
-      onSuccess: () => {
-        setConfirmOpen(false)
-        setPassword("")
-
-        if (sendDeleteAccountVerification) {
-          toast.success(deleteUserLocalization.deleteUserVerificationSent)
-        } else {
-          toast.success(deleteUserLocalization.deleteUserSuccess)
-          queryClient.removeQueries({ queryKey: authQueryKeys.all })
-          navigate({
-            to: `${basePaths.auth}/${viewPaths.auth.signIn}`,
-            replace: true
-          })
-        }
-      }
-    })
   }
 
   return (
@@ -121,82 +118,103 @@ export function DeleteAccount({ className }: DeleteAccountProps) {
           </AlertDialogTrigger>
 
           <AlertDialogContent>
-            <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-              <AlertDialogHeader>
-                <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
-                  <TriangleAlert />
-                </AlertDialogMedia>
+            <form.AppForm>
+              <form.AuthFormRoot className="flex flex-col gap-6">
+                <AlertDialogHeader>
+                  <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
+                    <TriangleAlert />
+                  </AlertDialogMedia>
 
-                <AlertDialogTitle>
-                  {deleteUserLocalization.deleteAccount}
-                </AlertDialogTitle>
+                  <AlertDialogTitle>
+                    {deleteUserLocalization.deleteAccount}
+                  </AlertDialogTitle>
 
-                <AlertDialogDescription>
-                  {deleteUserLocalization.deleteAccountDescription}
-                </AlertDialogDescription>
-              </AlertDialogHeader>
+                  <AlertDialogDescription>
+                    {deleteUserLocalization.deleteAccountDescription}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
 
-              {needsPassword && (
-                <Field>
-                  <FieldLabel htmlFor="delete-password">
-                    {localization.auth.password}
-                  </FieldLabel>
+                {needsPassword && (
+                  <form.AppField
+                    name="password"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          requiredMessage: localization.auth.fieldRequired
+                        })
+                    }}
+                  >
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="delete-password">
+                            {localization.auth.password}
+                          </FieldLabel>
 
-                  <InputGroup>
-                    <InputGroupInput
-                      id="delete-password"
-                      name="password"
-                      type={isPasswordVisible ? "text" : "password"}
-                      autoComplete="current-password"
-                      placeholder={localization.auth.passwordPlaceholder}
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      disabled={isPending}
-                      required
-                    />
+                          <InputGroup>
+                            <InputGroupInput
+                              id="delete-password"
+                              name={field.name}
+                              type={isPasswordVisible ? "text" : "password"}
+                              autoComplete="current-password"
+                              placeholder={
+                                localization.auth.passwordPlaceholder
+                              }
+                              value={field.state.value}
+                              onBlur={field.handleBlur}
+                              onChange={(event) =>
+                                field.handleChange(event.target.value)
+                              }
+                              disabled={isPending}
+                              required
+                            />
 
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        title={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() => {
-                          setIsPasswordVisible((visible) => !visible)
-                        }}
-                      >
-                        {isPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                size="icon-xs"
+                                aria-label={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                title={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                onClick={() => {
+                                  setIsPasswordVisible((visible) => !visible)
+                                }}
+                              >
+                                {isPasswordVisible ? <EyeOff /> : <Eye />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
 
-                  <FieldError />
-                </Field>
-              )}
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
+                )}
 
-              <AlertDialogFooter>
-                <AlertDialogCancel disabled={isPending}>
-                  {localization.settings.cancel}
-                </AlertDialogCancel>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={isPending}>
+                    {localization.settings.cancel}
+                  </AlertDialogCancel>
 
-                <Button
-                  type="submit"
-                  variant="destructive"
-                  disabled={isPending}
-                >
-                  {isPending && <Spinner />}
+                  <form.AuthFormSubmitButton
+                    variant="destructive"
+                    disabled={isPending}
+                  >
+                    {isPending && <Spinner />}
 
-                  {deleteUserLocalization.deleteAccount}
-                </Button>
-              </AlertDialogFooter>
-            </form>
+                    {deleteUserLocalization.deleteAccount}
+                  </form.AuthFormSubmitButton>
+                </AlertDialogFooter>
+              </form.AuthFormRoot>
+            </form.AppForm>
           </AlertDialogContent>
         </AlertDialog>
       </CardContent>

--- a/examples/start-shadcn-baseui-example/src/components/auth/device-authorization/device-authorization.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/device-authorization/device-authorization.tsx
@@ -13,7 +13,6 @@ import {
 import { REGEXP_ONLY_DIGITS_AND_CHARS } from "input-otp"
 import { CheckIcon, CircleCheckIcon, CircleXIcon, XIcon } from "lucide-react"
 import {
-  type FormEvent,
   type ReactNode,
   useCallback,
   useEffect,
@@ -47,6 +46,7 @@ import { Separator } from "@/components/ui/separator"
 import { Spinner } from "@/components/ui/spinner"
 import { deviceAuthorizationPlugin } from "@/lib/auth/device-authorization-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 
 type DeviceAuthorizationStep = "code" | "approval" | "approved" | "denied"
 
@@ -131,7 +131,6 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
     initialDeviceAuthorizationState
   )
   const submittedCodeRef = useRef<string | null>(null)
-  const normalizedUserCode = normalizeDeviceCode(userCode)
 
   const handleAuthorizationError = () => {
     dispatch({
@@ -175,19 +174,6 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
     }
   )
 
-  const handleCodeChange = (value: string) => {
-    const nextCode = normalizeDeviceCode(value)
-      .replace(/[^A-Z0-9]/g, "")
-      .slice(0, userCodeLength)
-
-    if (nextCode !== submittedCodeRef.current) {
-      submittedCodeRef.current = null
-    }
-
-    setUserCode(nextCode)
-    dispatch({ type: "codeChanged" })
-  }
-
   const submitCode = useCallback(
     (completedCode: string) => {
       const normalizedCode = normalizeDeviceCode(completedCode)
@@ -227,22 +213,22 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
     ]
   )
 
-  useEffect(() => {
-    if (normalizedUserCode.length === userCodeLength) {
-      submitCode(normalizedUserCode)
-    }
-  }, [normalizedUserCode, submitCode, userCodeLength])
+  const handleSubmit = useCallback(
+    (code: string) => {
+      const normalizedCode = normalizeDeviceCode(code)
+      if (normalizedCode.length !== userCodeLength) {
+        dispatch({
+          type: "verificationFailed",
+          message: localization.invalidDeviceCode
+        })
+        return
+      }
+      submitCode(normalizedCode)
+    },
+    [localization.invalidDeviceCode, submitCode, userCodeLength]
+  )
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-
-    if (normalizedUserCode.length !== userCodeLength) {
-      handleAuthorizationError()
-      return
-    }
-
-    submitCode(normalizedUserCode)
-  }
+  const authorizedCode = submittedCodeRef.current ?? ""
 
   const cardClassName = cn("w-full max-w-sm", className)
 
@@ -251,12 +237,12 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
       <DeviceApproval
         className={cardClassName}
         localization={localization}
-        userCode={normalizedUserCode}
+        userCode={authorizedCode}
         user={session.user}
         isApproving={isApproving}
         isDenying={isDenying}
-        onApprove={() => approveDevice({ userCode: normalizedUserCode })}
-        onDeny={() => denyDevice({ userCode: normalizedUserCode })}
+        onApprove={() => approveDevice({ userCode: authorizedCode })}
+        onDeny={() => denyDevice({ userCode: authorizedCode })}
       />
     )
   }
@@ -286,10 +272,10 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
       isSessionPending={isSessionPending}
       isVerifying={isVerifying}
       localization={localization}
-      userCode={userCode}
+      initialUserCode={userCode}
       userCodeLength={userCodeLength}
-      onCodeChange={handleCodeChange}
-      onSubmit={handleSubmit}
+      onCodeChange={() => dispatch({ type: "codeChanged" })}
+      onSubmitCode={handleSubmit}
     />
   )
 }
@@ -300,10 +286,10 @@ type DeviceCodeFormProps = {
   isSessionPending: boolean
   isVerifying: boolean
   localization: DeviceAuthorizationLocalization
-  userCode: string
+  initialUserCode: string
   userCodeLength: number
   onCodeChange: (value: string) => void
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void
+  onSubmitCode: (code: string) => void
 }
 
 function DeviceCodeForm({
@@ -312,16 +298,27 @@ function DeviceCodeForm({
   isSessionPending,
   isVerifying,
   localization,
-  userCode,
+  initialUserCode,
   userCodeLength,
   onCodeChange,
-  onSubmit
+  onSubmitCode
 }: DeviceCodeFormProps) {
   const slots = createDeviceCodeSlots(userCodeLength)
   const groupBreak = Math.ceil(userCodeLength / 2)
   const firstGroup = slots.slice(0, groupBreak)
   const secondGroup = slots.slice(groupBreak)
   const errorId = "device-code-error"
+  const form = useAuthForm({
+    defaultValues: { userCode: initialUserCode },
+    onSubmit: ({ value }) => onSubmitCode(value.userCode)
+  })
+
+  useEffect(() => {
+    form.setFieldValue("userCode", initialUserCode)
+    if (initialUserCode.length === userCodeLength) {
+      onSubmitCode(initialUserCode)
+    }
+  }, [form.setFieldValue, initialUserCode, onSubmitCode, userCodeLength])
 
   return (
     <Card className={className}>
@@ -335,63 +332,77 @@ function DeviceCodeForm({
       </CardHeader>
 
       <CardContent>
-        <form aria-label={localization.deviceAuthorization} onSubmit={onSubmit}>
-          <FieldGroup>
-            <Field data-invalid={Boolean(codeError)}>
-              <FieldLabel htmlFor="device-code">
-                {localization.deviceCode}
-              </FieldLabel>
+        <form.AppForm>
+          <form.AuthFormRoot aria-label={localization.deviceAuthorization}>
+            <FieldGroup>
+              <form.AppField name="userCode">
+                {(field) => (
+                  <Field data-invalid={Boolean(codeError)}>
+                    <FieldLabel htmlFor="device-code">
+                      {localization.deviceCode}
+                    </FieldLabel>
 
-              <InputOTP
-                id="device-code"
-                aria-describedby={codeError ? errorId : undefined}
-                aria-invalid={Boolean(codeError)}
-                autoComplete="one-time-code"
-                containerClassName="w-full justify-center"
-                disabled={isVerifying}
-                inputMode="text"
-                maxLength={userCodeLength}
-                name="userCode"
-                pasteTransformer={normalizeDeviceCode}
-                pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
-                value={userCode}
-                onChange={onCodeChange}
+                    <InputOTP
+                      id="device-code"
+                      aria-describedby={codeError ? errorId : undefined}
+                      aria-invalid={Boolean(codeError)}
+                      autoComplete="one-time-code"
+                      containerClassName="w-full justify-center"
+                      disabled={isVerifying}
+                      inputMode="text"
+                      maxLength={userCodeLength}
+                      name={field.name}
+                      pasteTransformer={normalizeDeviceCode}
+                      pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+                      value={field.state.value}
+                      onChange={(value) => {
+                        const nextCode = normalizeDeviceCode(value)
+                          .replace(/[^A-Z0-9]/g, "")
+                          .slice(0, userCodeLength)
+                        field.handleChange(nextCode)
+                        onCodeChange(nextCode)
+                        if (nextCode.length === userCodeLength)
+                          onSubmitCode(nextCode)
+                      }}
+                    >
+                      <InputOTPGroup>
+                        {firstGroup.map((slot) => (
+                          <InputOTPSlot key={slot.id} index={slot.index} />
+                        ))}
+                      </InputOTPGroup>
+
+                      {secondGroup.length > 0 ? (
+                        <>
+                          <InputOTPSeparator />
+                          <InputOTPGroup>
+                            {secondGroup.map((slot) => (
+                              <InputOTPSlot key={slot.id} index={slot.index} />
+                            ))}
+                          </InputOTPGroup>
+                        </>
+                      ) : null}
+                    </InputOTP>
+
+                    <FieldError id={errorId}>{codeError}</FieldError>
+                  </Field>
+                )}
+              </form.AppField>
+
+              <form.AuthFormSubmitButton
+                className="w-full"
+                disabled={
+                  form.state.values.userCode.length !== userCodeLength ||
+                  isSessionPending ||
+                  isVerifying
+                }
+                type="submit"
               >
-                <InputOTPGroup>
-                  {firstGroup.map((slot) => (
-                    <InputOTPSlot key={slot.id} index={slot.index} />
-                  ))}
-                </InputOTPGroup>
-
-                {secondGroup.length > 0 ? (
-                  <>
-                    <InputOTPSeparator />
-                    <InputOTPGroup>
-                      {secondGroup.map((slot) => (
-                        <InputOTPSlot key={slot.id} index={slot.index} />
-                      ))}
-                    </InputOTPGroup>
-                  </>
-                ) : null}
-              </InputOTP>
-
-              <FieldError id={errorId}>{codeError}</FieldError>
-            </Field>
-
-            <Button
-              className="w-full"
-              disabled={
-                userCode.length !== userCodeLength ||
-                isSessionPending ||
-                isVerifying
-              }
-              type="submit"
-            >
-              {isVerifying ? <Spinner data-icon="inline-start" /> : null}
-              {localization.continue}
-            </Button>
-          </FieldGroup>
-        </form>
+                {isVerifying ? <Spinner data-icon="inline-start" /> : null}
+                {localization.continue}
+              </form.AuthFormSubmitButton>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
     </Card>
   )

--- a/examples/start-shadcn-baseui-example/src/components/auth/email-otp/change-email-otp.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/email-otp/change-email-otp.tsx
@@ -7,17 +7,18 @@ import {
   useRequestEmailChangeOtp,
   useSendVerificationOtp
 } from "@better-auth-ui/react/plugins/email-otp"
-import { type SyntheticEvent, useReducer, useState } from "react"
+import { useEffect, useReducer } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 
@@ -84,14 +85,6 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
     changeEmailReducer,
     initialChangeEmailState
   )
-  const [code, setCode] = useState("")
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({})
-
-  const resetFlow = () => {
-    setCode("")
-    dispatch({ type: "restarted" })
-  }
-
   // The step transition is attached per call: the code goes to the current
   // address while the pending change targets the new one, so the address to
   // remember isn't in this mutation's variables.
@@ -100,9 +93,9 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
 
   const { mutate: requestEmailChangeOtp, isPending: isRequesting } =
     useRequestEmailChangeOtp(otpClient, {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: (_data, { newEmail }) => {
-        setCode("")
+        form.setFieldValue("code", "")
         dispatch({ type: "changeRequested", newEmail })
       }
     })
@@ -110,7 +103,7 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
   const { mutate: changeEmailOtp, isPending: isChanging } = useChangeEmailOtp(
     otpClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
         toast.success(localization.settings.changeEmailSuccess)
         resetFlow()
@@ -134,30 +127,39 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
     changeEmailOtp({ newEmail: state.newEmail, otp: completedCode })
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useAuthForm({
+    defaultValues: { code: "", email: "" },
+    onSubmit: ({ value }) => {
+      if (state.step === "email") {
+        const newEmail = value.email
 
-    if (state.step === "email") {
-      const formData = new FormData(e.currentTarget)
-      const newEmail = formData.get("email") as string
+        if (verifyCurrentEmail && currentEmail) {
+          sendVerificationOtp(
+            { email: currentEmail, type: "change-email" },
+            {
+              onSuccess: () =>
+                dispatch({ type: "currentEmailChallenged", newEmail })
+            }
+          )
+          return
+        }
 
-      if (verifyCurrentEmail && currentEmail) {
-        sendVerificationOtp(
-          { email: currentEmail, type: "change-email" },
-          {
-            onSuccess: () =>
-              dispatch({ type: "currentEmailChallenged", newEmail })
-          }
-        )
+        requestEmailChangeOtp({ newEmail })
         return
       }
-
-      requestEmailChangeOtp({ newEmail })
-      return
+      submitCode(value.code)
     }
+  })
 
-    submitCode(code)
+  const resetFlow = () => {
+    form.reset()
+    if (currentEmail) form.setFieldValue("email", currentEmail)
+    dispatch({ type: "restarted" })
   }
+
+  useEffect(() => {
+    if (currentEmail) form.setFieldValue("email", currentEmail)
+  }, [currentEmail, form])
 
   const codeTarget =
     state.step === "currentCode" ? currentEmail : state.newEmail
@@ -168,109 +170,111 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
         {localization.settings.changeEmail}
       </h2>
 
-      <form onSubmit={handleSubmit}>
-        <Card className={cn(className)}>
-          <CardContent className="flex flex-col gap-6">
-            {state.step === "email" ? (
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="email">
-                  {localization.auth.email}
-                </FieldLabel>
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card className={cn(className)}>
+            <CardContent className="flex flex-col gap-6">
+              {state.step === "email" ? (
+                <form.AppField name="email">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
 
-                {session ? (
-                  <Input
-                    key={currentEmail}
-                    id="email"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    defaultValue={currentEmail}
-                    placeholder={localization.auth.emailPlaceholder}
-                    disabled={isPending}
-                    required
-                    onChange={() =>
-                      setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                    }
-                    onInvalid={(e) => {
-                      e.preventDefault()
+                      {session ? (
+                        <Input
+                          key={currentEmail}
+                          id="email"
+                          name="email"
+                          type="email"
+                          autoComplete="email"
+                          value={field.state.value}
+                          placeholder={localization.auth.emailPlaceholder}
+                          disabled={isPending}
+                          required
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                        />
+                      ) : (
+                        <Skeleton>
+                          <Input className="invisible" />
+                        </Skeleton>
+                      )}
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: (e.target as HTMLInputElement).validationMessage
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
-                ) : (
-                  <Skeleton>
-                    <Input className="invisible" />
-                  </Skeleton>
-                )}
-
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
-            ) : (
-              <div className="flex flex-col gap-3">
-                <p className="text-muted-foreground text-sm">
-                  {emailOtpLocalization.confirmEmailDescription.replace(
-                    "{{email}}",
-                    codeTarget ?? ""
+                      <field.AuthFormFieldError />
+                    </Field>
                   )}
-                </p>
+                </form.AppField>
+              ) : (
+                <div className="flex flex-col gap-3">
+                  <p className="text-muted-foreground text-sm">
+                    {emailOtpLocalization.confirmEmailDescription.replace(
+                      "{{email}}",
+                      codeTarget ?? ""
+                    )}
+                  </p>
 
-                <OtpField
-                  autoFocus
+                  <form.AppField name="code">
+                    {(field) => (
+                      <OtpField
+                        autoFocus
+                        disabled={isPending}
+                        label={
+                          state.step === "currentCode"
+                            ? emailOtpLocalization.confirmCurrentEmail
+                            : emailOtpLocalization.confirmNewEmail
+                        }
+                        length={otpLength}
+                        name="otp"
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        onComplete={submitCode}
+                      />
+                    )}
+                  </form.AppField>
+
+                  {codeTarget && (
+                    <OpenEmailButton email={codeTarget} variant="secondary" />
+                  )}
+                </div>
+              )}
+            </CardContent>
+
+            <CardFooter className="gap-3">
+              {state.step !== "email" && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
                   disabled={isPending}
-                  label={
-                    state.step === "currentCode"
-                      ? emailOtpLocalization.confirmCurrentEmail
-                      : emailOtpLocalization.confirmNewEmail
-                  }
-                  length={otpLength}
-                  name="otp"
-                  value={code}
-                  onChange={setCode}
-                  onComplete={submitCode}
-                />
+                  onClick={resetFlow}
+                >
+                  {localization.settings.cancel}
+                </Button>
+              )}
 
-                {codeTarget && (
-                  <OpenEmailButton email={codeTarget} variant="secondary" />
-                )}
-              </div>
-            )}
-          </CardContent>
-
-          <CardFooter className="gap-3">
-            {state.step !== "email" && (
-              <Button
-                type="button"
+              <form.AuthFormSubmitButton
                 size="sm"
-                variant="outline"
-                disabled={isPending}
-                onClick={resetFlow}
+                disabled={
+                  isPending ||
+                  !session ||
+                  (state.step !== "email" &&
+                    form.state.values.code.length !== otpLength)
+                }
               >
-                {localization.settings.cancel}
-              </Button>
-            )}
+                {isPending && <Spinner />}
 
-            <Button
-              type="submit"
-              size="sm"
-              disabled={
-                isPending ||
-                !session ||
-                (state.step !== "email" && code.length !== otpLength)
-              }
-            >
-              {isPending && <Spinner />}
-
-              {state.step === "email"
-                ? localization.settings.updateEmail
-                : emailOtpLocalization.verifyCode}
-            </Button>
-          </CardFooter>
-        </Card>
-      </form>
+                {state.step === "email"
+                  ? localization.settings.updateEmail
+                  : emailOtpLocalization.verifyCode}
+              </form.AuthFormSubmitButton>
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/examples/start-shadcn-baseui-example/src/components/auth/email-otp/email-otp.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/email-otp/email-otp.tsx
@@ -9,7 +9,7 @@ import {
   useSignInEmailOtp
 } from "@better-auth-ui/react/plugins/email-otp"
 import { useIsMutating } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -22,7 +22,6 @@ import {
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -33,6 +32,7 @@ import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { useResendCooldown } from "@/lib/auth/use-resend-cooldown"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
@@ -75,10 +75,7 @@ export function EmailOtp({
   const continueSignIn = useSignInContinuation()
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
 
-  const [email, setEmail] = useState(getSsoFallbackEmail)
-  const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({})
 
   const { mutate: sendVerificationOtp, isPending: isSending } =
     useSendVerificationOtp(otpClient, {
@@ -91,7 +88,7 @@ export function EmailOtp({
   const { mutate: signInEmailOtp, isPending: isSigningIn } = useSignInEmailOtp(
     otpClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: (data) => continueSignIn(data)
     }
   )
@@ -104,23 +101,28 @@ export function EmailOtp({
   })
   const isPending = signInMutating + signUpMutating > 0 || isSending
 
-  const sendCode = () => sendVerificationOtp({ email, type: "sign-in" })
+  const sendCode = () =>
+    sendVerificationOtp({
+      email: form.state.values.email,
+      type: "sign-in"
+    })
   const verifyCode = (completedCode: string) => {
     if (isPending || isSigningIn) return
 
-    signInEmailOtp({ email, otp: completedCode })
+    signInEmailOtp({ email: form.state.values.email, otp: completedCode })
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useAuthForm({
+    defaultValues: { code: "", email: getSsoFallbackEmail() },
+    onSubmit: ({ value }) => {
+      if (!codeSent) {
+        sendVerificationOtp({ email: value.email, type: "sign-in" })
+        return
+      }
 
-    if (!codeSent) {
-      sendCode()
-      return
+      verifyCode(value.code)
     }
-
-    verifyCode(code)
-  }
+  })
 
   const showSeparator = socialProviders && socialProviders.length > 0
 
@@ -131,7 +133,10 @@ export function EmailOtp({
 
         {codeSent && (
           <CardDescription>
-            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
+            {emailOtpLocalization.codeSentTo.replace(
+              "{{email}}",
+              form.state.values.email
+            )}
           </CardDescription>
         )}
       </CardHeader>
@@ -152,112 +157,113 @@ export function EmailOtp({
             </>
           )}
 
-          <form onSubmit={handleSubmit}>
-            <FieldGroup>
-              {codeSent ? (
-                <OtpField
-                  autoFocus
-                  disabled={isPending || isSigningIn}
-                  label={emailOtpLocalization.code}
-                  length={otpLength}
-                  name="otp"
-                  value={code}
-                  onChange={setCode}
-                  onComplete={verifyCode}
-                />
-              ) : (
-                <Field data-invalid={!!fieldErrors.email}>
-                  <FieldLabel htmlFor="email">
-                    {localization.auth.email}
-                  </FieldLabel>
-
-                  <Input
-                    id="email"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    value={email}
-                    onChange={(e) => {
-                      setEmail(e.target.value)
-                      setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                    }}
-                    placeholder={localization.auth.emailPlaceholder}
-                    required
-                    disabled={isPending}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: (e.target as HTMLInputElement).validationMessage
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
-
-                  <FieldError>{fieldErrors.email}</FieldError>
-                </Field>
-              )}
-
-              <div className="flex flex-col gap-3">
-                <Button
-                  type="submit"
-                  disabled={
-                    isPending ||
-                    isSigningIn ||
-                    (codeSent && code.length !== otpLength)
-                  }
-                >
-                  {(isSending || isSigningIn) && <Spinner />}
-
-                  {codeSent
-                    ? emailOtpLocalization.verifyCode
-                    : emailOtpLocalization.sendCode}
-                </Button>
-
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <FieldGroup>
                 {codeSent ? (
-                  <>
-                    <OpenEmailButton email={email} variant="secondary" />
-
-                    <Button
-                      type="button"
-                      variant="outline"
-                      disabled={isPending || isSigningIn || isCoolingDown}
-                      onClick={sendCode}
-                    >
-                      {isCoolingDown
-                        ? localization.auth.resendIn.replace(
-                            "{{seconds}}",
-                            String(cooldown)
-                          )
-                        : localization.auth.resend}
-                    </Button>
-
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      disabled={isPending || isSigningIn}
-                      onClick={() => {
-                        setCodeSent(false)
-                        setCode("")
-                      }}
-                    >
-                      {emailOtpLocalization.useDifferentEmail}
-                    </Button>
-                  </>
-                ) : (
-                  plugins.flatMap((plugin) =>
-                    (plugin.authButtons ?? []).map((AuthButton, index) => (
-                      <AuthButton
-                        key={`${plugin.id}-${index.toString()}`}
-                        view="emailOtp"
+                  <form.AppField name="code">
+                    {(field) => (
+                      <OtpField
+                        autoFocus
+                        disabled={isPending || isSigningIn}
+                        label={emailOtpLocalization.code}
+                        length={otpLength}
+                        name={field.name}
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        onComplete={verifyCode}
                       />
-                    ))
-                  )
+                    )}
+                  </form.AppField>
+                ) : (
+                  <form.AppField name="email">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel htmlFor="email">
+                          {localization.auth.email}
+                        </FieldLabel>
+                        <Input
+                          id="email"
+                          name={field.name}
+                          type="email"
+                          autoComplete="email"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          placeholder={localization.auth.emailPlaceholder}
+                          required
+                          disabled={isPending}
+                        />
+                        <field.AuthFormFieldError />
+                      </Field>
+                    )}
+                  </form.AppField>
                 )}
-              </div>
-            </FieldGroup>
-          </form>
+
+                <div className="flex flex-col gap-3">
+                  <form.AuthFormSubmitButton
+                    disabled={
+                      isPending ||
+                      isSigningIn ||
+                      (codeSent && form.state.values.code.length !== otpLength)
+                    }
+                  >
+                    {(isSending || isSigningIn) && <Spinner />}
+
+                    {codeSent
+                      ? emailOtpLocalization.verifyCode
+                      : emailOtpLocalization.sendCode}
+                  </form.AuthFormSubmitButton>
+
+                  {codeSent ? (
+                    <>
+                      <OpenEmailButton
+                        email={form.state.values.email}
+                        variant="secondary"
+                      />
+
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isPending || isSigningIn || isCoolingDown}
+                        onClick={sendCode}
+                      >
+                        {isCoolingDown
+                          ? localization.auth.resendIn.replace(
+                              "{{seconds}}",
+                              String(cooldown)
+                            )
+                          : localization.auth.resend}
+                      </Button>
+
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        disabled={isPending || isSigningIn}
+                        onClick={() => {
+                          setCodeSent(false)
+                          form.setFieldValue("code", "")
+                        }}
+                      >
+                        {emailOtpLocalization.useDifferentEmail}
+                      </Button>
+                    </>
+                  ) : (
+                    plugins.flatMap((plugin) =>
+                      (plugin.authButtons ?? []).map((AuthButton, index) => (
+                        <AuthButton
+                          key={`${plugin.id}-${index.toString()}`}
+                          view="emailOtp"
+                        />
+                      ))
+                    )
+                  )}
+                </div>
+              </FieldGroup>
+            </form.AuthFormRoot>
+          </form.AppForm>
 
           {socialPosition === "bottom" && !codeSent && (
             <>

--- a/examples/start-shadcn-baseui-example/src/components/auth/email-otp/forgot-password-otp.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/email-otp/forgot-password-otp.tsx
@@ -1,17 +1,14 @@
 "use client"
 
-import { getAuthLinkURL } from "@better-auth-ui/core"
+import { getAuthLinkURL, validateEmailAddress } from "@better-auth-ui/core"
 import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin, useFetchOptions } from "@better-auth-ui/react"
 import { useRequestPasswordResetOtp } from "@better-auth-ui/react/plugins/email-otp"
-import { type SyntheticEvent, useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel
 } from "@/components/ui/field"
@@ -19,6 +16,7 @@ import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 
 /** `sessionStorage` key the reset-code form reads the pending address from. */
 export const RESET_PASSWORD_OTP_STORAGE_KEY =
@@ -52,7 +50,6 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
   const { localization: emailOtpLocalization } = useAuthPlugin(emailOtpPlugin)
 
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({})
 
   const { mutate: requestPasswordResetOtp, isPending } =
     useRequestPasswordResetOtp(authClient as EmailOtpAuthClient, {
@@ -63,15 +60,11 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
       }
     })
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    requestPasswordResetOtp({
-      email: formData.get("email") as string,
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) =>
+      requestPasswordResetOtp({ email: value.email, fetchOptions })
+  })
 
   const Captcha = plugins.find(
     (plugin) => plugin.captchaComponent
@@ -86,45 +79,57 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            <Field data-invalid={!!fieldErrors.email}>
-              <FieldLabel htmlFor="email">{localization.auth.email}</FieldLabel>
-
-              <Input
-                id="email"
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              <form.AppField
                 name="email"
-                type="email"
-                autoComplete="email"
-                placeholder={localization.auth.emailPlaceholder}
-                required
-                disabled={isPending}
-                onChange={() =>
-                  setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                }
-                onInvalid={(e) => {
-                  e.preventDefault()
-
-                  setFieldErrors((prev) => ({
-                    ...prev,
-                    email: (e.target as HTMLInputElement).validationMessage
-                  }))
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
                 }}
-                aria-invalid={!!fieldErrors.email}
-              />
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        aria-invalid={isInvalid}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
 
-              <FieldError>{fieldErrors.email}</FieldError>
-            </Field>
+              {Captcha && <div className="flex justify-center">{Captcha}</div>}
 
-            {Captcha && <div className="flex justify-center">{Captcha}</div>}
+              <form.AuthFormSubmitButton disabled={isPending}>
+                {isPending && <Spinner />}
 
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Spinner />}
-
-              {emailOtpLocalization.sendCode}
-            </Button>
-          </FieldGroup>
-        </form>
+                {emailOtpLocalization.sendCode}
+              </form.AuthFormSubmitButton>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/examples/start-shadcn-baseui-example/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/email-otp/reset-password-otp.tsx
@@ -8,10 +8,9 @@ import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPasswordOtp } from "@better-auth-ui/react/plugins/email-otp"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -36,6 +35,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 import { PasswordStrengthMeter } from "../password-strength-meter"
@@ -74,24 +74,9 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
   const isHydrated = useIsHydrated()
   const initialEmail =
     (isHydrated && sessionStorage.getItem(RESET_PASSWORD_OTP_STORAGE_KEY)) || ""
-  const [email, setEmail] = useState(initialEmail)
   const [hasStoredEmail, setHasStoredEmail] = useState(Boolean(initialEmail))
-  const [code, setCode] = useState("")
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-  const formRef = useRef<HTMLFormElement>(null)
-  const submissionLockedRef = useRef(false)
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-    password?: string
-  }>({})
-
-  useEffect(() => {
-    const storedEmail =
-      sessionStorage.getItem(RESET_PASSWORD_OTP_STORAGE_KEY) ?? ""
-    setEmail(storedEmail)
-    setHasStoredEmail(Boolean(storedEmail))
-  }, [])
+  const [passwordError, setPasswordError] = useState("")
 
   const { mutate: resetPasswordOtp, isPending } = useResetPasswordOtp(
     authClient as EmailOtpAuthClient,
@@ -100,14 +85,9 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
         // The haveIBeenPwned plugin rejects on the password itself, so it
         // belongs against the field rather than in a toast.
         if (isPasswordCompromisedError(error)) {
-          setFieldErrors((prev) => ({
-            ...prev,
-            password: localization.auth.passwordCompromised
-          }))
+          setPasswordError(localization.auth.passwordCompromised)
         }
-
-        submissionLockedRef.current = false
-        setCode("")
+        form.setFieldValue("code", "")
       },
       onSuccess: () => {
         sessionStorage.removeItem(RESET_PASSWORD_OTP_STORAGE_KEY)
@@ -117,58 +97,44 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
     }
   )
 
-  const submitReset = (
-    form: HTMLFormElement,
-    submittedCode: string,
-    reportErrors: boolean
-  ) => {
-    if (isPending || submissionLockedRef.current) return
-
-    const formData = new FormData(form)
-    const password = formData.get("password") as string
-    const confirmPassword = formData.get("confirmPassword") as string
-    const submittedEmail = hasStoredEmail
-      ? email
-      : (formData.get("email") as string)
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      if (reportErrors) {
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      confirmPassword: "",
+      email: initialEmail,
+      password: ""
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
         toast.error(localization.auth.passwordsDoNotMatch)
+        return
       }
-      return
-    }
-
-    if (submittedCode.length !== otpLength) {
-      if (reportErrors) {
+      if (value.code.length !== otpLength) {
         toast.error(
           emailOtpLocalization.codeLengthMismatch.replace(
             "{{length}}",
             String(otpLength)
           )
         )
+        return
       }
-      return
+      resetPasswordOtp({
+        email: value.email,
+        otp: value.code,
+        password: value.password
+      })
     }
+  })
 
-    submissionLockedRef.current = true
-    resetPasswordOtp({ email: submittedEmail, otp: submittedCode, password })
-  }
-
-  const tryAutoSubmit = (completedCode?: string) => {
-    const form = formRef.current
-
-    if (!form?.matches(":valid")) return
-
-    const formData = new FormData(form)
-    const submittedCode = completedCode ?? String(formData.get("otp") ?? "")
-
-    submitReset(form, submittedCode, false)
-  }
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    submitReset(e.currentTarget, code, true)
-  }
+  useEffect(() => {
+    const storedEmail =
+      sessionStorage.getItem(RESET_PASSWORD_OTP_STORAGE_KEY) ?? ""
+    form.setFieldValue("email", storedEmail)
+    setHasStoredEmail(Boolean(storedEmail))
+  }, [form.setFieldValue])
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -177,160 +143,171 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
           {localization.auth.resetPassword}
         </CardTitle>
 
-        {hasStoredEmail && email && (
+        {hasStoredEmail && form.state.values.email && (
           <CardDescription>
-            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
+            {emailOtpLocalization.codeSentTo.replace(
+              "{{email}}",
+              form.state.values.email
+            )}
           </CardDescription>
         )}
       </CardHeader>
 
       <CardContent>
-        <form ref={formRef} onSubmit={handleSubmit}>
-          <FieldGroup>
-            {!hasStoredEmail && (
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="email">
-                  {localization.auth.email}
-                </FieldLabel>
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              {!hasStoredEmail && (
+                <form.AppField name="email">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
 
-                <Input
-                  id="email"
-                  name="email"
-                  type="email"
-                  autoComplete="email"
-                  value={email}
-                  placeholder={localization.auth.emailPlaceholder}
-                  required
-                  disabled={isPending}
-                  onChange={(event) => {
-                    setEmail(event.target.value)
-                    setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        value={field.state.value}
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: (e.target as HTMLInputElement).validationMessage
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.email}
-                />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
-            )}
+              <form.AppField name="code">
+                {(field) => (
+                  <OtpField
+                    autoFocus={hasStoredEmail}
+                    disabled={isPending}
+                    label={emailOtpLocalization.code}
+                    length={otpLength}
+                    name="otp"
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                    onComplete={(code) => {
+                      field.handleChange(code)
+                      if (form.state.values.password) void form.handleSubmit()
+                    }}
+                  />
+                )}
+              </form.AppField>
 
-            <OtpField
-              autoFocus={hasStoredEmail}
-              disabled={isPending}
-              label={emailOtpLocalization.code}
-              length={otpLength}
-              name="otp"
-              value={code}
-              onChange={setCode}
-              onComplete={tryAutoSubmit}
-            />
+              <form.AppField name="password">
+                {(field) => (
+                  <Field data-invalid={Boolean(passwordError)}>
+                    <FieldLabel htmlFor="password">
+                      {localization.auth.newPassword}
+                    </FieldLabel>
 
-            <Field data-invalid={!!fieldErrors.password}>
-              <FieldLabel htmlFor="password">
-                {localization.auth.newPassword}
-              </FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        id="password"
+                        name={field.name}
+                        type={isPasswordVisible ? "text" : "password"}
+                        autoComplete="new-password"
+                        placeholder={localization.auth.newPasswordPlaceholder}
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => {
+                          setPasswordError("")
+                          field.handleChange(event.target.value)
+                        }}
+                        aria-invalid={Boolean(passwordError)}
+                      />
 
-              <InputGroup>
-                <InputGroupInput
-                  id="password"
-                  name="password"
-                  type={isPasswordVisible ? "text" : "password"}
-                  autoComplete="new-password"
-                  placeholder={localization.auth.newPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                  onChange={(e) => {
-                    setPassword(e.target.value)
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={
+                            isPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          title={
+                            isPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() =>
+                            setIsPasswordVisible((visible) => !visible)
+                          }
+                        >
+                          {isPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
 
-                    setFieldErrors((prev) => ({ ...prev, password: undefined }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
-                    const el = e.target as HTMLInputElement
-                    const min = emailAndPassword?.minPasswordLength
-                    const max = emailAndPassword?.maxPasswordLength
-                    const msg = el.validity.valueMissing
-                      ? localization.auth.fieldRequired
-                      : el.validity.tooShort
-                        ? localization.auth.tooShort.replace(
-                            "{{min}}",
-                            String(min)
-                          )
-                        : localization.auth.tooLong.replace(
-                            "{{max}}",
-                            String(max)
-                          )
+                    {passwordError && <FieldError>{passwordError}</FieldError>}
 
-                    setFieldErrors((prev) => ({ ...prev, password: msg }))
-                  }}
-                  aria-invalid={!!fieldErrors.password}
-                />
+                    <PasswordStrengthMeter password={field.state.value} />
+                  </Field>
+                )}
+              </form.AppField>
 
-                <InputGroupAddon align="inline-end">
-                  <InputGroupButton
-                    size="icon-xs"
-                    aria-label={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    title={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    onClick={() => setIsPasswordVisible((visible) => !visible)}
-                  >
-                    {isPasswordVisible ? <EyeOff /> : <Eye />}
-                  </InputGroupButton>
-                </InputGroupAddon>
-              </InputGroup>
+              {emailAndPassword?.confirmPassword && (
+                <form.AppField name="confirmPassword">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="confirmPassword">
+                        {localization.auth.confirmPassword}
+                      </FieldLabel>
 
-              <FieldError>{fieldErrors.password}</FieldError>
+                      <Input
+                        id="confirmPassword"
+                        name={field.name}
+                        type="password"
+                        autoComplete="new-password"
+                        placeholder={
+                          localization.auth.confirmPasswordPlaceholder
+                        }
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-              <PasswordStrengthMeter password={password} />
-            </Field>
+              <div className="flex flex-col gap-3">
+                <form.AuthFormSubmitButton disabled={isPending}>
+                  {isPending && <Spinner />}
 
-            {emailAndPassword?.confirmPassword && (
-              <Field>
-                <FieldLabel htmlFor="confirmPassword">
-                  {localization.auth.confirmPassword}
-                </FieldLabel>
+                  {localization.auth.resetPassword}
+                </form.AuthFormSubmitButton>
 
-                <Input
-                  id="confirmPassword"
-                  name="confirmPassword"
-                  type="password"
-                  autoComplete="new-password"
-                  placeholder={localization.auth.confirmPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                />
-              </Field>
-            )}
-
-            <div className="flex flex-col gap-3">
-              <Button type="submit" disabled={isPending}>
-                {isPending && <Spinner />}
-
-                {localization.auth.resetPassword}
-              </Button>
-
-              {email && <OpenEmailButton email={email} variant="secondary" />}
-            </div>
-          </FieldGroup>
-        </form>
+                {form.state.values.email && (
+                  <OpenEmailButton
+                    email={form.state.values.email}
+                    variant="secondary"
+                  />
+                )}
+              </div>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/examples/start-shadcn-baseui-example/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/email-otp/verify-email-otp.tsx
@@ -7,7 +7,7 @@ import {
   useSendVerificationOtp,
   useVerifyEmailOtp
 } from "@better-auth-ui/react/plugins/email-otp"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -21,7 +21,6 @@ import {
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel
 } from "@/components/ui/field"
@@ -33,6 +32,7 @@ import {
   useResendCooldown
 } from "@/lib/auth/use-resend-cooldown"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 import { useIsHydrated } from "../use-is-hydrated"
@@ -74,8 +74,6 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
   const [email, setEmail] = useState(
     (isHydrated && sessionStorage.getItem(VERIFY_EMAIL_STORAGE_KEY)) || ""
   )
-  const [code, setCode] = useState("")
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({})
 
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
 
@@ -102,7 +100,7 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
   const { mutate: verifyEmailOtp, isPending: isVerifying } = useVerifyEmailOtp(
     otpClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
         sessionStorage.removeItem(VERIFY_EMAIL_STORAGE_KEY)
         toast.success(emailOtpLocalization.emailVerified)
@@ -119,20 +117,19 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
     verifyEmailOtp({ email, otp: completedCode })
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (!email) {
-      const formData = new FormData(e.currentTarget)
-      sendVerificationOtp({
-        email: formData.get("email") as string,
-        type: "email-verification"
-      })
-      return
+  const form = useAuthForm({
+    defaultValues: { code: "", email: "" },
+    onSubmit: ({ value }) => {
+      if (!email) {
+        sendVerificationOtp({
+          email: value.email,
+          type: "email-verification"
+        })
+        return
+      }
+      verifyCode(value.code)
     }
-
-    verifyCode(code)
-  }
+  })
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -149,87 +146,91 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            {email ? (
-              <OtpField
-                autoFocus
-                disabled={isPending}
-                label={emailOtpLocalization.code}
-                length={otpLength}
-                name="otp"
-                value={code}
-                onChange={setCode}
-                onComplete={verifyCode}
-              />
-            ) : (
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="email">
-                  {localization.auth.email}
-                </FieldLabel>
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              {email ? (
+                <form.AppField name="code">
+                  {(field) => (
+                    <OtpField
+                      autoFocus
+                      disabled={isPending}
+                      label={emailOtpLocalization.code}
+                      length={otpLength}
+                      name="otp"
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      onComplete={verifyCode}
+                    />
+                  )}
+                </form.AppField>
+              ) : (
+                <form.AppField name="email">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
 
-                <Input
-                  id="email"
-                  name="email"
-                  type="email"
-                  autoComplete="email"
-                  placeholder={localization.auth.emailPlaceholder}
-                  required
-                  disabled={isPending}
-                  onChange={() =>
-                    setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                  }
-                  onInvalid={(e) => {
-                    e.preventDefault()
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: (e.target as HTMLInputElement).validationMessage
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.email}
-                />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
-            )}
-
-            <div className="flex flex-col gap-3">
-              <Button
-                type="submit"
-                disabled={
-                  isPending || (Boolean(email) && code.length !== otpLength)
-                }
-              >
-                {isPending && <Spinner />}
-
-                {email
-                  ? emailOtpLocalization.verifyCode
-                  : emailOtpLocalization.sendCode}
-              </Button>
-
-              {email && <OpenEmailButton email={email} variant="secondary" />}
-
-              {email && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={isPending || isCoolingDown}
-                  onClick={() =>
-                    sendVerificationOtp({ email, type: "email-verification" })
+              <div className="flex flex-col gap-3">
+                <form.AuthFormSubmitButton
+                  disabled={
+                    isPending ||
+                    (Boolean(email) &&
+                      form.state.values.code.length !== otpLength)
                   }
                 >
-                  {isCoolingDown
-                    ? localization.auth.resendIn.replace(
-                        "{{seconds}}",
-                        String(cooldown)
-                      )
-                    : localization.auth.resend}
-                </Button>
-              )}
-            </div>
-          </FieldGroup>
-        </form>
+                  {isPending && <Spinner />}
+
+                  {email
+                    ? emailOtpLocalization.verifyCode
+                    : emailOtpLocalization.sendCode}
+                </form.AuthFormSubmitButton>
+
+                {email && <OpenEmailButton email={email} variant="secondary" />}
+
+                {email && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={isPending || isCoolingDown}
+                    onClick={() =>
+                      sendVerificationOtp({ email, type: "email-verification" })
+                    }
+                  >
+                    {isCoolingDown
+                      ? localization.auth.resendIn.replace(
+                          "{{seconds}}",
+                          String(cooldown)
+                        )
+                      : localization.auth.resend}
+                  </Button>
+                )}
+              </div>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/examples/start-shadcn-baseui-example/src/components/auth/forgot-password.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/forgot-password.tsx
@@ -1,25 +1,23 @@
 "use client"
 
-import { getViewURL } from "@better-auth-ui/core"
+import { getViewURL, validateEmailAddress } from "@better-auth-ui/core"
 import {
   useAuth,
   useFetchOptions,
   useRequestPasswordReset
 } from "@better-auth-ui/react"
-import { type SyntheticEvent, useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel
 } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
 import { RESET_LINK_SENT_STORAGE_KEY } from "./reset-link-sent"
 
 export type ForgotPasswordProps = {
@@ -64,27 +62,23 @@ export function ForgotPassword({ className }: ForgotPasswordProps) {
     }
   )
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    const formData = new FormData(e.currentTarget)
-    requestPasswordReset({
-      email: formData.get("email") as string,
-      redirectTo: getViewURL(
-        baseURL,
-        basePaths.auth,
-        viewPaths.auth.resetPassword
-      ),
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) =>
+      requestPasswordReset({
+        email: value.email,
+        redirectTo: getViewURL(
+          baseURL,
+          basePaths.auth,
+          viewPaths.auth.resetPassword
+        ),
+        fetchOptions
+      })
+  })
 
   const Captcha = plugins.find(
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
-
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-  }>({})
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -95,54 +89,58 @@ export function ForgotPassword({ className }: ForgotPasswordProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            <Field data-invalid={!!fieldErrors.email}>
-              <FieldLabel htmlFor="email">{localization.auth.email}</FieldLabel>
-
-              <Input
-                id="email"
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              <form.AppField
                 name="email"
-                type="email"
-                autoComplete="email"
-                placeholder={localization.auth.emailPlaceholder}
-                required
-                disabled={isPending}
-                onChange={() => {
-                  setFieldErrors((prev) => ({
-                    ...prev,
-                    email: undefined
-                  }))
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
                 }}
-                onInvalid={(e) => {
-                  e.preventDefault()
-                  const el = e.target as HTMLInputElement
-                  const msg = el.validity.valueMissing
-                    ? localization.auth.fieldRequired
-                    : localization.auth.invalidEmail
-
-                  setFieldErrors((prev) => ({
-                    ...prev,
-                    email: msg
-                  }))
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        aria-invalid={isInvalid}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
                 }}
-                aria-invalid={!!fieldErrors.email}
-              />
+              </form.AppField>
 
-              <FieldError>{fieldErrors.email}</FieldError>
-            </Field>
+              {Captcha && <div className="flex justify-center">{Captcha}</div>}
 
-            {Captcha && <div className="flex justify-center">{Captcha}</div>}
-
-            <div className="flex flex-col gap-3">
-              <Button type="submit" disabled={isPending}>
-                {isPending && <Spinner />}
-
-                {localization.auth.sendResetLink}
-              </Button>
-            </div>
-          </FieldGroup>
-        </form>
+              <div className="flex flex-col gap-3">
+                <form.AuthFormSubmitButton disabled={isPending}>
+                  {isPending && <Spinner />}
+                  {localization.auth.sendResetLink}
+                </form.AuthFormSubmitButton>
+              </div>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/examples/start-shadcn-baseui-example/src/components/auth/magic-link.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/magic-link.tsx
@@ -1,19 +1,16 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import { authMutationKeys, validateEmailAddress } from "@better-auth-ui/core"
 import type { MagicLinkAuthClient } from "@better-auth-ui/core/plugins/magic-link"
 import { getSsoFallbackEmail } from "@better-auth-ui/core/plugins/sso"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useSignInMagicLink } from "@better-auth-ui/react/plugins/magic-link"
 import { useIsMutating } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -22,6 +19,7 @@ import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { magicLinkPlugin } from "@/lib/auth/magic-link-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
 import { MAGIC_LINK_SENT_STORAGE_KEY } from "./magic-link-sent"
 import { ProviderButtons, type SocialLayout } from "./provider-buttons"
 
@@ -60,8 +58,6 @@ export function MagicLink({
   const { localization: magicLinkLocalization, viewPaths: magicLinkViewPaths } =
     useAuthPlugin(magicLinkPlugin)
 
-  const [email, setEmail] = useState(getSsoFallbackEmail)
-
   const { mutate: signInMagicLink, isPending: signInMagicLinkPending } =
     useSignInMagicLink(authClient, {
       onSuccess: (_data, variables) => {
@@ -80,14 +76,14 @@ export function MagicLink({
   })
   const isPending = signInMutating + signUpMutating > 0
 
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-  }>({})
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    signInMagicLink({ email, callbackURL: `${baseURL}${redirectTo}` })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: getSsoFallbackEmail() },
+    onSubmit: ({ value }) =>
+      signInMagicLink({
+        callbackURL: `${baseURL}${redirectTo}`,
+        email: value.email
+      })
+  })
 
   const showSeparator = socialProviders && socialProviders.length > 0
 
@@ -113,62 +109,65 @@ export function MagicLink({
             </>
           )}
 
-          <form onSubmit={handleSubmit}>
-            <FieldGroup>
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="email">
-                  {localization.auth.email}
-                </FieldLabel>
-
-                <Input
-                  id="email"
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <FieldGroup>
+                <form.AppField
                   name="email"
-                  type="email"
-                  autoComplete="email"
-                  value={email}
-                  onChange={(e) => {
-                    setEmail(e.target.value)
-
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: undefined
-                    }))
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateEmailAddress(value, {
+                        invalidMessage: localization.auth.invalidEmail,
+                        requiredMessage: localization.auth.fieldRequired
+                      })
                   }}
-                  placeholder={localization.auth.emailPlaceholder}
-                  required
-                  disabled={isPending}
-                  onInvalid={(e) => {
-                    e.preventDefault()
-
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: (e.target as HTMLInputElement).validationMessage
-                    }))
+                >
+                  {(field) => {
+                    const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                    return (
+                      <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor="email">
+                          {localization.auth.email}
+                        </FieldLabel>
+                        <Input
+                          id="email"
+                          name={field.name}
+                          type="email"
+                          autoComplete="email"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          placeholder={localization.auth.emailPlaceholder}
+                          required
+                          disabled={isPending}
+                          aria-invalid={isInvalid}
+                        />
+                        <field.AuthFormFieldError />
+                      </Field>
+                    )
                   }}
-                  aria-invalid={!!fieldErrors.email}
-                />
+                </form.AppField>
 
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
+                <div className="flex flex-col gap-3">
+                  <form.AuthFormSubmitButton disabled={isPending}>
+                    {signInMagicLinkPending && <Spinner />}
+                    {magicLinkLocalization.sendMagicLink}
+                  </form.AuthFormSubmitButton>
 
-              <div className="flex flex-col gap-3">
-                <Button type="submit" disabled={isPending}>
-                  {signInMagicLinkPending && <Spinner />}
-
-                  {magicLinkLocalization.sendMagicLink}
-                </Button>
-
-                {plugins.flatMap((plugin) =>
-                  (plugin.authButtons ?? []).map((AuthButton, index) => (
-                    <AuthButton
-                      key={`${plugin.id}-${index.toString()}`}
-                      view="magicLink"
-                    />
-                  ))
-                )}
-              </div>
-            </FieldGroup>
-          </form>
+                  {plugins.flatMap((plugin) =>
+                    (plugin.authButtons ?? []).map((AuthButton, index) => (
+                      <AuthButton
+                        key={`${plugin.id}-${index.toString()}`}
+                        view="magicLink"
+                      />
+                    ))
+                  )}
+                </div>
+              </FieldGroup>
+            </form.AuthFormRoot>
+          </form.AppForm>
 
           {socialPosition === "bottom" && (
             <>

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/delete-organization-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/delete-organization-dialog.tsx
@@ -5,7 +5,6 @@ import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useDeleteOrganization } from "@better-auth-ui/react/plugins/organization"
 import type { Organization } from "better-auth/client"
 import { TriangleAlert } from "lucide-react"
-import type { SyntheticEvent } from "react"
 import { toast } from "sonner"
 
 import {
@@ -18,10 +17,10 @@ import {
   AlertDialogMedia,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
+import { useAuthForm } from "../auth-form"
 import { OrganizationView } from "./organization-view"
 
 export type DeleteOrganizationDialogProps = {
@@ -57,47 +56,52 @@ export function DeleteOrganizationDialog({
     }
   )
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    deleteOrganization({ organizationId: organization.id })
-  }
+  const form = useAuthForm({
+    defaultValues: {},
+    onSubmit: () => deleteOrganization({ organizationId: organization.id })
+  })
 
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <AlertDialogHeader>
-            <AlertDialogMedia className="bg-destructive/10 text-destructive">
-              <TriangleAlert />
-            </AlertDialogMedia>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <AlertDialogHeader>
+              <AlertDialogMedia className="bg-destructive/10 text-destructive">
+                <TriangleAlert />
+              </AlertDialogMedia>
 
-            <AlertDialogTitle>
-              {organizationLocalization.deleteOrganization}
-            </AlertDialogTitle>
+              <AlertDialogTitle>
+                {organizationLocalization.deleteOrganization}
+              </AlertDialogTitle>
 
-            <AlertDialogDescription>
-              {organizationLocalization.deleteOrganizationDescription}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+              <AlertDialogDescription>
+                {organizationLocalization.deleteOrganizationDescription}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
 
-          <Card>
-            <CardContent>
-              <OrganizationView organization={organization} hideRole />
-            </CardContent>
-          </Card>
+            <Card>
+              <CardContent>
+                <OrganizationView organization={organization} hideRole />
+              </CardContent>
+            </Card>
 
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>
-              {localization.settings.cancel}
-            </AlertDialogCancel>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isPending}>
+                {localization.settings.cancel}
+              </AlertDialogCancel>
 
-            <Button type="submit" variant="destructive" disabled={isPending}>
-              {isPending && <Spinner />}
+              <form.AuthFormSubmitButton
+                variant="destructive"
+                disabled={isPending}
+              >
+                {isPending && <Spinner />}
 
-              {organizationLocalization.deleteOrganization}
-            </Button>
-          </AlertDialogFooter>
-        </form>
+                {organizationLocalization.deleteOrganization}
+              </form.AuthFormSubmitButton>
+            </AlertDialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </AlertDialogContent>
     </AlertDialog>
   )

--- a/examples/start-shadcn-baseui-example/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -8,8 +8,8 @@ import type {
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useAddPasskey } from "@better-auth-ui/react/plugins/passkey"
 import { Fingerprint } from "lucide-react"
-import { type SyntheticEvent, useRef } from "react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useRef } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -23,6 +23,7 @@ import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
+import { useAuthForm } from "../auth-form"
 import { FreshSessionPrompt } from "../settings/security/fresh-session-prompt"
 
 export type AddPasskeyDialogProps = {
@@ -41,14 +42,6 @@ export function AddPasskeyDialog({
   const addPasskey = useAddPasskey(authClient)
   const pendingRequest = useRef<AddPasskeyParams<PasskeyAuthClient>>(undefined)
 
-  const handleOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen) {
-      addPasskey.reset()
-      pendingRequest.current = undefined
-    }
-    onOpenChange(nextOpen)
-  }
-
   const submitRequest = (request: AddPasskeyParams<PasskeyAuthClient>) => {
     const requestWithCallbacks = {
       ...request,
@@ -61,16 +54,24 @@ export function AddPasskeyDialog({
     addPasskey.mutate(requestWithCallbacks)
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useAuthForm({
+    defaultValues: { name: "" },
+    onSubmit: ({ value }) => {
+      const name = value.name.trim()
+      submitRequest({
+        ...(name ? { name } : {}),
+        ...(authenticatorAttachment ? { authenticatorAttachment } : {})
+      } as AddPasskeyParams<PasskeyAuthClient>)
+    }
+  })
 
-    const formData = new FormData(e.target as HTMLFormElement)
-    const name = (formData.get("name") as string)?.trim()
-
-    submitRequest({
-      ...(name ? { name } : {}),
-      ...(authenticatorAttachment ? { authenticatorAttachment } : {})
-    } as AddPasskeyParams<PasskeyAuthClient>)
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      addPasskey.reset()
+      form.reset()
+      pendingRequest.current = undefined
+    }
+    onOpenChange(nextOpen)
   }
 
   const needsFreshSession = isSessionNotFreshError(addPasskey.error)
@@ -93,55 +94,65 @@ export function AddPasskeyDialog({
             />
           </>
         ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <Fingerprint />
-                {passkeyLocalization.addPasskey}
-              </DialogTitle>
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-6">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <Fingerprint />
+                  {passkeyLocalization.addPasskey}
+                </DialogTitle>
 
-              <DialogDescription>
-                {passkeyLocalization.passkeysDescription}
-              </DialogDescription>
-            </DialogHeader>
+                <DialogDescription>
+                  {passkeyLocalization.passkeysDescription}
+                </DialogDescription>
+              </DialogHeader>
 
-            <Field data-invalid={addPasskey.isError}>
-              <FieldLabel htmlFor="passkey-name">
-                {passkeyLocalization.name}
-              </FieldLabel>
+              <form.AppField name="name">
+                {(field) => (
+                  <Field data-invalid={addPasskey.isError}>
+                    <FieldLabel htmlFor="passkey-name">
+                      {passkeyLocalization.name}
+                    </FieldLabel>
+                    <Input
+                      id="passkey-name"
+                      name={field.name}
+                      autoFocus
+                      placeholder={localization.settings.optional}
+                      disabled={addPasskey.isPending}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      aria-invalid={addPasskey.isError}
+                    />
+                    {addPasskey.error && (
+                      <FieldError>
+                        {addPasskey.error.error?.message ??
+                          addPasskey.error.message}
+                      </FieldError>
+                    )}
+                  </Field>
+                )}
+              </form.AppField>
 
-              <Input
-                id="passkey-name"
-                name="name"
-                autoFocus
-                placeholder={localization.settings.optional}
-                disabled={addPasskey.isPending}
-                aria-invalid={addPasskey.isError}
-              />
+              <DialogFooter>
+                <DialogClose
+                  className={buttonVariants({ variant: "outline" })}
+                  disabled={addPasskey.isPending}
+                  type="button"
+                >
+                  {localization.settings.cancel}
+                </DialogClose>
 
-              {addPasskey.error && (
-                <FieldError>
-                  {addPasskey.error.error?.message ?? addPasskey.error.message}
-                </FieldError>
-              )}
-            </Field>
+                <form.AuthFormSubmitButton disabled={addPasskey.isPending}>
+                  {addPasskey.isPending && <Spinner />}
 
-            <DialogFooter>
-              <DialogClose
-                className={buttonVariants({ variant: "outline" })}
-                disabled={addPasskey.isPending}
-                type="button"
-              >
-                {localization.settings.cancel}
-              </DialogClose>
-
-              <Button type="submit" disabled={addPasskey.isPending}>
-                {addPasskey.isPending && <Spinner />}
-
-                {passkeyLocalization.addPasskey}
-              </Button>
-            </DialogFooter>
-          </form>
+                  {passkeyLocalization.addPasskey}
+                </form.AuthFormSubmitButton>
+              </DialogFooter>
+            </form.AuthFormRoot>
+          </form.AppForm>
         )}
       </DialogContent>
     </Dialog>

--- a/examples/start-shadcn-baseui-example/src/components/auth/passkey/rename-passkey-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/passkey/rename-passkey-dialog.tsx
@@ -3,8 +3,8 @@
 import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useUpdatePasskey } from "@better-auth-ui/react/plugins/passkey"
-import { type FormEvent, useEffect, useState } from "react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useEffect } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -17,6 +17,7 @@ import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
+import { useAuthForm } from "../auth-form"
 import type { ListedPasskey } from "./delete-passkey-dialog"
 
 export function RenamePasskeyDialog({
@@ -30,56 +31,61 @@ export function RenamePasskeyDialog({
 }) {
   const { authClient, localization } = useAuth<PasskeyAuthClient>()
   const { localization: labels } = useAuthPlugin(passkeyPlugin)
-  const [name, setName] = useState(passkey.name ?? "")
-
-  useEffect(() => {
-    if (open) setName(passkey.name ?? "")
-  }, [open, passkey.name])
-
   const updatePasskey = useUpdatePasskey(authClient, {
     onSuccess: () => onOpenChange(false)
   })
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const nextName = name.trim()
-    if (nextName) updatePasskey.mutate({ id: passkey.id, name: nextName })
-  }
+  const form = useAuthForm({
+    defaultValues: { name: passkey.name ?? "" },
+    onSubmit: ({ value }) => {
+      const name = value.name.trim()
+      if (name) updatePasskey.mutate({ id: passkey.id, name })
+    }
+  })
+
+  useEffect(() => {
+    if (open) form.reset({ name: passkey.name ?? "" })
+  }, [form, open, passkey.name])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form className="flex flex-col gap-6" onSubmit={submit}>
-          <DialogHeader>
-            <DialogTitle>{labels.renamePasskey}</DialogTitle>
-          </DialogHeader>
-          <Field>
-            <FieldLabel htmlFor={`passkey-name-${passkey.id}`}>
-              {labels.name}
-            </FieldLabel>
-            <Input
-              id={`passkey-name-${passkey.id}`}
-              autoFocus
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              required
-            />
-          </Field>
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-            <Button
-              disabled={!name.trim() || updatePasskey.isPending}
-              type="submit"
-            >
-              {updatePasskey.isPending && <Spinner />}
-              {localization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
-        </form>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle>{labels.renamePasskey}</DialogTitle>
+            </DialogHeader>
+            <form.AppField name="name">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor={`passkey-name-${passkey.id}`}>
+                    {labels.name}
+                  </FieldLabel>
+                  <Input
+                    id={`passkey-name-${passkey.id}`}
+                    name={field.name}
+                    autoFocus
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(event) => field.handleChange(event.target.value)}
+                    required
+                  />
+                </Field>
+              )}
+            </form.AppField>
+            <DialogFooter>
+              <DialogClose
+                className={buttonVariants({ variant: "outline" })}
+                type="button"
+              >
+                {localization.settings.cancel}
+              </DialogClose>
+              <form.AuthFormSubmitButton disabled={updatePasskey.isPending}>
+                {updatePasskey.isPending && <Spinner />}
+                {localization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-shadcn-baseui-example/src/components/auth/phone-number/change-phone-number.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/phone-number/change-phone-number.tsx
@@ -14,7 +14,7 @@ import {
   useSendPhoneNumberOtp,
   useVerifyPhoneNumber
 } from "@better-auth-ui/react/plugins/phone-number"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -24,6 +24,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { InternationalPhoneField } from "./international-phone-field"
 import { RemovePhoneNumberDialog } from "./remove-phone-number-dialog"
@@ -51,20 +52,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
   const { data: session } = useSession(phoneClient)
   const currentPhoneNumber =
     (session?.user as PhoneNumberUser | undefined)?.phoneNumber ?? ""
-  const [phoneNumber, setPhoneNumber] = useState(() =>
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
-  const [fieldError, setFieldError] = useState<string>()
-
-  useEffect(() => {
-    if (session) {
-      setPhoneNumber(
-        createPhoneNumberValue(currentPhoneNumber, defaultCountry, adapter)
-      )
-    }
-  }, [adapter, currentPhoneNumber, defaultCountry, session])
 
   const { mutate: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
     phoneClient,
@@ -73,9 +61,9 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
   const { mutate: verify, isPending: isVerifying } = useVerifyPhoneNumber(
     phoneClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
-        setCode("")
+        form.setFieldValue("code", "")
         setCodeSent(false)
         toast.success(localization.phoneNumberUpdated)
       }
@@ -85,26 +73,43 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
     phoneClient,
     {
       onSuccess: () => {
-        setPhoneNumber(createPhoneNumberValue("", defaultCountry, adapter))
+        form.setFieldValue(
+          "phoneNumber",
+          createPhoneNumberValue("", defaultCountry, adapter)
+        )
         toast.success(localization.phoneNumberRemoved)
       }
     }
   )
   const isPending = isSending || isVerifying || isRemoving
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!phoneNumber.e164) {
-      setFieldError(localization.invalidPhoneNumber)
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter)
+    },
+    onSubmit: ({ value }) => {
+      if (!value.phoneNumber.e164) return
+      if (!codeSent) {
+        sendOtp({ phoneNumber: value.phoneNumber.e164 })
+        return
+      }
+      verify({
+        phoneNumber: value.phoneNumber.e164,
+        code: value.code,
+        updatePhoneNumber: true
+      })
     }
-    if (!codeSent) {
-      sendOtp({ phoneNumber: phoneNumber.e164 })
-      return
-    }
+  })
 
-    verify({ phoneNumber: phoneNumber.e164, code, updatePhoneNumber: true })
-  }
+  useEffect(() => {
+    if (session) {
+      form.setFieldValue(
+        "phoneNumber",
+        createPhoneNumberValue(currentPhoneNumber, defaultCountry, adapter)
+      )
+    }
+  }, [adapter, currentPhoneNumber, defaultCountry, form.setFieldValue, session])
   const removePhoneNumber = () =>
     updateUser({
       phoneNumber: null
@@ -115,94 +120,109 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
       <h2 className="mb-3 text-sm font-semibold">
         {localization.changePhoneNumber}
       </h2>
-      <form onSubmit={handleSubmit}>
-        <Card className={cn(className)}>
-          <CardContent className="flex flex-col gap-6">
-            {codeSent ? (
-              <>
-                <FieldDescription>
-                  {localization.codeSentTo.replace(
-                    "{{phoneNumber}}",
-                    phoneNumber.display
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card className={cn(className)}>
+            <CardContent className="flex flex-col gap-6">
+              {codeSent ? (
+                <>
+                  <FieldDescription>
+                    {localization.codeSentTo.replace(
+                      "{{phoneNumber}}",
+                      form.state.values.phoneNumber.display
+                    )}
+                  </FieldDescription>
+                  <form.AppField name="code">
+                    {(field) => (
+                      <OtpField
+                        autoFocus
+                        disabled={isPending}
+                        label={localization.phoneCode}
+                        length={otpLength}
+                        name="otp"
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                      />
+                    )}
+                  </form.AppField>
+                </>
+              ) : session ? (
+                <form.AppField
+                  name="phoneNumber"
+                  validators={{
+                    onChange: ({ value }) =>
+                      value.e164 ? undefined : localization.invalidPhoneNumber
+                  }}
+                >
+                  {(field) => (
+                    <InternationalPhoneField
+                      adapter={adapter}
+                      countryCodes={countries}
+                      countryLabel={localization.country}
+                      disabled={isPending}
+                      error={field.state.meta.errors[0]?.toString()}
+                      locale={locale}
+                      phoneLabel={localization.phoneNumber}
+                      placeholder={localization.phoneNumberPlaceholder}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                    />
                   )}
-                </FieldDescription>
-                <OtpField
-                  autoFocus
+                </form.AppField>
+              ) : (
+                <Skeleton className="h-14 w-full" />
+              )}
+            </CardContent>
+            <CardFooter className="gap-3">
+              {codeSent && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
                   disabled={isPending}
-                  label={localization.phoneCode}
-                  length={otpLength}
-                  name="otp"
-                  value={code}
-                  onChange={setCode}
-                />
-              </>
-            ) : session ? (
-              <InternationalPhoneField
-                adapter={adapter}
-                countryCodes={countries}
-                countryLabel={localization.country}
-                disabled={isPending}
-                error={fieldError}
-                locale={locale}
-                phoneLabel={localization.phoneNumber}
-                placeholder={localization.phoneNumberPlaceholder}
-                value={phoneNumber}
-                onChange={(value) => {
-                  setPhoneNumber(value)
-                  setFieldError(undefined)
-                }}
-              />
-            ) : (
-              <Skeleton className="h-14 w-full" />
-            )}
-          </CardContent>
-          <CardFooter className="gap-3">
-            {codeSent && (
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                disabled={isPending}
-                onClick={() => {
-                  setCode("")
-                  setCodeSent(false)
-                  setPhoneNumber(
-                    createPhoneNumberValue(
-                      currentPhoneNumber,
-                      defaultCountry,
-                      adapter
+                  onClick={() => {
+                    form.setFieldValue("code", "")
+                    setCodeSent(false)
+                    form.setFieldValue(
+                      "phoneNumber",
+                      createPhoneNumberValue(
+                        currentPhoneNumber,
+                        defaultCountry,
+                        adapter
+                      )
                     )
-                  )
-                }}
+                  }}
+                >
+                  {localization.cancel}
+                </Button>
+              )}
+              <form.AuthFormSubmitButton
+                size="sm"
+                disabled={
+                  isPending ||
+                  !session ||
+                  (codeSent && form.state.values.code.length !== otpLength)
+                }
               >
-                {localization.cancel}
-              </Button>
-            )}
-            <Button
-              type="submit"
-              size="sm"
-              disabled={
-                isPending || !session || (codeSent && code.length !== otpLength)
-              }
-            >
-              {(isSending || isVerifying) && <Spinner />}
-              {codeSent
-                ? localization.verifyCode
-                : localization.updatePhoneNumber}
-            </Button>
-            {!codeSent && currentPhoneNumber && (
-              <RemovePhoneNumberDialog
-                cancelLabel={localization.cancel}
-                description={localization.removePhoneNumberDescription}
-                isPending={isRemoving}
-                label={localization.removePhoneNumber}
-                title={localization.removePhoneNumberTitle}
-                onConfirm={removePhoneNumber}
-              />
-            )}
-          </CardFooter>
-        </Card>
-      </form>
+                {(isSending || isVerifying) && <Spinner />}
+                {codeSent
+                  ? localization.verifyCode
+                  : localization.updatePhoneNumber}
+              </form.AuthFormSubmitButton>
+              {!codeSent && currentPhoneNumber && (
+                <RemovePhoneNumberDialog
+                  cancelLabel={localization.cancel}
+                  description={localization.removePhoneNumberDescription}
+                  isPending={isRemoving}
+                  label={localization.removePhoneNumber}
+                  title={localization.removePhoneNumberTitle}
+                  onConfirm={removePhoneNumber}
+                />
+              )}
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/examples/start-shadcn-baseui-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -6,14 +6,13 @@ import {
 } from "@better-auth-ui/core/plugins/phone-number"
 import { useAuth, useAuthPlugin, useFetchOptions } from "@better-auth-ui/react"
 import { useRequestPhoneNumberPasswordReset } from "@better-auth-ui/react/plugins/phone-number"
-import { type SyntheticEvent, useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { FieldDescription, FieldGroup } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { InternationalPhoneField } from "./international-phone-field"
 
 export const PHONE_NUMBER_RESET_STORAGE_KEY =
@@ -38,10 +37,6 @@ export function ForgotPhoneNumberPassword({
     viewPaths: phoneNumberViewPaths
   } = useAuthPlugin(phoneNumberPlugin)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
-  const [phoneNumber, setPhoneNumber] = useState(() =>
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [fieldError, setFieldError] = useState<string>()
   const { mutate: requestReset, isPending } =
     useRequestPhoneNumberPasswordReset(authClient as PhoneNumberAuthClient, {
       onError: () => resetFetchOptions(),
@@ -56,17 +51,15 @@ export function ForgotPhoneNumberPassword({
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!phoneNumber.e164) {
-      setFieldError(phoneLocalization.invalidPhoneNumber)
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter)
+    },
+    onSubmit: ({ value }) => {
+      if (!value.phoneNumber.e164) return
+      requestReset({ phoneNumber: value.phoneNumber.e164, fetchOptions })
     }
-    requestReset({
-      phoneNumber: phoneNumber.e164,
-      fetchOptions
-    })
-  }
+  })
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -76,30 +69,41 @@ export function ForgotPhoneNumberPassword({
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            <InternationalPhoneField
-              adapter={adapter}
-              countryCodes={countries}
-              countryLabel={phoneLocalization.country}
-              disabled={isPending}
-              error={fieldError}
-              locale={locale}
-              phoneLabel={phoneLocalization.phoneNumber}
-              placeholder={phoneLocalization.phoneNumberPlaceholder}
-              value={phoneNumber}
-              onChange={(value) => {
-                setPhoneNumber(value)
-                setFieldError(undefined)
-              }}
-            />
-            {Captcha && <div className="flex justify-center">{Captcha}</div>}
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Spinner />}
-              {phoneLocalization.sendCode}
-            </Button>
-          </FieldGroup>
-        </form>
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              <form.AppField
+                name="phoneNumber"
+                validators={{
+                  onChange: ({ value }) =>
+                    value.e164
+                      ? undefined
+                      : phoneLocalization.invalidPhoneNumber
+                }}
+              >
+                {(field) => (
+                  <InternationalPhoneField
+                    adapter={adapter}
+                    countryCodes={countries}
+                    countryLabel={phoneLocalization.country}
+                    disabled={isPending}
+                    error={field.state.meta.errors[0]?.toString()}
+                    locale={locale}
+                    phoneLabel={phoneLocalization.phoneNumber}
+                    placeholder={phoneLocalization.phoneNumberPlaceholder}
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                  />
+                )}
+              </form.AppField>
+              {Captcha && <div className="flex justify-center">{Captcha}</div>}
+              <form.AuthFormSubmitButton disabled={isPending}>
+                {isPending && <Spinner />}
+                {phoneLocalization.sendCode}
+              </form.AuthFormSubmitButton>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
         <FieldDescription className="mt-4 text-center">
           {localization.auth.rememberYourPassword}{" "}
           <Link

--- a/examples/start-shadcn-baseui-example/src/components/auth/phone-number/phone-number.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/phone-number/phone-number.tsx
@@ -18,7 +18,7 @@ import {
 } from "@better-auth-ui/react/plugins/phone-number"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -32,7 +32,6 @@ import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -48,6 +47,7 @@ import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { useResendCooldown } from "@/lib/auth/use-resend-cooldown"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
 import { InternationalPhoneField } from "./international-phone-field"
@@ -95,17 +95,8 @@ export function PhoneNumber({
   const [mode, setMode] = useState<PhoneNumberMode>(
     signIn ? "code" : "password"
   )
-  const [phoneNumber, setPhoneNumber] = useState(() =>
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [password, setPassword] = useState("")
-  const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-  const [fieldErrors, setFieldErrors] = useState<{
-    phoneNumber?: string
-    password?: string
-  }>({})
 
   const { mutate: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
     phoneClient,
@@ -120,14 +111,14 @@ export function PhoneNumber({
   const { mutate: verify, isPending: isVerifying } = useVerifyPhoneNumber(
     phoneClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: (data) => continueSignIn(data)
     }
   )
   const { mutate: signInWithPassword, isPending: isPasswordPending } =
     useSignInPhoneNumber(phoneClient, {
       onError: (error) => {
-        setPassword("")
+        form.setFieldValue("password", "")
         resetFetchOptions()
 
         if (signIn && error.error?.code === "PHONE_NUMBER_NOT_VERIFIED") {
@@ -159,15 +150,8 @@ export function PhoneNumber({
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
 
-  const getPhoneNumber = () => {
-    if (phoneNumber.e164) return phoneNumber.e164
-    setFieldErrors((current) => ({
-      ...current,
-      phoneNumber: phoneLocalization.invalidPhoneNumber
-    }))
-  }
   const sendCode = () => {
-    const normalizedPhoneNumber = getPhoneNumber()
+    const normalizedPhoneNumber = form.state.values.phoneNumber.e164
     if (!normalizedPhoneNumber) return
     sendOtp({
       phoneNumber: normalizedPhoneNumber,
@@ -177,41 +161,49 @@ export function PhoneNumber({
   const verifyCode = (completedCode: string) => {
     if (isPending || completedCode.length !== otpLength) return
 
-    if (!phoneNumber.e164) return
-    verify({ phoneNumber: phoneNumber.e164, code: completedCode })
+    if (!form.state.values.phoneNumber.e164) return
+    verify({
+      phoneNumber: form.state.values.phoneNumber.e164,
+      code: completedCode
+    })
   }
   const switchMode = () => {
     setMode((current) => (current === "code" ? "password" : "code"))
-    setCode("")
+    form.setFieldValue("code", "")
     setCodeSent(false)
-    setPassword("")
+    form.setFieldValue("password", "")
   }
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      password: "",
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter),
+      rememberMe: false
+    },
+    onSubmit: ({ value }) => {
+      if (mode === "password") {
+        const normalizedPhoneNumber = value.phoneNumber.e164
+        if (!normalizedPhoneNumber) return
+        signInWithPassword({
+          phoneNumber: normalizedPhoneNumber,
+          password: value.password,
+          ...(emailAndPassword?.rememberMe
+            ? { rememberMe: value.rememberMe }
+            : {}),
+          fetchOptions
+        })
+        return
+      }
 
-    if (mode === "password") {
-      const normalizedPhoneNumber = getPhoneNumber()
-      if (!normalizedPhoneNumber) return
-      const formData = new FormData(event.currentTarget)
-      signInWithPassword({
-        phoneNumber: normalizedPhoneNumber,
-        password,
-        ...(emailAndPassword?.rememberMe
-          ? { rememberMe: formData.get("rememberMe") === "on" }
-          : {}),
-        fetchOptions
-      })
-      return
+      if (!codeSent) {
+        sendCode()
+        return
+      }
+
+      verifyCode(value.code)
     }
-
-    if (!codeSent) {
-      sendCode()
-      return
-    }
-
-    verifyCode(code)
-  }
+  })
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -225,7 +217,7 @@ export function PhoneNumber({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              phoneNumber.display
+              form.state.values.phoneNumber.display
             )}
           </CardDescription>
         )}
@@ -244,192 +236,207 @@ export function PhoneNumber({
             </>
           )}
 
-          <form onSubmit={handleSubmit}>
-            <FieldGroup>
-              {codeSent ? (
-                <OtpField
-                  autoFocus
-                  disabled={isPending}
-                  label={phoneLocalization.phoneCode}
-                  length={otpLength}
-                  name="otp"
-                  value={code}
-                  onChange={setCode}
-                  onComplete={verifyCode}
-                />
-              ) : (
-                <>
-                  <InternationalPhoneField
-                    adapter={adapter}
-                    countryCodes={countries}
-                    countryLabel={phoneLocalization.country}
-                    disabled={isPending}
-                    error={fieldErrors.phoneNumber}
-                    locale={locale}
-                    phoneLabel={phoneLocalization.phoneNumber}
-                    placeholder={phoneLocalization.phoneNumberPlaceholder}
-                    value={phoneNumber}
-                    onChange={(value) => {
-                      setPhoneNumber(value)
-                      setFieldErrors((current) => ({
-                        ...current,
-                        phoneNumber: undefined
-                      }))
-                    }}
-                  />
-
-                  {mode === "password" && (
-                    <Field data-invalid={Boolean(fieldErrors.password)}>
-                      <FieldLabel htmlFor="phoneNumberPassword">
-                        {localization.auth.password}
-                      </FieldLabel>
-                      <InputGroup>
-                        <InputGroupInput
-                          id="phoneNumberPassword"
-                          name="password"
-                          type={isPasswordVisible ? "text" : "password"}
-                          autoComplete="current-password"
-                          value={password}
-                          placeholder={localization.auth.passwordPlaceholder}
-                          required
-                          minLength={emailAndPassword?.minPasswordLength}
-                          maxLength={emailAndPassword?.maxPasswordLength}
-                          disabled={isPending}
-                          onChange={(event) => {
-                            setPassword(event.target.value)
-                            setFieldErrors((current) => ({
-                              ...current,
-                              password: undefined
-                            }))
-                          }}
-                          onInvalid={(event) => {
-                            event.preventDefault()
-                            setFieldErrors((current) => ({
-                              ...current,
-                              password: event.currentTarget.validationMessage
-                            }))
-                          }}
-                          aria-invalid={Boolean(fieldErrors.password)}
-                        />
-                        <InputGroupAddon align="inline-end">
-                          <InputGroupButton
-                            type="button"
-                            size="icon-xs"
-                            aria-label={
-                              isPasswordVisible
-                                ? localization.auth.hidePassword
-                                : localization.auth.showPassword
-                            }
-                            title={
-                              isPasswordVisible
-                                ? localization.auth.hidePassword
-                                : localization.auth.showPassword
-                            }
-                            onClick={() =>
-                              setIsPasswordVisible((visible) => !visible)
-                            }
-                          >
-                            {isPasswordVisible ? <EyeOff /> : <Eye />}
-                          </InputGroupButton>
-                        </InputGroupAddon>
-                      </InputGroup>
-                      <FieldError>{fieldErrors.password}</FieldError>
-                    </Field>
-                  )}
-
-                  {mode === "password" && emailAndPassword?.rememberMe && (
-                    <Field orientation="horizontal">
-                      <Checkbox
-                        id="phoneNumberRememberMe"
-                        name="rememberMe"
-                        disabled={isPending}
-                      />
-                      <FieldLabel
-                        htmlFor="phoneNumberRememberMe"
-                        className="cursor-pointer font-normal"
-                      >
-                        {localization.auth.rememberMe}
-                      </FieldLabel>
-                    </Field>
-                  )}
-
-                  {Captcha && (
-                    <div className="flex justify-center">{Captcha}</div>
-                  )}
-                </>
-              )}
-
-              <div className="flex flex-col gap-3">
-                <Button
-                  type="submit"
-                  disabled={
-                    isPending || (codeSent && code.length !== otpLength)
-                  }
-                >
-                  {(isSending || isVerifying || isPasswordPending) && (
-                    <Spinner />
-                  )}
-                  {mode === "password"
-                    ? localization.auth.signIn
-                    : codeSent
-                      ? phoneLocalization.verifyCode
-                      : phoneLocalization.sendCode}
-                </Button>
-
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <FieldGroup>
                 {codeSent ? (
-                  <>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      disabled={isPending || isCoolingDown}
-                      onClick={sendCode}
-                    >
-                      {isCoolingDown
-                        ? localization.auth.resendIn.replace(
-                            "{{seconds}}",
-                            String(cooldown)
-                          )
-                        : localization.auth.resend}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      disabled={isPending}
-                      onClick={() => {
-                        setCode("")
-                        setCodeSent(false)
-                      }}
-                    >
-                      {phoneLocalization.useDifferentPhoneNumber}
-                    </Button>
-                  </>
+                  <form.AppField name="code">
+                    {(field) => (
+                      <OtpField
+                        autoFocus
+                        disabled={isPending}
+                        label={phoneLocalization.phoneCode}
+                        length={otpLength}
+                        name="otp"
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        onComplete={verifyCode}
+                      />
+                    )}
+                  </form.AppField>
                 ) : (
                   <>
-                    {canSwitchMode && (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        disabled={isPending}
-                        onClick={switchMode}
-                      >
-                        {mode === "code"
-                          ? phoneLocalization.usePassword
-                          : phoneLocalization.useVerificationCode}
-                      </Button>
-                    )}
-                    {plugins.flatMap((plugin) =>
-                      (plugin.authButtons ?? []).map((AuthButton) => (
-                        <AuthButton
-                          key={`${plugin.id}-${AuthButton.displayName ?? AuthButton.name}`}
-                          view="phoneNumber"
+                    <form.AppField
+                      name="phoneNumber"
+                      validators={{
+                        onChange: ({ value }) =>
+                          value.e164
+                            ? undefined
+                            : phoneLocalization.invalidPhoneNumber
+                      }}
+                    >
+                      {(field) => (
+                        <InternationalPhoneField
+                          adapter={adapter}
+                          countryCodes={countries}
+                          countryLabel={phoneLocalization.country}
+                          disabled={isPending}
+                          error={field.state.meta.errors[0]?.toString()}
+                          locale={locale}
+                          phoneLabel={phoneLocalization.phoneNumber}
+                          placeholder={phoneLocalization.phoneNumberPlaceholder}
+                          value={field.state.value}
+                          onChange={field.handleChange}
                         />
-                      ))
+                      )}
+                    </form.AppField>
+
+                    {mode === "password" && (
+                      <form.AppField name="password">
+                        {(field) => (
+                          <Field>
+                            <FieldLabel htmlFor="phoneNumberPassword">
+                              {localization.auth.password}
+                            </FieldLabel>
+                            <InputGroup>
+                              <InputGroupInput
+                                id="phoneNumberPassword"
+                                name={field.name}
+                                type={isPasswordVisible ? "text" : "password"}
+                                autoComplete="current-password"
+                                value={field.state.value}
+                                placeholder={
+                                  localization.auth.passwordPlaceholder
+                                }
+                                required
+                                minLength={emailAndPassword?.minPasswordLength}
+                                maxLength={emailAndPassword?.maxPasswordLength}
+                                disabled={isPending}
+                                onBlur={field.handleBlur}
+                                onChange={(event) =>
+                                  field.handleChange(event.target.value)
+                                }
+                              />
+                              <InputGroupAddon align="inline-end">
+                                <InputGroupButton
+                                  type="button"
+                                  size="icon-xs"
+                                  aria-label={
+                                    isPasswordVisible
+                                      ? localization.auth.hidePassword
+                                      : localization.auth.showPassword
+                                  }
+                                  title={
+                                    isPasswordVisible
+                                      ? localization.auth.hidePassword
+                                      : localization.auth.showPassword
+                                  }
+                                  onClick={() =>
+                                    setIsPasswordVisible((visible) => !visible)
+                                  }
+                                >
+                                  {isPasswordVisible ? <EyeOff /> : <Eye />}
+                                </InputGroupButton>
+                              </InputGroupAddon>
+                            </InputGroup>
+                            <field.AuthFormFieldError />
+                          </Field>
+                        )}
+                      </form.AppField>
+                    )}
+
+                    {mode === "password" && emailAndPassword?.rememberMe && (
+                      <form.AppField name="rememberMe">
+                        {(field) => (
+                          <Field orientation="horizontal">
+                            <Checkbox
+                              id="phoneNumberRememberMe"
+                              name={field.name}
+                              disabled={isPending}
+                              checked={field.state.value}
+                              onCheckedChange={(checked) =>
+                                field.handleChange(checked === true)
+                              }
+                            />
+                            <FieldLabel
+                              htmlFor="phoneNumberRememberMe"
+                              className="cursor-pointer font-normal"
+                            >
+                              {localization.auth.rememberMe}
+                            </FieldLabel>
+                          </Field>
+                        )}
+                      </form.AppField>
+                    )}
+
+                    {Captcha && (
+                      <div className="flex justify-center">{Captcha}</div>
                     )}
                   </>
                 )}
-              </div>
-            </FieldGroup>
-          </form>
+
+                <div className="flex flex-col gap-3">
+                  <form.AuthFormSubmitButton
+                    disabled={
+                      isPending ||
+                      (codeSent && form.state.values.code.length !== otpLength)
+                    }
+                  >
+                    {(isSending || isVerifying || isPasswordPending) && (
+                      <Spinner />
+                    )}
+                    {mode === "password"
+                      ? localization.auth.signIn
+                      : codeSent
+                        ? phoneLocalization.verifyCode
+                        : phoneLocalization.sendCode}
+                  </form.AuthFormSubmitButton>
+
+                  {codeSent ? (
+                    <>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isPending || isCoolingDown}
+                        onClick={sendCode}
+                      >
+                        {isCoolingDown
+                          ? localization.auth.resendIn.replace(
+                              "{{seconds}}",
+                              String(cooldown)
+                            )
+                          : localization.auth.resend}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        disabled={isPending}
+                        onClick={() => {
+                          form.setFieldValue("code", "")
+                          setCodeSent(false)
+                        }}
+                      >
+                        {phoneLocalization.useDifferentPhoneNumber}
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      {canSwitchMode && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          disabled={isPending}
+                          onClick={switchMode}
+                        >
+                          {mode === "code"
+                            ? phoneLocalization.usePassword
+                            : phoneLocalization.useVerificationCode}
+                        </Button>
+                      )}
+                      {plugins.flatMap((plugin) =>
+                        (plugin.authButtons ?? []).map((AuthButton) => (
+                          <AuthButton
+                            key={`${plugin.id}-${AuthButton.displayName ?? AuthButton.name}`}
+                            view="phoneNumber"
+                          />
+                        ))
+                      )}
+                    </>
+                  )}
+                </div>
+              </FieldGroup>
+            </form.AuthFormRoot>
+          </form.AppForm>
 
           {socialPosition === "bottom" && showProviders && (
             <>

--- a/examples/start-shadcn-baseui-example/src/components/auth/phone-number/reset-phone-number-password.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/phone-number/reset-phone-number-password.tsx
@@ -5,10 +5,9 @@ import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-n
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPhoneNumberPassword } from "@better-auth-ui/react/plugins/phone-number"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -32,6 +31,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { PasswordStrengthMeter } from "../password-strength-meter"
 import { useIsHydrated } from "../use-is-hydrated"
@@ -55,23 +55,11 @@ export function ResetPhoneNumberPassword({
   const isHydrated = useIsHydrated()
   const initialPhoneNumber =
     (isHydrated && sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY)) || ""
-  const [phoneNumber, setPhoneNumber] = useState(initialPhoneNumber)
   const [hasStoredPhoneNumber, setHasStoredPhoneNumber] = useState(
     Boolean(initialPhoneNumber)
   )
-  const [code, setCode] = useState("")
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-  const [fieldErrors, setFieldErrors] = useState<{
-    phoneNumber?: string
-    password?: string
-  }>({})
-
-  useEffect(() => {
-    const stored = sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY) ?? ""
-    setPhoneNumber(stored)
-    setHasStoredPhoneNumber(Boolean(stored))
-  }, [])
+  const [passwordError, setPasswordError] = useState("")
 
   const { mutate: resetPassword, isPending } = useResetPhoneNumberPassword(
     authClient as PhoneNumberAuthClient,
@@ -80,13 +68,10 @@ export function ResetPhoneNumberPassword({
         // The haveIBeenPwned plugin rejects on the password itself, so it
         // belongs against the field rather than in a toast.
         if (isPasswordCompromisedError(error)) {
-          setFieldErrors((prev) => ({
-            ...prev,
-            password: localization.auth.passwordCompromised
-          }))
+          setPasswordError(localization.auth.passwordCompromised)
         }
 
-        setCode("")
+        form.setFieldValue("code", "")
       },
       onSuccess: () => {
         sessionStorage.removeItem(PHONE_NUMBER_RESET_STORAGE_KEY)
@@ -98,31 +83,44 @@ export function ResetPhoneNumberPassword({
     }
   )
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    const confirmPassword = String(formData.get("confirmPassword") ?? "")
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      toast.error(localization.auth.passwordsDoNotMatch)
-      return
-    }
-    if (code.length !== otpLength) {
-      toast.error(
-        phoneLocalization.codeLengthMismatch.replace(
-          "{{length}}",
-          String(otpLength)
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      confirmPassword: "",
+      password: "",
+      phoneNumber: initialPhoneNumber
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
+        toast.error(localization.auth.passwordsDoNotMatch)
+        return
+      }
+      if (value.code.length !== otpLength) {
+        toast.error(
+          phoneLocalization.codeLengthMismatch.replace(
+            "{{length}}",
+            String(otpLength)
+          )
         )
-      )
-      return
-    }
+        return
+      }
 
-    resetPassword({
-      phoneNumber,
-      otp: code,
-      newPassword: password
-    })
-  }
+      resetPassword({
+        phoneNumber: value.phoneNumber,
+        otp: value.code,
+        newPassword: value.password
+      })
+    }
+  })
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY) ?? ""
+    form.setFieldValue("phoneNumber", stored)
+    setHasStoredPhoneNumber(Boolean(stored))
+  }, [form.setFieldValue])
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -134,139 +132,146 @@ export function ResetPhoneNumberPassword({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              phoneNumber
+              form.state.values.phoneNumber
             )}
           </CardDescription>
         )}
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            {!hasStoredPhoneNumber && (
-              <Field data-invalid={Boolean(fieldErrors.phoneNumber)}>
-                <FieldLabel htmlFor="passwordResetPhoneNumber">
-                  {phoneLocalization.phoneNumber}
-                </FieldLabel>
-                <Input
-                  id="passwordResetPhoneNumber"
-                  name="phoneNumber"
-                  type="tel"
-                  autoComplete="tel"
-                  inputMode="tel"
-                  value={phoneNumber}
-                  placeholder={phoneLocalization.phoneNumberPlaceholder}
-                  required
-                  disabled={isPending}
-                  onChange={(event) => {
-                    setPhoneNumber(event.target.value)
-                    setFieldErrors((current) => ({
-                      ...current,
-                      phoneNumber: undefined
-                    }))
-                  }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    setFieldErrors((current) => ({
-                      ...current,
-                      phoneNumber: event.currentTarget.validationMessage
-                    }))
-                  }}
-                  aria-invalid={Boolean(fieldErrors.phoneNumber)}
-                />
-                <FieldError>{fieldErrors.phoneNumber}</FieldError>
-              </Field>
-            )}
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              {!hasStoredPhoneNumber && (
+                <form.AppField name="phoneNumber">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="passwordResetPhoneNumber">
+                        {phoneLocalization.phoneNumber}
+                      </FieldLabel>
+                      <Input
+                        id="passwordResetPhoneNumber"
+                        name={field.name}
+                        type="tel"
+                        autoComplete="tel"
+                        inputMode="tel"
+                        value={field.state.value}
+                        placeholder={phoneLocalization.phoneNumberPlaceholder}
+                        required
+                        disabled={isPending}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-            <OtpField
-              autoFocus={hasStoredPhoneNumber}
-              disabled={isPending}
-              label={phoneLocalization.phoneCode}
-              length={otpLength}
-              name="otp"
-              value={code}
-              onChange={setCode}
-            />
+              <form.AppField name="code">
+                {(field) => (
+                  <OtpField
+                    autoFocus={hasStoredPhoneNumber}
+                    disabled={isPending}
+                    label={phoneLocalization.phoneCode}
+                    length={otpLength}
+                    name="otp"
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                  />
+                )}
+              </form.AppField>
 
-            <Field data-invalid={Boolean(fieldErrors.password)}>
-              <FieldLabel htmlFor="phoneNumberNewPassword">
-                {localization.auth.newPassword}
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupInput
-                  id="phoneNumberNewPassword"
-                  name="password"
-                  type={isPasswordVisible ? "text" : "password"}
-                  autoComplete="new-password"
-                  value={password}
-                  placeholder={localization.auth.newPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                  onChange={(event) => {
-                    setPassword(event.target.value)
-                    setFieldErrors((current) => ({
-                      ...current,
-                      password: undefined
-                    }))
-                  }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    setFieldErrors((current) => ({
-                      ...current,
-                      password: event.currentTarget.validationMessage
-                    }))
-                  }}
-                  aria-invalid={Boolean(fieldErrors.password)}
-                />
-                <InputGroupAddon align="inline-end">
-                  <InputGroupButton
-                    type="button"
-                    size="icon-xs"
-                    aria-label={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    onClick={() => setIsPasswordVisible((visible) => !visible)}
-                  >
-                    {isPasswordVisible ? <EyeOff /> : <Eye />}
-                  </InputGroupButton>
-                </InputGroupAddon>
-              </InputGroup>
-              <FieldError>{fieldErrors.password}</FieldError>
+              <form.AppField name="password">
+                {(field) => (
+                  <Field data-invalid={Boolean(passwordError)}>
+                    <FieldLabel htmlFor="phoneNumberNewPassword">
+                      {localization.auth.newPassword}
+                    </FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        id="phoneNumberNewPassword"
+                        name={field.name}
+                        type={isPasswordVisible ? "text" : "password"}
+                        autoComplete="new-password"
+                        value={field.state.value}
+                        placeholder={localization.auth.newPasswordPlaceholder}
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        onChange={(event) => {
+                          setPasswordError("")
+                          field.handleChange(event.target.value)
+                        }}
+                        aria-invalid={Boolean(passwordError)}
+                      />
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          type="button"
+                          size="icon-xs"
+                          aria-label={
+                            isPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() =>
+                            setIsPasswordVisible((visible) => !visible)
+                          }
+                        >
+                          {isPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                    {passwordError && <FieldError>{passwordError}</FieldError>}
 
-              <PasswordStrengthMeter password={password} />
-            </Field>
+                    <PasswordStrengthMeter password={field.state.value} />
+                  </Field>
+                )}
+              </form.AppField>
 
-            {emailAndPassword?.confirmPassword && (
-              <Field>
-                <FieldLabel htmlFor="phoneNumberConfirmPassword">
-                  {localization.auth.confirmPassword}
-                </FieldLabel>
-                <Input
-                  id="phoneNumberConfirmPassword"
-                  name="confirmPassword"
-                  type="password"
-                  autoComplete="new-password"
-                  placeholder={localization.auth.confirmPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                />
-              </Field>
-            )}
+              {emailAndPassword?.confirmPassword && (
+                <form.AppField name="confirmPassword">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="phoneNumberConfirmPassword">
+                        {localization.auth.confirmPassword}
+                      </FieldLabel>
+                      <Input
+                        id="phoneNumberConfirmPassword"
+                        name={field.name}
+                        type="password"
+                        autoComplete="new-password"
+                        placeholder={
+                          localization.auth.confirmPasswordPlaceholder
+                        }
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-            <Button
-              type="submit"
-              disabled={isPending || code.length !== otpLength}
-            >
-              {isPending && <Spinner />}
-              {phoneLocalization.resetPassword}
-            </Button>
-          </FieldGroup>
-        </form>
+              <form.AuthFormSubmitButton
+                disabled={
+                  isPending || form.state.values.code.length !== otpLength
+                }
+              >
+                {isPending && <Spinner />}
+                {phoneLocalization.resetPassword}
+              </form.AuthFormSubmitButton>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
     </Card>
   )

--- a/examples/start-shadcn-baseui-example/src/components/auth/settings/account/change-email.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/settings/account/change-email.tsx
@@ -1,17 +1,17 @@
 "use client"
 
-import { getViewURL } from "@better-auth-ui/core"
+import { getViewURL, validateEmailAddress } from "@better-auth-ui/core"
 import { useAuth, useChangeEmail, useSession } from "@better-auth-ui/react"
-import { type SyntheticEvent, useState } from "react"
+import { useEffect } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../../auth-form"
 
 export type ChangeEmailProps = {
   className?: string
@@ -34,23 +34,22 @@ export function ChangeEmail({ className }: ChangeEmailProps) {
     onSuccess: () => toast.success(localization.settings.changeEmailSuccess)
   })
 
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-  }>({})
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) =>
+      changeEmail({
+        callbackURL: getViewURL(
+          baseURL,
+          basePaths.settings,
+          viewPaths.settings.account
+        ),
+        newEmail: value.email
+      })
+  })
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    changeEmail({
-      newEmail: formData.get("email") as string,
-      callbackURL: getViewURL(
-        baseURL,
-        basePaths.settings,
-        viewPaths.settings.account
-      )
-    })
-  }
+  useEffect(() => {
+    if (session) form.reset({ email: session.user.email })
+  }, [form, session])
 
   return (
     <div>
@@ -58,57 +57,68 @@ export function ChangeEmail({ className }: ChangeEmailProps) {
         {localization.settings.changeEmail}
       </h2>
 
-      <form onSubmit={handleSubmit}>
-        <Card className={cn(className)}>
-          <CardContent className="flex flex-col gap-6">
-            <Field data-invalid={!!fieldErrors.email}>
-              <FieldLabel htmlFor="email">{localization.auth.email}</FieldLabel>
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card className={cn(className)}>
+            <CardContent className="flex flex-col gap-6">
+              <form.AppField
+                name="email"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
+                }}
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
+                      {session ? (
+                        <Input
+                          id="email"
+                          name={field.name}
+                          type="email"
+                          autoComplete="email"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          placeholder={localization.auth.emailPlaceholder}
+                          disabled={isPending}
+                          required
+                          aria-invalid={isInvalid}
+                        />
+                      ) : (
+                        <Skeleton>
+                          <Input className="invisible" />
+                        </Skeleton>
+                      )}
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+            </CardContent>
 
-              {session ? (
-                <Input
-                  key={session?.user.email}
-                  id="email"
-                  name="email"
-                  type="email"
-                  autoComplete="email"
-                  defaultValue={session?.user.email}
-                  placeholder={localization.auth.emailPlaceholder}
-                  disabled={isPending}
-                  required
-                  onChange={() => {
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: undefined
-                    }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: (e.target as HTMLInputElement).validationMessage
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.email}
-                />
-              ) : (
-                <Skeleton>
-                  <Input className="invisible" />
-                </Skeleton>
-              )}
+            <CardFooter>
+              <form.AuthFormSubmitButton
+                size="sm"
+                disabled={isPending || !session}
+              >
+                {isPending && <Spinner />}
 
-              <FieldError>{fieldErrors.email}</FieldError>
-            </Field>
-          </CardContent>
-
-          <CardFooter>
-            <Button type="submit" size="sm" disabled={isPending || !session}>
-              {isPending && <Spinner />}
-
-              {localization.settings.updateEmail}
-            </Button>
-          </CardFooter>
-        </Card>
-      </form>
+                {localization.settings.updateEmail}
+              </form.AuthFormSubmitButton>
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/examples/start-shadcn-baseui-example/src/components/auth/settings/security/fresh-session-prompt.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/settings/security/fresh-session-prompt.tsx
@@ -2,7 +2,6 @@
 
 import { isTwoFactorRedirect } from "@better-auth-ui/core/plugins/two-factor"
 import { useAuth, useSession, useSignInEmail } from "@better-auth-ui/react"
-import { type FormEvent, useState } from "react"
 import { Button } from "@/components/ui/button"
 import {
   Field,
@@ -14,6 +13,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
+import { useAuthForm } from "../../auth-form"
 
 export interface FreshSessionPromptProps {
   onFresh: () => unknown | Promise<unknown>
@@ -23,26 +23,25 @@ export function FreshSessionPrompt({ onFresh }: FreshSessionPromptProps) {
   const auth = useAuth()
   const session = useSession(auth.authClient)
   const continueSignIn = useSignInContinuation()
-  const [password, setPassword] = useState("")
   const signIn = useSignInEmail(auth.authClient, {
     meta: { errorPresentation: "inline" },
-    onError: () => setPassword(""),
+    onError: () => form.reset(),
     onSuccess: async (data) => {
       if (isTwoFactorRedirect(data)) {
         continueSignIn(data)
         return
       }
-      setPassword("")
+      form.reset()
       await onFresh()
     }
   })
-
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const email = session.data?.user.email
-    if (!email) return
-    signIn.mutate({ email, password })
-  }
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) => {
+      const email = session.data?.user.email
+      if (email) signIn.mutate({ email, password: value.password })
+    }
+  })
 
   return (
     <div className="p-4">
@@ -56,31 +55,41 @@ export function FreshSessionPrompt({ onFresh }: FreshSessionPromptProps) {
           </FieldDescription>
         </div>
         {auth.emailAndPassword?.enabled ? (
-          <form className="flex flex-col gap-3" onSubmit={submit}>
-            <Field data-invalid={signIn.isError}>
-              <FieldLabel htmlFor="fresh-session-password">
-                {auth.localization.auth.password}
-              </FieldLabel>
-              <Input
-                id="fresh-session-password"
-                autoComplete="current-password"
-                disabled={signIn.isPending}
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                type="password"
-                required
-              />
-              {signIn.error && (
-                <FieldError>
-                  {signIn.error.error?.message ?? signIn.error.message}
-                </FieldError>
-              )}
-            </Field>
-            <Button disabled={!password || signIn.isPending} type="submit">
-              {signIn.isPending && <Spinner />}
-              {auth.localization.settings.freshSessionSubmit}
-            </Button>
-          </form>
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-3">
+              <form.AppField name="password">
+                {(field) => (
+                  <Field data-invalid={signIn.isError}>
+                    <FieldLabel htmlFor="fresh-session-password">
+                      {auth.localization.auth.password}
+                    </FieldLabel>
+                    <Input
+                      id="fresh-session-password"
+                      autoComplete="current-password"
+                      disabled={signIn.isPending}
+                      name={field.name}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      type="password"
+                      required
+                    />
+                    {signIn.error && (
+                      <FieldError>
+                        {signIn.error.error?.message ?? signIn.error.message}
+                      </FieldError>
+                    )}
+                  </Field>
+                )}
+              </form.AppField>
+              <form.AuthFormSubmitButton disabled={signIn.isPending}>
+                {signIn.isPending && <Spinner />}
+                {auth.localization.settings.freshSessionSubmit}
+              </form.AuthFormSubmitButton>
+            </form.AuthFormRoot>
+          </form.AppForm>
         ) : (
           <Button
             onClick={() =>

--- a/examples/start-shadcn-baseui-example/src/components/auth/sign-in.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/sign-in.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import {
+  authMutationKeys,
+  validateEmailAddress,
+  validateStringLength
+} from "@better-auth-ui/core"
 import {
   isPasskeyAutoFillEnabled,
   withPasskeyAutoFill
@@ -13,15 +17,13 @@ import {
 } from "@better-auth-ui/react"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -36,6 +38,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
 import { LastUsedBadge } from "./last-login-method/last-used-badge"
 import { ProviderButtons, type SocialLayout } from "./provider-buttons"
 
@@ -73,13 +76,11 @@ export function SignIn({
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
   const continueSignIn = useSignInContinuation()
 
-  const [password, setPassword] = useState("")
-
   const { mutate: signInEmail, isPending: signInEmailPending } = useSignInEmail(
     authClient,
     {
       onError: (error, { email }) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
           sessionStorage.setItem("better-auth-ui.verify-email", email)
@@ -109,26 +110,18 @@ export function SignIn({
   const passkeyAutoFill = isPasskeyAutoFillEnabled(plugins)
 
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-    password?: string
-  }>({})
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const email = formData.get("email") as string
-    const rememberMe = formData.get("rememberMe") === "on"
-
-    signInEmail({
-      email,
-      password,
-      ...(emailAndPassword?.rememberMe ? { rememberMe } : {}),
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "", password: "", rememberMe: false },
+    onSubmit: ({ value }) =>
+      signInEmail({
+        email: value.email,
+        password: value.password,
+        ...(emailAndPassword?.rememberMe
+          ? { rememberMe: value.rememberMe }
+          : {}),
+        fetchOptions
+      })
+  })
 
   const showSeparator =
     emailAndPassword?.enabled && socialProviders && socialProviders.length > 0
@@ -159,170 +152,185 @@ export function SignIn({
           )}
 
           {emailAndPassword?.enabled && (
-            <form onSubmit={handleSubmit}>
-              <FieldGroup>
-                <Field data-invalid={!!fieldErrors.email}>
-                  <FieldLabel htmlFor="email">
-                    {localization.auth.email}
-                  </FieldLabel>
-
-                  <Input
-                    id="email"
+            <form.AppForm>
+              <form.AuthFormRoot>
+                <FieldGroup>
+                  <form.AppField
                     name="email"
-                    type="email"
-                    autoComplete={withPasskeyAutoFill("email", passkeyAutoFill)}
-                    placeholder={localization.auth.emailPlaceholder}
-                    required
-                    disabled={isPending}
-                    onChange={() => {
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: undefined
-                      }))
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateEmailAddress(value, {
+                          invalidMessage: localization.auth.invalidEmail,
+                          requiredMessage: localization.auth.fieldRequired
+                        })
                     }}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-                      const el = e.target as HTMLInputElement
-                      const msg = el.validity.valueMissing
-                        ? localization.auth.fieldRequired
-                        : localization.auth.invalidEmail
-
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: msg
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
-
-                  <FieldError>{fieldErrors.email}</FieldError>
-                </Field>
-
-                <Field data-invalid={!!fieldErrors.password}>
-                  <FieldLabel htmlFor="password">
-                    {localization.auth.password}
-                  </FieldLabel>
-
-                  <InputGroup>
-                    <InputGroupInput
-                      id="password"
-                      name="password"
-                      type={isPasswordVisible ? "text" : "password"}
-                      autoComplete={withPasskeyAutoFill(
-                        "current-password",
-                        passkeyAutoFill
-                      )}
-                      value={password}
-                      onChange={(e) => {
-                        setPassword(e.target.value)
-
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: undefined
-                        }))
-                      }}
-                      placeholder={localization.auth.passwordPlaceholder}
-                      required
-                      minLength={emailAndPassword?.minPasswordLength}
-                      maxLength={emailAndPassword?.maxPasswordLength}
-                      disabled={isPending}
-                      onInvalid={(e) => {
-                        e.preventDefault()
-                        const el = e.target as HTMLInputElement
-                        const min = emailAndPassword?.minPasswordLength
-                        const max = emailAndPassword?.maxPasswordLength
-                        const msg = el.validity.valueMissing
-                          ? localization.auth.fieldRequired
-                          : el.validity.tooShort
-                            ? localization.auth.tooShort.replace(
-                                "{{min}}",
-                                String(min)
-                              )
-                            : localization.auth.tooLong.replace(
-                                "{{max}}",
-                                String(max)
-                              )
-
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: msg
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.password}
-                    />
-
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        title={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() => {
-                          setIsPasswordVisible((visible) => !visible)
-                        }}
-                      >
-                        {isPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-
-                  <FieldError>{fieldErrors.password}</FieldError>
-                </Field>
-
-                {emailAndPassword.rememberMe && (
-                  <Field className="my-1">
-                    <div className="flex items-center gap-3">
-                      <Checkbox
-                        id="rememberMe"
-                        name="rememberMe"
-                        disabled={isPending}
-                      />
-
-                      <FieldLabel
-                        htmlFor="rememberMe"
-                        className="cursor-pointer text-sm font-normal"
-                      >
-                        {localization.auth.rememberMe}
-                      </FieldLabel>
-                    </div>
-                  </Field>
-                )}
-
-                {Captcha && (
-                  <div className="flex justify-center">{Captcha}</div>
-                )}
-
-                <div className="flex flex-col gap-3">
-                  <Button
-                    type="submit"
-                    className="relative overflow-visible"
-                    disabled={isPending}
                   >
-                    {signInEmailPending && <Spinner />}
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="email">
+                            {localization.auth.email}
+                          </FieldLabel>
 
-                    {localization.auth.signIn}
+                          <Input
+                            id="email"
+                            name={field.name}
+                            type="email"
+                            autoComplete={withPasskeyAutoFill(
+                              "email",
+                              passkeyAutoFill
+                            )}
+                            placeholder={localization.auth.emailPlaceholder}
+                            required
+                            disabled={isPending}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) =>
+                              field.handleChange(event.target.value)
+                            }
+                            aria-invalid={isInvalid}
+                          />
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
 
-                    <LastUsedBadge method="email" floating />
-                  </Button>
+                  <form.AppField
+                    name="password"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          maxLength: emailAndPassword?.maxPasswordLength,
+                          maxLengthMessage: localization.auth.tooLong.replace(
+                            "{{max}}",
+                            String(emailAndPassword?.maxPasswordLength)
+                          ),
+                          minLength: emailAndPassword?.minPasswordLength,
+                          minLengthMessage: localization.auth.tooShort.replace(
+                            "{{min}}",
+                            String(emailAndPassword?.minPasswordLength)
+                          ),
+                          requiredMessage: localization.auth.fieldRequired
+                        })
+                    }}
+                  >
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="password">
+                            {localization.auth.password}
+                          </FieldLabel>
 
-                  {plugins.flatMap((plugin) =>
-                    (plugin.authButtons ?? []).map((AuthButton, index) => (
-                      <AuthButton
-                        key={`${plugin.id}-${index.toString()}`}
-                        view="signIn"
-                      />
-                    ))
+                          <InputGroup>
+                            <InputGroupInput
+                              id="password"
+                              name={field.name}
+                              type={isPasswordVisible ? "text" : "password"}
+                              autoComplete={withPasskeyAutoFill(
+                                "current-password",
+                                passkeyAutoFill
+                              )}
+                              value={field.state.value}
+                              onBlur={field.handleBlur}
+                              onChange={(event) =>
+                                field.handleChange(event.target.value)
+                              }
+                              placeholder={
+                                localization.auth.passwordPlaceholder
+                              }
+                              required
+                              minLength={emailAndPassword?.minPasswordLength}
+                              maxLength={emailAndPassword?.maxPasswordLength}
+                              disabled={isPending}
+                              aria-invalid={isInvalid}
+                            />
+
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                size="icon-xs"
+                                aria-label={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                title={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                onClick={() => {
+                                  setIsPasswordVisible((visible) => !visible)
+                                }}
+                              >
+                                {isPasswordVisible ? <EyeOff /> : <Eye />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
+
+                  {emailAndPassword.rememberMe && (
+                    <form.AppField name="rememberMe">
+                      {(field) => (
+                        <Field className="my-1">
+                          <div className="flex items-center gap-3">
+                            <Checkbox
+                              id="rememberMe"
+                              name={field.name}
+                              checked={field.state.value}
+                              disabled={isPending}
+                              onCheckedChange={(checked) =>
+                                field.handleChange(checked === true)
+                              }
+                            />
+
+                            <FieldLabel
+                              htmlFor="rememberMe"
+                              className="cursor-pointer text-sm font-normal"
+                            >
+                              {localization.auth.rememberMe}
+                            </FieldLabel>
+                          </div>
+                        </Field>
+                      )}
+                    </form.AppField>
                   )}
-                </div>
-              </FieldGroup>
-            </form>
+
+                  {Captcha && (
+                    <div className="flex justify-center">{Captcha}</div>
+                  )}
+
+                  <div className="flex flex-col gap-3">
+                    <form.AuthFormSubmitButton
+                      className="relative overflow-visible"
+                      disabled={isPending}
+                    >
+                      {signInEmailPending && <Spinner />}
+
+                      {localization.auth.signIn}
+
+                      <LastUsedBadge method="email" floating />
+                    </form.AuthFormSubmitButton>
+
+                    {plugins.flatMap((plugin) =>
+                      (plugin.authButtons ?? []).map((AuthButton, index) => (
+                        <AuthButton
+                          key={`${plugin.id}-${index.toString()}`}
+                          view="signIn"
+                        />
+                      ))
+                    )}
+                  </div>
+                </FieldGroup>
+              </form.AuthFormRoot>
+            </form.AppForm>
           )}
 
           {socialPosition === "bottom" && (

--- a/examples/start-shadcn-baseui-example/src/components/auth/siwe/sign-in-ethereum-button.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/siwe/sign-in-ethereum-button.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { type AuthView, authMutationKeys } from "@better-auth-ui/core"
+import {
+  type AuthView,
+  authMutationKeys,
+  validateEmailAddress
+} from "@better-auth-ui/core"
 import {
   type SiweAuthClient,
   siweMutationKeys
@@ -9,7 +13,7 @@ import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useSignInSiwe } from "@better-auth-ui/react/plugins/siwe"
 import { useIsMutating } from "@tanstack/react-query"
 import { Wallet } from "lucide-react"
-import { type FormEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -20,16 +24,12 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel
-} from "@/components/ui/field"
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { siwePlugin } from "@/lib/auth/siwe-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 
 export type SignInEthereumButtonProps = { view?: AuthView }
 
@@ -50,8 +50,6 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
       useIsMutating({ mutationKey: siweMutationKeys.all }) >
     0
 
-  if (view === "signUp") return null
-
   const complete = (email?: string) => {
     signIn.mutate(email ? { email } : undefined, {
       onSuccess: () => {
@@ -61,13 +59,12 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
     })
   }
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const email = String(
-      new FormData(event.currentTarget).get("email") ?? ""
-    ).trim()
-    complete(email || undefined)
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) => complete(value.email.trim() || undefined)
+  })
+
+  if (view === "signUp") return null
 
   return (
     <>
@@ -84,50 +81,77 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <Wallet />
-                {plugin.localization.continueWithEthereum}
-              </DialogTitle>
-              <DialogDescription>
-                {plugin.localization.emailDescription}
-              </DialogDescription>
-            </DialogHeader>
-            <Field>
-              <FieldLabel htmlFor="siwe-email">
-                {plugin.email === "required"
-                  ? plugin.localization.email
-                  : plugin.localization.emailOptional}
-              </FieldLabel>
-              <Input
-                id="siwe-email"
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-4">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <Wallet />
+                  {plugin.localization.continueWithEthereum}
+                </DialogTitle>
+                <DialogDescription>
+                  {plugin.localization.emailDescription}
+                </DialogDescription>
+              </DialogHeader>
+              <form.AppField
                 name="email"
-                type="email"
-                autoComplete="email"
-                required={plugin.email === "required"}
-                disabled={signIn.isPending}
-              />
-              <FieldDescription>
-                {plugin.localization.emailDescription}
-              </FieldDescription>
-              <FieldError />
-            </Field>
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                disabled={signIn.isPending}
-                onClick={() => setOpen(false)}
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage:
+                        plugin.email === "required"
+                          ? localization.auth.fieldRequired
+                          : undefined
+                    })
+                }}
               >
-                {localization.settings.cancel}
-              </Button>
-              <Button type="submit" disabled={signIn.isPending}>
-                {signIn.isPending && <Spinner />}
-                {plugin.localization.signMessage}
-              </Button>
-            </DialogFooter>
-          </form>
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="siwe-email">
+                        {plugin.email === "required"
+                          ? plugin.localization.email
+                          : plugin.localization.emailOptional}
+                      </FieldLabel>
+                      <Input
+                        id="siwe-email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        required={plugin.email === "required"}
+                        disabled={signIn.isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        aria-invalid={isInvalid}
+                      />
+                      <FieldDescription>
+                        {plugin.localization.emailDescription}
+                      </FieldDescription>
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={signIn.isPending}
+                  onClick={() => setOpen(false)}
+                >
+                  {localization.settings.cancel}
+                </Button>
+                <form.AuthFormSubmitButton disabled={signIn.isPending}>
+                  {signIn.isPending && <Spinner />}
+                  {plugin.localization.signMessage}
+                </form.AuthFormSubmitButton>
+              </DialogFooter>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </DialogContent>
       </Dialog>
     </>

--- a/examples/start-shadcn-baseui-example/src/components/auth/sso/email-first-sign-in.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/sso/email-first-sign-in.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import {
+  authMutationKeys,
+  validateEmailAddress,
+  validateStringLength
+} from "@better-auth-ui/core"
 import {
   isPasskeyAutoFillEnabled,
   withPasskeyAutoFill
@@ -20,7 +24,7 @@ import {
 import { useSignInSso } from "@better-auth-ui/react/plugins/sso"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -35,7 +39,6 @@ import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -51,6 +54,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { ssoPlugin } from "@/lib/auth/sso-plugin"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 import { ProviderButtons } from "../provider-buttons"
 
 export type EmailFirstSignInProps = {
@@ -83,21 +87,15 @@ export function EmailFirstSignIn({
   const continueSignIn = useSignInContinuation()
 
   const [step, setStep] = useState<"email" | "fallback">("email")
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
   const [discoveryError, setDiscoveryError] = useState("")
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-    password?: string
-  }>({})
 
   const { mutate: signInSso, isPending: isDiscovering } = useSignInSso(
     authClient as SsoAuthClient,
     {
       onError: (error) => {
         if (error.status === 404) {
-          setSsoFallbackEmail(email)
+          setSsoFallbackEmail(form.state.values.email)
           setDiscoveryError(ssoLocalization.noProvider)
           setStep("fallback")
           return
@@ -112,10 +110,13 @@ export function EmailFirstSignIn({
     authClient,
     {
       onError: (error) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
-          sessionStorage.setItem("better-auth-ui.verify-email", email)
+          sessionStorage.setItem(
+            "better-auth-ui.verify-email",
+            form.state.values.email
+          )
           navigate({
             to: `${basePaths.auth}/${viewPaths.auth.verifyEmail}`
           })
@@ -139,33 +140,33 @@ export function EmailFirstSignIn({
   const showSocialSeparator =
     emailAndPassword.enabled && !!socialProviders?.length
 
-  const submitEmail = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setDiscoveryError("")
-    setSsoFallbackEmail(email)
-    signInSso({
-      email,
-      callbackURL: `${baseURL}${redirectTo}`,
-      loginHint: email
-    })
-  }
-
-  const submitPassword = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    signInEmail({
-      email,
-      password,
-      ...(emailAndPassword.rememberMe
-        ? { rememberMe: formData.get("rememberMe") === "on" }
-        : {}),
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "", password: "", rememberMe: false },
+    onSubmit: ({ value }) => {
+      if (step === "email") {
+        setDiscoveryError("")
+        setSsoFallbackEmail(value.email)
+        signInSso({
+          callbackURL: `${baseURL}${redirectTo}`,
+          email: value.email,
+          loginHint: value.email
+        })
+        return
+      }
+      signInEmail({
+        email: value.email,
+        password: value.password,
+        ...(emailAndPassword.rememberMe
+          ? { rememberMe: value.rememberMe }
+          : {}),
+        fetchOptions
+      })
+    }
+  })
 
   const startOver = () => {
     setStep("email")
-    setPassword("")
+    form.setFieldValue("password", "")
     setDiscoveryError("")
   }
 
@@ -177,207 +178,238 @@ export function EmailFirstSignIn({
           {localization.auth.signIn}
         </CardTitle>
         <CardDescription>
-          {step === "email" ? ssoLocalization.emailFirstDescription : email}
+          {step === "email"
+            ? ssoLocalization.emailFirstDescription
+            : form.state.values.email}
         </CardDescription>
       </CardHeader>
 
       <CardContent>
-        {step === "email" ? (
-          <form onSubmit={submitEmail}>
-            <FieldGroup>
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="sso-email">
-                  {localization.auth.email}
-                </FieldLabel>
-                <Input
-                  id="sso-email"
+        <form.AppForm>
+          {step === "email" ? (
+            <form.AuthFormRoot>
+              <FieldGroup>
+                <form.AppField
                   name="email"
-                  type="email"
-                  autoComplete={withPasskeyAutoFill("email", passkeyAutoFill)}
-                  autoFocus
-                  value={email}
-                  onChange={(event) => {
-                    setEmail(event.target.value)
-                    setFieldErrors((current) => ({
-                      ...current,
-                      email: undefined
-                    }))
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateEmailAddress(value, {
+                        invalidMessage: localization.auth.invalidEmail,
+                        requiredMessage: localization.auth.fieldRequired
+                      })
                   }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    const element = event.currentTarget
-                    setFieldErrors((current) => ({
-                      ...current,
-                      email: element.validity.valueMissing
-                        ? localization.auth.fieldRequired
-                        : localization.auth.invalidEmail
-                    }))
+                >
+                  {(field) => {
+                    const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                    return (
+                      <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor="sso-email">
+                          {localization.auth.email}
+                        </FieldLabel>
+                        <Input
+                          id="sso-email"
+                          name={field.name}
+                          type="email"
+                          autoComplete={withPasskeyAutoFill(
+                            "email",
+                            passkeyAutoFill
+                          )}
+                          autoFocus
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          placeholder={localization.auth.emailPlaceholder}
+                          required
+                          disabled={isPending}
+                          aria-invalid={isInvalid}
+                        />
+                        <field.AuthFormFieldError />
+                      </Field>
+                    )
                   }}
-                  placeholder={localization.auth.emailPlaceholder}
-                  required
-                  disabled={isPending}
-                  aria-invalid={!!fieldErrors.email}
-                />
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
+                </form.AppField>
+
+                {discoveryError && (
+                  <FieldDescription role="alert" className="text-destructive">
+                    {discoveryError}
+                  </FieldDescription>
+                )}
+
+                <form.AuthFormSubmitButton disabled={isPending}>
+                  {isDiscovering && <Spinner data-icon="inline-start" />}
+                  {ssoLocalization.continueWithEmail}
+                </form.AuthFormSubmitButton>
+              </FieldGroup>
+            </form.AuthFormRoot>
+          ) : (
+            <div className="flex flex-col gap-4">
+              {socialPosition === "top" && (
+                <>
+                  {!!socialProviders?.length && (
+                    <ProviderButtons
+                      socialLayout={socialLayout}
+                      view="signIn"
+                    />
+                  )}
+                  {showSocialSeparator && (
+                    <FieldSeparator>{localization.auth.or}</FieldSeparator>
+                  )}
+                </>
+              )}
 
               {discoveryError && (
-                <FieldDescription role="alert" className="text-destructive">
+                <FieldDescription role="status">
                   {discoveryError}
                 </FieldDescription>
               )}
 
-              <Button type="submit" disabled={isPending}>
-                {isDiscovering && <Spinner data-icon="inline-start" />}
-                {ssoLocalization.continueWithEmail}
-              </Button>
-            </FieldGroup>
-          </form>
-        ) : (
-          <div className="flex flex-col gap-4">
-            {socialPosition === "top" && (
-              <>
-                {!!socialProviders?.length && (
-                  <ProviderButtons socialLayout={socialLayout} view="signIn" />
-                )}
-                {showSocialSeparator && (
-                  <FieldSeparator>{localization.auth.or}</FieldSeparator>
-                )}
-              </>
-            )}
+              {emailAndPassword.enabled && (
+                <form.AuthFormRoot>
+                  <FieldGroup>
+                    <form.AppField
+                      name="password"
+                      validators={{
+                        onChange: ({ value }) =>
+                          validateStringLength(value, {
+                            maxLength: emailAndPassword.maxPasswordLength,
+                            maxLengthMessage: localization.auth.tooLong.replace(
+                              "{{max}}",
+                              String(emailAndPassword.maxPasswordLength)
+                            ),
+                            minLength: emailAndPassword.minPasswordLength,
+                            minLengthMessage:
+                              localization.auth.tooShort.replace(
+                                "{{min}}",
+                                String(emailAndPassword.minPasswordLength)
+                              ),
+                            requiredMessage: localization.auth.fieldRequired
+                          })
+                      }}
+                    >
+                      {(field) => {
+                        const isInvalid = isAuthFormFieldInvalid(
+                          field.state.meta
+                        )
+                        return (
+                          <Field data-invalid={isInvalid}>
+                            <FieldLabel htmlFor="sso-password">
+                              {localization.auth.password}
+                            </FieldLabel>
+                            <InputGroup>
+                              <InputGroupInput
+                                id="sso-password"
+                                name={field.name}
+                                type={isPasswordVisible ? "text" : "password"}
+                                autoComplete={withPasskeyAutoFill(
+                                  "current-password",
+                                  passkeyAutoFill
+                                )}
+                                autoFocus
+                                value={field.state.value}
+                                onBlur={field.handleBlur}
+                                onChange={(event) =>
+                                  field.handleChange(event.target.value)
+                                }
+                                placeholder={
+                                  localization.auth.passwordPlaceholder
+                                }
+                                minLength={emailAndPassword.minPasswordLength}
+                                maxLength={emailAndPassword.maxPasswordLength}
+                                required
+                                disabled={isPending}
+                                aria-invalid={isInvalid}
+                              />
+                              <InputGroupAddon align="inline-end">
+                                <InputGroupButton
+                                  size="icon-xs"
+                                  aria-label={
+                                    isPasswordVisible
+                                      ? localization.auth.hidePassword
+                                      : localization.auth.showPassword
+                                  }
+                                  onClick={() =>
+                                    setIsPasswordVisible((visible) => !visible)
+                                  }
+                                >
+                                  {isPasswordVisible ? <EyeOff /> : <Eye />}
+                                </InputGroupButton>
+                              </InputGroupAddon>
+                            </InputGroup>
+                            <field.AuthFormFieldError />
+                          </Field>
+                        )
+                      }}
+                    </form.AppField>
 
-            {discoveryError && (
-              <FieldDescription role="status">
-                {discoveryError}
-              </FieldDescription>
-            )}
-
-            {emailAndPassword.enabled && (
-              <form onSubmit={submitPassword}>
-                <FieldGroup>
-                  <Field data-invalid={!!fieldErrors.password}>
-                    <FieldLabel htmlFor="sso-password">
-                      {localization.auth.password}
-                    </FieldLabel>
-                    <InputGroup>
-                      <InputGroupInput
-                        id="sso-password"
-                        name="password"
-                        type={isPasswordVisible ? "text" : "password"}
-                        autoComplete={withPasskeyAutoFill(
-                          "current-password",
-                          passkeyAutoFill
+                    {emailAndPassword.rememberMe && (
+                      <form.AppField name="rememberMe">
+                        {(field) => (
+                          <Field>
+                            <div className="flex items-center gap-3">
+                              <Checkbox
+                                id="sso-remember-me"
+                                name={field.name}
+                                checked={field.state.value}
+                                disabled={isPending}
+                                onCheckedChange={(checked) =>
+                                  field.handleChange(checked === true)
+                                }
+                              />
+                              <FieldLabel
+                                htmlFor="sso-remember-me"
+                                className="cursor-pointer text-sm font-normal"
+                              >
+                                {localization.auth.rememberMe}
+                              </FieldLabel>
+                            </div>
+                          </Field>
                         )}
-                        autoFocus
-                        value={password}
-                        onChange={(event) => {
-                          setPassword(event.target.value)
-                          setFieldErrors((current) => ({
-                            ...current,
-                            password: undefined
-                          }))
-                        }}
-                        onInvalid={(event) => {
-                          event.preventDefault()
-                          const element = event.currentTarget
-                          const message = element.validity.valueMissing
-                            ? localization.auth.fieldRequired
-                            : element.validity.tooShort
-                              ? localization.auth.tooShort.replace(
-                                  "{{min}}",
-                                  String(emailAndPassword.minPasswordLength)
-                                )
-                              : localization.auth.tooLong.replace(
-                                  "{{max}}",
-                                  String(emailAndPassword.maxPasswordLength)
-                                )
+                      </form.AppField>
+                    )}
 
-                          setFieldErrors((current) => ({
-                            ...current,
-                            password: message
-                          }))
-                        }}
-                        placeholder={localization.auth.passwordPlaceholder}
-                        minLength={emailAndPassword.minPasswordLength}
-                        maxLength={emailAndPassword.maxPasswordLength}
-                        required
-                        disabled={isPending}
-                        aria-invalid={!!fieldErrors.password}
-                      />
-                      <InputGroupAddon align="inline-end">
-                        <InputGroupButton
-                          size="icon-xs"
-                          aria-label={
-                            isPasswordVisible
-                              ? localization.auth.hidePassword
-                              : localization.auth.showPassword
-                          }
-                          onClick={() =>
-                            setIsPasswordVisible((visible) => !visible)
-                          }
-                        >
-                          {isPasswordVisible ? <EyeOff /> : <Eye />}
-                        </InputGroupButton>
-                      </InputGroupAddon>
-                    </InputGroup>
-                    <FieldError>{fieldErrors.password}</FieldError>
-                  </Field>
+                    {Captcha && (
+                      <div className="flex justify-center">{Captcha}</div>
+                    )}
 
-                  {emailAndPassword.rememberMe && (
-                    <Field>
-                      <div className="flex items-center gap-3">
-                        <Checkbox
-                          id="sso-remember-me"
-                          name="rememberMe"
-                          disabled={isPending}
-                        />
-                        <FieldLabel
-                          htmlFor="sso-remember-me"
-                          className="cursor-pointer text-sm font-normal"
-                        >
-                          {localization.auth.rememberMe}
-                        </FieldLabel>
-                      </div>
-                    </Field>
+                    <form.AuthFormSubmitButton disabled={isPending}>
+                      {isSigningIn && <Spinner data-icon="inline-start" />}
+                      {localization.auth.signIn}
+                    </form.AuthFormSubmitButton>
+                  </FieldGroup>
+                </form.AuthFormRoot>
+              )}
+
+              {plugins.flatMap((plugin) =>
+                (plugin.authButtons ?? []).map((AuthButton) => (
+                  <AuthButton
+                    key={getAuthButtonKey(plugin.id, AuthButton)}
+                    view="signIn"
+                  />
+                ))
+              )}
+
+              {socialPosition === "bottom" && (
+                <>
+                  {showSocialSeparator && (
+                    <FieldSeparator>{localization.auth.or}</FieldSeparator>
                   )}
-
-                  {Captcha && (
-                    <div className="flex justify-center">{Captcha}</div>
+                  {!!socialProviders?.length && (
+                    <ProviderButtons
+                      socialLayout={socialLayout}
+                      view="signIn"
+                    />
                   )}
+                </>
+              )}
 
-                  <Button type="submit" disabled={isPending}>
-                    {isSigningIn && <Spinner data-icon="inline-start" />}
-                    {localization.auth.signIn}
-                  </Button>
-                </FieldGroup>
-              </form>
-            )}
-
-            {plugins.flatMap((plugin) =>
-              (plugin.authButtons ?? []).map((AuthButton) => (
-                <AuthButton
-                  key={getAuthButtonKey(plugin.id, AuthButton)}
-                  view="signIn"
-                />
-              ))
-            )}
-
-            {socialPosition === "bottom" && (
-              <>
-                {showSocialSeparator && (
-                  <FieldSeparator>{localization.auth.or}</FieldSeparator>
-                )}
-                {!!socialProviders?.length && (
-                  <ProviderButtons socialLayout={socialLayout} view="signIn" />
-                )}
-              </>
-            )}
-
-            <Button variant="ghost" onClick={startOver}>
-              {ssoLocalization.useDifferentEmail}
-            </Button>
-          </div>
-        )}
+              <Button variant="ghost" onClick={startOver}>
+                {ssoLocalization.useDifferentEmail}
+              </Button>
+            </div>
+          )}
+        </form.AppForm>
       </CardContent>
 
       {emailAndPassword.enabled && (

--- a/examples/start-shadcn-baseui-example/src/components/auth/sso/sso-domain-verification.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/sso/sso-domain-verification.tsx
@@ -12,7 +12,7 @@ import {
 } from "@better-auth-ui/react/plugins/sso"
 import type { BetterFetchError } from "better-auth/client"
 import { CheckIcon, CopyIcon } from "lucide-react"
-import { type FormEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -39,6 +39,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { ssoPlugin } from "@/lib/auth/sso-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 
 export type SsoDomainVerificationProps = {
   className?: string
@@ -61,7 +62,6 @@ export function SsoDomainVerification({
 }: SsoDomainVerificationProps) {
   const { authClient } = useAuth()
   const { localization } = useAuthPlugin(ssoPlugin)
-  const [providerId, setProviderId] = useState(defaultProviderId)
   const [token, setToken] = useState(defaultToken)
   const [verified, setVerified] = useState(false)
   const [copyError, setCopyError] = useState("")
@@ -74,7 +74,6 @@ export function SsoDomainVerification({
   const verify = useVerifySsoDomain(authClient as SsoAuthClient, {
     onSuccess: () => setVerified(true)
   })
-  const host = providerId ? `_${tokenPrefix}-${providerId}` : ""
   const hostCopy = useCopyToClipboard({
     onError: (error) =>
       setCopyError(error instanceof Error ? error.message : String(error))
@@ -88,12 +87,14 @@ export function SsoDomainVerification({
       ? requestToken.error
       : verify.error
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setCopyError("")
-    setVerified(false)
-    verify.mutate({ providerId })
-  }
+  const form = useAuthForm({
+    defaultValues: { providerId: defaultProviderId },
+    onSubmit: ({ value }) => {
+      setCopyError("")
+      setVerified(false)
+      verify.mutate({ providerId: value.providerId })
+    }
+  })
 
   return (
     <Card className={cn("w-full max-w-xl", className)}>
@@ -104,120 +105,144 @@ export function SsoDomainVerification({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="sso-verification-provider-id">
-                {localization.providerId}
-              </FieldLabel>
-              <Input
-                id="sso-verification-provider-id"
-                name="providerId"
-                value={providerId}
-                onChange={(event) => {
-                  setProviderId(event.target.value.trim())
-                  setToken("")
-                  setVerified(false)
-                }}
-                required
-              />
-            </Field>
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <form.Subscribe selector={(state) => state.values.providerId}>
+              {(providerId) => {
+                const host = providerId ? `_${tokenPrefix}-${providerId}` : ""
+                return (
+                  <FieldGroup>
+                    <form.AppField name="providerId">
+                      {(field) => (
+                        <Field>
+                          <FieldLabel htmlFor="sso-verification-provider-id">
+                            {localization.providerId}
+                          </FieldLabel>
+                          <Input
+                            id="sso-verification-provider-id"
+                            name={field.name}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              field.handleChange(event.target.value.trim())
+                              setToken("")
+                              setVerified(false)
+                            }}
+                            required
+                          />
+                        </Field>
+                      )}
+                    </form.AppField>
 
-            {token ? (
-              <div className="grid gap-3 rounded-lg border p-3">
-                <Field>
-                  <FieldLabel htmlFor="sso-dns-host">
-                    {localization.txtRecordHost}
-                  </FieldLabel>
-                  <InputGroup>
-                    <InputGroupInput
-                      className="font-mono text-xs"
-                      id="sso-dns-host"
-                      readOnly
-                      value={host}
-                    />
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        aria-label={localization.copyDnsHost}
-                        size="icon-xs"
+                    {token ? (
+                      <div className="grid gap-3 rounded-lg border p-3">
+                        <Field>
+                          <FieldLabel htmlFor="sso-dns-host">
+                            {localization.txtRecordHost}
+                          </FieldLabel>
+                          <InputGroup>
+                            <InputGroupInput
+                              className="font-mono text-xs"
+                              id="sso-dns-host"
+                              readOnly
+                              value={host}
+                            />
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                aria-label={localization.copyDnsHost}
+                                size="icon-xs"
+                                onClick={() => {
+                                  setCopyError("")
+                                  void hostCopy.copy(host)
+                                }}
+                              >
+                                {hostCopy.copied ? <CheckIcon /> : <CopyIcon />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+                        </Field>
+                        <Field>
+                          <FieldLabel htmlFor="sso-dns-value">
+                            {localization.txtRecordValue}
+                          </FieldLabel>
+                          <InputGroup>
+                            <InputGroupInput
+                              className="font-mono text-xs"
+                              id="sso-dns-value"
+                              readOnly
+                              value={token}
+                            />
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                aria-label={localization.copyDnsValue}
+                                size="icon-xs"
+                                onClick={() => {
+                                  setCopyError("")
+                                  void tokenCopy.copy(token)
+                                }}
+                              >
+                                {tokenCopy.copied ? (
+                                  <CheckIcon />
+                                ) : (
+                                  <CopyIcon />
+                                )}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+                        </Field>
+                      </div>
+                    ) : null}
+
+                    {error ? (
+                      <FieldError>{getErrorMessage(error)}</FieldError>
+                    ) : null}
+                    {copyError ? <FieldError>{copyError}</FieldError> : null}
+                    {verified ? (
+                      <FieldDescription
+                        role="status"
+                        className="text-foreground"
+                      >
+                        {localization.domainVerified}
+                      </FieldDescription>
+                    ) : null}
+
+                    <div className="flex flex-wrap justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={!providerId || verify.isPending}
                         onClick={() => {
                           setCopyError("")
-                          void hostCopy.copy(host)
+                          setVerified(false)
+                          requestToken.mutate({ providerId })
                         }}
                       >
-                        {hostCopy.copied ? <CheckIcon /> : <CopyIcon />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                </Field>
-                <Field>
-                  <FieldLabel htmlFor="sso-dns-value">
-                    {localization.txtRecordValue}
-                  </FieldLabel>
-                  <InputGroup>
-                    <InputGroupInput
-                      className="font-mono text-xs"
-                      id="sso-dns-value"
-                      readOnly
-                      value={token}
-                    />
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        aria-label={localization.copyDnsValue}
-                        size="icon-xs"
-                        onClick={() => {
-                          setCopyError("")
-                          void tokenCopy.copy(token)
-                        }}
+                        {requestToken.isPending ? (
+                          <Spinner data-icon="inline-start" />
+                        ) : null}
+                        {localization.requestNewToken}
+                      </Button>
+                      <form.AuthFormSubmitButton
+                        disabled={!providerId || requestToken.isPending}
                       >
-                        {tokenCopy.copied ? <CheckIcon /> : <CopyIcon />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                </Field>
-              </div>
-            ) : null}
+                        {verify.isPending ? (
+                          <Spinner data-icon="inline-start" />
+                        ) : null}
+                        {localization.verifyDomain}
+                      </form.AuthFormSubmitButton>
+                    </div>
 
-            {error ? <FieldError>{getErrorMessage(error)}</FieldError> : null}
-            {copyError ? <FieldError>{copyError}</FieldError> : null}
-            {verified ? (
-              <FieldDescription role="status" className="text-foreground">
-                {localization.domainVerified}
-              </FieldDescription>
-            ) : null}
-
-            <div className="flex flex-wrap justify-end gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                disabled={!providerId || verify.isPending}
-                onClick={() => {
-                  setCopyError("")
-                  setVerified(false)
-                  requestToken.mutate({ providerId })
-                }}
-              >
-                {requestToken.isPending ? (
-                  <Spinner data-icon="inline-start" />
-                ) : null}
-                {localization.requestNewToken}
-              </Button>
-              <Button
-                type="submit"
-                disabled={!providerId || requestToken.isPending}
-              >
-                {verify.isPending ? <Spinner data-icon="inline-start" /> : null}
-                {localization.verifyDomain}
-              </Button>
-            </div>
-
-            <span className="sr-only" aria-live="polite">
-              {token && !verified
-                ? localization.domainVerificationRequested
-                : ""}
-            </span>
-          </FieldGroup>
-        </form>
+                    <span className="sr-only" aria-live="polite">
+                      {token && !verified
+                        ? localization.domainVerificationRequested
+                        : ""}
+                    </span>
+                  </FieldGroup>
+                )
+              }}
+            </form.Subscribe>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
     </Card>
   )

--- a/examples/start-shadcn-baseui-example/src/components/auth/two-factor/disable-two-factor-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/two-factor/disable-two-factor-dialog.tsx
@@ -4,7 +4,6 @@ import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-facto
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useDisableTwoFactor } from "@better-auth-ui/react/plugins/two-factor"
 import { ShieldAlert } from "lucide-react"
-import type { SyntheticEvent } from "react"
 import { toast } from "sonner"
 
 import {
@@ -17,12 +16,12 @@ import {
   AlertDialogMedia,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
-import { Button } from "@/components/ui/button"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
+import { useAuthForm } from "../auth-form"
 
 export type DisableTwoFactorDialogProps = {
   open: boolean
@@ -54,68 +53,79 @@ export function DisableTwoFactorDialog({
 
   const isPending = isDisabling || isResolvingPasswordRequirement
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-
-    disableTwoFactor(requiresPassword ? { password } : {})
-  }
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) =>
+      disableTwoFactor(requiresPassword ? { password: value.password } : {})
+  })
 
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <AlertDialogHeader>
-            <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
-              <ShieldAlert />
-            </AlertDialogMedia>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <AlertDialogHeader>
+              <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
+                <ShieldAlert />
+              </AlertDialogMedia>
 
-            <AlertDialogTitle>
-              {twoFactorLocalization.disableTwoFactor}
-            </AlertDialogTitle>
+              <AlertDialogTitle>
+                {twoFactorLocalization.disableTwoFactor}
+              </AlertDialogTitle>
 
-            <AlertDialogDescription>
-              {requiresPassword
-                ? twoFactorLocalization.passwordConfirmation
-                : twoFactorLocalization.twoFactorDescription}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+              <AlertDialogDescription>
+                {requiresPassword
+                  ? twoFactorLocalization.passwordConfirmation
+                  : twoFactorLocalization.twoFactorDescription}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
 
-          {requiresPassword && (
-            <Field>
-              <FieldLabel htmlFor="disable-two-factor-password">
-                {localization.auth.password}
-              </FieldLabel>
+            {requiresPassword && (
+              <form.AppField name="password">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="disable-two-factor-password">
+                      {localization.auth.password}
+                    </FieldLabel>
 
-              <Input
-                id="disable-two-factor-password"
-                name="password"
-                type="password"
-                autoComplete="current-password"
-                autoFocus
-                required
-                placeholder={localization.auth.passwordPlaceholder}
+                    <Input
+                      id="disable-two-factor-password"
+                      name={field.name}
+                      type="password"
+                      autoComplete="current-password"
+                      autoFocus
+                      required
+                      placeholder={localization.auth.passwordPlaceholder}
+                      disabled={isPending}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                    />
+
+                    <FieldError />
+                  </Field>
+                )}
+              </form.AppField>
+            )}
+
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isPending}>
+                {localization.settings.cancel}
+              </AlertDialogCancel>
+
+              <form.AuthFormSubmitButton
+                variant="destructive"
                 disabled={isPending}
-              />
+              >
+                {isPending && <Spinner />}
 
-              <FieldError />
-            </Field>
-          )}
-
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>
-              {localization.settings.cancel}
-            </AlertDialogCancel>
-
-            <Button type="submit" variant="destructive" disabled={isPending}>
-              {isPending && <Spinner />}
-
-              {twoFactorLocalization.disableTwoFactor}
-            </Button>
-          </AlertDialogFooter>
-        </form>
+                {twoFactorLocalization.disableTwoFactor}
+              </form.AuthFormSubmitButton>
+            </AlertDialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </AlertDialogContent>
     </AlertDialog>
   )

--- a/examples/start-shadcn-baseui-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -15,9 +15,9 @@ import {
   useVerifyTotp
 } from "@better-auth-ui/react/plugins/two-factor"
 import { Check, Copy, ShieldCheck } from "lucide-react"
-import { type SyntheticEvent, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -39,6 +39,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { BackupCodes } from "./backup-codes"
 
@@ -79,7 +80,6 @@ export function EnableTwoFactorDialog({
   )
   const [totpUri, setTotpUri] = useState("")
   const [backupCodes, setBackupCodes] = useState<string[]>([])
-  const [code, setCode] = useState("")
   const {
     copied: setupKeyCopied,
     copy: copySetupKeyValue,
@@ -132,7 +132,7 @@ export function EnableTwoFactorDialog({
   const { mutate: verifyTotp, isPending: isVerifying } = useVerifyTotp(
     twoFactorClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
         toast.success(twoFactorLocalization.twoFactorEnabled)
         setStep("backupCodes")
@@ -141,6 +141,23 @@ export function EnableTwoFactorDialog({
   )
 
   const isPending = isEnabling || isVerifying || isResolvingPasswordRequirement
+
+  const form = useAuthForm({
+    defaultValues: { code: "", password: "" },
+    onSubmit: ({ value }) => {
+      if (step === "backupCodes") {
+        handleOpenChange(false)
+        return
+      }
+      if (step === "verify") {
+        verifyCode(value.code)
+        return
+      }
+      enableTwoFactor(
+        requiresPassword ? { method, password: value.password } : { method }
+      )
+    }
+  })
 
   const verifyCode = (completedCode: string) => {
     if (isPending || step !== "verify" || completedCode.length !== codeLength) {
@@ -158,30 +175,11 @@ export function EnableTwoFactorDialog({
       setMethod(enrollmentMethods[0] ?? "totp")
       setTotpUri("")
       setBackupCodes([])
-      setCode("")
+      form.reset()
       resetSetupKeyCopy()
       // Clears the resolved TOTP URI and backup codes from the mutation cache.
       resetEnrollment()
     }
-  }
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (step === "backupCodes") {
-      handleOpenChange(false)
-      return
-    }
-
-    if (step === "verify") {
-      verifyCode(code)
-      return
-    }
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-
-    enableTwoFactor(requiresPassword ? { method, password } : { method })
   }
 
   const submitLabel =
@@ -194,169 +192,189 @@ export function EnableTwoFactorDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <ShieldCheck />
-              {twoFactorLocalization.twoFactor}
-            </DialogTitle>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <ShieldCheck />
+                {twoFactorLocalization.twoFactor}
+              </DialogTitle>
 
-            <DialogDescription>
-              {step === "password" && requiresPassword
-                ? twoFactorLocalization.passwordConfirmation
-                : step === "verify"
-                  ? twoFactorLocalization.scanQrCode
-                  : twoFactorLocalization.twoFactorDescription}
-            </DialogDescription>
-          </DialogHeader>
+              <DialogDescription>
+                {step === "password" && requiresPassword
+                  ? twoFactorLocalization.passwordConfirmation
+                  : step === "verify"
+                    ? twoFactorLocalization.scanQrCode
+                    : twoFactorLocalization.twoFactorDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          {step === "password" && (
-            <div className="flex flex-col gap-4">
-              {enrollmentMethods.length > 1 && (
-                <Tabs
-                  value={method}
-                  onValueChange={(value) => setMethod(value as TwoFactorMethod)}
-                >
-                  <TabsList
-                    aria-label={twoFactorLocalization.chooseEnrollmentMethod}
-                    className="w-full"
+            {step === "password" && (
+              <div className="flex flex-col gap-4">
+                {enrollmentMethods.length > 1 && (
+                  <Tabs
+                    value={method}
+                    onValueChange={(value) =>
+                      setMethod(value as TwoFactorMethod)
+                    }
                   >
-                    {enrollmentMethods.includes("totp") && (
-                      <TabsTrigger value="totp">
-                        {twoFactorLocalization.authenticatorApp}
-                      </TabsTrigger>
+                    <TabsList
+                      aria-label={twoFactorLocalization.chooseEnrollmentMethod}
+                      className="w-full"
+                    >
+                      {enrollmentMethods.includes("totp") && (
+                        <TabsTrigger value="totp">
+                          {twoFactorLocalization.authenticatorApp}
+                        </TabsTrigger>
+                      )}
+                      {enrollmentMethods.includes("otp") && (
+                        <TabsTrigger value="otp">
+                          {twoFactorLocalization.deliveredCode}
+                        </TabsTrigger>
+                      )}
+                    </TabsList>
+                  </Tabs>
+                )}
+
+                <p className="text-muted-foreground text-sm">
+                  {method === "totp"
+                    ? twoFactorLocalization.authenticatorAppDescription
+                    : twoFactorLocalization.deliveredCodeDescription}
+                </p>
+
+                {requiresPassword && (
+                  <form.AppField name="password">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel htmlFor="two-factor-password">
+                          {localization.auth.password}
+                        </FieldLabel>
+
+                        <Input
+                          id="two-factor-password"
+                          name={field.name}
+                          type="password"
+                          autoComplete="current-password"
+                          autoFocus
+                          required
+                          placeholder={localization.auth.passwordPlaceholder}
+                          disabled={isPending}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                        />
+
+                        <FieldError />
+                      </Field>
                     )}
-                    {enrollmentMethods.includes("otp") && (
-                      <TabsTrigger value="otp">
-                        {twoFactorLocalization.deliveredCode}
-                      </TabsTrigger>
-                    )}
-                  </TabsList>
-                </Tabs>
-              )}
-
-              <p className="text-muted-foreground text-sm">
-                {method === "totp"
-                  ? twoFactorLocalization.authenticatorAppDescription
-                  : twoFactorLocalization.deliveredCodeDescription}
-              </p>
-
-              {requiresPassword && (
-                <Field>
-                  <FieldLabel htmlFor="two-factor-password">
-                    {localization.auth.password}
-                  </FieldLabel>
-
-                  <Input
-                    id="two-factor-password"
-                    name="password"
-                    type="password"
-                    autoComplete="current-password"
-                    autoFocus
-                    required
-                    placeholder={localization.auth.passwordPlaceholder}
-                    disabled={isPending}
-                  />
-
-                  <FieldError />
-                </Field>
-              )}
-            </div>
-          )}
-
-          {step === "verify" && (
-            <div className="flex flex-col items-center gap-4">
-              {qrCode && (
-                <svg
-                  aria-hidden="true"
-                  className="size-44 rounded-md border"
-                  viewBox={`0 0 ${qrCode.size} ${qrCode.size}`}
-                >
-                  <path
-                    fill="white"
-                    d={`M0 0h${qrCode.size}v${qrCode.size}H0z`}
-                  />
-                  <path
-                    fill="black"
-                    d={qrCode.path}
-                    shapeRendering="crispEdges"
-                  />
-                </svg>
-              )}
-
-              {setupKey && (
-                <Field className="w-full gap-1">
-                  <FieldLabel
-                    className="text-muted-foreground text-xs"
-                    htmlFor="two-factor-setup-key"
-                  >
-                    {twoFactorLocalization.setupKey}
-                  </FieldLabel>
-
-                  <InputGroup>
-                    <InputGroupInput
-                      className="font-mono text-xs"
-                      id="two-factor-setup-key"
-                      readOnly
-                      value={setupKey}
-                    />
-
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        aria-label={
-                          setupKeyCopied
-                            ? twoFactorLocalization.setupKeyCopied
-                            : localization.settings.copyToClipboard
-                        }
-                        onClick={copySetupKey}
-                        size="icon-xs"
-                      >
-                        {setupKeyCopied ? <Check /> : <Copy />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                </Field>
-              )}
-
-              <OtpField
-                autoFocus
-                className="w-full"
-                disabled={isPending}
-                label={twoFactorLocalization.authenticatorCode}
-                length={codeLength}
-                name="code"
-                value={code}
-                onChange={setCode}
-                onComplete={verifyCode}
-              />
-            </div>
-          )}
-
-          {step === "backupCodes" && <BackupCodes codes={backupCodes} />}
-
-          <DialogFooter>
-            {step !== "backupCodes" && (
-              <DialogClose
-                className={buttonVariants({ variant: "outline" })}
-                disabled={isPending}
-                type="button"
-              >
-                {localization.settings.cancel}
-              </DialogClose>
+                  </form.AppField>
+                )}
+              </div>
             )}
 
-            <Button
-              type="submit"
-              disabled={
-                isPending || (step === "verify" && code.length !== codeLength)
-              }
-            >
-              {isPending && <Spinner />}
+            {step === "verify" && (
+              <div className="flex flex-col items-center gap-4">
+                {qrCode && (
+                  <svg
+                    aria-hidden="true"
+                    className="size-44 rounded-md border"
+                    viewBox={`0 0 ${qrCode.size} ${qrCode.size}`}
+                  >
+                    <path
+                      fill="white"
+                      d={`M0 0h${qrCode.size}v${qrCode.size}H0z`}
+                    />
+                    <path
+                      fill="black"
+                      d={qrCode.path}
+                      shapeRendering="crispEdges"
+                    />
+                  </svg>
+                )}
 
-              {submitLabel}
-            </Button>
-          </DialogFooter>
-        </form>
+                {setupKey && (
+                  <Field className="w-full gap-1">
+                    <FieldLabel
+                      className="text-muted-foreground text-xs"
+                      htmlFor="two-factor-setup-key"
+                    >
+                      {twoFactorLocalization.setupKey}
+                    </FieldLabel>
+
+                    <InputGroup>
+                      <InputGroupInput
+                        className="font-mono text-xs"
+                        id="two-factor-setup-key"
+                        readOnly
+                        value={setupKey}
+                      />
+
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          aria-label={
+                            setupKeyCopied
+                              ? twoFactorLocalization.setupKeyCopied
+                              : localization.settings.copyToClipboard
+                          }
+                          onClick={copySetupKey}
+                          size="icon-xs"
+                        >
+                          {setupKeyCopied ? <Check /> : <Copy />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  </Field>
+                )}
+
+                <form.AppField name="code">
+                  {(field) => (
+                    <OtpField
+                      autoFocus
+                      className="w-full"
+                      disabled={isPending}
+                      label={twoFactorLocalization.authenticatorCode}
+                      length={codeLength}
+                      name={field.name}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      onComplete={verifyCode}
+                    />
+                  )}
+                </form.AppField>
+              </div>
+            )}
+
+            {step === "backupCodes" && <BackupCodes codes={backupCodes} />}
+
+            <DialogFooter>
+              {step !== "backupCodes" && (
+                <DialogClose
+                  className={buttonVariants({ variant: "outline" })}
+                  disabled={isPending}
+                  type="button"
+                >
+                  {localization.settings.cancel}
+                </DialogClose>
+              )}
+
+              <form.Subscribe selector={(state) => state.values.code}>
+                {(code) => (
+                  <form.AuthFormSubmitButton
+                    disabled={
+                      isPending ||
+                      (step === "verify" && code.length !== codeLength)
+                    }
+                  >
+                    {isPending && <Spinner />}
+                    {submitLabel}
+                  </form.AuthFormSubmitButton>
+                )}
+              </form.Subscribe>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-shadcn-baseui-example/src/components/auth/two-factor/regenerate-backup-codes-dialog.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/two-factor/regenerate-backup-codes-dialog.tsx
@@ -4,7 +4,7 @@ import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-facto
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useGenerateBackupCodes } from "@better-auth-ui/react/plugins/two-factor"
 import { KeyRound } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -17,12 +17,12 @@ import {
   AlertDialogMedia,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
-import { Button } from "@/components/ui/button"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
+import { useAuthForm } from "../auth-form"
 import { BackupCodes } from "./backup-codes"
 
 export type RegenerateBackupCodesDialogProps = {
@@ -63,91 +63,100 @@ export function RegenerateBackupCodesDialog({
 
   const isPending = isGenerating || isResolvingPasswordRequirement
 
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) => {
+      if (codes.length) {
+        handleOpenChange(false)
+        return
+      }
+      generateBackupCodes(requiresPassword ? { password: value.password } : {})
+    }
+  })
+
   const handleOpenChange = (nextOpen: boolean) => {
     onOpenChange(nextOpen)
 
     if (!nextOpen) {
       setCodes([])
+      form.reset()
       // Clears the resolved backup codes from the mutation cache.
       resetGeneration()
     }
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (codes.length) {
-      handleOpenChange(false)
-      return
-    }
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-
-    generateBackupCodes(requiresPassword ? { password } : {})
-  }
-
   return (
     <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <AlertDialogHeader>
-            <AlertDialogMedia>
-              <KeyRound />
-            </AlertDialogMedia>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <AlertDialogHeader>
+              <AlertDialogMedia>
+                <KeyRound />
+              </AlertDialogMedia>
 
-            <AlertDialogTitle>
-              {twoFactorLocalization.backupCodes}
-            </AlertDialogTitle>
+              <AlertDialogTitle>
+                {twoFactorLocalization.backupCodes}
+              </AlertDialogTitle>
 
-            <AlertDialogDescription>
-              {codes.length || !requiresPassword
-                ? twoFactorLocalization.backupCodesDescription
-                : twoFactorLocalization.passwordConfirmation}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+              <AlertDialogDescription>
+                {codes.length || !requiresPassword
+                  ? twoFactorLocalization.backupCodesDescription
+                  : twoFactorLocalization.passwordConfirmation}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
 
-          {codes.length ? (
-            <BackupCodes codes={codes} />
-          ) : (
-            requiresPassword && (
-              <Field>
-                <FieldLabel htmlFor="regenerate-backup-codes-password">
-                  {localization.auth.password}
-                </FieldLabel>
+            {codes.length ? (
+              <BackupCodes codes={codes} />
+            ) : (
+              requiresPassword && (
+                <form.AppField name="password">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="regenerate-backup-codes-password">
+                        {localization.auth.password}
+                      </FieldLabel>
 
-                <Input
-                  id="regenerate-backup-codes-password"
-                  name="password"
-                  type="password"
-                  autoComplete="current-password"
-                  autoFocus
-                  required
-                  placeholder={localization.auth.passwordPlaceholder}
-                  disabled={isPending}
-                />
+                      <Input
+                        id="regenerate-backup-codes-password"
+                        name={field.name}
+                        type="password"
+                        autoComplete="current-password"
+                        autoFocus
+                        required
+                        placeholder={localization.auth.passwordPlaceholder}
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
 
-                <FieldError />
-              </Field>
-            )
-          )}
-
-          <AlertDialogFooter>
-            {!codes.length && (
-              <AlertDialogCancel disabled={isPending}>
-                {localization.settings.cancel}
-              </AlertDialogCancel>
+                      <FieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              )
             )}
 
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Spinner />}
+            <AlertDialogFooter>
+              {!codes.length && (
+                <AlertDialogCancel disabled={isPending}>
+                  {localization.settings.cancel}
+                </AlertDialogCancel>
+              )}
 
-              {codes.length
-                ? twoFactorLocalization.done
-                : twoFactorLocalization.regenerateBackupCodes}
-            </Button>
-          </AlertDialogFooter>
-        </form>
+              <form.AuthFormSubmitButton disabled={isPending}>
+                {isPending && <Spinner />}
+
+                {codes.length
+                  ? twoFactorLocalization.done
+                  : twoFactorLocalization.regenerateBackupCodes}
+              </form.AuthFormSubmitButton>
+            </AlertDialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </AlertDialogContent>
     </AlertDialog>
   )

--- a/examples/start-shadcn-baseui-example/src/components/auth/two-factor/two-factor-challenge.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/two-factor/two-factor-challenge.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { authQueryKeys } from "@better-auth-ui/core"
+import { authQueryKeys, validateStringLength } from "@better-auth-ui/core"
 import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-factor"
 import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
 import {
@@ -10,7 +10,7 @@ import {
   useVerifyTwoFactorOtp
 } from "@better-auth-ui/react/plugins/two-factor"
 import { useQueryClient } from "@tanstack/react-query"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -40,6 +40,7 @@ import {
   useResendCooldown
 } from "@/lib/auth/use-resend-cooldown"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { useIsHydrated } from "../use-is-hydrated"
 
@@ -88,8 +89,6 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
   const [method, setMethod] = useState<ChallengeMethod>(
     () => methods[0] ?? "totp"
   )
-  const [code, setCode] = useState("")
-  const [trustDevice, setTrustDevice] = useState(false)
   const [otpRequested, setOtpRequested] = useState(false)
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
 
@@ -117,12 +116,15 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
 
   const { mutate: verifyTotp, isPending: isVerifyingTotp } = useVerifyTotp(
     twoFactorClient,
-    { onError: () => setCode(""), onSuccess: onVerified }
+    {
+      onError: () => form.setFieldValue("code", ""),
+      onSuccess: onVerified
+    }
   )
 
   const { mutate: verifyTwoFactorOtp, isPending: isVerifyingOtp } =
     useVerifyTwoFactorOtp(twoFactorClient, {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: onVerified
     })
 
@@ -133,8 +135,21 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
     isSendingOtp || isVerifyingTotp || isVerifyingOtp || isVerifyingBackupCode
   const needsOtpRequest = method === "otp" && !otpRequested
 
+  const form = useAuthForm({
+    defaultValues: { backupCode: "", code: "", trustDevice: false },
+    onSubmit: ({ value }) => {
+      const trust = trustDeviceEnabled ? { trustDevice: value.trustDevice } : {}
+      if (method === "backup") {
+        verifyBackupCode({ code: value.backupCode.trim(), ...trust })
+        return
+      }
+      verifyCode(value.code)
+    }
+  })
+
   const switchMethod = (next: ChallengeMethod) => {
-    setCode("")
+    form.setFieldValue("code", "")
+    form.setFieldValue("backupCode", "")
     setMethod(next)
   }
 
@@ -148,7 +163,9 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
       return
     }
 
-    const trust = trustDeviceEnabled ? { trustDevice } : {}
+    const trust = trustDeviceEnabled
+      ? { trustDevice: form.state.values.trustDevice }
+      : {}
 
     if (method === "otp") {
       verifyTwoFactorOtp({ code: completedCode, ...trust })
@@ -156,23 +173,6 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
     }
 
     verifyTotp({ code: completedCode, ...trust })
-  }
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const trust = trustDeviceEnabled ? { trustDevice } : {}
-
-    if (method === "backup") {
-      const formData = new FormData(e.currentTarget)
-      verifyBackupCode({
-        code: (formData.get("backupCode") as string).trim(),
-        ...trust
-      })
-      return
-    }
-
-    verifyCode(code)
   }
 
   const description =
@@ -210,113 +210,143 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            {method === "backup" ? (
-              <Field>
-                <FieldLabel htmlFor="backupCode">
-                  {twoFactorLocalization.backupCode}
-                </FieldLabel>
-
-                <Input
-                  id="backupCode"
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              {method === "backup" ? (
+                <form.AppField
                   name="backupCode"
-                  autoComplete="one-time-code"
-                  autoFocus
-                  required
-                  disabled={isPending}
-                />
-              </Field>
-            ) : (
-              <OtpField
-                autoFocus
-                disabled={isPending || needsOtpRequest}
-                label={
-                  method === "otp"
-                    ? twoFactorLocalization.emailedCode
-                    : twoFactorLocalization.authenticatorCode
-                }
-                length={codeLength}
-                name="code"
-                value={code}
-                onChange={setCode}
-                onComplete={verifyCode}
-              />
-            )}
-
-            {trustDeviceEnabled && (
-              <Field orientation="horizontal">
-                <Checkbox
-                  id="trustDevice"
-                  name="trustDevice"
-                  checked={trustDevice}
-                  disabled={isPending}
-                  onCheckedChange={(checked) =>
-                    setTrustDevice(checked === true)
-                  }
-                />
-
-                <FieldLabel htmlFor="trustDevice" className="font-normal">
-                  {twoFactorLocalization.trustDevice}
-                </FieldLabel>
-              </Field>
-            )}
-
-            <div className="flex flex-col gap-3">
-              {needsOtpRequest ? (
-                <Button
-                  type="button"
-                  disabled={isSendingOtp}
-                  onClick={() => sendTwoFactorOtp()}
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateStringLength(value, {
+                        requiredMessage: localization.auth.fieldRequired,
+                        trim: true
+                      })
+                  }}
                 >
-                  {isSendingOtp && <Spinner />}
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="backupCode">
+                        {twoFactorLocalization.backupCode}
+                      </FieldLabel>
 
-                  {twoFactorLocalization.sendEmailCode}
-                </Button>
+                      <Input
+                        id="backupCode"
+                        name={field.name}
+                        autoComplete="one-time-code"
+                        autoFocus
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                    </Field>
+                  )}
+                </form.AppField>
               ) : (
-                <Button
-                  type="submit"
-                  disabled={
-                    isPending ||
-                    (method !== "backup" && code.length !== codeLength)
-                  }
-                >
-                  {isPending && <Spinner />}
-
-                  {twoFactorLocalization.verify}
-                </Button>
+                <form.AppField name="code">
+                  {(field) => (
+                    <OtpField
+                      autoFocus
+                      disabled={isPending || needsOtpRequest}
+                      label={
+                        method === "otp"
+                          ? twoFactorLocalization.emailedCode
+                          : twoFactorLocalization.authenticatorCode
+                      }
+                      length={codeLength}
+                      name={field.name}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      onComplete={verifyCode}
+                    />
+                  )}
+                </form.AppField>
               )}
 
-              {method === "otp" && otpRequested && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={isPending || isCoolingDown}
-                  onClick={() => sendTwoFactorOtp()}
-                >
-                  {isCoolingDown
-                    ? localization.auth.resendIn.replace(
-                        "{{seconds}}",
-                        String(cooldown)
-                      )
-                    : localization.auth.resend}
-                </Button>
+              {trustDeviceEnabled && (
+                <form.AppField name="trustDevice">
+                  {(field) => (
+                    <Field orientation="horizontal">
+                      <Checkbox
+                        id="trustDevice"
+                        name={field.name}
+                        checked={field.state.value}
+                        disabled={isPending}
+                        onCheckedChange={(checked) =>
+                          field.handleChange(checked === true)
+                        }
+                      />
+
+                      <FieldLabel htmlFor="trustDevice" className="font-normal">
+                        {twoFactorLocalization.trustDevice}
+                      </FieldLabel>
+                    </Field>
+                  )}
+                </form.AppField>
               )}
 
-              {alternatives.map((alternative) => (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  key={alternative.key}
-                  disabled={isPending}
-                  onClick={() => switchMethod(alternative.key)}
-                >
-                  {alternative.label}
-                </Button>
-              ))}
-            </div>
-          </FieldGroup>
-        </form>
+              <div className="flex flex-col gap-3">
+                {needsOtpRequest ? (
+                  <Button
+                    type="button"
+                    disabled={isSendingOtp}
+                    onClick={() => sendTwoFactorOtp()}
+                  >
+                    {isSendingOtp && <Spinner />}
+
+                    {twoFactorLocalization.sendEmailCode}
+                  </Button>
+                ) : (
+                  <form.Subscribe selector={(state) => state.values.code}>
+                    {(code) => (
+                      <form.AuthFormSubmitButton
+                        disabled={
+                          isPending ||
+                          (method !== "backup" && code.length !== codeLength)
+                        }
+                      >
+                        {isPending && <Spinner />}
+                        {twoFactorLocalization.verify}
+                      </form.AuthFormSubmitButton>
+                    )}
+                  </form.Subscribe>
+                )}
+
+                {method === "otp" && otpRequested && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={isPending || isCoolingDown}
+                    onClick={() => sendTwoFactorOtp()}
+                  >
+                    {isCoolingDown
+                      ? localization.auth.resendIn.replace(
+                          "{{seconds}}",
+                          String(cooldown)
+                        )
+                      : localization.auth.resend}
+                  </Button>
+                )}
+
+                {alternatives.map((alternative) => (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    key={alternative.key}
+                    disabled={isPending}
+                    onClick={() => switchMethod(alternative.key)}
+                  >
+                    {alternative.label}
+                  </Button>
+                ))}
+              </div>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/examples/start-shadcn-baseui-example/src/components/auth/username/sign-in-username.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/username/sign-in-username.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import { authMutationKeys, validateStringLength } from "@better-auth-ui/core"
 import {
   isPasskeyAutoFillEnabled,
   withPasskeyAutoFill
@@ -16,18 +16,16 @@ import {
 import { useSignInUsername } from "@better-auth-ui/react/plugins/username"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import {
   ProviderButtons,
   type SocialLayout
 } from "@/components/auth/provider-buttons"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -43,6 +41,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { usernamePlugin } from "@/lib/auth/username-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 import { LastUsedBadge } from "../last-login-method/last-used-badge"
 
 export type SignInUsernameProps = {
@@ -82,12 +81,10 @@ export function SignInUsername({
 
   const { localization: usernameLocalization } = useAuthPlugin(usernamePlugin)
 
-  const [password, setPassword] = useState("")
-
   const { mutate: signInEmail, isPending: isSignInEmailPending } =
     useSignInEmail(authClient, {
       onError: (error, { email }) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
           sessionStorage.setItem("better-auth-ui.verify-email", email)
@@ -107,7 +104,7 @@ export function SignInUsername({
   const { mutate: signInUsername, isPending: isSignInUsernamePending } =
     useSignInUsername(authClient, {
       onError: (error) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
           sessionStorage.removeItem("better-auth-ui.verify-email")
@@ -141,35 +138,30 @@ export function SignInUsername({
   const passkeyAutoFill = isPasskeyAutoFillEnabled(plugins)
 
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-    password?: string
-  }>({})
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const email = formData.get("email") as string
-    const rememberMe = formData.get("rememberMe") === "on"
-
-    if (isEmail(email)) {
-      signInEmail({
-        email,
-        password,
-        ...(emailAndPassword?.rememberMe ? { rememberMe } : {}),
-        fetchOptions
-      })
-    } else {
-      signInUsername({
-        username: email,
-        password,
-        ...(emailAndPassword?.rememberMe ? { rememberMe } : {}),
-        fetchOptions
-      })
+  const form = useAuthForm({
+    defaultValues: { identifier: "", password: "", rememberMe: false },
+    onSubmit: ({ value }) => {
+      if (isEmail(value.identifier)) {
+        signInEmail({
+          email: value.identifier,
+          password: value.password,
+          ...(emailAndPassword?.rememberMe
+            ? { rememberMe: value.rememberMe }
+            : {}),
+          fetchOptions
+        })
+      } else {
+        signInUsername({
+          username: value.identifier,
+          password: value.password,
+          ...(emailAndPassword?.rememberMe
+            ? { rememberMe: value.rememberMe }
+            : {}),
+          fetchOptions
+        })
+      }
     }
-  }
+  })
 
   const showSeparator =
     emailAndPassword?.enabled && socialProviders && socialProviders.length > 0
@@ -200,171 +192,187 @@ export function SignInUsername({
           )}
 
           {emailAndPassword?.enabled && (
-            <form onSubmit={handleSubmit}>
-              <FieldGroup>
-                <Field data-invalid={!!fieldErrors.email}>
-                  <FieldLabel htmlFor="email">
-                    {usernameLocalization.username}
-                  </FieldLabel>
-
-                  <Input
-                    id="email"
-                    name="email"
-                    type="text"
-                    autoComplete={withPasskeyAutoFill(
-                      "username",
-                      passkeyAutoFill
-                    )}
-                    placeholder={
-                      usernameLocalization.usernameOrEmailPlaceholder
-                    }
-                    required
-                    disabled={isPending}
-                    onChange={() => {
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: undefined
-                      }))
+            <form.AppForm>
+              <form.AuthFormRoot>
+                <FieldGroup>
+                  <form.AppField
+                    name="identifier"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          requiredMessage: localization.auth.fieldRequired,
+                          trim: true
+                        })
                     }}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: localization.auth.fieldRequired
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
-
-                  <FieldError>{fieldErrors.email}</FieldError>
-                </Field>
-
-                <Field data-invalid={!!fieldErrors.password}>
-                  <FieldLabel htmlFor="password">
-                    {localization.auth.password}
-                  </FieldLabel>
-
-                  <InputGroup>
-                    <InputGroupInput
-                      id="password"
-                      name="password"
-                      type={isPasswordVisible ? "text" : "password"}
-                      autoComplete={withPasskeyAutoFill(
-                        "current-password",
-                        passkeyAutoFill
-                      )}
-                      value={password}
-                      onChange={(e) => {
-                        setPassword(e.target.value)
-
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: undefined
-                        }))
-                      }}
-                      placeholder={localization.auth.passwordPlaceholder}
-                      required
-                      minLength={emailAndPassword?.minPasswordLength}
-                      maxLength={emailAndPassword?.maxPasswordLength}
-                      disabled={isPending}
-                      onInvalid={(e) => {
-                        e.preventDefault()
-                        const el = e.target as HTMLInputElement
-                        const min = emailAndPassword?.minPasswordLength
-                        const max = emailAndPassword?.maxPasswordLength
-                        const msg = el.validity.valueMissing
-                          ? localization.auth.fieldRequired
-                          : el.validity.tooShort
-                            ? localization.auth.tooShort.replace(
-                                "{{min}}",
-                                String(min)
-                              )
-                            : localization.auth.tooLong.replace(
-                                "{{max}}",
-                                String(max)
-                              )
-
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: msg
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.password}
-                    />
-
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        title={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() => {
-                          setIsPasswordVisible((visible) => !visible)
-                        }}
-                      >
-                        {isPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-
-                  <FieldError>{fieldErrors.password}</FieldError>
-                </Field>
-
-                {emailAndPassword.rememberMe && (
-                  <Field className="my-1">
-                    <div className="flex items-center gap-3">
-                      <Checkbox
-                        id="rememberMe"
-                        name="rememberMe"
-                        disabled={isPending}
-                      />
-
-                      <FieldLabel
-                        htmlFor="rememberMe"
-                        className="cursor-pointer text-sm font-normal"
-                      >
-                        {localization.auth.rememberMe}
-                      </FieldLabel>
-                    </div>
-                  </Field>
-                )}
-
-                {Captcha && (
-                  <div className="flex justify-center">{Captcha}</div>
-                )}
-
-                <div className="flex flex-col gap-3">
-                  <Button
-                    type="submit"
-                    className="relative overflow-visible"
-                    disabled={isPending}
                   >
-                    {isSignInPending && <Spinner />}
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="email">
+                            {usernameLocalization.username}
+                          </FieldLabel>
 
-                    {localization.auth.signIn}
+                          <Input
+                            id="email"
+                            name={field.name}
+                            type="text"
+                            autoComplete={withPasskeyAutoFill(
+                              "username",
+                              passkeyAutoFill
+                            )}
+                            placeholder={
+                              usernameLocalization.usernameOrEmailPlaceholder
+                            }
+                            required
+                            disabled={isPending}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) =>
+                              field.handleChange(event.target.value)
+                            }
+                            aria-invalid={isInvalid}
+                          />
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
 
-                    <LastUsedBadge method={["email", "username"]} floating />
-                  </Button>
+                  <form.AppField
+                    name="password"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          maxLength: emailAndPassword?.maxPasswordLength,
+                          maxLengthMessage: localization.auth.tooLong.replace(
+                            "{{max}}",
+                            String(emailAndPassword?.maxPasswordLength)
+                          ),
+                          minLength: emailAndPassword?.minPasswordLength,
+                          minLengthMessage: localization.auth.tooShort.replace(
+                            "{{min}}",
+                            String(emailAndPassword?.minPasswordLength)
+                          ),
+                          requiredMessage: localization.auth.fieldRequired
+                        })
+                    }}
+                  >
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="password">
+                            {localization.auth.password}
+                          </FieldLabel>
 
-                  {plugins.flatMap((plugin) =>
-                    (plugin.authButtons ?? []).map((AuthButton, index) => (
-                      <AuthButton
-                        key={`${plugin.id}-${index.toString()}`}
-                        view="signIn"
-                      />
-                    ))
+                          <InputGroup>
+                            <InputGroupInput
+                              id="password"
+                              name={field.name}
+                              type={isPasswordVisible ? "text" : "password"}
+                              autoComplete={withPasskeyAutoFill(
+                                "current-password",
+                                passkeyAutoFill
+                              )}
+                              value={field.state.value}
+                              onBlur={field.handleBlur}
+                              onChange={(event) =>
+                                field.handleChange(event.target.value)
+                              }
+                              placeholder={
+                                localization.auth.passwordPlaceholder
+                              }
+                              required
+                              minLength={emailAndPassword?.minPasswordLength}
+                              maxLength={emailAndPassword?.maxPasswordLength}
+                              disabled={isPending}
+                              aria-invalid={isInvalid}
+                            />
+
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                size="icon-xs"
+                                aria-label={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                title={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                onClick={() => {
+                                  setIsPasswordVisible((visible) => !visible)
+                                }}
+                              >
+                                {isPasswordVisible ? <EyeOff /> : <Eye />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
+
+                  {emailAndPassword.rememberMe && (
+                    <form.AppField name="rememberMe">
+                      {(field) => (
+                        <Field className="my-1">
+                          <div className="flex items-center gap-3">
+                            <Checkbox
+                              id="rememberMe"
+                              name={field.name}
+                              checked={field.state.value}
+                              disabled={isPending}
+                              onCheckedChange={(checked) =>
+                                field.handleChange(checked === true)
+                              }
+                            />
+
+                            <FieldLabel
+                              htmlFor="rememberMe"
+                              className="cursor-pointer text-sm font-normal"
+                            >
+                              {localization.auth.rememberMe}
+                            </FieldLabel>
+                          </div>
+                        </Field>
+                      )}
+                    </form.AppField>
                   )}
-                </div>
-              </FieldGroup>
-            </form>
+
+                  {Captcha && (
+                    <div className="flex justify-center">{Captcha}</div>
+                  )}
+
+                  <div className="flex flex-col gap-3">
+                    <form.AuthFormSubmitButton
+                      className="relative overflow-visible"
+                      disabled={isPending}
+                    >
+                      {isSignInPending && <Spinner />}
+
+                      {localization.auth.signIn}
+
+                      <LastUsedBadge method={["email", "username"]} floating />
+                    </form.AuthFormSubmitButton>
+
+                    {plugins.flatMap((plugin) =>
+                      (plugin.authButtons ?? []).map((AuthButton, index) => (
+                        <AuthButton
+                          key={`${plugin.id}-${index.toString()}`}
+                          view="signIn"
+                        />
+                      ))
+                    )}
+                  </div>
+                </FieldGroup>
+              </form.AuthFormRoot>
+            </form.AppForm>
           )}
 
           {socialPosition === "bottom" && (

--- a/examples/start-shadcn-example/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -7,8 +7,8 @@ import {
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useCreateApiKey } from "@better-auth-ui/react/plugins/api-key"
 import { Key } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useState } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -35,6 +35,7 @@ import {
 } from "@/components/ui/select"
 import { Spinner } from "@/components/ui/spinner"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
+import { useAuthForm } from "../auth-form"
 import { NewApiKeyDialog } from "./new-api-key-dialog"
 
 export type CreateApiKeyDialogProps = {
@@ -66,10 +67,47 @@ export function CreateApiKeyDialog({
     (configuration) => configuration.organization === Boolean(organizationId)
   )
 
+  const form = useAuthForm({
+    defaultValues: {
+      configId: availableConfigurations[0]?.id ?? "",
+      expiration:
+        keyExpiration && keyExpiration.defaultInterval === null
+          ? "never"
+          : String((keyExpiration && keyExpiration.defaultInterval) ?? "never"),
+      name: ""
+    },
+    onSubmit: ({ value }) => {
+      const name = value.name.trim()
+      const expirationDays =
+        value.expiration !== "never" ? Number(value.expiration) : undefined
+      const expiresIn = expirationDays
+        ? apiKeyExpirationDaysToSeconds(expirationDays)
+        : undefined
+      const configId = value.configId.trim()
+      const resolvedConfigId =
+        configId || (organizationId ? "organization" : undefined)
+      const payload = {
+        ...(name ? { name } : {}),
+        ...(expiresIn ? { expiresIn } : {}),
+        ...(resolvedConfigId ? { configId: resolvedConfigId } : {}),
+        ...(organizationId ? { organizationId } : {})
+      }
+      createApiKey(Object.keys(payload).length > 0 ? payload : undefined, {
+        onSuccess: (result) => {
+          handleOpenChange(false)
+          setKeyName(name)
+          setSecretKey(result.key)
+          setIsNewKeyDialogOpen(true)
+        }
+      })
+    }
+  })
+
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {
       setKeyName(null)
       setSecretKey(null)
+      form.reset()
     }
 
     onOpenChange(nextOpen)
@@ -84,163 +122,149 @@ export function CreateApiKeyDialog({
     }
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.target as HTMLFormElement)
-    const name = (formData.get("name") as string).trim()
-    const expiration = formData.get("expiration")
-    const expirationDays =
-      typeof expiration === "string" && expiration !== "never"
-        ? Number(expiration)
-        : undefined
-    const expiresIn = expirationDays
-      ? apiKeyExpirationDaysToSeconds(expirationDays)
-      : undefined
-
-    const configId = String(formData.get("configId") ?? "").trim()
-    const resolvedConfigId =
-      configId || (organizationId ? "organization" : undefined)
-    const payload = {
-      ...(name ? { name } : {}),
-      ...(expiresIn ? { expiresIn } : {}),
-      ...(resolvedConfigId ? { configId: resolvedConfigId } : {}),
-      ...(organizationId ? { organizationId } : {})
-    }
-
-    createApiKey(Object.keys(payload).length > 0 ? payload : undefined, {
-      onSuccess: (result) => {
-        handleOpenChange(false)
-        setKeyName(name)
-        setSecretKey(result.key)
-        setIsNewKeyDialogOpen(true)
-      }
-    })
-  }
-
   return (
     <>
       <Dialog open={open} onOpenChange={handleOpenChange}>
         <DialogContent>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <Key />
-                {apiKeyLocalization.createApiKey}
-              </DialogTitle>
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-6">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <Key />
+                  {apiKeyLocalization.createApiKey}
+                </DialogTitle>
 
-              <DialogDescription>
-                {apiKeyLocalization.apiKeysDescription}
-              </DialogDescription>
-            </DialogHeader>
+                <DialogDescription>
+                  {apiKeyLocalization.apiKeysDescription}
+                </DialogDescription>
+              </DialogHeader>
 
-            <FieldGroup>
-              <Field>
-                <FieldLabel htmlFor="api-key-name">
-                  {apiKeyLocalization.name}
-                </FieldLabel>
+              <FieldGroup>
+                <form.AppField name="name">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="api-key-name">
+                        {apiKeyLocalization.name}
+                      </FieldLabel>
 
-                <Input
-                  id="api-key-name"
-                  name="name"
-                  autoFocus
-                  placeholder={localization.settings.optional}
-                  disabled={isCreating}
-                />
+                      <Input
+                        id="api-key-name"
+                        name={field.name}
+                        autoFocus
+                        placeholder={localization.settings.optional}
+                        disabled={isCreating}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
 
-                <FieldError />
-              </Field>
+                      <FieldError />
+                    </Field>
+                  )}
+                </form.AppField>
 
-              {availableConfigurations.length > 0 && (
-                <Field>
-                  <FieldLabel htmlFor="api-key-configuration">
-                    {apiKeyLocalization.configuration}
-                  </FieldLabel>
-                  <Select
-                    name="configId"
-                    defaultValue={availableConfigurations[0]?.id}
-                    disabled={isCreating}
-                  >
-                    <SelectTrigger
-                      id="api-key-configuration"
-                      className="w-full"
-                    >
-                      <SelectValue />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        {availableConfigurations.map((configuration) => (
-                          <SelectItem
-                            key={configuration.id}
-                            value={configuration.id}
+                {availableConfigurations.length > 0 && (
+                  <form.AppField name="configId">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel htmlFor="api-key-configuration">
+                          {apiKeyLocalization.configuration}
+                        </FieldLabel>
+                        <Select
+                          name={field.name}
+                          value={field.state.value}
+                          onValueChange={(value) => field.handleChange(value)}
+                          disabled={isCreating}
+                        >
+                          <SelectTrigger
+                            id="api-key-configuration"
+                            className="w-full"
                           >
-                            {configuration.label}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </Field>
-              )}
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectGroup>
+                              {availableConfigurations.map((configuration) => (
+                                <SelectItem
+                                  key={configuration.id}
+                                  value={configuration.id}
+                                >
+                                  {configuration.label}
+                                </SelectItem>
+                              ))}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      </Field>
+                    )}
+                  </form.AppField>
+                )}
 
-              {keyExpiration ? (
-                <Field>
-                  <FieldLabel htmlFor="api-key-expiration">
-                    {apiKeyLocalization.expiration}
-                  </FieldLabel>
+                {keyExpiration ? (
+                  <form.AppField name="expiration">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel htmlFor="api-key-expiration">
+                          {apiKeyLocalization.expiration}
+                        </FieldLabel>
 
-                  <Select
-                    name="expiration"
-                    defaultValue={
-                      keyExpiration.defaultInterval === null
-                        ? "never"
-                        : String(keyExpiration.defaultInterval)
-                    }
-                    disabled={isCreating}
-                  >
-                    <SelectTrigger id="api-key-expiration" className="w-full">
-                      <SelectValue />
-                    </SelectTrigger>
+                        <Select
+                          name={field.name}
+                          value={field.state.value}
+                          onValueChange={(value) => field.handleChange(value)}
+                          disabled={isCreating}
+                        >
+                          <SelectTrigger
+                            id="api-key-expiration"
+                            className="w-full"
+                          >
+                            <SelectValue />
+                          </SelectTrigger>
 
-                    <SelectContent>
-                      <SelectGroup>
-                        {keyExpiration.intervals.map((days) => (
-                          <SelectItem key={days} value={String(days)}>
-                            {days.toLocaleString()}{" "}
-                            {days === 1
-                              ? apiKeyLocalization.day
-                              : apiKeyLocalization.days}
-                          </SelectItem>
-                        ))}
+                          <SelectContent>
+                            <SelectGroup>
+                              {keyExpiration.intervals.map((days) => (
+                                <SelectItem key={days} value={String(days)}>
+                                  {days.toLocaleString()}{" "}
+                                  {days === 1
+                                    ? apiKeyLocalization.day
+                                    : apiKeyLocalization.days}
+                                </SelectItem>
+                              ))}
 
-                        {keyExpiration.allowNever ? (
-                          <SelectItem value="never">
-                            {apiKeyLocalization.never}
-                          </SelectItem>
-                        ) : null}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                </Field>
-              ) : null}
-            </FieldGroup>
+                              {keyExpiration.allowNever ? (
+                                <SelectItem value="never">
+                                  {apiKeyLocalization.never}
+                                </SelectItem>
+                              ) : null}
+                            </SelectGroup>
+                          </SelectContent>
+                        </Select>
+                      </Field>
+                    )}
+                  </form.AppField>
+                ) : null}
+              </FieldGroup>
 
-            <DialogFooter>
-              <DialogClose
-                className={buttonVariants({ variant: "outline" })}
-                disabled={isCreating}
-                type="button"
-              >
-                {localization.settings.cancel}
-              </DialogClose>
+              <DialogFooter>
+                <DialogClose
+                  className={buttonVariants({ variant: "outline" })}
+                  disabled={isCreating}
+                  type="button"
+                >
+                  {localization.settings.cancel}
+                </DialogClose>
 
-              <Button type="submit" disabled={isCreating}>
-                {isCreating && <Spinner />}
+                <form.AuthFormSubmitButton disabled={isCreating}>
+                  {isCreating && <Spinner />}
 
-                {apiKeyLocalization.createApiKey}
-              </Button>
-            </DialogFooter>
-          </form>
+                  {apiKeyLocalization.createApiKey}
+                </form.AuthFormSubmitButton>
+              </DialogFooter>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </DialogContent>
       </Dialog>
 

--- a/examples/start-shadcn-example/src/components/auth/api-key/edit-api-key-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/api-key/edit-api-key-dialog.tsx
@@ -6,8 +6,8 @@ import type {
 } from "@better-auth-ui/core/plugins/api-key"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useUpdateApiKey } from "@better-auth-ui/react/plugins/api-key"
-import type { FormEvent } from "react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useEffect } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -25,6 +25,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
+import { useAuthForm } from "../auth-form"
 
 export function EditApiKeyDialog({
   apiKey,
@@ -41,53 +42,66 @@ export function EditApiKeyDialog({
   const updateApiKey = useUpdateApiKey(authClient, {
     onSuccess: () => onOpenChange(false)
   })
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    updateApiKey.mutate({
-      keyId: apiKey.id,
-      configId: apiKey.configId,
-      name: String(formData.get("name") ?? "").trim()
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { name: apiKey.name ?? "" },
+    onSubmit: ({ value }) =>
+      updateApiKey.mutate({
+        configId: apiKey.configId,
+        keyId: apiKey.id,
+        name: value.name.trim()
+      })
+  })
+  useEffect(() => {
+    if (open) form.reset({ name: apiKey.name ?? "" })
+  }, [apiKey.name, form, open])
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form className="flex flex-col gap-6" onSubmit={submit}>
-          <DialogHeader>
-            <DialogTitle>{labels.editApiKey}</DialogTitle>
-          </DialogHeader>
-          <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor={`api-key-name-${apiKey.id}`}>
-                {labels.name}
-              </FieldLabel>
-              <Input
-                id={`api-key-name-${apiKey.id}`}
-                name="name"
-                defaultValue={apiKey.name ?? ""}
-              />
-            </Field>
-            {updateApiKey.error && (
-              <FieldError>
-                {updateApiKey.error.error?.message ??
-                  updateApiKey.error.message}
-              </FieldError>
-            )}
-          </FieldGroup>
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-            <Button disabled={updateApiKey.isPending} type="submit">
-              {updateApiKey.isPending && <Spinner />}
-              {localization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
-        </form>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle>{labels.editApiKey}</DialogTitle>
+            </DialogHeader>
+            <FieldGroup>
+              <form.AppField name="name">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor={`api-key-name-${apiKey.id}`}>
+                      {labels.name}
+                    </FieldLabel>
+                    <Input
+                      id={`api-key-name-${apiKey.id}`}
+                      name={field.name}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                    />
+                  </Field>
+                )}
+              </form.AppField>
+              {updateApiKey.error && (
+                <FieldError>
+                  {updateApiKey.error.error?.message ??
+                    updateApiKey.error.message}
+                </FieldError>
+              )}
+            </FieldGroup>
+            <DialogFooter>
+              <DialogClose
+                className={buttonVariants({ variant: "outline" })}
+                type="button"
+              >
+                {localization.settings.cancel}
+              </DialogClose>
+              <form.AuthFormSubmitButton disabled={updateApiKey.isPending}>
+                {updateApiKey.isPending && <Spinner />}
+                {localization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-shadcn-example/src/components/auth/delete-user/delete-account.tsx
+++ b/examples/start-shadcn-example/src/components/auth/delete-user/delete-account.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { authQueryKeys } from "@better-auth-ui/core"
+import { authQueryKeys, validateStringLength } from "@better-auth-ui/core"
 import {
   useAuth,
   useAuthPlugin,
@@ -9,7 +9,7 @@ import {
 } from "@better-auth-ui/react"
 import { useQueryClient } from "@tanstack/react-query"
 import { Eye, EyeOff, TriangleAlert } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 import {
   AlertDialog,
@@ -22,9 +22,9 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger
 } from "@/components/ui/alert-dialog"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import {
   InputGroup,
   InputGroupAddon,
@@ -34,6 +34,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { deleteUserPlugin } from "@/lib/auth/delete-user-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 
 export type DeleteAccountProps = {
   className?: string
@@ -55,7 +56,6 @@ export function DeleteAccount({ className }: DeleteAccountProps) {
   const queryClient = useQueryClient()
 
   const [confirmOpen, setConfirmOpen] = useState(false)
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
 
   const hasCredentialAccount = accounts?.some(
@@ -65,36 +65,33 @@ export function DeleteAccount({ className }: DeleteAccountProps) {
 
   const { mutate: deleteUser, isPending } = useDeleteUser(authClient)
 
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) => {
+      deleteUser(needsPassword ? { password: value.password } : {}, {
+        onSuccess: () => {
+          setConfirmOpen(false)
+          form.reset()
+
+          if (sendDeleteAccountVerification) {
+            toast.success(deleteUserLocalization.deleteUserVerificationSent)
+          } else {
+            toast.success(deleteUserLocalization.deleteUserSuccess)
+            queryClient.removeQueries({ queryKey: authQueryKeys.all })
+            navigate({
+              to: `${basePaths.auth}/${viewPaths.auth.signIn}`,
+              replace: true
+            })
+          }
+        }
+      })
+    }
+  })
+
   const handleDialogOpenChange = (open: boolean) => {
     setConfirmOpen(open)
-    setPassword("")
+    form.reset()
     setIsPasswordVisible(false)
-  }
-
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const params = {
-      ...(needsPassword ? { password } : {})
-    }
-
-    deleteUser(params, {
-      onSuccess: () => {
-        setConfirmOpen(false)
-        setPassword("")
-
-        if (sendDeleteAccountVerification) {
-          toast.success(deleteUserLocalization.deleteUserVerificationSent)
-        } else {
-          toast.success(deleteUserLocalization.deleteUserSuccess)
-          queryClient.removeQueries({ queryKey: authQueryKeys.all })
-          navigate({
-            to: `${basePaths.auth}/${viewPaths.auth.signIn}`,
-            replace: true
-          })
-        }
-      }
-    })
   }
 
   return (
@@ -121,82 +118,103 @@ export function DeleteAccount({ className }: DeleteAccountProps) {
           </AlertDialogTrigger>
 
           <AlertDialogContent>
-            <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-              <AlertDialogHeader>
-                <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
-                  <TriangleAlert />
-                </AlertDialogMedia>
+            <form.AppForm>
+              <form.AuthFormRoot className="flex flex-col gap-6">
+                <AlertDialogHeader>
+                  <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
+                    <TriangleAlert />
+                  </AlertDialogMedia>
 
-                <AlertDialogTitle>
-                  {deleteUserLocalization.deleteAccount}
-                </AlertDialogTitle>
+                  <AlertDialogTitle>
+                    {deleteUserLocalization.deleteAccount}
+                  </AlertDialogTitle>
 
-                <AlertDialogDescription>
-                  {deleteUserLocalization.deleteAccountDescription}
-                </AlertDialogDescription>
-              </AlertDialogHeader>
+                  <AlertDialogDescription>
+                    {deleteUserLocalization.deleteAccountDescription}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
 
-              {needsPassword && (
-                <Field>
-                  <FieldLabel htmlFor="delete-password">
-                    {localization.auth.password}
-                  </FieldLabel>
+                {needsPassword && (
+                  <form.AppField
+                    name="password"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          requiredMessage: localization.auth.fieldRequired
+                        })
+                    }}
+                  >
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="delete-password">
+                            {localization.auth.password}
+                          </FieldLabel>
 
-                  <InputGroup>
-                    <InputGroupInput
-                      id="delete-password"
-                      name="password"
-                      type={isPasswordVisible ? "text" : "password"}
-                      autoComplete="current-password"
-                      placeholder={localization.auth.passwordPlaceholder}
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      disabled={isPending}
-                      required
-                    />
+                          <InputGroup>
+                            <InputGroupInput
+                              id="delete-password"
+                              name={field.name}
+                              type={isPasswordVisible ? "text" : "password"}
+                              autoComplete="current-password"
+                              placeholder={
+                                localization.auth.passwordPlaceholder
+                              }
+                              value={field.state.value}
+                              onBlur={field.handleBlur}
+                              onChange={(event) =>
+                                field.handleChange(event.target.value)
+                              }
+                              disabled={isPending}
+                              required
+                            />
 
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        title={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() => {
-                          setIsPasswordVisible((visible) => !visible)
-                        }}
-                      >
-                        {isPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                size="icon-xs"
+                                aria-label={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                title={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                onClick={() => {
+                                  setIsPasswordVisible((visible) => !visible)
+                                }}
+                              >
+                                {isPasswordVisible ? <EyeOff /> : <Eye />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
 
-                  <FieldError />
-                </Field>
-              )}
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
+                )}
 
-              <AlertDialogFooter>
-                <AlertDialogCancel disabled={isPending}>
-                  {localization.settings.cancel}
-                </AlertDialogCancel>
+                <AlertDialogFooter>
+                  <AlertDialogCancel disabled={isPending}>
+                    {localization.settings.cancel}
+                  </AlertDialogCancel>
 
-                <Button
-                  type="submit"
-                  variant="destructive"
-                  disabled={isPending}
-                >
-                  {isPending && <Spinner />}
+                  <form.AuthFormSubmitButton
+                    variant="destructive"
+                    disabled={isPending}
+                  >
+                    {isPending && <Spinner />}
 
-                  {deleteUserLocalization.deleteAccount}
-                </Button>
-              </AlertDialogFooter>
-            </form>
+                    {deleteUserLocalization.deleteAccount}
+                  </form.AuthFormSubmitButton>
+                </AlertDialogFooter>
+              </form.AuthFormRoot>
+            </form.AppForm>
           </AlertDialogContent>
         </AlertDialog>
       </CardContent>

--- a/examples/start-shadcn-example/src/components/auth/device-authorization/device-authorization.tsx
+++ b/examples/start-shadcn-example/src/components/auth/device-authorization/device-authorization.tsx
@@ -13,7 +13,6 @@ import {
 import { REGEXP_ONLY_DIGITS_AND_CHARS } from "input-otp"
 import { CheckIcon, CircleCheckIcon, CircleXIcon, XIcon } from "lucide-react"
 import {
-  type FormEvent,
   type ReactNode,
   useCallback,
   useEffect,
@@ -47,6 +46,7 @@ import { Separator } from "@/components/ui/separator"
 import { Spinner } from "@/components/ui/spinner"
 import { deviceAuthorizationPlugin } from "@/lib/auth/device-authorization-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 
 type DeviceAuthorizationStep = "code" | "approval" | "approved" | "denied"
 
@@ -131,7 +131,6 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
     initialDeviceAuthorizationState
   )
   const submittedCodeRef = useRef<string | null>(null)
-  const normalizedUserCode = normalizeDeviceCode(userCode)
 
   const handleAuthorizationError = () => {
     dispatch({
@@ -175,19 +174,6 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
     }
   )
 
-  const handleCodeChange = (value: string) => {
-    const nextCode = normalizeDeviceCode(value)
-      .replace(/[^A-Z0-9]/g, "")
-      .slice(0, userCodeLength)
-
-    if (nextCode !== submittedCodeRef.current) {
-      submittedCodeRef.current = null
-    }
-
-    setUserCode(nextCode)
-    dispatch({ type: "codeChanged" })
-  }
-
   const submitCode = useCallback(
     (completedCode: string) => {
       const normalizedCode = normalizeDeviceCode(completedCode)
@@ -227,22 +213,22 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
     ]
   )
 
-  useEffect(() => {
-    if (normalizedUserCode.length === userCodeLength) {
-      submitCode(normalizedUserCode)
-    }
-  }, [normalizedUserCode, submitCode, userCodeLength])
+  const handleSubmit = useCallback(
+    (code: string) => {
+      const normalizedCode = normalizeDeviceCode(code)
+      if (normalizedCode.length !== userCodeLength) {
+        dispatch({
+          type: "verificationFailed",
+          message: localization.invalidDeviceCode
+        })
+        return
+      }
+      submitCode(normalizedCode)
+    },
+    [localization.invalidDeviceCode, submitCode, userCodeLength]
+  )
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-
-    if (normalizedUserCode.length !== userCodeLength) {
-      handleAuthorizationError()
-      return
-    }
-
-    submitCode(normalizedUserCode)
-  }
+  const authorizedCode = submittedCodeRef.current ?? ""
 
   const cardClassName = cn("w-full max-w-sm", className)
 
@@ -251,12 +237,12 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
       <DeviceApproval
         className={cardClassName}
         localization={localization}
-        userCode={normalizedUserCode}
+        userCode={authorizedCode}
         user={session.user}
         isApproving={isApproving}
         isDenying={isDenying}
-        onApprove={() => approveDevice({ userCode: normalizedUserCode })}
-        onDeny={() => denyDevice({ userCode: normalizedUserCode })}
+        onApprove={() => approveDevice({ userCode: authorizedCode })}
+        onDeny={() => denyDevice({ userCode: authorizedCode })}
       />
     )
   }
@@ -286,10 +272,10 @@ export function DeviceAuthorization({ className }: DeviceAuthorizationProps) {
       isSessionPending={isSessionPending}
       isVerifying={isVerifying}
       localization={localization}
-      userCode={userCode}
+      initialUserCode={userCode}
       userCodeLength={userCodeLength}
-      onCodeChange={handleCodeChange}
-      onSubmit={handleSubmit}
+      onCodeChange={() => dispatch({ type: "codeChanged" })}
+      onSubmitCode={handleSubmit}
     />
   )
 }
@@ -300,10 +286,10 @@ type DeviceCodeFormProps = {
   isSessionPending: boolean
   isVerifying: boolean
   localization: DeviceAuthorizationLocalization
-  userCode: string
+  initialUserCode: string
   userCodeLength: number
   onCodeChange: (value: string) => void
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void
+  onSubmitCode: (code: string) => void
 }
 
 function DeviceCodeForm({
@@ -312,16 +298,27 @@ function DeviceCodeForm({
   isSessionPending,
   isVerifying,
   localization,
-  userCode,
+  initialUserCode,
   userCodeLength,
   onCodeChange,
-  onSubmit
+  onSubmitCode
 }: DeviceCodeFormProps) {
   const slots = createDeviceCodeSlots(userCodeLength)
   const groupBreak = Math.ceil(userCodeLength / 2)
   const firstGroup = slots.slice(0, groupBreak)
   const secondGroup = slots.slice(groupBreak)
   const errorId = "device-code-error"
+  const form = useAuthForm({
+    defaultValues: { userCode: initialUserCode },
+    onSubmit: ({ value }) => onSubmitCode(value.userCode)
+  })
+
+  useEffect(() => {
+    form.setFieldValue("userCode", initialUserCode)
+    if (initialUserCode.length === userCodeLength) {
+      onSubmitCode(initialUserCode)
+    }
+  }, [form.setFieldValue, initialUserCode, onSubmitCode, userCodeLength])
 
   return (
     <Card className={className}>
@@ -335,63 +332,77 @@ function DeviceCodeForm({
       </CardHeader>
 
       <CardContent>
-        <form aria-label={localization.deviceAuthorization} onSubmit={onSubmit}>
-          <FieldGroup>
-            <Field data-invalid={Boolean(codeError)}>
-              <FieldLabel htmlFor="device-code">
-                {localization.deviceCode}
-              </FieldLabel>
+        <form.AppForm>
+          <form.AuthFormRoot aria-label={localization.deviceAuthorization}>
+            <FieldGroup>
+              <form.AppField name="userCode">
+                {(field) => (
+                  <Field data-invalid={Boolean(codeError)}>
+                    <FieldLabel htmlFor="device-code">
+                      {localization.deviceCode}
+                    </FieldLabel>
 
-              <InputOTP
-                id="device-code"
-                aria-describedby={codeError ? errorId : undefined}
-                aria-invalid={Boolean(codeError)}
-                autoComplete="one-time-code"
-                containerClassName="w-full justify-center"
-                disabled={isVerifying}
-                inputMode="text"
-                maxLength={userCodeLength}
-                name="userCode"
-                pasteTransformer={normalizeDeviceCode}
-                pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
-                value={userCode}
-                onChange={onCodeChange}
+                    <InputOTP
+                      id="device-code"
+                      aria-describedby={codeError ? errorId : undefined}
+                      aria-invalid={Boolean(codeError)}
+                      autoComplete="one-time-code"
+                      containerClassName="w-full justify-center"
+                      disabled={isVerifying}
+                      inputMode="text"
+                      maxLength={userCodeLength}
+                      name={field.name}
+                      pasteTransformer={normalizeDeviceCode}
+                      pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+                      value={field.state.value}
+                      onChange={(value) => {
+                        const nextCode = normalizeDeviceCode(value)
+                          .replace(/[^A-Z0-9]/g, "")
+                          .slice(0, userCodeLength)
+                        field.handleChange(nextCode)
+                        onCodeChange(nextCode)
+                        if (nextCode.length === userCodeLength)
+                          onSubmitCode(nextCode)
+                      }}
+                    >
+                      <InputOTPGroup>
+                        {firstGroup.map((slot) => (
+                          <InputOTPSlot key={slot.id} index={slot.index} />
+                        ))}
+                      </InputOTPGroup>
+
+                      {secondGroup.length > 0 ? (
+                        <>
+                          <InputOTPSeparator />
+                          <InputOTPGroup>
+                            {secondGroup.map((slot) => (
+                              <InputOTPSlot key={slot.id} index={slot.index} />
+                            ))}
+                          </InputOTPGroup>
+                        </>
+                      ) : null}
+                    </InputOTP>
+
+                    <FieldError id={errorId}>{codeError}</FieldError>
+                  </Field>
+                )}
+              </form.AppField>
+
+              <form.AuthFormSubmitButton
+                className="w-full"
+                disabled={
+                  form.state.values.userCode.length !== userCodeLength ||
+                  isSessionPending ||
+                  isVerifying
+                }
+                type="submit"
               >
-                <InputOTPGroup>
-                  {firstGroup.map((slot) => (
-                    <InputOTPSlot key={slot.id} index={slot.index} />
-                  ))}
-                </InputOTPGroup>
-
-                {secondGroup.length > 0 ? (
-                  <>
-                    <InputOTPSeparator />
-                    <InputOTPGroup>
-                      {secondGroup.map((slot) => (
-                        <InputOTPSlot key={slot.id} index={slot.index} />
-                      ))}
-                    </InputOTPGroup>
-                  </>
-                ) : null}
-              </InputOTP>
-
-              <FieldError id={errorId}>{codeError}</FieldError>
-            </Field>
-
-            <Button
-              className="w-full"
-              disabled={
-                userCode.length !== userCodeLength ||
-                isSessionPending ||
-                isVerifying
-              }
-              type="submit"
-            >
-              {isVerifying ? <Spinner data-icon="inline-start" /> : null}
-              {localization.continue}
-            </Button>
-          </FieldGroup>
-        </form>
+                {isVerifying ? <Spinner data-icon="inline-start" /> : null}
+                {localization.continue}
+              </form.AuthFormSubmitButton>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
     </Card>
   )

--- a/examples/start-shadcn-example/src/components/auth/email-otp/change-email-otp.tsx
+++ b/examples/start-shadcn-example/src/components/auth/email-otp/change-email-otp.tsx
@@ -7,17 +7,18 @@ import {
   useRequestEmailChangeOtp,
   useSendVerificationOtp
 } from "@better-auth-ui/react/plugins/email-otp"
-import { type SyntheticEvent, useReducer, useState } from "react"
+import { useEffect, useReducer } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 
@@ -84,14 +85,6 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
     changeEmailReducer,
     initialChangeEmailState
   )
-  const [code, setCode] = useState("")
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({})
-
-  const resetFlow = () => {
-    setCode("")
-    dispatch({ type: "restarted" })
-  }
-
   // The step transition is attached per call: the code goes to the current
   // address while the pending change targets the new one, so the address to
   // remember isn't in this mutation's variables.
@@ -100,9 +93,9 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
 
   const { mutate: requestEmailChangeOtp, isPending: isRequesting } =
     useRequestEmailChangeOtp(otpClient, {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: (_data, { newEmail }) => {
-        setCode("")
+        form.setFieldValue("code", "")
         dispatch({ type: "changeRequested", newEmail })
       }
     })
@@ -110,7 +103,7 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
   const { mutate: changeEmailOtp, isPending: isChanging } = useChangeEmailOtp(
     otpClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
         toast.success(localization.settings.changeEmailSuccess)
         resetFlow()
@@ -134,30 +127,39 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
     changeEmailOtp({ newEmail: state.newEmail, otp: completedCode })
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useAuthForm({
+    defaultValues: { code: "", email: "" },
+    onSubmit: ({ value }) => {
+      if (state.step === "email") {
+        const newEmail = value.email
 
-    if (state.step === "email") {
-      const formData = new FormData(e.currentTarget)
-      const newEmail = formData.get("email") as string
+        if (verifyCurrentEmail && currentEmail) {
+          sendVerificationOtp(
+            { email: currentEmail, type: "change-email" },
+            {
+              onSuccess: () =>
+                dispatch({ type: "currentEmailChallenged", newEmail })
+            }
+          )
+          return
+        }
 
-      if (verifyCurrentEmail && currentEmail) {
-        sendVerificationOtp(
-          { email: currentEmail, type: "change-email" },
-          {
-            onSuccess: () =>
-              dispatch({ type: "currentEmailChallenged", newEmail })
-          }
-        )
+        requestEmailChangeOtp({ newEmail })
         return
       }
-
-      requestEmailChangeOtp({ newEmail })
-      return
+      submitCode(value.code)
     }
+  })
 
-    submitCode(code)
+  const resetFlow = () => {
+    form.reset()
+    if (currentEmail) form.setFieldValue("email", currentEmail)
+    dispatch({ type: "restarted" })
   }
+
+  useEffect(() => {
+    if (currentEmail) form.setFieldValue("email", currentEmail)
+  }, [currentEmail, form])
 
   const codeTarget =
     state.step === "currentCode" ? currentEmail : state.newEmail
@@ -168,109 +170,111 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
         {localization.settings.changeEmail}
       </h2>
 
-      <form onSubmit={handleSubmit}>
-        <Card className={cn(className)}>
-          <CardContent className="flex flex-col gap-6">
-            {state.step === "email" ? (
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="email">
-                  {localization.auth.email}
-                </FieldLabel>
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card className={cn(className)}>
+            <CardContent className="flex flex-col gap-6">
+              {state.step === "email" ? (
+                <form.AppField name="email">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
 
-                {session ? (
-                  <Input
-                    key={currentEmail}
-                    id="email"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    defaultValue={currentEmail}
-                    placeholder={localization.auth.emailPlaceholder}
-                    disabled={isPending}
-                    required
-                    onChange={() =>
-                      setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                    }
-                    onInvalid={(e) => {
-                      e.preventDefault()
+                      {session ? (
+                        <Input
+                          key={currentEmail}
+                          id="email"
+                          name="email"
+                          type="email"
+                          autoComplete="email"
+                          value={field.state.value}
+                          placeholder={localization.auth.emailPlaceholder}
+                          disabled={isPending}
+                          required
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                        />
+                      ) : (
+                        <Skeleton>
+                          <Input className="invisible" />
+                        </Skeleton>
+                      )}
 
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: (e.target as HTMLInputElement).validationMessage
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
-                ) : (
-                  <Skeleton>
-                    <Input className="invisible" />
-                  </Skeleton>
-                )}
-
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
-            ) : (
-              <div className="flex flex-col gap-3">
-                <p className="text-muted-foreground text-sm">
-                  {emailOtpLocalization.confirmEmailDescription.replace(
-                    "{{email}}",
-                    codeTarget ?? ""
+                      <field.AuthFormFieldError />
+                    </Field>
                   )}
-                </p>
+                </form.AppField>
+              ) : (
+                <div className="flex flex-col gap-3">
+                  <p className="text-muted-foreground text-sm">
+                    {emailOtpLocalization.confirmEmailDescription.replace(
+                      "{{email}}",
+                      codeTarget ?? ""
+                    )}
+                  </p>
 
-                <OtpField
-                  autoFocus
+                  <form.AppField name="code">
+                    {(field) => (
+                      <OtpField
+                        autoFocus
+                        disabled={isPending}
+                        label={
+                          state.step === "currentCode"
+                            ? emailOtpLocalization.confirmCurrentEmail
+                            : emailOtpLocalization.confirmNewEmail
+                        }
+                        length={otpLength}
+                        name="otp"
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        onComplete={submitCode}
+                      />
+                    )}
+                  </form.AppField>
+
+                  {codeTarget && (
+                    <OpenEmailButton email={codeTarget} variant="secondary" />
+                  )}
+                </div>
+              )}
+            </CardContent>
+
+            <CardFooter className="gap-3">
+              {state.step !== "email" && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
                   disabled={isPending}
-                  label={
-                    state.step === "currentCode"
-                      ? emailOtpLocalization.confirmCurrentEmail
-                      : emailOtpLocalization.confirmNewEmail
-                  }
-                  length={otpLength}
-                  name="otp"
-                  value={code}
-                  onChange={setCode}
-                  onComplete={submitCode}
-                />
+                  onClick={resetFlow}
+                >
+                  {localization.settings.cancel}
+                </Button>
+              )}
 
-                {codeTarget && (
-                  <OpenEmailButton email={codeTarget} variant="secondary" />
-                )}
-              </div>
-            )}
-          </CardContent>
-
-          <CardFooter className="gap-3">
-            {state.step !== "email" && (
-              <Button
-                type="button"
+              <form.AuthFormSubmitButton
                 size="sm"
-                variant="outline"
-                disabled={isPending}
-                onClick={resetFlow}
+                disabled={
+                  isPending ||
+                  !session ||
+                  (state.step !== "email" &&
+                    form.state.values.code.length !== otpLength)
+                }
               >
-                {localization.settings.cancel}
-              </Button>
-            )}
+                {isPending && <Spinner />}
 
-            <Button
-              type="submit"
-              size="sm"
-              disabled={
-                isPending ||
-                !session ||
-                (state.step !== "email" && code.length !== otpLength)
-              }
-            >
-              {isPending && <Spinner />}
-
-              {state.step === "email"
-                ? localization.settings.updateEmail
-                : emailOtpLocalization.verifyCode}
-            </Button>
-          </CardFooter>
-        </Card>
-      </form>
+                {state.step === "email"
+                  ? localization.settings.updateEmail
+                  : emailOtpLocalization.verifyCode}
+              </form.AuthFormSubmitButton>
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/examples/start-shadcn-example/src/components/auth/email-otp/email-otp.tsx
+++ b/examples/start-shadcn-example/src/components/auth/email-otp/email-otp.tsx
@@ -9,7 +9,7 @@ import {
   useSignInEmailOtp
 } from "@better-auth-ui/react/plugins/email-otp"
 import { useIsMutating } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -22,7 +22,6 @@ import {
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -33,6 +32,7 @@ import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { useResendCooldown } from "@/lib/auth/use-resend-cooldown"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
@@ -75,10 +75,7 @@ export function EmailOtp({
   const continueSignIn = useSignInContinuation()
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
 
-  const [email, setEmail] = useState(getSsoFallbackEmail)
-  const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({})
 
   const { mutate: sendVerificationOtp, isPending: isSending } =
     useSendVerificationOtp(otpClient, {
@@ -91,7 +88,7 @@ export function EmailOtp({
   const { mutate: signInEmailOtp, isPending: isSigningIn } = useSignInEmailOtp(
     otpClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: (data) => continueSignIn(data)
     }
   )
@@ -104,23 +101,28 @@ export function EmailOtp({
   })
   const isPending = signInMutating + signUpMutating > 0 || isSending
 
-  const sendCode = () => sendVerificationOtp({ email, type: "sign-in" })
+  const sendCode = () =>
+    sendVerificationOtp({
+      email: form.state.values.email,
+      type: "sign-in"
+    })
   const verifyCode = (completedCode: string) => {
     if (isPending || isSigningIn) return
 
-    signInEmailOtp({ email, otp: completedCode })
+    signInEmailOtp({ email: form.state.values.email, otp: completedCode })
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useAuthForm({
+    defaultValues: { code: "", email: getSsoFallbackEmail() },
+    onSubmit: ({ value }) => {
+      if (!codeSent) {
+        sendVerificationOtp({ email: value.email, type: "sign-in" })
+        return
+      }
 
-    if (!codeSent) {
-      sendCode()
-      return
+      verifyCode(value.code)
     }
-
-    verifyCode(code)
-  }
+  })
 
   const showSeparator = socialProviders && socialProviders.length > 0
 
@@ -131,7 +133,10 @@ export function EmailOtp({
 
         {codeSent && (
           <CardDescription>
-            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
+            {emailOtpLocalization.codeSentTo.replace(
+              "{{email}}",
+              form.state.values.email
+            )}
           </CardDescription>
         )}
       </CardHeader>
@@ -152,112 +157,113 @@ export function EmailOtp({
             </>
           )}
 
-          <form onSubmit={handleSubmit}>
-            <FieldGroup>
-              {codeSent ? (
-                <OtpField
-                  autoFocus
-                  disabled={isPending || isSigningIn}
-                  label={emailOtpLocalization.code}
-                  length={otpLength}
-                  name="otp"
-                  value={code}
-                  onChange={setCode}
-                  onComplete={verifyCode}
-                />
-              ) : (
-                <Field data-invalid={!!fieldErrors.email}>
-                  <FieldLabel htmlFor="email">
-                    {localization.auth.email}
-                  </FieldLabel>
-
-                  <Input
-                    id="email"
-                    name="email"
-                    type="email"
-                    autoComplete="email"
-                    value={email}
-                    onChange={(e) => {
-                      setEmail(e.target.value)
-                      setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                    }}
-                    placeholder={localization.auth.emailPlaceholder}
-                    required
-                    disabled={isPending}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: (e.target as HTMLInputElement).validationMessage
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
-
-                  <FieldError>{fieldErrors.email}</FieldError>
-                </Field>
-              )}
-
-              <div className="flex flex-col gap-3">
-                <Button
-                  type="submit"
-                  disabled={
-                    isPending ||
-                    isSigningIn ||
-                    (codeSent && code.length !== otpLength)
-                  }
-                >
-                  {(isSending || isSigningIn) && <Spinner />}
-
-                  {codeSent
-                    ? emailOtpLocalization.verifyCode
-                    : emailOtpLocalization.sendCode}
-                </Button>
-
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <FieldGroup>
                 {codeSent ? (
-                  <>
-                    <OpenEmailButton email={email} variant="secondary" />
-
-                    <Button
-                      type="button"
-                      variant="outline"
-                      disabled={isPending || isSigningIn || isCoolingDown}
-                      onClick={sendCode}
-                    >
-                      {isCoolingDown
-                        ? localization.auth.resendIn.replace(
-                            "{{seconds}}",
-                            String(cooldown)
-                          )
-                        : localization.auth.resend}
-                    </Button>
-
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      disabled={isPending || isSigningIn}
-                      onClick={() => {
-                        setCodeSent(false)
-                        setCode("")
-                      }}
-                    >
-                      {emailOtpLocalization.useDifferentEmail}
-                    </Button>
-                  </>
-                ) : (
-                  plugins.flatMap((plugin) =>
-                    (plugin.authButtons ?? []).map((AuthButton, index) => (
-                      <AuthButton
-                        key={`${plugin.id}-${index.toString()}`}
-                        view="emailOtp"
+                  <form.AppField name="code">
+                    {(field) => (
+                      <OtpField
+                        autoFocus
+                        disabled={isPending || isSigningIn}
+                        label={emailOtpLocalization.code}
+                        length={otpLength}
+                        name={field.name}
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        onComplete={verifyCode}
                       />
-                    ))
-                  )
+                    )}
+                  </form.AppField>
+                ) : (
+                  <form.AppField name="email">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel htmlFor="email">
+                          {localization.auth.email}
+                        </FieldLabel>
+                        <Input
+                          id="email"
+                          name={field.name}
+                          type="email"
+                          autoComplete="email"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          placeholder={localization.auth.emailPlaceholder}
+                          required
+                          disabled={isPending}
+                        />
+                        <field.AuthFormFieldError />
+                      </Field>
+                    )}
+                  </form.AppField>
                 )}
-              </div>
-            </FieldGroup>
-          </form>
+
+                <div className="flex flex-col gap-3">
+                  <form.AuthFormSubmitButton
+                    disabled={
+                      isPending ||
+                      isSigningIn ||
+                      (codeSent && form.state.values.code.length !== otpLength)
+                    }
+                  >
+                    {(isSending || isSigningIn) && <Spinner />}
+
+                    {codeSent
+                      ? emailOtpLocalization.verifyCode
+                      : emailOtpLocalization.sendCode}
+                  </form.AuthFormSubmitButton>
+
+                  {codeSent ? (
+                    <>
+                      <OpenEmailButton
+                        email={form.state.values.email}
+                        variant="secondary"
+                      />
+
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isPending || isSigningIn || isCoolingDown}
+                        onClick={sendCode}
+                      >
+                        {isCoolingDown
+                          ? localization.auth.resendIn.replace(
+                              "{{seconds}}",
+                              String(cooldown)
+                            )
+                          : localization.auth.resend}
+                      </Button>
+
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        disabled={isPending || isSigningIn}
+                        onClick={() => {
+                          setCodeSent(false)
+                          form.setFieldValue("code", "")
+                        }}
+                      >
+                        {emailOtpLocalization.useDifferentEmail}
+                      </Button>
+                    </>
+                  ) : (
+                    plugins.flatMap((plugin) =>
+                      (plugin.authButtons ?? []).map((AuthButton, index) => (
+                        <AuthButton
+                          key={`${plugin.id}-${index.toString()}`}
+                          view="emailOtp"
+                        />
+                      ))
+                    )
+                  )}
+                </div>
+              </FieldGroup>
+            </form.AuthFormRoot>
+          </form.AppForm>
 
           {socialPosition === "bottom" && !codeSent && (
             <>

--- a/examples/start-shadcn-example/src/components/auth/email-otp/forgot-password-otp.tsx
+++ b/examples/start-shadcn-example/src/components/auth/email-otp/forgot-password-otp.tsx
@@ -1,17 +1,14 @@
 "use client"
 
-import { getAuthLinkURL } from "@better-auth-ui/core"
+import { getAuthLinkURL, validateEmailAddress } from "@better-auth-ui/core"
 import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin, useFetchOptions } from "@better-auth-ui/react"
 import { useRequestPasswordResetOtp } from "@better-auth-ui/react/plugins/email-otp"
-import { type SyntheticEvent, useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel
 } from "@/components/ui/field"
@@ -19,6 +16,7 @@ import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 
 /** `sessionStorage` key the reset-code form reads the pending address from. */
 export const RESET_PASSWORD_OTP_STORAGE_KEY =
@@ -52,7 +50,6 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
   const { localization: emailOtpLocalization } = useAuthPlugin(emailOtpPlugin)
 
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({})
 
   const { mutate: requestPasswordResetOtp, isPending } =
     useRequestPasswordResetOtp(authClient as EmailOtpAuthClient, {
@@ -63,15 +60,11 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
       }
     })
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    requestPasswordResetOtp({
-      email: formData.get("email") as string,
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) =>
+      requestPasswordResetOtp({ email: value.email, fetchOptions })
+  })
 
   const Captcha = plugins.find(
     (plugin) => plugin.captchaComponent
@@ -86,45 +79,57 @@ export function ForgotPasswordOtp({ className }: ForgotPasswordOtpProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            <Field data-invalid={!!fieldErrors.email}>
-              <FieldLabel htmlFor="email">{localization.auth.email}</FieldLabel>
-
-              <Input
-                id="email"
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              <form.AppField
                 name="email"
-                type="email"
-                autoComplete="email"
-                placeholder={localization.auth.emailPlaceholder}
-                required
-                disabled={isPending}
-                onChange={() =>
-                  setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                }
-                onInvalid={(e) => {
-                  e.preventDefault()
-
-                  setFieldErrors((prev) => ({
-                    ...prev,
-                    email: (e.target as HTMLInputElement).validationMessage
-                  }))
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
                 }}
-                aria-invalid={!!fieldErrors.email}
-              />
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        aria-invalid={isInvalid}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
 
-              <FieldError>{fieldErrors.email}</FieldError>
-            </Field>
+              {Captcha && <div className="flex justify-center">{Captcha}</div>}
 
-            {Captcha && <div className="flex justify-center">{Captcha}</div>}
+              <form.AuthFormSubmitButton disabled={isPending}>
+                {isPending && <Spinner />}
 
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Spinner />}
-
-              {emailOtpLocalization.sendCode}
-            </Button>
-          </FieldGroup>
-        </form>
+                {emailOtpLocalization.sendCode}
+              </form.AuthFormSubmitButton>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/examples/start-shadcn-example/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/examples/start-shadcn-example/src/components/auth/email-otp/reset-password-otp.tsx
@@ -8,10 +8,9 @@ import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPasswordOtp } from "@better-auth-ui/react/plugins/email-otp"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useEffect, useRef, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -36,6 +35,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 import { PasswordStrengthMeter } from "../password-strength-meter"
@@ -74,24 +74,9 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
   const isHydrated = useIsHydrated()
   const initialEmail =
     (isHydrated && sessionStorage.getItem(RESET_PASSWORD_OTP_STORAGE_KEY)) || ""
-  const [email, setEmail] = useState(initialEmail)
   const [hasStoredEmail, setHasStoredEmail] = useState(Boolean(initialEmail))
-  const [code, setCode] = useState("")
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-  const formRef = useRef<HTMLFormElement>(null)
-  const submissionLockedRef = useRef(false)
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-    password?: string
-  }>({})
-
-  useEffect(() => {
-    const storedEmail =
-      sessionStorage.getItem(RESET_PASSWORD_OTP_STORAGE_KEY) ?? ""
-    setEmail(storedEmail)
-    setHasStoredEmail(Boolean(storedEmail))
-  }, [])
+  const [passwordError, setPasswordError] = useState("")
 
   const { mutate: resetPasswordOtp, isPending } = useResetPasswordOtp(
     authClient as EmailOtpAuthClient,
@@ -100,14 +85,9 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
         // The haveIBeenPwned plugin rejects on the password itself, so it
         // belongs against the field rather than in a toast.
         if (isPasswordCompromisedError(error)) {
-          setFieldErrors((prev) => ({
-            ...prev,
-            password: localization.auth.passwordCompromised
-          }))
+          setPasswordError(localization.auth.passwordCompromised)
         }
-
-        submissionLockedRef.current = false
-        setCode("")
+        form.setFieldValue("code", "")
       },
       onSuccess: () => {
         sessionStorage.removeItem(RESET_PASSWORD_OTP_STORAGE_KEY)
@@ -117,58 +97,44 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
     }
   )
 
-  const submitReset = (
-    form: HTMLFormElement,
-    submittedCode: string,
-    reportErrors: boolean
-  ) => {
-    if (isPending || submissionLockedRef.current) return
-
-    const formData = new FormData(form)
-    const password = formData.get("password") as string
-    const confirmPassword = formData.get("confirmPassword") as string
-    const submittedEmail = hasStoredEmail
-      ? email
-      : (formData.get("email") as string)
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      if (reportErrors) {
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      confirmPassword: "",
+      email: initialEmail,
+      password: ""
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
         toast.error(localization.auth.passwordsDoNotMatch)
+        return
       }
-      return
-    }
-
-    if (submittedCode.length !== otpLength) {
-      if (reportErrors) {
+      if (value.code.length !== otpLength) {
         toast.error(
           emailOtpLocalization.codeLengthMismatch.replace(
             "{{length}}",
             String(otpLength)
           )
         )
+        return
       }
-      return
+      resetPasswordOtp({
+        email: value.email,
+        otp: value.code,
+        password: value.password
+      })
     }
+  })
 
-    submissionLockedRef.current = true
-    resetPasswordOtp({ email: submittedEmail, otp: submittedCode, password })
-  }
-
-  const tryAutoSubmit = (completedCode?: string) => {
-    const form = formRef.current
-
-    if (!form?.matches(":valid")) return
-
-    const formData = new FormData(form)
-    const submittedCode = completedCode ?? String(formData.get("otp") ?? "")
-
-    submitReset(form, submittedCode, false)
-  }
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    submitReset(e.currentTarget, code, true)
-  }
+  useEffect(() => {
+    const storedEmail =
+      sessionStorage.getItem(RESET_PASSWORD_OTP_STORAGE_KEY) ?? ""
+    form.setFieldValue("email", storedEmail)
+    setHasStoredEmail(Boolean(storedEmail))
+  }, [form.setFieldValue])
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -177,160 +143,171 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
           {localization.auth.resetPassword}
         </CardTitle>
 
-        {hasStoredEmail && email && (
+        {hasStoredEmail && form.state.values.email && (
           <CardDescription>
-            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
+            {emailOtpLocalization.codeSentTo.replace(
+              "{{email}}",
+              form.state.values.email
+            )}
           </CardDescription>
         )}
       </CardHeader>
 
       <CardContent>
-        <form ref={formRef} onSubmit={handleSubmit}>
-          <FieldGroup>
-            {!hasStoredEmail && (
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="email">
-                  {localization.auth.email}
-                </FieldLabel>
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              {!hasStoredEmail && (
+                <form.AppField name="email">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
 
-                <Input
-                  id="email"
-                  name="email"
-                  type="email"
-                  autoComplete="email"
-                  value={email}
-                  placeholder={localization.auth.emailPlaceholder}
-                  required
-                  disabled={isPending}
-                  onChange={(event) => {
-                    setEmail(event.target.value)
-                    setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        value={field.state.value}
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: (e.target as HTMLInputElement).validationMessage
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.email}
-                />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
-            )}
+              <form.AppField name="code">
+                {(field) => (
+                  <OtpField
+                    autoFocus={hasStoredEmail}
+                    disabled={isPending}
+                    label={emailOtpLocalization.code}
+                    length={otpLength}
+                    name="otp"
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                    onComplete={(code) => {
+                      field.handleChange(code)
+                      if (form.state.values.password) void form.handleSubmit()
+                    }}
+                  />
+                )}
+              </form.AppField>
 
-            <OtpField
-              autoFocus={hasStoredEmail}
-              disabled={isPending}
-              label={emailOtpLocalization.code}
-              length={otpLength}
-              name="otp"
-              value={code}
-              onChange={setCode}
-              onComplete={tryAutoSubmit}
-            />
+              <form.AppField name="password">
+                {(field) => (
+                  <Field data-invalid={Boolean(passwordError)}>
+                    <FieldLabel htmlFor="password">
+                      {localization.auth.newPassword}
+                    </FieldLabel>
 
-            <Field data-invalid={!!fieldErrors.password}>
-              <FieldLabel htmlFor="password">
-                {localization.auth.newPassword}
-              </FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        id="password"
+                        name={field.name}
+                        type={isPasswordVisible ? "text" : "password"}
+                        autoComplete="new-password"
+                        placeholder={localization.auth.newPasswordPlaceholder}
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) => {
+                          setPasswordError("")
+                          field.handleChange(event.target.value)
+                        }}
+                        aria-invalid={Boolean(passwordError)}
+                      />
 
-              <InputGroup>
-                <InputGroupInput
-                  id="password"
-                  name="password"
-                  type={isPasswordVisible ? "text" : "password"}
-                  autoComplete="new-password"
-                  placeholder={localization.auth.newPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                  onChange={(e) => {
-                    setPassword(e.target.value)
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          size="icon-xs"
+                          aria-label={
+                            isPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          title={
+                            isPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() =>
+                            setIsPasswordVisible((visible) => !visible)
+                          }
+                        >
+                          {isPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
 
-                    setFieldErrors((prev) => ({ ...prev, password: undefined }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
-                    const el = e.target as HTMLInputElement
-                    const min = emailAndPassword?.minPasswordLength
-                    const max = emailAndPassword?.maxPasswordLength
-                    const msg = el.validity.valueMissing
-                      ? localization.auth.fieldRequired
-                      : el.validity.tooShort
-                        ? localization.auth.tooShort.replace(
-                            "{{min}}",
-                            String(min)
-                          )
-                        : localization.auth.tooLong.replace(
-                            "{{max}}",
-                            String(max)
-                          )
+                    {passwordError && <FieldError>{passwordError}</FieldError>}
 
-                    setFieldErrors((prev) => ({ ...prev, password: msg }))
-                  }}
-                  aria-invalid={!!fieldErrors.password}
-                />
+                    <PasswordStrengthMeter password={field.state.value} />
+                  </Field>
+                )}
+              </form.AppField>
 
-                <InputGroupAddon align="inline-end">
-                  <InputGroupButton
-                    size="icon-xs"
-                    aria-label={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    title={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    onClick={() => setIsPasswordVisible((visible) => !visible)}
-                  >
-                    {isPasswordVisible ? <EyeOff /> : <Eye />}
-                  </InputGroupButton>
-                </InputGroupAddon>
-              </InputGroup>
+              {emailAndPassword?.confirmPassword && (
+                <form.AppField name="confirmPassword">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="confirmPassword">
+                        {localization.auth.confirmPassword}
+                      </FieldLabel>
 
-              <FieldError>{fieldErrors.password}</FieldError>
+                      <Input
+                        id="confirmPassword"
+                        name={field.name}
+                        type="password"
+                        autoComplete="new-password"
+                        placeholder={
+                          localization.auth.confirmPasswordPlaceholder
+                        }
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-              <PasswordStrengthMeter password={password} />
-            </Field>
+              <div className="flex flex-col gap-3">
+                <form.AuthFormSubmitButton disabled={isPending}>
+                  {isPending && <Spinner />}
 
-            {emailAndPassword?.confirmPassword && (
-              <Field>
-                <FieldLabel htmlFor="confirmPassword">
-                  {localization.auth.confirmPassword}
-                </FieldLabel>
+                  {localization.auth.resetPassword}
+                </form.AuthFormSubmitButton>
 
-                <Input
-                  id="confirmPassword"
-                  name="confirmPassword"
-                  type="password"
-                  autoComplete="new-password"
-                  placeholder={localization.auth.confirmPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                />
-              </Field>
-            )}
-
-            <div className="flex flex-col gap-3">
-              <Button type="submit" disabled={isPending}>
-                {isPending && <Spinner />}
-
-                {localization.auth.resetPassword}
-              </Button>
-
-              {email && <OpenEmailButton email={email} variant="secondary" />}
-            </div>
-          </FieldGroup>
-        </form>
+                {form.state.values.email && (
+                  <OpenEmailButton
+                    email={form.state.values.email}
+                    variant="secondary"
+                  />
+                )}
+              </div>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/examples/start-shadcn-example/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/examples/start-shadcn-example/src/components/auth/email-otp/verify-email-otp.tsx
@@ -7,7 +7,7 @@ import {
   useSendVerificationOtp,
   useVerifyEmailOtp
 } from "@better-auth-ui/react/plugins/email-otp"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -21,7 +21,6 @@ import {
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel
 } from "@/components/ui/field"
@@ -33,6 +32,7 @@ import {
   useResendCooldown
 } from "@/lib/auth/use-resend-cooldown"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 import { useIsHydrated } from "../use-is-hydrated"
@@ -74,8 +74,6 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
   const [email, setEmail] = useState(
     (isHydrated && sessionStorage.getItem(VERIFY_EMAIL_STORAGE_KEY)) || ""
   )
-  const [code, setCode] = useState("")
-  const [fieldErrors, setFieldErrors] = useState<{ email?: string }>({})
 
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
 
@@ -102,7 +100,7 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
   const { mutate: verifyEmailOtp, isPending: isVerifying } = useVerifyEmailOtp(
     otpClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
         sessionStorage.removeItem(VERIFY_EMAIL_STORAGE_KEY)
         toast.success(emailOtpLocalization.emailVerified)
@@ -119,20 +117,19 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
     verifyEmailOtp({ email, otp: completedCode })
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (!email) {
-      const formData = new FormData(e.currentTarget)
-      sendVerificationOtp({
-        email: formData.get("email") as string,
-        type: "email-verification"
-      })
-      return
+  const form = useAuthForm({
+    defaultValues: { code: "", email: "" },
+    onSubmit: ({ value }) => {
+      if (!email) {
+        sendVerificationOtp({
+          email: value.email,
+          type: "email-verification"
+        })
+        return
+      }
+      verifyCode(value.code)
     }
-
-    verifyCode(code)
-  }
+  })
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -149,87 +146,91 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            {email ? (
-              <OtpField
-                autoFocus
-                disabled={isPending}
-                label={emailOtpLocalization.code}
-                length={otpLength}
-                name="otp"
-                value={code}
-                onChange={setCode}
-                onComplete={verifyCode}
-              />
-            ) : (
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="email">
-                  {localization.auth.email}
-                </FieldLabel>
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              {email ? (
+                <form.AppField name="code">
+                  {(field) => (
+                    <OtpField
+                      autoFocus
+                      disabled={isPending}
+                      label={emailOtpLocalization.code}
+                      length={otpLength}
+                      name="otp"
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      onComplete={verifyCode}
+                    />
+                  )}
+                </form.AppField>
+              ) : (
+                <form.AppField name="email">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
 
-                <Input
-                  id="email"
-                  name="email"
-                  type="email"
-                  autoComplete="email"
-                  placeholder={localization.auth.emailPlaceholder}
-                  required
-                  disabled={isPending}
-                  onChange={() =>
-                    setFieldErrors((prev) => ({ ...prev, email: undefined }))
-                  }
-                  onInvalid={(e) => {
-                    e.preventDefault()
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
 
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: (e.target as HTMLInputElement).validationMessage
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.email}
-                />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
-            )}
-
-            <div className="flex flex-col gap-3">
-              <Button
-                type="submit"
-                disabled={
-                  isPending || (Boolean(email) && code.length !== otpLength)
-                }
-              >
-                {isPending && <Spinner />}
-
-                {email
-                  ? emailOtpLocalization.verifyCode
-                  : emailOtpLocalization.sendCode}
-              </Button>
-
-              {email && <OpenEmailButton email={email} variant="secondary" />}
-
-              {email && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={isPending || isCoolingDown}
-                  onClick={() =>
-                    sendVerificationOtp({ email, type: "email-verification" })
+              <div className="flex flex-col gap-3">
+                <form.AuthFormSubmitButton
+                  disabled={
+                    isPending ||
+                    (Boolean(email) &&
+                      form.state.values.code.length !== otpLength)
                   }
                 >
-                  {isCoolingDown
-                    ? localization.auth.resendIn.replace(
-                        "{{seconds}}",
-                        String(cooldown)
-                      )
-                    : localization.auth.resend}
-                </Button>
-              )}
-            </div>
-          </FieldGroup>
-        </form>
+                  {isPending && <Spinner />}
+
+                  {email
+                    ? emailOtpLocalization.verifyCode
+                    : emailOtpLocalization.sendCode}
+                </form.AuthFormSubmitButton>
+
+                {email && <OpenEmailButton email={email} variant="secondary" />}
+
+                {email && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={isPending || isCoolingDown}
+                    onClick={() =>
+                      sendVerificationOtp({ email, type: "email-verification" })
+                    }
+                  >
+                    {isCoolingDown
+                      ? localization.auth.resendIn.replace(
+                          "{{seconds}}",
+                          String(cooldown)
+                        )
+                      : localization.auth.resend}
+                  </Button>
+                )}
+              </div>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/examples/start-shadcn-example/src/components/auth/forgot-password.tsx
+++ b/examples/start-shadcn-example/src/components/auth/forgot-password.tsx
@@ -1,25 +1,23 @@
 "use client"
 
-import { getViewURL } from "@better-auth-ui/core"
+import { getViewURL, validateEmailAddress } from "@better-auth-ui/core"
 import {
   useAuth,
   useFetchOptions,
   useRequestPasswordReset
 } from "@better-auth-ui/react"
-import { type SyntheticEvent, useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel
 } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
 import { RESET_LINK_SENT_STORAGE_KEY } from "./reset-link-sent"
 
 export type ForgotPasswordProps = {
@@ -64,27 +62,23 @@ export function ForgotPassword({ className }: ForgotPasswordProps) {
     }
   )
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    const formData = new FormData(e.currentTarget)
-    requestPasswordReset({
-      email: formData.get("email") as string,
-      redirectTo: getViewURL(
-        baseURL,
-        basePaths.auth,
-        viewPaths.auth.resetPassword
-      ),
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) =>
+      requestPasswordReset({
+        email: value.email,
+        redirectTo: getViewURL(
+          baseURL,
+          basePaths.auth,
+          viewPaths.auth.resetPassword
+        ),
+        fetchOptions
+      })
+  })
 
   const Captcha = plugins.find(
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
-
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-  }>({})
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -95,54 +89,58 @@ export function ForgotPassword({ className }: ForgotPasswordProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            <Field data-invalid={!!fieldErrors.email}>
-              <FieldLabel htmlFor="email">{localization.auth.email}</FieldLabel>
-
-              <Input
-                id="email"
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              <form.AppField
                 name="email"
-                type="email"
-                autoComplete="email"
-                placeholder={localization.auth.emailPlaceholder}
-                required
-                disabled={isPending}
-                onChange={() => {
-                  setFieldErrors((prev) => ({
-                    ...prev,
-                    email: undefined
-                  }))
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
                 }}
-                onInvalid={(e) => {
-                  e.preventDefault()
-                  const el = e.target as HTMLInputElement
-                  const msg = el.validity.valueMissing
-                    ? localization.auth.fieldRequired
-                    : localization.auth.invalidEmail
-
-                  setFieldErrors((prev) => ({
-                    ...prev,
-                    email: msg
-                  }))
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
+                      <Input
+                        id="email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        placeholder={localization.auth.emailPlaceholder}
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        aria-invalid={isInvalid}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
                 }}
-                aria-invalid={!!fieldErrors.email}
-              />
+              </form.AppField>
 
-              <FieldError>{fieldErrors.email}</FieldError>
-            </Field>
+              {Captcha && <div className="flex justify-center">{Captcha}</div>}
 
-            {Captcha && <div className="flex justify-center">{Captcha}</div>}
-
-            <div className="flex flex-col gap-3">
-              <Button type="submit" disabled={isPending}>
-                {isPending && <Spinner />}
-
-                {localization.auth.sendResetLink}
-              </Button>
-            </div>
-          </FieldGroup>
-        </form>
+              <div className="flex flex-col gap-3">
+                <form.AuthFormSubmitButton disabled={isPending}>
+                  {isPending && <Spinner />}
+                  {localization.auth.sendResetLink}
+                </form.AuthFormSubmitButton>
+              </div>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/examples/start-shadcn-example/src/components/auth/magic-link.tsx
+++ b/examples/start-shadcn-example/src/components/auth/magic-link.tsx
@@ -1,19 +1,16 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import { authMutationKeys, validateEmailAddress } from "@better-auth-ui/core"
 import type { MagicLinkAuthClient } from "@better-auth-ui/core/plugins/magic-link"
 import { getSsoFallbackEmail } from "@better-auth-ui/core/plugins/sso"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useSignInMagicLink } from "@better-auth-ui/react/plugins/magic-link"
 import { useIsMutating } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -22,6 +19,7 @@ import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { magicLinkPlugin } from "@/lib/auth/magic-link-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
 import { MAGIC_LINK_SENT_STORAGE_KEY } from "./magic-link-sent"
 import { ProviderButtons, type SocialLayout } from "./provider-buttons"
 
@@ -60,8 +58,6 @@ export function MagicLink({
   const { localization: magicLinkLocalization, viewPaths: magicLinkViewPaths } =
     useAuthPlugin(magicLinkPlugin)
 
-  const [email, setEmail] = useState(getSsoFallbackEmail)
-
   const { mutate: signInMagicLink, isPending: signInMagicLinkPending } =
     useSignInMagicLink(authClient, {
       onSuccess: (_data, variables) => {
@@ -80,14 +76,14 @@ export function MagicLink({
   })
   const isPending = signInMutating + signUpMutating > 0
 
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-  }>({})
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    signInMagicLink({ email, callbackURL: `${baseURL}${redirectTo}` })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: getSsoFallbackEmail() },
+    onSubmit: ({ value }) =>
+      signInMagicLink({
+        callbackURL: `${baseURL}${redirectTo}`,
+        email: value.email
+      })
+  })
 
   const showSeparator = socialProviders && socialProviders.length > 0
 
@@ -113,62 +109,65 @@ export function MagicLink({
             </>
           )}
 
-          <form onSubmit={handleSubmit}>
-            <FieldGroup>
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="email">
-                  {localization.auth.email}
-                </FieldLabel>
-
-                <Input
-                  id="email"
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <FieldGroup>
+                <form.AppField
                   name="email"
-                  type="email"
-                  autoComplete="email"
-                  value={email}
-                  onChange={(e) => {
-                    setEmail(e.target.value)
-
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: undefined
-                    }))
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateEmailAddress(value, {
+                        invalidMessage: localization.auth.invalidEmail,
+                        requiredMessage: localization.auth.fieldRequired
+                      })
                   }}
-                  placeholder={localization.auth.emailPlaceholder}
-                  required
-                  disabled={isPending}
-                  onInvalid={(e) => {
-                    e.preventDefault()
-
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: (e.target as HTMLInputElement).validationMessage
-                    }))
+                >
+                  {(field) => {
+                    const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                    return (
+                      <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor="email">
+                          {localization.auth.email}
+                        </FieldLabel>
+                        <Input
+                          id="email"
+                          name={field.name}
+                          type="email"
+                          autoComplete="email"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          placeholder={localization.auth.emailPlaceholder}
+                          required
+                          disabled={isPending}
+                          aria-invalid={isInvalid}
+                        />
+                        <field.AuthFormFieldError />
+                      </Field>
+                    )
                   }}
-                  aria-invalid={!!fieldErrors.email}
-                />
+                </form.AppField>
 
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
+                <div className="flex flex-col gap-3">
+                  <form.AuthFormSubmitButton disabled={isPending}>
+                    {signInMagicLinkPending && <Spinner />}
+                    {magicLinkLocalization.sendMagicLink}
+                  </form.AuthFormSubmitButton>
 
-              <div className="flex flex-col gap-3">
-                <Button type="submit" disabled={isPending}>
-                  {signInMagicLinkPending && <Spinner />}
-
-                  {magicLinkLocalization.sendMagicLink}
-                </Button>
-
-                {plugins.flatMap((plugin) =>
-                  (plugin.authButtons ?? []).map((AuthButton, index) => (
-                    <AuthButton
-                      key={`${plugin.id}-${index.toString()}`}
-                      view="magicLink"
-                    />
-                  ))
-                )}
-              </div>
-            </FieldGroup>
-          </form>
+                  {plugins.flatMap((plugin) =>
+                    (plugin.authButtons ?? []).map((AuthButton, index) => (
+                      <AuthButton
+                        key={`${plugin.id}-${index.toString()}`}
+                        view="magicLink"
+                      />
+                    ))
+                  )}
+                </div>
+              </FieldGroup>
+            </form.AuthFormRoot>
+          </form.AppForm>
 
           {socialPosition === "bottom" && (
             <>

--- a/examples/start-shadcn-example/src/components/auth/organization/delete-organization-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/delete-organization-dialog.tsx
@@ -5,7 +5,6 @@ import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useDeleteOrganization } from "@better-auth-ui/react/plugins/organization"
 import type { Organization } from "better-auth/client"
 import { TriangleAlert } from "lucide-react"
-import type { SyntheticEvent } from "react"
 import { toast } from "sonner"
 
 import {
@@ -18,10 +17,10 @@ import {
   AlertDialogMedia,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Spinner } from "@/components/ui/spinner"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
+import { useAuthForm } from "../auth-form"
 import { OrganizationView } from "./organization-view"
 
 export type DeleteOrganizationDialogProps = {
@@ -57,47 +56,52 @@ export function DeleteOrganizationDialog({
     }
   )
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    deleteOrganization({ organizationId: organization.id })
-  }
+  const form = useAuthForm({
+    defaultValues: {},
+    onSubmit: () => deleteOrganization({ organizationId: organization.id })
+  })
 
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <AlertDialogHeader>
-            <AlertDialogMedia className="bg-destructive/10 text-destructive">
-              <TriangleAlert />
-            </AlertDialogMedia>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <AlertDialogHeader>
+              <AlertDialogMedia className="bg-destructive/10 text-destructive">
+                <TriangleAlert />
+              </AlertDialogMedia>
 
-            <AlertDialogTitle>
-              {organizationLocalization.deleteOrganization}
-            </AlertDialogTitle>
+              <AlertDialogTitle>
+                {organizationLocalization.deleteOrganization}
+              </AlertDialogTitle>
 
-            <AlertDialogDescription>
-              {organizationLocalization.deleteOrganizationDescription}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+              <AlertDialogDescription>
+                {organizationLocalization.deleteOrganizationDescription}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
 
-          <Card>
-            <CardContent>
-              <OrganizationView organization={organization} hideRole />
-            </CardContent>
-          </Card>
+            <Card>
+              <CardContent>
+                <OrganizationView organization={organization} hideRole />
+              </CardContent>
+            </Card>
 
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>
-              {localization.settings.cancel}
-            </AlertDialogCancel>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isPending}>
+                {localization.settings.cancel}
+              </AlertDialogCancel>
 
-            <Button type="submit" variant="destructive" disabled={isPending}>
-              {isPending && <Spinner />}
+              <form.AuthFormSubmitButton
+                variant="destructive"
+                disabled={isPending}
+              >
+                {isPending && <Spinner />}
 
-              {organizationLocalization.deleteOrganization}
-            </Button>
-          </AlertDialogFooter>
-        </form>
+                {organizationLocalization.deleteOrganization}
+              </form.AuthFormSubmitButton>
+            </AlertDialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </AlertDialogContent>
     </AlertDialog>
   )

--- a/examples/start-shadcn-example/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -8,8 +8,8 @@ import type {
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useAddPasskey } from "@better-auth-ui/react/plugins/passkey"
 import { Fingerprint } from "lucide-react"
-import { type SyntheticEvent, useRef } from "react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useRef } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -23,6 +23,7 @@ import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
+import { useAuthForm } from "../auth-form"
 import { FreshSessionPrompt } from "../settings/security/fresh-session-prompt"
 
 export type AddPasskeyDialogProps = {
@@ -41,14 +42,6 @@ export function AddPasskeyDialog({
   const addPasskey = useAddPasskey(authClient)
   const pendingRequest = useRef<AddPasskeyParams<PasskeyAuthClient>>(undefined)
 
-  const handleOpenChange = (nextOpen: boolean) => {
-    if (!nextOpen) {
-      addPasskey.reset()
-      pendingRequest.current = undefined
-    }
-    onOpenChange(nextOpen)
-  }
-
   const submitRequest = (request: AddPasskeyParams<PasskeyAuthClient>) => {
     const requestWithCallbacks = {
       ...request,
@@ -61,16 +54,24 @@ export function AddPasskeyDialog({
     addPasskey.mutate(requestWithCallbacks)
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useAuthForm({
+    defaultValues: { name: "" },
+    onSubmit: ({ value }) => {
+      const name = value.name.trim()
+      submitRequest({
+        ...(name ? { name } : {}),
+        ...(authenticatorAttachment ? { authenticatorAttachment } : {})
+      } as AddPasskeyParams<PasskeyAuthClient>)
+    }
+  })
 
-    const formData = new FormData(e.target as HTMLFormElement)
-    const name = (formData.get("name") as string)?.trim()
-
-    submitRequest({
-      ...(name ? { name } : {}),
-      ...(authenticatorAttachment ? { authenticatorAttachment } : {})
-    } as AddPasskeyParams<PasskeyAuthClient>)
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      addPasskey.reset()
+      form.reset()
+      pendingRequest.current = undefined
+    }
+    onOpenChange(nextOpen)
   }
 
   const needsFreshSession = isSessionNotFreshError(addPasskey.error)
@@ -93,55 +94,65 @@ export function AddPasskeyDialog({
             />
           </>
         ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <Fingerprint />
-                {passkeyLocalization.addPasskey}
-              </DialogTitle>
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-6">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <Fingerprint />
+                  {passkeyLocalization.addPasskey}
+                </DialogTitle>
 
-              <DialogDescription>
-                {passkeyLocalization.passkeysDescription}
-              </DialogDescription>
-            </DialogHeader>
+                <DialogDescription>
+                  {passkeyLocalization.passkeysDescription}
+                </DialogDescription>
+              </DialogHeader>
 
-            <Field data-invalid={addPasskey.isError}>
-              <FieldLabel htmlFor="passkey-name">
-                {passkeyLocalization.name}
-              </FieldLabel>
+              <form.AppField name="name">
+                {(field) => (
+                  <Field data-invalid={addPasskey.isError}>
+                    <FieldLabel htmlFor="passkey-name">
+                      {passkeyLocalization.name}
+                    </FieldLabel>
+                    <Input
+                      id="passkey-name"
+                      name={field.name}
+                      autoFocus
+                      placeholder={localization.settings.optional}
+                      disabled={addPasskey.isPending}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      aria-invalid={addPasskey.isError}
+                    />
+                    {addPasskey.error && (
+                      <FieldError>
+                        {addPasskey.error.error?.message ??
+                          addPasskey.error.message}
+                      </FieldError>
+                    )}
+                  </Field>
+                )}
+              </form.AppField>
 
-              <Input
-                id="passkey-name"
-                name="name"
-                autoFocus
-                placeholder={localization.settings.optional}
-                disabled={addPasskey.isPending}
-                aria-invalid={addPasskey.isError}
-              />
+              <DialogFooter>
+                <DialogClose
+                  className={buttonVariants({ variant: "outline" })}
+                  disabled={addPasskey.isPending}
+                  type="button"
+                >
+                  {localization.settings.cancel}
+                </DialogClose>
 
-              {addPasskey.error && (
-                <FieldError>
-                  {addPasskey.error.error?.message ?? addPasskey.error.message}
-                </FieldError>
-              )}
-            </Field>
+                <form.AuthFormSubmitButton disabled={addPasskey.isPending}>
+                  {addPasskey.isPending && <Spinner />}
 
-            <DialogFooter>
-              <DialogClose
-                className={buttonVariants({ variant: "outline" })}
-                disabled={addPasskey.isPending}
-                type="button"
-              >
-                {localization.settings.cancel}
-              </DialogClose>
-
-              <Button type="submit" disabled={addPasskey.isPending}>
-                {addPasskey.isPending && <Spinner />}
-
-                {passkeyLocalization.addPasskey}
-              </Button>
-            </DialogFooter>
-          </form>
+                  {passkeyLocalization.addPasskey}
+                </form.AuthFormSubmitButton>
+              </DialogFooter>
+            </form.AuthFormRoot>
+          </form.AppForm>
         )}
       </DialogContent>
     </Dialog>

--- a/examples/start-shadcn-example/src/components/auth/passkey/rename-passkey-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/passkey/rename-passkey-dialog.tsx
@@ -3,8 +3,8 @@
 import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useUpdatePasskey } from "@better-auth-ui/react/plugins/passkey"
-import { type FormEvent, useEffect, useState } from "react"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { useEffect } from "react"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -17,6 +17,7 @@ import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
+import { useAuthForm } from "../auth-form"
 import type { ListedPasskey } from "./delete-passkey-dialog"
 
 export function RenamePasskeyDialog({
@@ -30,56 +31,61 @@ export function RenamePasskeyDialog({
 }) {
   const { authClient, localization } = useAuth<PasskeyAuthClient>()
   const { localization: labels } = useAuthPlugin(passkeyPlugin)
-  const [name, setName] = useState(passkey.name ?? "")
-
-  useEffect(() => {
-    if (open) setName(passkey.name ?? "")
-  }, [open, passkey.name])
-
   const updatePasskey = useUpdatePasskey(authClient, {
     onSuccess: () => onOpenChange(false)
   })
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const nextName = name.trim()
-    if (nextName) updatePasskey.mutate({ id: passkey.id, name: nextName })
-  }
+  const form = useAuthForm({
+    defaultValues: { name: passkey.name ?? "" },
+    onSubmit: ({ value }) => {
+      const name = value.name.trim()
+      if (name) updatePasskey.mutate({ id: passkey.id, name })
+    }
+  })
+
+  useEffect(() => {
+    if (open) form.reset({ name: passkey.name ?? "" })
+  }, [form, open, passkey.name])
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <form className="flex flex-col gap-6" onSubmit={submit}>
-          <DialogHeader>
-            <DialogTitle>{labels.renamePasskey}</DialogTitle>
-          </DialogHeader>
-          <Field>
-            <FieldLabel htmlFor={`passkey-name-${passkey.id}`}>
-              {labels.name}
-            </FieldLabel>
-            <Input
-              id={`passkey-name-${passkey.id}`}
-              autoFocus
-              value={name}
-              onChange={(event) => setName(event.target.value)}
-              required
-            />
-          </Field>
-          <DialogFooter>
-            <DialogClose
-              className={buttonVariants({ variant: "outline" })}
-              type="button"
-            >
-              {localization.settings.cancel}
-            </DialogClose>
-            <Button
-              disabled={!name.trim() || updatePasskey.isPending}
-              type="submit"
-            >
-              {updatePasskey.isPending && <Spinner />}
-              {localization.settings.saveChanges}
-            </Button>
-          </DialogFooter>
-        </form>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle>{labels.renamePasskey}</DialogTitle>
+            </DialogHeader>
+            <form.AppField name="name">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor={`passkey-name-${passkey.id}`}>
+                    {labels.name}
+                  </FieldLabel>
+                  <Input
+                    id={`passkey-name-${passkey.id}`}
+                    name={field.name}
+                    autoFocus
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(event) => field.handleChange(event.target.value)}
+                    required
+                  />
+                </Field>
+              )}
+            </form.AppField>
+            <DialogFooter>
+              <DialogClose
+                className={buttonVariants({ variant: "outline" })}
+                type="button"
+              >
+                {localization.settings.cancel}
+              </DialogClose>
+              <form.AuthFormSubmitButton disabled={updatePasskey.isPending}>
+                {updatePasskey.isPending && <Spinner />}
+                {localization.settings.saveChanges}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-shadcn-example/src/components/auth/phone-number/change-phone-number.tsx
+++ b/examples/start-shadcn-example/src/components/auth/phone-number/change-phone-number.tsx
@@ -14,7 +14,7 @@ import {
   useSendPhoneNumberOtp,
   useVerifyPhoneNumber
 } from "@better-auth-ui/react/plugins/phone-number"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
 import { Button } from "@/components/ui/button"
@@ -24,6 +24,7 @@ import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { InternationalPhoneField } from "./international-phone-field"
 import { RemovePhoneNumberDialog } from "./remove-phone-number-dialog"
@@ -51,20 +52,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
   const { data: session } = useSession(phoneClient)
   const currentPhoneNumber =
     (session?.user as PhoneNumberUser | undefined)?.phoneNumber ?? ""
-  const [phoneNumber, setPhoneNumber] = useState(() =>
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
-  const [fieldError, setFieldError] = useState<string>()
-
-  useEffect(() => {
-    if (session) {
-      setPhoneNumber(
-        createPhoneNumberValue(currentPhoneNumber, defaultCountry, adapter)
-      )
-    }
-  }, [adapter, currentPhoneNumber, defaultCountry, session])
 
   const { mutate: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
     phoneClient,
@@ -73,9 +61,9 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
   const { mutate: verify, isPending: isVerifying } = useVerifyPhoneNumber(
     phoneClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
-        setCode("")
+        form.setFieldValue("code", "")
         setCodeSent(false)
         toast.success(localization.phoneNumberUpdated)
       }
@@ -85,26 +73,43 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
     phoneClient,
     {
       onSuccess: () => {
-        setPhoneNumber(createPhoneNumberValue("", defaultCountry, adapter))
+        form.setFieldValue(
+          "phoneNumber",
+          createPhoneNumberValue("", defaultCountry, adapter)
+        )
         toast.success(localization.phoneNumberRemoved)
       }
     }
   )
   const isPending = isSending || isVerifying || isRemoving
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!phoneNumber.e164) {
-      setFieldError(localization.invalidPhoneNumber)
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter)
+    },
+    onSubmit: ({ value }) => {
+      if (!value.phoneNumber.e164) return
+      if (!codeSent) {
+        sendOtp({ phoneNumber: value.phoneNumber.e164 })
+        return
+      }
+      verify({
+        phoneNumber: value.phoneNumber.e164,
+        code: value.code,
+        updatePhoneNumber: true
+      })
     }
-    if (!codeSent) {
-      sendOtp({ phoneNumber: phoneNumber.e164 })
-      return
-    }
+  })
 
-    verify({ phoneNumber: phoneNumber.e164, code, updatePhoneNumber: true })
-  }
+  useEffect(() => {
+    if (session) {
+      form.setFieldValue(
+        "phoneNumber",
+        createPhoneNumberValue(currentPhoneNumber, defaultCountry, adapter)
+      )
+    }
+  }, [adapter, currentPhoneNumber, defaultCountry, form.setFieldValue, session])
   const removePhoneNumber = () =>
     updateUser({
       phoneNumber: null
@@ -115,94 +120,109 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
       <h2 className="mb-3 text-sm font-semibold">
         {localization.changePhoneNumber}
       </h2>
-      <form onSubmit={handleSubmit}>
-        <Card className={cn(className)}>
-          <CardContent className="flex flex-col gap-6">
-            {codeSent ? (
-              <>
-                <FieldDescription>
-                  {localization.codeSentTo.replace(
-                    "{{phoneNumber}}",
-                    phoneNumber.display
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card className={cn(className)}>
+            <CardContent className="flex flex-col gap-6">
+              {codeSent ? (
+                <>
+                  <FieldDescription>
+                    {localization.codeSentTo.replace(
+                      "{{phoneNumber}}",
+                      form.state.values.phoneNumber.display
+                    )}
+                  </FieldDescription>
+                  <form.AppField name="code">
+                    {(field) => (
+                      <OtpField
+                        autoFocus
+                        disabled={isPending}
+                        label={localization.phoneCode}
+                        length={otpLength}
+                        name="otp"
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                      />
+                    )}
+                  </form.AppField>
+                </>
+              ) : session ? (
+                <form.AppField
+                  name="phoneNumber"
+                  validators={{
+                    onChange: ({ value }) =>
+                      value.e164 ? undefined : localization.invalidPhoneNumber
+                  }}
+                >
+                  {(field) => (
+                    <InternationalPhoneField
+                      adapter={adapter}
+                      countryCodes={countries}
+                      countryLabel={localization.country}
+                      disabled={isPending}
+                      error={field.state.meta.errors[0]?.toString()}
+                      locale={locale}
+                      phoneLabel={localization.phoneNumber}
+                      placeholder={localization.phoneNumberPlaceholder}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                    />
                   )}
-                </FieldDescription>
-                <OtpField
-                  autoFocus
+                </form.AppField>
+              ) : (
+                <Skeleton className="h-14 w-full" />
+              )}
+            </CardContent>
+            <CardFooter className="gap-3">
+              {codeSent && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
                   disabled={isPending}
-                  label={localization.phoneCode}
-                  length={otpLength}
-                  name="otp"
-                  value={code}
-                  onChange={setCode}
-                />
-              </>
-            ) : session ? (
-              <InternationalPhoneField
-                adapter={adapter}
-                countryCodes={countries}
-                countryLabel={localization.country}
-                disabled={isPending}
-                error={fieldError}
-                locale={locale}
-                phoneLabel={localization.phoneNumber}
-                placeholder={localization.phoneNumberPlaceholder}
-                value={phoneNumber}
-                onChange={(value) => {
-                  setPhoneNumber(value)
-                  setFieldError(undefined)
-                }}
-              />
-            ) : (
-              <Skeleton className="h-14 w-full" />
-            )}
-          </CardContent>
-          <CardFooter className="gap-3">
-            {codeSent && (
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                disabled={isPending}
-                onClick={() => {
-                  setCode("")
-                  setCodeSent(false)
-                  setPhoneNumber(
-                    createPhoneNumberValue(
-                      currentPhoneNumber,
-                      defaultCountry,
-                      adapter
+                  onClick={() => {
+                    form.setFieldValue("code", "")
+                    setCodeSent(false)
+                    form.setFieldValue(
+                      "phoneNumber",
+                      createPhoneNumberValue(
+                        currentPhoneNumber,
+                        defaultCountry,
+                        adapter
+                      )
                     )
-                  )
-                }}
+                  }}
+                >
+                  {localization.cancel}
+                </Button>
+              )}
+              <form.AuthFormSubmitButton
+                size="sm"
+                disabled={
+                  isPending ||
+                  !session ||
+                  (codeSent && form.state.values.code.length !== otpLength)
+                }
               >
-                {localization.cancel}
-              </Button>
-            )}
-            <Button
-              type="submit"
-              size="sm"
-              disabled={
-                isPending || !session || (codeSent && code.length !== otpLength)
-              }
-            >
-              {(isSending || isVerifying) && <Spinner />}
-              {codeSent
-                ? localization.verifyCode
-                : localization.updatePhoneNumber}
-            </Button>
-            {!codeSent && currentPhoneNumber && (
-              <RemovePhoneNumberDialog
-                cancelLabel={localization.cancel}
-                description={localization.removePhoneNumberDescription}
-                isPending={isRemoving}
-                label={localization.removePhoneNumber}
-                title={localization.removePhoneNumberTitle}
-                onConfirm={removePhoneNumber}
-              />
-            )}
-          </CardFooter>
-        </Card>
-      </form>
+                {(isSending || isVerifying) && <Spinner />}
+                {codeSent
+                  ? localization.verifyCode
+                  : localization.updatePhoneNumber}
+              </form.AuthFormSubmitButton>
+              {!codeSent && currentPhoneNumber && (
+                <RemovePhoneNumberDialog
+                  cancelLabel={localization.cancel}
+                  description={localization.removePhoneNumberDescription}
+                  isPending={isRemoving}
+                  label={localization.removePhoneNumber}
+                  title={localization.removePhoneNumberTitle}
+                  onConfirm={removePhoneNumber}
+                />
+              )}
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/examples/start-shadcn-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/examples/start-shadcn-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -6,14 +6,13 @@ import {
 } from "@better-auth-ui/core/plugins/phone-number"
 import { useAuth, useAuthPlugin, useFetchOptions } from "@better-auth-ui/react"
 import { useRequestPhoneNumberPasswordReset } from "@better-auth-ui/react/plugins/phone-number"
-import { type SyntheticEvent, useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { FieldDescription, FieldGroup } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { InternationalPhoneField } from "./international-phone-field"
 
 export const PHONE_NUMBER_RESET_STORAGE_KEY =
@@ -38,10 +37,6 @@ export function ForgotPhoneNumberPassword({
     viewPaths: phoneNumberViewPaths
   } = useAuthPlugin(phoneNumberPlugin)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
-  const [phoneNumber, setPhoneNumber] = useState(() =>
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [fieldError, setFieldError] = useState<string>()
   const { mutate: requestReset, isPending } =
     useRequestPhoneNumberPasswordReset(authClient as PhoneNumberAuthClient, {
       onError: () => resetFetchOptions(),
@@ -56,17 +51,15 @@ export function ForgotPhoneNumberPassword({
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!phoneNumber.e164) {
-      setFieldError(phoneLocalization.invalidPhoneNumber)
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter)
+    },
+    onSubmit: ({ value }) => {
+      if (!value.phoneNumber.e164) return
+      requestReset({ phoneNumber: value.phoneNumber.e164, fetchOptions })
     }
-    requestReset({
-      phoneNumber: phoneNumber.e164,
-      fetchOptions
-    })
-  }
+  })
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -76,30 +69,41 @@ export function ForgotPhoneNumberPassword({
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            <InternationalPhoneField
-              adapter={adapter}
-              countryCodes={countries}
-              countryLabel={phoneLocalization.country}
-              disabled={isPending}
-              error={fieldError}
-              locale={locale}
-              phoneLabel={phoneLocalization.phoneNumber}
-              placeholder={phoneLocalization.phoneNumberPlaceholder}
-              value={phoneNumber}
-              onChange={(value) => {
-                setPhoneNumber(value)
-                setFieldError(undefined)
-              }}
-            />
-            {Captcha && <div className="flex justify-center">{Captcha}</div>}
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Spinner />}
-              {phoneLocalization.sendCode}
-            </Button>
-          </FieldGroup>
-        </form>
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              <form.AppField
+                name="phoneNumber"
+                validators={{
+                  onChange: ({ value }) =>
+                    value.e164
+                      ? undefined
+                      : phoneLocalization.invalidPhoneNumber
+                }}
+              >
+                {(field) => (
+                  <InternationalPhoneField
+                    adapter={adapter}
+                    countryCodes={countries}
+                    countryLabel={phoneLocalization.country}
+                    disabled={isPending}
+                    error={field.state.meta.errors[0]?.toString()}
+                    locale={locale}
+                    phoneLabel={phoneLocalization.phoneNumber}
+                    placeholder={phoneLocalization.phoneNumberPlaceholder}
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                  />
+                )}
+              </form.AppField>
+              {Captcha && <div className="flex justify-center">{Captcha}</div>}
+              <form.AuthFormSubmitButton disabled={isPending}>
+                {isPending && <Spinner />}
+                {phoneLocalization.sendCode}
+              </form.AuthFormSubmitButton>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
         <FieldDescription className="mt-4 text-center">
           {localization.auth.rememberYourPassword}{" "}
           <Link

--- a/examples/start-shadcn-example/src/components/auth/phone-number/phone-number.tsx
+++ b/examples/start-shadcn-example/src/components/auth/phone-number/phone-number.tsx
@@ -18,7 +18,7 @@ import {
 } from "@better-auth-ui/react/plugins/phone-number"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -32,7 +32,6 @@ import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -48,6 +47,7 @@ import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { useResendCooldown } from "@/lib/auth/use-resend-cooldown"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
 import { InternationalPhoneField } from "./international-phone-field"
@@ -95,17 +95,8 @@ export function PhoneNumber({
   const [mode, setMode] = useState<PhoneNumberMode>(
     signIn ? "code" : "password"
   )
-  const [phoneNumber, setPhoneNumber] = useState(() =>
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [password, setPassword] = useState("")
-  const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-  const [fieldErrors, setFieldErrors] = useState<{
-    phoneNumber?: string
-    password?: string
-  }>({})
 
   const { mutate: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
     phoneClient,
@@ -120,14 +111,14 @@ export function PhoneNumber({
   const { mutate: verify, isPending: isVerifying } = useVerifyPhoneNumber(
     phoneClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: (data) => continueSignIn(data)
     }
   )
   const { mutate: signInWithPassword, isPending: isPasswordPending } =
     useSignInPhoneNumber(phoneClient, {
       onError: (error) => {
-        setPassword("")
+        form.setFieldValue("password", "")
         resetFetchOptions()
 
         if (signIn && error.error?.code === "PHONE_NUMBER_NOT_VERIFIED") {
@@ -159,15 +150,8 @@ export function PhoneNumber({
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
 
-  const getPhoneNumber = () => {
-    if (phoneNumber.e164) return phoneNumber.e164
-    setFieldErrors((current) => ({
-      ...current,
-      phoneNumber: phoneLocalization.invalidPhoneNumber
-    }))
-  }
   const sendCode = () => {
-    const normalizedPhoneNumber = getPhoneNumber()
+    const normalizedPhoneNumber = form.state.values.phoneNumber.e164
     if (!normalizedPhoneNumber) return
     sendOtp({
       phoneNumber: normalizedPhoneNumber,
@@ -177,41 +161,49 @@ export function PhoneNumber({
   const verifyCode = (completedCode: string) => {
     if (isPending || completedCode.length !== otpLength) return
 
-    if (!phoneNumber.e164) return
-    verify({ phoneNumber: phoneNumber.e164, code: completedCode })
+    if (!form.state.values.phoneNumber.e164) return
+    verify({
+      phoneNumber: form.state.values.phoneNumber.e164,
+      code: completedCode
+    })
   }
   const switchMode = () => {
     setMode((current) => (current === "code" ? "password" : "code"))
-    setCode("")
+    form.setFieldValue("code", "")
     setCodeSent(false)
-    setPassword("")
+    form.setFieldValue("password", "")
   }
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      password: "",
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter),
+      rememberMe: false
+    },
+    onSubmit: ({ value }) => {
+      if (mode === "password") {
+        const normalizedPhoneNumber = value.phoneNumber.e164
+        if (!normalizedPhoneNumber) return
+        signInWithPassword({
+          phoneNumber: normalizedPhoneNumber,
+          password: value.password,
+          ...(emailAndPassword?.rememberMe
+            ? { rememberMe: value.rememberMe }
+            : {}),
+          fetchOptions
+        })
+        return
+      }
 
-    if (mode === "password") {
-      const normalizedPhoneNumber = getPhoneNumber()
-      if (!normalizedPhoneNumber) return
-      const formData = new FormData(event.currentTarget)
-      signInWithPassword({
-        phoneNumber: normalizedPhoneNumber,
-        password,
-        ...(emailAndPassword?.rememberMe
-          ? { rememberMe: formData.get("rememberMe") === "on" }
-          : {}),
-        fetchOptions
-      })
-      return
+      if (!codeSent) {
+        sendCode()
+        return
+      }
+
+      verifyCode(value.code)
     }
-
-    if (!codeSent) {
-      sendCode()
-      return
-    }
-
-    verifyCode(code)
-  }
+  })
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -225,7 +217,7 @@ export function PhoneNumber({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              phoneNumber.display
+              form.state.values.phoneNumber.display
             )}
           </CardDescription>
         )}
@@ -244,192 +236,207 @@ export function PhoneNumber({
             </>
           )}
 
-          <form onSubmit={handleSubmit}>
-            <FieldGroup>
-              {codeSent ? (
-                <OtpField
-                  autoFocus
-                  disabled={isPending}
-                  label={phoneLocalization.phoneCode}
-                  length={otpLength}
-                  name="otp"
-                  value={code}
-                  onChange={setCode}
-                  onComplete={verifyCode}
-                />
-              ) : (
-                <>
-                  <InternationalPhoneField
-                    adapter={adapter}
-                    countryCodes={countries}
-                    countryLabel={phoneLocalization.country}
-                    disabled={isPending}
-                    error={fieldErrors.phoneNumber}
-                    locale={locale}
-                    phoneLabel={phoneLocalization.phoneNumber}
-                    placeholder={phoneLocalization.phoneNumberPlaceholder}
-                    value={phoneNumber}
-                    onChange={(value) => {
-                      setPhoneNumber(value)
-                      setFieldErrors((current) => ({
-                        ...current,
-                        phoneNumber: undefined
-                      }))
-                    }}
-                  />
-
-                  {mode === "password" && (
-                    <Field data-invalid={Boolean(fieldErrors.password)}>
-                      <FieldLabel htmlFor="phoneNumberPassword">
-                        {localization.auth.password}
-                      </FieldLabel>
-                      <InputGroup>
-                        <InputGroupInput
-                          id="phoneNumberPassword"
-                          name="password"
-                          type={isPasswordVisible ? "text" : "password"}
-                          autoComplete="current-password"
-                          value={password}
-                          placeholder={localization.auth.passwordPlaceholder}
-                          required
-                          minLength={emailAndPassword?.minPasswordLength}
-                          maxLength={emailAndPassword?.maxPasswordLength}
-                          disabled={isPending}
-                          onChange={(event) => {
-                            setPassword(event.target.value)
-                            setFieldErrors((current) => ({
-                              ...current,
-                              password: undefined
-                            }))
-                          }}
-                          onInvalid={(event) => {
-                            event.preventDefault()
-                            setFieldErrors((current) => ({
-                              ...current,
-                              password: event.currentTarget.validationMessage
-                            }))
-                          }}
-                          aria-invalid={Boolean(fieldErrors.password)}
-                        />
-                        <InputGroupAddon align="inline-end">
-                          <InputGroupButton
-                            type="button"
-                            size="icon-xs"
-                            aria-label={
-                              isPasswordVisible
-                                ? localization.auth.hidePassword
-                                : localization.auth.showPassword
-                            }
-                            title={
-                              isPasswordVisible
-                                ? localization.auth.hidePassword
-                                : localization.auth.showPassword
-                            }
-                            onClick={() =>
-                              setIsPasswordVisible((visible) => !visible)
-                            }
-                          >
-                            {isPasswordVisible ? <EyeOff /> : <Eye />}
-                          </InputGroupButton>
-                        </InputGroupAddon>
-                      </InputGroup>
-                      <FieldError>{fieldErrors.password}</FieldError>
-                    </Field>
-                  )}
-
-                  {mode === "password" && emailAndPassword?.rememberMe && (
-                    <Field orientation="horizontal">
-                      <Checkbox
-                        id="phoneNumberRememberMe"
-                        name="rememberMe"
-                        disabled={isPending}
-                      />
-                      <FieldLabel
-                        htmlFor="phoneNumberRememberMe"
-                        className="cursor-pointer font-normal"
-                      >
-                        {localization.auth.rememberMe}
-                      </FieldLabel>
-                    </Field>
-                  )}
-
-                  {Captcha && (
-                    <div className="flex justify-center">{Captcha}</div>
-                  )}
-                </>
-              )}
-
-              <div className="flex flex-col gap-3">
-                <Button
-                  type="submit"
-                  disabled={
-                    isPending || (codeSent && code.length !== otpLength)
-                  }
-                >
-                  {(isSending || isVerifying || isPasswordPending) && (
-                    <Spinner />
-                  )}
-                  {mode === "password"
-                    ? localization.auth.signIn
-                    : codeSent
-                      ? phoneLocalization.verifyCode
-                      : phoneLocalization.sendCode}
-                </Button>
-
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <FieldGroup>
                 {codeSent ? (
-                  <>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      disabled={isPending || isCoolingDown}
-                      onClick={sendCode}
-                    >
-                      {isCoolingDown
-                        ? localization.auth.resendIn.replace(
-                            "{{seconds}}",
-                            String(cooldown)
-                          )
-                        : localization.auth.resend}
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      disabled={isPending}
-                      onClick={() => {
-                        setCode("")
-                        setCodeSent(false)
-                      }}
-                    >
-                      {phoneLocalization.useDifferentPhoneNumber}
-                    </Button>
-                  </>
+                  <form.AppField name="code">
+                    {(field) => (
+                      <OtpField
+                        autoFocus
+                        disabled={isPending}
+                        label={phoneLocalization.phoneCode}
+                        length={otpLength}
+                        name="otp"
+                        value={field.state.value}
+                        onChange={field.handleChange}
+                        onComplete={verifyCode}
+                      />
+                    )}
+                  </form.AppField>
                 ) : (
                   <>
-                    {canSwitchMode && (
-                      <Button
-                        type="button"
-                        variant="outline"
-                        disabled={isPending}
-                        onClick={switchMode}
-                      >
-                        {mode === "code"
-                          ? phoneLocalization.usePassword
-                          : phoneLocalization.useVerificationCode}
-                      </Button>
-                    )}
-                    {plugins.flatMap((plugin) =>
-                      (plugin.authButtons ?? []).map((AuthButton) => (
-                        <AuthButton
-                          key={`${plugin.id}-${AuthButton.displayName ?? AuthButton.name}`}
-                          view="phoneNumber"
+                    <form.AppField
+                      name="phoneNumber"
+                      validators={{
+                        onChange: ({ value }) =>
+                          value.e164
+                            ? undefined
+                            : phoneLocalization.invalidPhoneNumber
+                      }}
+                    >
+                      {(field) => (
+                        <InternationalPhoneField
+                          adapter={adapter}
+                          countryCodes={countries}
+                          countryLabel={phoneLocalization.country}
+                          disabled={isPending}
+                          error={field.state.meta.errors[0]?.toString()}
+                          locale={locale}
+                          phoneLabel={phoneLocalization.phoneNumber}
+                          placeholder={phoneLocalization.phoneNumberPlaceholder}
+                          value={field.state.value}
+                          onChange={field.handleChange}
                         />
-                      ))
+                      )}
+                    </form.AppField>
+
+                    {mode === "password" && (
+                      <form.AppField name="password">
+                        {(field) => (
+                          <Field>
+                            <FieldLabel htmlFor="phoneNumberPassword">
+                              {localization.auth.password}
+                            </FieldLabel>
+                            <InputGroup>
+                              <InputGroupInput
+                                id="phoneNumberPassword"
+                                name={field.name}
+                                type={isPasswordVisible ? "text" : "password"}
+                                autoComplete="current-password"
+                                value={field.state.value}
+                                placeholder={
+                                  localization.auth.passwordPlaceholder
+                                }
+                                required
+                                minLength={emailAndPassword?.minPasswordLength}
+                                maxLength={emailAndPassword?.maxPasswordLength}
+                                disabled={isPending}
+                                onBlur={field.handleBlur}
+                                onChange={(event) =>
+                                  field.handleChange(event.target.value)
+                                }
+                              />
+                              <InputGroupAddon align="inline-end">
+                                <InputGroupButton
+                                  type="button"
+                                  size="icon-xs"
+                                  aria-label={
+                                    isPasswordVisible
+                                      ? localization.auth.hidePassword
+                                      : localization.auth.showPassword
+                                  }
+                                  title={
+                                    isPasswordVisible
+                                      ? localization.auth.hidePassword
+                                      : localization.auth.showPassword
+                                  }
+                                  onClick={() =>
+                                    setIsPasswordVisible((visible) => !visible)
+                                  }
+                                >
+                                  {isPasswordVisible ? <EyeOff /> : <Eye />}
+                                </InputGroupButton>
+                              </InputGroupAddon>
+                            </InputGroup>
+                            <field.AuthFormFieldError />
+                          </Field>
+                        )}
+                      </form.AppField>
+                    )}
+
+                    {mode === "password" && emailAndPassword?.rememberMe && (
+                      <form.AppField name="rememberMe">
+                        {(field) => (
+                          <Field orientation="horizontal">
+                            <Checkbox
+                              id="phoneNumberRememberMe"
+                              name={field.name}
+                              disabled={isPending}
+                              checked={field.state.value}
+                              onCheckedChange={(checked) =>
+                                field.handleChange(checked === true)
+                              }
+                            />
+                            <FieldLabel
+                              htmlFor="phoneNumberRememberMe"
+                              className="cursor-pointer font-normal"
+                            >
+                              {localization.auth.rememberMe}
+                            </FieldLabel>
+                          </Field>
+                        )}
+                      </form.AppField>
+                    )}
+
+                    {Captcha && (
+                      <div className="flex justify-center">{Captcha}</div>
                     )}
                   </>
                 )}
-              </div>
-            </FieldGroup>
-          </form>
+
+                <div className="flex flex-col gap-3">
+                  <form.AuthFormSubmitButton
+                    disabled={
+                      isPending ||
+                      (codeSent && form.state.values.code.length !== otpLength)
+                    }
+                  >
+                    {(isSending || isVerifying || isPasswordPending) && (
+                      <Spinner />
+                    )}
+                    {mode === "password"
+                      ? localization.auth.signIn
+                      : codeSent
+                        ? phoneLocalization.verifyCode
+                        : phoneLocalization.sendCode}
+                  </form.AuthFormSubmitButton>
+
+                  {codeSent ? (
+                    <>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={isPending || isCoolingDown}
+                        onClick={sendCode}
+                      >
+                        {isCoolingDown
+                          ? localization.auth.resendIn.replace(
+                              "{{seconds}}",
+                              String(cooldown)
+                            )
+                          : localization.auth.resend}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        disabled={isPending}
+                        onClick={() => {
+                          form.setFieldValue("code", "")
+                          setCodeSent(false)
+                        }}
+                      >
+                        {phoneLocalization.useDifferentPhoneNumber}
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      {canSwitchMode && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          disabled={isPending}
+                          onClick={switchMode}
+                        >
+                          {mode === "code"
+                            ? phoneLocalization.usePassword
+                            : phoneLocalization.useVerificationCode}
+                        </Button>
+                      )}
+                      {plugins.flatMap((plugin) =>
+                        (plugin.authButtons ?? []).map((AuthButton) => (
+                          <AuthButton
+                            key={`${plugin.id}-${AuthButton.displayName ?? AuthButton.name}`}
+                            view="phoneNumber"
+                          />
+                        ))
+                      )}
+                    </>
+                  )}
+                </div>
+              </FieldGroup>
+            </form.AuthFormRoot>
+          </form.AppForm>
 
           {socialPosition === "bottom" && showProviders && (
             <>

--- a/examples/start-shadcn-example/src/components/auth/phone-number/reset-phone-number-password.tsx
+++ b/examples/start-shadcn-example/src/components/auth/phone-number/reset-phone-number-password.tsx
@@ -5,10 +5,9 @@ import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-n
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPhoneNumberPassword } from "@better-auth-ui/react/plugins/phone-number"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -32,6 +31,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { PasswordStrengthMeter } from "../password-strength-meter"
 import { useIsHydrated } from "../use-is-hydrated"
@@ -55,23 +55,11 @@ export function ResetPhoneNumberPassword({
   const isHydrated = useIsHydrated()
   const initialPhoneNumber =
     (isHydrated && sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY)) || ""
-  const [phoneNumber, setPhoneNumber] = useState(initialPhoneNumber)
   const [hasStoredPhoneNumber, setHasStoredPhoneNumber] = useState(
     Boolean(initialPhoneNumber)
   )
-  const [code, setCode] = useState("")
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-  const [fieldErrors, setFieldErrors] = useState<{
-    phoneNumber?: string
-    password?: string
-  }>({})
-
-  useEffect(() => {
-    const stored = sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY) ?? ""
-    setPhoneNumber(stored)
-    setHasStoredPhoneNumber(Boolean(stored))
-  }, [])
+  const [passwordError, setPasswordError] = useState("")
 
   const { mutate: resetPassword, isPending } = useResetPhoneNumberPassword(
     authClient as PhoneNumberAuthClient,
@@ -80,13 +68,10 @@ export function ResetPhoneNumberPassword({
         // The haveIBeenPwned plugin rejects on the password itself, so it
         // belongs against the field rather than in a toast.
         if (isPasswordCompromisedError(error)) {
-          setFieldErrors((prev) => ({
-            ...prev,
-            password: localization.auth.passwordCompromised
-          }))
+          setPasswordError(localization.auth.passwordCompromised)
         }
 
-        setCode("")
+        form.setFieldValue("code", "")
       },
       onSuccess: () => {
         sessionStorage.removeItem(PHONE_NUMBER_RESET_STORAGE_KEY)
@@ -98,31 +83,44 @@ export function ResetPhoneNumberPassword({
     }
   )
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    const confirmPassword = String(formData.get("confirmPassword") ?? "")
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      toast.error(localization.auth.passwordsDoNotMatch)
-      return
-    }
-    if (code.length !== otpLength) {
-      toast.error(
-        phoneLocalization.codeLengthMismatch.replace(
-          "{{length}}",
-          String(otpLength)
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      confirmPassword: "",
+      password: "",
+      phoneNumber: initialPhoneNumber
+    },
+    onSubmit: ({ value }) => {
+      if (
+        emailAndPassword?.confirmPassword &&
+        value.password !== value.confirmPassword
+      ) {
+        toast.error(localization.auth.passwordsDoNotMatch)
+        return
+      }
+      if (value.code.length !== otpLength) {
+        toast.error(
+          phoneLocalization.codeLengthMismatch.replace(
+            "{{length}}",
+            String(otpLength)
+          )
         )
-      )
-      return
-    }
+        return
+      }
 
-    resetPassword({
-      phoneNumber,
-      otp: code,
-      newPassword: password
-    })
-  }
+      resetPassword({
+        phoneNumber: value.phoneNumber,
+        otp: value.code,
+        newPassword: value.password
+      })
+    }
+  })
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY) ?? ""
+    form.setFieldValue("phoneNumber", stored)
+    setHasStoredPhoneNumber(Boolean(stored))
+  }, [form.setFieldValue])
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -134,139 +132,146 @@ export function ResetPhoneNumberPassword({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              phoneNumber
+              form.state.values.phoneNumber
             )}
           </CardDescription>
         )}
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            {!hasStoredPhoneNumber && (
-              <Field data-invalid={Boolean(fieldErrors.phoneNumber)}>
-                <FieldLabel htmlFor="passwordResetPhoneNumber">
-                  {phoneLocalization.phoneNumber}
-                </FieldLabel>
-                <Input
-                  id="passwordResetPhoneNumber"
-                  name="phoneNumber"
-                  type="tel"
-                  autoComplete="tel"
-                  inputMode="tel"
-                  value={phoneNumber}
-                  placeholder={phoneLocalization.phoneNumberPlaceholder}
-                  required
-                  disabled={isPending}
-                  onChange={(event) => {
-                    setPhoneNumber(event.target.value)
-                    setFieldErrors((current) => ({
-                      ...current,
-                      phoneNumber: undefined
-                    }))
-                  }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    setFieldErrors((current) => ({
-                      ...current,
-                      phoneNumber: event.currentTarget.validationMessage
-                    }))
-                  }}
-                  aria-invalid={Boolean(fieldErrors.phoneNumber)}
-                />
-                <FieldError>{fieldErrors.phoneNumber}</FieldError>
-              </Field>
-            )}
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              {!hasStoredPhoneNumber && (
+                <form.AppField name="phoneNumber">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="passwordResetPhoneNumber">
+                        {phoneLocalization.phoneNumber}
+                      </FieldLabel>
+                      <Input
+                        id="passwordResetPhoneNumber"
+                        name={field.name}
+                        type="tel"
+                        autoComplete="tel"
+                        inputMode="tel"
+                        value={field.state.value}
+                        placeholder={phoneLocalization.phoneNumberPlaceholder}
+                        required
+                        disabled={isPending}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-            <OtpField
-              autoFocus={hasStoredPhoneNumber}
-              disabled={isPending}
-              label={phoneLocalization.phoneCode}
-              length={otpLength}
-              name="otp"
-              value={code}
-              onChange={setCode}
-            />
+              <form.AppField name="code">
+                {(field) => (
+                  <OtpField
+                    autoFocus={hasStoredPhoneNumber}
+                    disabled={isPending}
+                    label={phoneLocalization.phoneCode}
+                    length={otpLength}
+                    name="otp"
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                  />
+                )}
+              </form.AppField>
 
-            <Field data-invalid={Boolean(fieldErrors.password)}>
-              <FieldLabel htmlFor="phoneNumberNewPassword">
-                {localization.auth.newPassword}
-              </FieldLabel>
-              <InputGroup>
-                <InputGroupInput
-                  id="phoneNumberNewPassword"
-                  name="password"
-                  type={isPasswordVisible ? "text" : "password"}
-                  autoComplete="new-password"
-                  value={password}
-                  placeholder={localization.auth.newPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                  onChange={(event) => {
-                    setPassword(event.target.value)
-                    setFieldErrors((current) => ({
-                      ...current,
-                      password: undefined
-                    }))
-                  }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    setFieldErrors((current) => ({
-                      ...current,
-                      password: event.currentTarget.validationMessage
-                    }))
-                  }}
-                  aria-invalid={Boolean(fieldErrors.password)}
-                />
-                <InputGroupAddon align="inline-end">
-                  <InputGroupButton
-                    type="button"
-                    size="icon-xs"
-                    aria-label={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    onClick={() => setIsPasswordVisible((visible) => !visible)}
-                  >
-                    {isPasswordVisible ? <EyeOff /> : <Eye />}
-                  </InputGroupButton>
-                </InputGroupAddon>
-              </InputGroup>
-              <FieldError>{fieldErrors.password}</FieldError>
+              <form.AppField name="password">
+                {(field) => (
+                  <Field data-invalid={Boolean(passwordError)}>
+                    <FieldLabel htmlFor="phoneNumberNewPassword">
+                      {localization.auth.newPassword}
+                    </FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        id="phoneNumberNewPassword"
+                        name={field.name}
+                        type={isPasswordVisible ? "text" : "password"}
+                        autoComplete="new-password"
+                        value={field.state.value}
+                        placeholder={localization.auth.newPasswordPlaceholder}
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        onChange={(event) => {
+                          setPasswordError("")
+                          field.handleChange(event.target.value)
+                        }}
+                        aria-invalid={Boolean(passwordError)}
+                      />
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          type="button"
+                          size="icon-xs"
+                          aria-label={
+                            isPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          onClick={() =>
+                            setIsPasswordVisible((visible) => !visible)
+                          }
+                        >
+                          {isPasswordVisible ? <EyeOff /> : <Eye />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                    {passwordError && <FieldError>{passwordError}</FieldError>}
 
-              <PasswordStrengthMeter password={password} />
-            </Field>
+                    <PasswordStrengthMeter password={field.state.value} />
+                  </Field>
+                )}
+              </form.AppField>
 
-            {emailAndPassword?.confirmPassword && (
-              <Field>
-                <FieldLabel htmlFor="phoneNumberConfirmPassword">
-                  {localization.auth.confirmPassword}
-                </FieldLabel>
-                <Input
-                  id="phoneNumberConfirmPassword"
-                  name="confirmPassword"
-                  type="password"
-                  autoComplete="new-password"
-                  placeholder={localization.auth.confirmPasswordPlaceholder}
-                  required
-                  minLength={emailAndPassword?.minPasswordLength}
-                  maxLength={emailAndPassword?.maxPasswordLength}
-                  disabled={isPending}
-                />
-              </Field>
-            )}
+              {emailAndPassword?.confirmPassword && (
+                <form.AppField name="confirmPassword">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="phoneNumberConfirmPassword">
+                        {localization.auth.confirmPassword}
+                      </FieldLabel>
+                      <Input
+                        id="phoneNumberConfirmPassword"
+                        name={field.name}
+                        type="password"
+                        autoComplete="new-password"
+                        placeholder={
+                          localization.auth.confirmPasswordPlaceholder
+                        }
+                        required
+                        minLength={emailAndPassword?.minPasswordLength}
+                        maxLength={emailAndPassword?.maxPasswordLength}
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                    </Field>
+                  )}
+                </form.AppField>
+              )}
 
-            <Button
-              type="submit"
-              disabled={isPending || code.length !== otpLength}
-            >
-              {isPending && <Spinner />}
-              {phoneLocalization.resetPassword}
-            </Button>
-          </FieldGroup>
-        </form>
+              <form.AuthFormSubmitButton
+                disabled={
+                  isPending || form.state.values.code.length !== otpLength
+                }
+              >
+                {isPending && <Spinner />}
+                {phoneLocalization.resetPassword}
+              </form.AuthFormSubmitButton>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
     </Card>
   )

--- a/examples/start-shadcn-example/src/components/auth/settings/account/change-email.tsx
+++ b/examples/start-shadcn-example/src/components/auth/settings/account/change-email.tsx
@@ -1,17 +1,17 @@
 "use client"
 
-import { getViewURL } from "@better-auth-ui/core"
+import { getViewURL, validateEmailAddress } from "@better-auth-ui/core"
 import { useAuth, useChangeEmail, useSession } from "@better-auth-ui/react"
-import { type SyntheticEvent, useState } from "react"
+import { useEffect } from "react"
 import { toast } from "sonner"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Spinner } from "@/components/ui/spinner"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../../auth-form"
 
 export type ChangeEmailProps = {
   className?: string
@@ -34,23 +34,22 @@ export function ChangeEmail({ className }: ChangeEmailProps) {
     onSuccess: () => toast.success(localization.settings.changeEmailSuccess)
   })
 
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-  }>({})
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) =>
+      changeEmail({
+        callbackURL: getViewURL(
+          baseURL,
+          basePaths.settings,
+          viewPaths.settings.account
+        ),
+        newEmail: value.email
+      })
+  })
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    changeEmail({
-      newEmail: formData.get("email") as string,
-      callbackURL: getViewURL(
-        baseURL,
-        basePaths.settings,
-        viewPaths.settings.account
-      )
-    })
-  }
+  useEffect(() => {
+    if (session) form.reset({ email: session.user.email })
+  }, [form, session])
 
   return (
     <div>
@@ -58,57 +57,68 @@ export function ChangeEmail({ className }: ChangeEmailProps) {
         {localization.settings.changeEmail}
       </h2>
 
-      <form onSubmit={handleSubmit}>
-        <Card className={cn(className)}>
-          <CardContent className="flex flex-col gap-6">
-            <Field data-invalid={!!fieldErrors.email}>
-              <FieldLabel htmlFor="email">{localization.auth.email}</FieldLabel>
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card className={cn(className)}>
+            <CardContent className="flex flex-col gap-6">
+              <form.AppField
+                name="email"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
+                }}
+              >
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="email">
+                        {localization.auth.email}
+                      </FieldLabel>
+                      {session ? (
+                        <Input
+                          id="email"
+                          name={field.name}
+                          type="email"
+                          autoComplete="email"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          placeholder={localization.auth.emailPlaceholder}
+                          disabled={isPending}
+                          required
+                          aria-invalid={isInvalid}
+                        />
+                      ) : (
+                        <Skeleton>
+                          <Input className="invisible" />
+                        </Skeleton>
+                      )}
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+            </CardContent>
 
-              {session ? (
-                <Input
-                  key={session?.user.email}
-                  id="email"
-                  name="email"
-                  type="email"
-                  autoComplete="email"
-                  defaultValue={session?.user.email}
-                  placeholder={localization.auth.emailPlaceholder}
-                  disabled={isPending}
-                  required
-                  onChange={() => {
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: undefined
-                    }))
-                  }}
-                  onInvalid={(e) => {
-                    e.preventDefault()
-                    setFieldErrors((prev) => ({
-                      ...prev,
-                      email: (e.target as HTMLInputElement).validationMessage
-                    }))
-                  }}
-                  aria-invalid={!!fieldErrors.email}
-                />
-              ) : (
-                <Skeleton>
-                  <Input className="invisible" />
-                </Skeleton>
-              )}
+            <CardFooter>
+              <form.AuthFormSubmitButton
+                size="sm"
+                disabled={isPending || !session}
+              >
+                {isPending && <Spinner />}
 
-              <FieldError>{fieldErrors.email}</FieldError>
-            </Field>
-          </CardContent>
-
-          <CardFooter>
-            <Button type="submit" size="sm" disabled={isPending || !session}>
-              {isPending && <Spinner />}
-
-              {localization.settings.updateEmail}
-            </Button>
-          </CardFooter>
-        </Card>
-      </form>
+                {localization.settings.updateEmail}
+              </form.AuthFormSubmitButton>
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/examples/start-shadcn-example/src/components/auth/settings/security/fresh-session-prompt.tsx
+++ b/examples/start-shadcn-example/src/components/auth/settings/security/fresh-session-prompt.tsx
@@ -2,7 +2,6 @@
 
 import { isTwoFactorRedirect } from "@better-auth-ui/core/plugins/two-factor"
 import { useAuth, useSession, useSignInEmail } from "@better-auth-ui/react"
-import { type FormEvent, useState } from "react"
 import { Button } from "@/components/ui/button"
 import {
   Field,
@@ -14,6 +13,7 @@ import {
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
+import { useAuthForm } from "../../auth-form"
 
 export interface FreshSessionPromptProps {
   onFresh: () => unknown | Promise<unknown>
@@ -23,26 +23,25 @@ export function FreshSessionPrompt({ onFresh }: FreshSessionPromptProps) {
   const auth = useAuth()
   const session = useSession(auth.authClient)
   const continueSignIn = useSignInContinuation()
-  const [password, setPassword] = useState("")
   const signIn = useSignInEmail(auth.authClient, {
     meta: { errorPresentation: "inline" },
-    onError: () => setPassword(""),
+    onError: () => form.reset(),
     onSuccess: async (data) => {
       if (isTwoFactorRedirect(data)) {
         continueSignIn(data)
         return
       }
-      setPassword("")
+      form.reset()
       await onFresh()
     }
   })
-
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const email = session.data?.user.email
-    if (!email) return
-    signIn.mutate({ email, password })
-  }
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) => {
+      const email = session.data?.user.email
+      if (email) signIn.mutate({ email, password: value.password })
+    }
+  })
 
   return (
     <div className="p-4">
@@ -56,31 +55,41 @@ export function FreshSessionPrompt({ onFresh }: FreshSessionPromptProps) {
           </FieldDescription>
         </div>
         {auth.emailAndPassword?.enabled ? (
-          <form className="flex flex-col gap-3" onSubmit={submit}>
-            <Field data-invalid={signIn.isError}>
-              <FieldLabel htmlFor="fresh-session-password">
-                {auth.localization.auth.password}
-              </FieldLabel>
-              <Input
-                id="fresh-session-password"
-                autoComplete="current-password"
-                disabled={signIn.isPending}
-                value={password}
-                onChange={(event) => setPassword(event.target.value)}
-                type="password"
-                required
-              />
-              {signIn.error && (
-                <FieldError>
-                  {signIn.error.error?.message ?? signIn.error.message}
-                </FieldError>
-              )}
-            </Field>
-            <Button disabled={!password || signIn.isPending} type="submit">
-              {signIn.isPending && <Spinner />}
-              {auth.localization.settings.freshSessionSubmit}
-            </Button>
-          </form>
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-3">
+              <form.AppField name="password">
+                {(field) => (
+                  <Field data-invalid={signIn.isError}>
+                    <FieldLabel htmlFor="fresh-session-password">
+                      {auth.localization.auth.password}
+                    </FieldLabel>
+                    <Input
+                      id="fresh-session-password"
+                      autoComplete="current-password"
+                      disabled={signIn.isPending}
+                      name={field.name}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                      type="password"
+                      required
+                    />
+                    {signIn.error && (
+                      <FieldError>
+                        {signIn.error.error?.message ?? signIn.error.message}
+                      </FieldError>
+                    )}
+                  </Field>
+                )}
+              </form.AppField>
+              <form.AuthFormSubmitButton disabled={signIn.isPending}>
+                {signIn.isPending && <Spinner />}
+                {auth.localization.settings.freshSessionSubmit}
+              </form.AuthFormSubmitButton>
+            </form.AuthFormRoot>
+          </form.AppForm>
         ) : (
           <Button
             onClick={() =>

--- a/examples/start-shadcn-example/src/components/auth/sign-in.tsx
+++ b/examples/start-shadcn-example/src/components/auth/sign-in.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import {
+  authMutationKeys,
+  validateEmailAddress,
+  validateStringLength
+} from "@better-auth-ui/core"
 import {
   isPasskeyAutoFillEnabled,
   withPasskeyAutoFill
@@ -13,15 +17,13 @@ import {
 } from "@better-auth-ui/react"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -36,6 +38,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
 import { LastUsedBadge } from "./last-login-method/last-used-badge"
 import { ProviderButtons, type SocialLayout } from "./provider-buttons"
 
@@ -73,13 +76,11 @@ export function SignIn({
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
   const continueSignIn = useSignInContinuation()
 
-  const [password, setPassword] = useState("")
-
   const { mutate: signInEmail, isPending: signInEmailPending } = useSignInEmail(
     authClient,
     {
       onError: (error, { email }) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
           sessionStorage.setItem("better-auth-ui.verify-email", email)
@@ -109,26 +110,18 @@ export function SignIn({
   const passkeyAutoFill = isPasskeyAutoFillEnabled(plugins)
 
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-    password?: string
-  }>({})
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const email = formData.get("email") as string
-    const rememberMe = formData.get("rememberMe") === "on"
-
-    signInEmail({
-      email,
-      password,
-      ...(emailAndPassword?.rememberMe ? { rememberMe } : {}),
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "", password: "", rememberMe: false },
+    onSubmit: ({ value }) =>
+      signInEmail({
+        email: value.email,
+        password: value.password,
+        ...(emailAndPassword?.rememberMe
+          ? { rememberMe: value.rememberMe }
+          : {}),
+        fetchOptions
+      })
+  })
 
   const showSeparator =
     emailAndPassword?.enabled && socialProviders && socialProviders.length > 0
@@ -159,170 +152,185 @@ export function SignIn({
           )}
 
           {emailAndPassword?.enabled && (
-            <form onSubmit={handleSubmit}>
-              <FieldGroup>
-                <Field data-invalid={!!fieldErrors.email}>
-                  <FieldLabel htmlFor="email">
-                    {localization.auth.email}
-                  </FieldLabel>
-
-                  <Input
-                    id="email"
+            <form.AppForm>
+              <form.AuthFormRoot>
+                <FieldGroup>
+                  <form.AppField
                     name="email"
-                    type="email"
-                    autoComplete={withPasskeyAutoFill("email", passkeyAutoFill)}
-                    placeholder={localization.auth.emailPlaceholder}
-                    required
-                    disabled={isPending}
-                    onChange={() => {
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: undefined
-                      }))
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateEmailAddress(value, {
+                          invalidMessage: localization.auth.invalidEmail,
+                          requiredMessage: localization.auth.fieldRequired
+                        })
                     }}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-                      const el = e.target as HTMLInputElement
-                      const msg = el.validity.valueMissing
-                        ? localization.auth.fieldRequired
-                        : localization.auth.invalidEmail
-
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: msg
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
-
-                  <FieldError>{fieldErrors.email}</FieldError>
-                </Field>
-
-                <Field data-invalid={!!fieldErrors.password}>
-                  <FieldLabel htmlFor="password">
-                    {localization.auth.password}
-                  </FieldLabel>
-
-                  <InputGroup>
-                    <InputGroupInput
-                      id="password"
-                      name="password"
-                      type={isPasswordVisible ? "text" : "password"}
-                      autoComplete={withPasskeyAutoFill(
-                        "current-password",
-                        passkeyAutoFill
-                      )}
-                      value={password}
-                      onChange={(e) => {
-                        setPassword(e.target.value)
-
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: undefined
-                        }))
-                      }}
-                      placeholder={localization.auth.passwordPlaceholder}
-                      required
-                      minLength={emailAndPassword?.minPasswordLength}
-                      maxLength={emailAndPassword?.maxPasswordLength}
-                      disabled={isPending}
-                      onInvalid={(e) => {
-                        e.preventDefault()
-                        const el = e.target as HTMLInputElement
-                        const min = emailAndPassword?.minPasswordLength
-                        const max = emailAndPassword?.maxPasswordLength
-                        const msg = el.validity.valueMissing
-                          ? localization.auth.fieldRequired
-                          : el.validity.tooShort
-                            ? localization.auth.tooShort.replace(
-                                "{{min}}",
-                                String(min)
-                              )
-                            : localization.auth.tooLong.replace(
-                                "{{max}}",
-                                String(max)
-                              )
-
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: msg
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.password}
-                    />
-
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        title={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() => {
-                          setIsPasswordVisible((visible) => !visible)
-                        }}
-                      >
-                        {isPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-
-                  <FieldError>{fieldErrors.password}</FieldError>
-                </Field>
-
-                {emailAndPassword.rememberMe && (
-                  <Field className="my-1">
-                    <div className="flex items-center gap-3">
-                      <Checkbox
-                        id="rememberMe"
-                        name="rememberMe"
-                        disabled={isPending}
-                      />
-
-                      <FieldLabel
-                        htmlFor="rememberMe"
-                        className="cursor-pointer text-sm font-normal"
-                      >
-                        {localization.auth.rememberMe}
-                      </FieldLabel>
-                    </div>
-                  </Field>
-                )}
-
-                {Captcha && (
-                  <div className="flex justify-center">{Captcha}</div>
-                )}
-
-                <div className="flex flex-col gap-3">
-                  <Button
-                    type="submit"
-                    className="relative overflow-visible"
-                    disabled={isPending}
                   >
-                    {signInEmailPending && <Spinner />}
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="email">
+                            {localization.auth.email}
+                          </FieldLabel>
 
-                    {localization.auth.signIn}
+                          <Input
+                            id="email"
+                            name={field.name}
+                            type="email"
+                            autoComplete={withPasskeyAutoFill(
+                              "email",
+                              passkeyAutoFill
+                            )}
+                            placeholder={localization.auth.emailPlaceholder}
+                            required
+                            disabled={isPending}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) =>
+                              field.handleChange(event.target.value)
+                            }
+                            aria-invalid={isInvalid}
+                          />
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
 
-                    <LastUsedBadge method="email" floating />
-                  </Button>
+                  <form.AppField
+                    name="password"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          maxLength: emailAndPassword?.maxPasswordLength,
+                          maxLengthMessage: localization.auth.tooLong.replace(
+                            "{{max}}",
+                            String(emailAndPassword?.maxPasswordLength)
+                          ),
+                          minLength: emailAndPassword?.minPasswordLength,
+                          minLengthMessage: localization.auth.tooShort.replace(
+                            "{{min}}",
+                            String(emailAndPassword?.minPasswordLength)
+                          ),
+                          requiredMessage: localization.auth.fieldRequired
+                        })
+                    }}
+                  >
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="password">
+                            {localization.auth.password}
+                          </FieldLabel>
 
-                  {plugins.flatMap((plugin) =>
-                    (plugin.authButtons ?? []).map((AuthButton, index) => (
-                      <AuthButton
-                        key={`${plugin.id}-${index.toString()}`}
-                        view="signIn"
-                      />
-                    ))
+                          <InputGroup>
+                            <InputGroupInput
+                              id="password"
+                              name={field.name}
+                              type={isPasswordVisible ? "text" : "password"}
+                              autoComplete={withPasskeyAutoFill(
+                                "current-password",
+                                passkeyAutoFill
+                              )}
+                              value={field.state.value}
+                              onBlur={field.handleBlur}
+                              onChange={(event) =>
+                                field.handleChange(event.target.value)
+                              }
+                              placeholder={
+                                localization.auth.passwordPlaceholder
+                              }
+                              required
+                              minLength={emailAndPassword?.minPasswordLength}
+                              maxLength={emailAndPassword?.maxPasswordLength}
+                              disabled={isPending}
+                              aria-invalid={isInvalid}
+                            />
+
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                size="icon-xs"
+                                aria-label={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                title={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                onClick={() => {
+                                  setIsPasswordVisible((visible) => !visible)
+                                }}
+                              >
+                                {isPasswordVisible ? <EyeOff /> : <Eye />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
+
+                  {emailAndPassword.rememberMe && (
+                    <form.AppField name="rememberMe">
+                      {(field) => (
+                        <Field className="my-1">
+                          <div className="flex items-center gap-3">
+                            <Checkbox
+                              id="rememberMe"
+                              name={field.name}
+                              checked={field.state.value}
+                              disabled={isPending}
+                              onCheckedChange={(checked) =>
+                                field.handleChange(checked === true)
+                              }
+                            />
+
+                            <FieldLabel
+                              htmlFor="rememberMe"
+                              className="cursor-pointer text-sm font-normal"
+                            >
+                              {localization.auth.rememberMe}
+                            </FieldLabel>
+                          </div>
+                        </Field>
+                      )}
+                    </form.AppField>
                   )}
-                </div>
-              </FieldGroup>
-            </form>
+
+                  {Captcha && (
+                    <div className="flex justify-center">{Captcha}</div>
+                  )}
+
+                  <div className="flex flex-col gap-3">
+                    <form.AuthFormSubmitButton
+                      className="relative overflow-visible"
+                      disabled={isPending}
+                    >
+                      {signInEmailPending && <Spinner />}
+
+                      {localization.auth.signIn}
+
+                      <LastUsedBadge method="email" floating />
+                    </form.AuthFormSubmitButton>
+
+                    {plugins.flatMap((plugin) =>
+                      (plugin.authButtons ?? []).map((AuthButton, index) => (
+                        <AuthButton
+                          key={`${plugin.id}-${index.toString()}`}
+                          view="signIn"
+                        />
+                      ))
+                    )}
+                  </div>
+                </FieldGroup>
+              </form.AuthFormRoot>
+            </form.AppForm>
           )}
 
           {socialPosition === "bottom" && (

--- a/examples/start-shadcn-example/src/components/auth/siwe/sign-in-ethereum-button.tsx
+++ b/examples/start-shadcn-example/src/components/auth/siwe/sign-in-ethereum-button.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { type AuthView, authMutationKeys } from "@better-auth-ui/core"
+import {
+  type AuthView,
+  authMutationKeys,
+  validateEmailAddress
+} from "@better-auth-ui/core"
 import {
   type SiweAuthClient,
   siweMutationKeys
@@ -9,7 +13,7 @@ import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useSignInSiwe } from "@better-auth-ui/react/plugins/siwe"
 import { useIsMutating } from "@tanstack/react-query"
 import { Wallet } from "lucide-react"
-import { type FormEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -20,16 +24,12 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import {
-  Field,
-  FieldDescription,
-  FieldError,
-  FieldLabel
-} from "@/components/ui/field"
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { siwePlugin } from "@/lib/auth/siwe-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 
 export type SignInEthereumButtonProps = { view?: AuthView }
 
@@ -50,8 +50,6 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
       useIsMutating({ mutationKey: siweMutationKeys.all }) >
     0
 
-  if (view === "signUp") return null
-
   const complete = (email?: string) => {
     signIn.mutate(email ? { email } : undefined, {
       onSuccess: () => {
@@ -61,13 +59,12 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
     })
   }
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const email = String(
-      new FormData(event.currentTarget).get("email") ?? ""
-    ).trim()
-    complete(email || undefined)
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) => complete(value.email.trim() || undefined)
+  })
+
+  if (view === "signUp") return null
 
   return (
     <>
@@ -84,50 +81,77 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
 
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogContent>
-          <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <Wallet />
-                {plugin.localization.continueWithEthereum}
-              </DialogTitle>
-              <DialogDescription>
-                {plugin.localization.emailDescription}
-              </DialogDescription>
-            </DialogHeader>
-            <Field>
-              <FieldLabel htmlFor="siwe-email">
-                {plugin.email === "required"
-                  ? plugin.localization.email
-                  : plugin.localization.emailOptional}
-              </FieldLabel>
-              <Input
-                id="siwe-email"
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-4">
+              <DialogHeader>
+                <DialogTitle className="flex items-center gap-2">
+                  <Wallet />
+                  {plugin.localization.continueWithEthereum}
+                </DialogTitle>
+                <DialogDescription>
+                  {plugin.localization.emailDescription}
+                </DialogDescription>
+              </DialogHeader>
+              <form.AppField
                 name="email"
-                type="email"
-                autoComplete="email"
-                required={plugin.email === "required"}
-                disabled={signIn.isPending}
-              />
-              <FieldDescription>
-                {plugin.localization.emailDescription}
-              </FieldDescription>
-              <FieldError />
-            </Field>
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                disabled={signIn.isPending}
-                onClick={() => setOpen(false)}
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage:
+                        plugin.email === "required"
+                          ? localization.auth.fieldRequired
+                          : undefined
+                    })
+                }}
               >
-                {localization.settings.cancel}
-              </Button>
-              <Button type="submit" disabled={signIn.isPending}>
-                {signIn.isPending && <Spinner />}
-                {plugin.localization.signMessage}
-              </Button>
-            </DialogFooter>
-          </form>
+                {(field) => {
+                  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                  return (
+                    <Field data-invalid={isInvalid}>
+                      <FieldLabel htmlFor="siwe-email">
+                        {plugin.email === "required"
+                          ? plugin.localization.email
+                          : plugin.localization.emailOptional}
+                      </FieldLabel>
+                      <Input
+                        id="siwe-email"
+                        name={field.name}
+                        type="email"
+                        autoComplete="email"
+                        required={plugin.email === "required"}
+                        disabled={signIn.isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                        aria-invalid={isInvalid}
+                      />
+                      <FieldDescription>
+                        {plugin.localization.emailDescription}
+                      </FieldDescription>
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )
+                }}
+              </form.AppField>
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  disabled={signIn.isPending}
+                  onClick={() => setOpen(false)}
+                >
+                  {localization.settings.cancel}
+                </Button>
+                <form.AuthFormSubmitButton disabled={signIn.isPending}>
+                  {signIn.isPending && <Spinner />}
+                  {plugin.localization.signMessage}
+                </form.AuthFormSubmitButton>
+              </DialogFooter>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </DialogContent>
       </Dialog>
     </>

--- a/examples/start-shadcn-example/src/components/auth/sso/email-first-sign-in.tsx
+++ b/examples/start-shadcn-example/src/components/auth/sso/email-first-sign-in.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import {
+  authMutationKeys,
+  validateEmailAddress,
+  validateStringLength
+} from "@better-auth-ui/core"
 import {
   isPasskeyAutoFillEnabled,
   withPasskeyAutoFill
@@ -20,7 +24,7 @@ import {
 import { useSignInSso } from "@better-auth-ui/react/plugins/sso"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -35,7 +39,6 @@ import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -51,6 +54,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { ssoPlugin } from "@/lib/auth/sso-plugin"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 import { ProviderButtons } from "../provider-buttons"
 
 export type EmailFirstSignInProps = {
@@ -83,21 +87,15 @@ export function EmailFirstSignIn({
   const continueSignIn = useSignInContinuation()
 
   const [step, setStep] = useState<"email" | "fallback">("email")
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
   const [discoveryError, setDiscoveryError] = useState("")
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-    password?: string
-  }>({})
 
   const { mutate: signInSso, isPending: isDiscovering } = useSignInSso(
     authClient as SsoAuthClient,
     {
       onError: (error) => {
         if (error.status === 404) {
-          setSsoFallbackEmail(email)
+          setSsoFallbackEmail(form.state.values.email)
           setDiscoveryError(ssoLocalization.noProvider)
           setStep("fallback")
           return
@@ -112,10 +110,13 @@ export function EmailFirstSignIn({
     authClient,
     {
       onError: (error) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
-          sessionStorage.setItem("better-auth-ui.verify-email", email)
+          sessionStorage.setItem(
+            "better-auth-ui.verify-email",
+            form.state.values.email
+          )
           navigate({
             to: `${basePaths.auth}/${viewPaths.auth.verifyEmail}`
           })
@@ -139,33 +140,33 @@ export function EmailFirstSignIn({
   const showSocialSeparator =
     emailAndPassword.enabled && !!socialProviders?.length
 
-  const submitEmail = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setDiscoveryError("")
-    setSsoFallbackEmail(email)
-    signInSso({
-      email,
-      callbackURL: `${baseURL}${redirectTo}`,
-      loginHint: email
-    })
-  }
-
-  const submitPassword = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    signInEmail({
-      email,
-      password,
-      ...(emailAndPassword.rememberMe
-        ? { rememberMe: formData.get("rememberMe") === "on" }
-        : {}),
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "", password: "", rememberMe: false },
+    onSubmit: ({ value }) => {
+      if (step === "email") {
+        setDiscoveryError("")
+        setSsoFallbackEmail(value.email)
+        signInSso({
+          callbackURL: `${baseURL}${redirectTo}`,
+          email: value.email,
+          loginHint: value.email
+        })
+        return
+      }
+      signInEmail({
+        email: value.email,
+        password: value.password,
+        ...(emailAndPassword.rememberMe
+          ? { rememberMe: value.rememberMe }
+          : {}),
+        fetchOptions
+      })
+    }
+  })
 
   const startOver = () => {
     setStep("email")
-    setPassword("")
+    form.setFieldValue("password", "")
     setDiscoveryError("")
   }
 
@@ -177,207 +178,238 @@ export function EmailFirstSignIn({
           {localization.auth.signIn}
         </CardTitle>
         <CardDescription>
-          {step === "email" ? ssoLocalization.emailFirstDescription : email}
+          {step === "email"
+            ? ssoLocalization.emailFirstDescription
+            : form.state.values.email}
         </CardDescription>
       </CardHeader>
 
       <CardContent>
-        {step === "email" ? (
-          <form onSubmit={submitEmail}>
-            <FieldGroup>
-              <Field data-invalid={!!fieldErrors.email}>
-                <FieldLabel htmlFor="sso-email">
-                  {localization.auth.email}
-                </FieldLabel>
-                <Input
-                  id="sso-email"
+        <form.AppForm>
+          {step === "email" ? (
+            <form.AuthFormRoot>
+              <FieldGroup>
+                <form.AppField
                   name="email"
-                  type="email"
-                  autoComplete={withPasskeyAutoFill("email", passkeyAutoFill)}
-                  autoFocus
-                  value={email}
-                  onChange={(event) => {
-                    setEmail(event.target.value)
-                    setFieldErrors((current) => ({
-                      ...current,
-                      email: undefined
-                    }))
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateEmailAddress(value, {
+                        invalidMessage: localization.auth.invalidEmail,
+                        requiredMessage: localization.auth.fieldRequired
+                      })
                   }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    const element = event.currentTarget
-                    setFieldErrors((current) => ({
-                      ...current,
-                      email: element.validity.valueMissing
-                        ? localization.auth.fieldRequired
-                        : localization.auth.invalidEmail
-                    }))
+                >
+                  {(field) => {
+                    const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                    return (
+                      <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor="sso-email">
+                          {localization.auth.email}
+                        </FieldLabel>
+                        <Input
+                          id="sso-email"
+                          name={field.name}
+                          type="email"
+                          autoComplete={withPasskeyAutoFill(
+                            "email",
+                            passkeyAutoFill
+                          )}
+                          autoFocus
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                          placeholder={localization.auth.emailPlaceholder}
+                          required
+                          disabled={isPending}
+                          aria-invalid={isInvalid}
+                        />
+                        <field.AuthFormFieldError />
+                      </Field>
+                    )
                   }}
-                  placeholder={localization.auth.emailPlaceholder}
-                  required
-                  disabled={isPending}
-                  aria-invalid={!!fieldErrors.email}
-                />
-                <FieldError>{fieldErrors.email}</FieldError>
-              </Field>
+                </form.AppField>
+
+                {discoveryError && (
+                  <FieldDescription role="alert" className="text-destructive">
+                    {discoveryError}
+                  </FieldDescription>
+                )}
+
+                <form.AuthFormSubmitButton disabled={isPending}>
+                  {isDiscovering && <Spinner data-icon="inline-start" />}
+                  {ssoLocalization.continueWithEmail}
+                </form.AuthFormSubmitButton>
+              </FieldGroup>
+            </form.AuthFormRoot>
+          ) : (
+            <div className="flex flex-col gap-4">
+              {socialPosition === "top" && (
+                <>
+                  {!!socialProviders?.length && (
+                    <ProviderButtons
+                      socialLayout={socialLayout}
+                      view="signIn"
+                    />
+                  )}
+                  {showSocialSeparator && (
+                    <FieldSeparator>{localization.auth.or}</FieldSeparator>
+                  )}
+                </>
+              )}
 
               {discoveryError && (
-                <FieldDescription role="alert" className="text-destructive">
+                <FieldDescription role="status">
                   {discoveryError}
                 </FieldDescription>
               )}
 
-              <Button type="submit" disabled={isPending}>
-                {isDiscovering && <Spinner data-icon="inline-start" />}
-                {ssoLocalization.continueWithEmail}
-              </Button>
-            </FieldGroup>
-          </form>
-        ) : (
-          <div className="flex flex-col gap-4">
-            {socialPosition === "top" && (
-              <>
-                {!!socialProviders?.length && (
-                  <ProviderButtons socialLayout={socialLayout} view="signIn" />
-                )}
-                {showSocialSeparator && (
-                  <FieldSeparator>{localization.auth.or}</FieldSeparator>
-                )}
-              </>
-            )}
+              {emailAndPassword.enabled && (
+                <form.AuthFormRoot>
+                  <FieldGroup>
+                    <form.AppField
+                      name="password"
+                      validators={{
+                        onChange: ({ value }) =>
+                          validateStringLength(value, {
+                            maxLength: emailAndPassword.maxPasswordLength,
+                            maxLengthMessage: localization.auth.tooLong.replace(
+                              "{{max}}",
+                              String(emailAndPassword.maxPasswordLength)
+                            ),
+                            minLength: emailAndPassword.minPasswordLength,
+                            minLengthMessage:
+                              localization.auth.tooShort.replace(
+                                "{{min}}",
+                                String(emailAndPassword.minPasswordLength)
+                              ),
+                            requiredMessage: localization.auth.fieldRequired
+                          })
+                      }}
+                    >
+                      {(field) => {
+                        const isInvalid = isAuthFormFieldInvalid(
+                          field.state.meta
+                        )
+                        return (
+                          <Field data-invalid={isInvalid}>
+                            <FieldLabel htmlFor="sso-password">
+                              {localization.auth.password}
+                            </FieldLabel>
+                            <InputGroup>
+                              <InputGroupInput
+                                id="sso-password"
+                                name={field.name}
+                                type={isPasswordVisible ? "text" : "password"}
+                                autoComplete={withPasskeyAutoFill(
+                                  "current-password",
+                                  passkeyAutoFill
+                                )}
+                                autoFocus
+                                value={field.state.value}
+                                onBlur={field.handleBlur}
+                                onChange={(event) =>
+                                  field.handleChange(event.target.value)
+                                }
+                                placeholder={
+                                  localization.auth.passwordPlaceholder
+                                }
+                                minLength={emailAndPassword.minPasswordLength}
+                                maxLength={emailAndPassword.maxPasswordLength}
+                                required
+                                disabled={isPending}
+                                aria-invalid={isInvalid}
+                              />
+                              <InputGroupAddon align="inline-end">
+                                <InputGroupButton
+                                  size="icon-xs"
+                                  aria-label={
+                                    isPasswordVisible
+                                      ? localization.auth.hidePassword
+                                      : localization.auth.showPassword
+                                  }
+                                  onClick={() =>
+                                    setIsPasswordVisible((visible) => !visible)
+                                  }
+                                >
+                                  {isPasswordVisible ? <EyeOff /> : <Eye />}
+                                </InputGroupButton>
+                              </InputGroupAddon>
+                            </InputGroup>
+                            <field.AuthFormFieldError />
+                          </Field>
+                        )
+                      }}
+                    </form.AppField>
 
-            {discoveryError && (
-              <FieldDescription role="status">
-                {discoveryError}
-              </FieldDescription>
-            )}
-
-            {emailAndPassword.enabled && (
-              <form onSubmit={submitPassword}>
-                <FieldGroup>
-                  <Field data-invalid={!!fieldErrors.password}>
-                    <FieldLabel htmlFor="sso-password">
-                      {localization.auth.password}
-                    </FieldLabel>
-                    <InputGroup>
-                      <InputGroupInput
-                        id="sso-password"
-                        name="password"
-                        type={isPasswordVisible ? "text" : "password"}
-                        autoComplete={withPasskeyAutoFill(
-                          "current-password",
-                          passkeyAutoFill
+                    {emailAndPassword.rememberMe && (
+                      <form.AppField name="rememberMe">
+                        {(field) => (
+                          <Field>
+                            <div className="flex items-center gap-3">
+                              <Checkbox
+                                id="sso-remember-me"
+                                name={field.name}
+                                checked={field.state.value}
+                                disabled={isPending}
+                                onCheckedChange={(checked) =>
+                                  field.handleChange(checked === true)
+                                }
+                              />
+                              <FieldLabel
+                                htmlFor="sso-remember-me"
+                                className="cursor-pointer text-sm font-normal"
+                              >
+                                {localization.auth.rememberMe}
+                              </FieldLabel>
+                            </div>
+                          </Field>
                         )}
-                        autoFocus
-                        value={password}
-                        onChange={(event) => {
-                          setPassword(event.target.value)
-                          setFieldErrors((current) => ({
-                            ...current,
-                            password: undefined
-                          }))
-                        }}
-                        onInvalid={(event) => {
-                          event.preventDefault()
-                          const element = event.currentTarget
-                          const message = element.validity.valueMissing
-                            ? localization.auth.fieldRequired
-                            : element.validity.tooShort
-                              ? localization.auth.tooShort.replace(
-                                  "{{min}}",
-                                  String(emailAndPassword.minPasswordLength)
-                                )
-                              : localization.auth.tooLong.replace(
-                                  "{{max}}",
-                                  String(emailAndPassword.maxPasswordLength)
-                                )
+                      </form.AppField>
+                    )}
 
-                          setFieldErrors((current) => ({
-                            ...current,
-                            password: message
-                          }))
-                        }}
-                        placeholder={localization.auth.passwordPlaceholder}
-                        minLength={emailAndPassword.minPasswordLength}
-                        maxLength={emailAndPassword.maxPasswordLength}
-                        required
-                        disabled={isPending}
-                        aria-invalid={!!fieldErrors.password}
-                      />
-                      <InputGroupAddon align="inline-end">
-                        <InputGroupButton
-                          size="icon-xs"
-                          aria-label={
-                            isPasswordVisible
-                              ? localization.auth.hidePassword
-                              : localization.auth.showPassword
-                          }
-                          onClick={() =>
-                            setIsPasswordVisible((visible) => !visible)
-                          }
-                        >
-                          {isPasswordVisible ? <EyeOff /> : <Eye />}
-                        </InputGroupButton>
-                      </InputGroupAddon>
-                    </InputGroup>
-                    <FieldError>{fieldErrors.password}</FieldError>
-                  </Field>
+                    {Captcha && (
+                      <div className="flex justify-center">{Captcha}</div>
+                    )}
 
-                  {emailAndPassword.rememberMe && (
-                    <Field>
-                      <div className="flex items-center gap-3">
-                        <Checkbox
-                          id="sso-remember-me"
-                          name="rememberMe"
-                          disabled={isPending}
-                        />
-                        <FieldLabel
-                          htmlFor="sso-remember-me"
-                          className="cursor-pointer text-sm font-normal"
-                        >
-                          {localization.auth.rememberMe}
-                        </FieldLabel>
-                      </div>
-                    </Field>
+                    <form.AuthFormSubmitButton disabled={isPending}>
+                      {isSigningIn && <Spinner data-icon="inline-start" />}
+                      {localization.auth.signIn}
+                    </form.AuthFormSubmitButton>
+                  </FieldGroup>
+                </form.AuthFormRoot>
+              )}
+
+              {plugins.flatMap((plugin) =>
+                (plugin.authButtons ?? []).map((AuthButton) => (
+                  <AuthButton
+                    key={getAuthButtonKey(plugin.id, AuthButton)}
+                    view="signIn"
+                  />
+                ))
+              )}
+
+              {socialPosition === "bottom" && (
+                <>
+                  {showSocialSeparator && (
+                    <FieldSeparator>{localization.auth.or}</FieldSeparator>
                   )}
-
-                  {Captcha && (
-                    <div className="flex justify-center">{Captcha}</div>
+                  {!!socialProviders?.length && (
+                    <ProviderButtons
+                      socialLayout={socialLayout}
+                      view="signIn"
+                    />
                   )}
+                </>
+              )}
 
-                  <Button type="submit" disabled={isPending}>
-                    {isSigningIn && <Spinner data-icon="inline-start" />}
-                    {localization.auth.signIn}
-                  </Button>
-                </FieldGroup>
-              </form>
-            )}
-
-            {plugins.flatMap((plugin) =>
-              (plugin.authButtons ?? []).map((AuthButton) => (
-                <AuthButton
-                  key={getAuthButtonKey(plugin.id, AuthButton)}
-                  view="signIn"
-                />
-              ))
-            )}
-
-            {socialPosition === "bottom" && (
-              <>
-                {showSocialSeparator && (
-                  <FieldSeparator>{localization.auth.or}</FieldSeparator>
-                )}
-                {!!socialProviders?.length && (
-                  <ProviderButtons socialLayout={socialLayout} view="signIn" />
-                )}
-              </>
-            )}
-
-            <Button variant="ghost" onClick={startOver}>
-              {ssoLocalization.useDifferentEmail}
-            </Button>
-          </div>
-        )}
+              <Button variant="ghost" onClick={startOver}>
+                {ssoLocalization.useDifferentEmail}
+              </Button>
+            </div>
+          )}
+        </form.AppForm>
       </CardContent>
 
       {emailAndPassword.enabled && (

--- a/examples/start-shadcn-example/src/components/auth/sso/sso-domain-verification.tsx
+++ b/examples/start-shadcn-example/src/components/auth/sso/sso-domain-verification.tsx
@@ -12,7 +12,7 @@ import {
 } from "@better-auth-ui/react/plugins/sso"
 import type { BetterFetchError } from "better-auth/client"
 import { CheckIcon, CopyIcon } from "lucide-react"
-import { type FormEvent, useState } from "react"
+import { useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -39,6 +39,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { ssoPlugin } from "@/lib/auth/sso-plugin"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 
 export type SsoDomainVerificationProps = {
   className?: string
@@ -61,7 +62,6 @@ export function SsoDomainVerification({
 }: SsoDomainVerificationProps) {
   const { authClient } = useAuth()
   const { localization } = useAuthPlugin(ssoPlugin)
-  const [providerId, setProviderId] = useState(defaultProviderId)
   const [token, setToken] = useState(defaultToken)
   const [verified, setVerified] = useState(false)
   const [copyError, setCopyError] = useState("")
@@ -74,7 +74,6 @@ export function SsoDomainVerification({
   const verify = useVerifySsoDomain(authClient as SsoAuthClient, {
     onSuccess: () => setVerified(true)
   })
-  const host = providerId ? `_${tokenPrefix}-${providerId}` : ""
   const hostCopy = useCopyToClipboard({
     onError: (error) =>
       setCopyError(error instanceof Error ? error.message : String(error))
@@ -88,12 +87,14 @@ export function SsoDomainVerification({
       ? requestToken.error
       : verify.error
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setCopyError("")
-    setVerified(false)
-    verify.mutate({ providerId })
-  }
+  const form = useAuthForm({
+    defaultValues: { providerId: defaultProviderId },
+    onSubmit: ({ value }) => {
+      setCopyError("")
+      setVerified(false)
+      verify.mutate({ providerId: value.providerId })
+    }
+  })
 
   return (
     <Card className={cn("w-full max-w-xl", className)}>
@@ -104,120 +105,144 @@ export function SsoDomainVerification({
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            <Field>
-              <FieldLabel htmlFor="sso-verification-provider-id">
-                {localization.providerId}
-              </FieldLabel>
-              <Input
-                id="sso-verification-provider-id"
-                name="providerId"
-                value={providerId}
-                onChange={(event) => {
-                  setProviderId(event.target.value.trim())
-                  setToken("")
-                  setVerified(false)
-                }}
-                required
-              />
-            </Field>
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <form.Subscribe selector={(state) => state.values.providerId}>
+              {(providerId) => {
+                const host = providerId ? `_${tokenPrefix}-${providerId}` : ""
+                return (
+                  <FieldGroup>
+                    <form.AppField name="providerId">
+                      {(field) => (
+                        <Field>
+                          <FieldLabel htmlFor="sso-verification-provider-id">
+                            {localization.providerId}
+                          </FieldLabel>
+                          <Input
+                            id="sso-verification-provider-id"
+                            name={field.name}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) => {
+                              field.handleChange(event.target.value.trim())
+                              setToken("")
+                              setVerified(false)
+                            }}
+                            required
+                          />
+                        </Field>
+                      )}
+                    </form.AppField>
 
-            {token ? (
-              <div className="grid gap-3 rounded-lg border p-3">
-                <Field>
-                  <FieldLabel htmlFor="sso-dns-host">
-                    {localization.txtRecordHost}
-                  </FieldLabel>
-                  <InputGroup>
-                    <InputGroupInput
-                      className="font-mono text-xs"
-                      id="sso-dns-host"
-                      readOnly
-                      value={host}
-                    />
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        aria-label={localization.copyDnsHost}
-                        size="icon-xs"
+                    {token ? (
+                      <div className="grid gap-3 rounded-lg border p-3">
+                        <Field>
+                          <FieldLabel htmlFor="sso-dns-host">
+                            {localization.txtRecordHost}
+                          </FieldLabel>
+                          <InputGroup>
+                            <InputGroupInput
+                              className="font-mono text-xs"
+                              id="sso-dns-host"
+                              readOnly
+                              value={host}
+                            />
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                aria-label={localization.copyDnsHost}
+                                size="icon-xs"
+                                onClick={() => {
+                                  setCopyError("")
+                                  void hostCopy.copy(host)
+                                }}
+                              >
+                                {hostCopy.copied ? <CheckIcon /> : <CopyIcon />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+                        </Field>
+                        <Field>
+                          <FieldLabel htmlFor="sso-dns-value">
+                            {localization.txtRecordValue}
+                          </FieldLabel>
+                          <InputGroup>
+                            <InputGroupInput
+                              className="font-mono text-xs"
+                              id="sso-dns-value"
+                              readOnly
+                              value={token}
+                            />
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                aria-label={localization.copyDnsValue}
+                                size="icon-xs"
+                                onClick={() => {
+                                  setCopyError("")
+                                  void tokenCopy.copy(token)
+                                }}
+                              >
+                                {tokenCopy.copied ? (
+                                  <CheckIcon />
+                                ) : (
+                                  <CopyIcon />
+                                )}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+                        </Field>
+                      </div>
+                    ) : null}
+
+                    {error ? (
+                      <FieldError>{getErrorMessage(error)}</FieldError>
+                    ) : null}
+                    {copyError ? <FieldError>{copyError}</FieldError> : null}
+                    {verified ? (
+                      <FieldDescription
+                        role="status"
+                        className="text-foreground"
+                      >
+                        {localization.domainVerified}
+                      </FieldDescription>
+                    ) : null}
+
+                    <div className="flex flex-wrap justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled={!providerId || verify.isPending}
                         onClick={() => {
                           setCopyError("")
-                          void hostCopy.copy(host)
+                          setVerified(false)
+                          requestToken.mutate({ providerId })
                         }}
                       >
-                        {hostCopy.copied ? <CheckIcon /> : <CopyIcon />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                </Field>
-                <Field>
-                  <FieldLabel htmlFor="sso-dns-value">
-                    {localization.txtRecordValue}
-                  </FieldLabel>
-                  <InputGroup>
-                    <InputGroupInput
-                      className="font-mono text-xs"
-                      id="sso-dns-value"
-                      readOnly
-                      value={token}
-                    />
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        aria-label={localization.copyDnsValue}
-                        size="icon-xs"
-                        onClick={() => {
-                          setCopyError("")
-                          void tokenCopy.copy(token)
-                        }}
+                        {requestToken.isPending ? (
+                          <Spinner data-icon="inline-start" />
+                        ) : null}
+                        {localization.requestNewToken}
+                      </Button>
+                      <form.AuthFormSubmitButton
+                        disabled={!providerId || requestToken.isPending}
                       >
-                        {tokenCopy.copied ? <CheckIcon /> : <CopyIcon />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                </Field>
-              </div>
-            ) : null}
+                        {verify.isPending ? (
+                          <Spinner data-icon="inline-start" />
+                        ) : null}
+                        {localization.verifyDomain}
+                      </form.AuthFormSubmitButton>
+                    </div>
 
-            {error ? <FieldError>{getErrorMessage(error)}</FieldError> : null}
-            {copyError ? <FieldError>{copyError}</FieldError> : null}
-            {verified ? (
-              <FieldDescription role="status" className="text-foreground">
-                {localization.domainVerified}
-              </FieldDescription>
-            ) : null}
-
-            <div className="flex flex-wrap justify-end gap-2">
-              <Button
-                type="button"
-                variant="outline"
-                disabled={!providerId || verify.isPending}
-                onClick={() => {
-                  setCopyError("")
-                  setVerified(false)
-                  requestToken.mutate({ providerId })
-                }}
-              >
-                {requestToken.isPending ? (
-                  <Spinner data-icon="inline-start" />
-                ) : null}
-                {localization.requestNewToken}
-              </Button>
-              <Button
-                type="submit"
-                disabled={!providerId || requestToken.isPending}
-              >
-                {verify.isPending ? <Spinner data-icon="inline-start" /> : null}
-                {localization.verifyDomain}
-              </Button>
-            </div>
-
-            <span className="sr-only" aria-live="polite">
-              {token && !verified
-                ? localization.domainVerificationRequested
-                : ""}
-            </span>
-          </FieldGroup>
-        </form>
+                    <span className="sr-only" aria-live="polite">
+                      {token && !verified
+                        ? localization.domainVerificationRequested
+                        : ""}
+                    </span>
+                  </FieldGroup>
+                )
+              }}
+            </form.Subscribe>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
     </Card>
   )

--- a/examples/start-shadcn-example/src/components/auth/two-factor/disable-two-factor-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/two-factor/disable-two-factor-dialog.tsx
@@ -4,7 +4,6 @@ import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-facto
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useDisableTwoFactor } from "@better-auth-ui/react/plugins/two-factor"
 import { ShieldAlert } from "lucide-react"
-import type { SyntheticEvent } from "react"
 import { toast } from "sonner"
 
 import {
@@ -17,12 +16,12 @@ import {
   AlertDialogMedia,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
-import { Button } from "@/components/ui/button"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
+import { useAuthForm } from "../auth-form"
 
 export type DisableTwoFactorDialogProps = {
   open: boolean
@@ -54,68 +53,79 @@ export function DisableTwoFactorDialog({
 
   const isPending = isDisabling || isResolvingPasswordRequirement
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-
-    disableTwoFactor(requiresPassword ? { password } : {})
-  }
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) =>
+      disableTwoFactor(requiresPassword ? { password: value.password } : {})
+  })
 
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <AlertDialogHeader>
-            <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
-              <ShieldAlert />
-            </AlertDialogMedia>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <AlertDialogHeader>
+              <AlertDialogMedia className="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
+                <ShieldAlert />
+              </AlertDialogMedia>
 
-            <AlertDialogTitle>
-              {twoFactorLocalization.disableTwoFactor}
-            </AlertDialogTitle>
+              <AlertDialogTitle>
+                {twoFactorLocalization.disableTwoFactor}
+              </AlertDialogTitle>
 
-            <AlertDialogDescription>
-              {requiresPassword
-                ? twoFactorLocalization.passwordConfirmation
-                : twoFactorLocalization.twoFactorDescription}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+              <AlertDialogDescription>
+                {requiresPassword
+                  ? twoFactorLocalization.passwordConfirmation
+                  : twoFactorLocalization.twoFactorDescription}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
 
-          {requiresPassword && (
-            <Field>
-              <FieldLabel htmlFor="disable-two-factor-password">
-                {localization.auth.password}
-              </FieldLabel>
+            {requiresPassword && (
+              <form.AppField name="password">
+                {(field) => (
+                  <Field>
+                    <FieldLabel htmlFor="disable-two-factor-password">
+                      {localization.auth.password}
+                    </FieldLabel>
 
-              <Input
-                id="disable-two-factor-password"
-                name="password"
-                type="password"
-                autoComplete="current-password"
-                autoFocus
-                required
-                placeholder={localization.auth.passwordPlaceholder}
+                    <Input
+                      id="disable-two-factor-password"
+                      name={field.name}
+                      type="password"
+                      autoComplete="current-password"
+                      autoFocus
+                      required
+                      placeholder={localization.auth.passwordPlaceholder}
+                      disabled={isPending}
+                      value={field.state.value}
+                      onBlur={field.handleBlur}
+                      onChange={(event) =>
+                        field.handleChange(event.target.value)
+                      }
+                    />
+
+                    <FieldError />
+                  </Field>
+                )}
+              </form.AppField>
+            )}
+
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isPending}>
+                {localization.settings.cancel}
+              </AlertDialogCancel>
+
+              <form.AuthFormSubmitButton
+                variant="destructive"
                 disabled={isPending}
-              />
+              >
+                {isPending && <Spinner />}
 
-              <FieldError />
-            </Field>
-          )}
-
-          <AlertDialogFooter>
-            <AlertDialogCancel disabled={isPending}>
-              {localization.settings.cancel}
-            </AlertDialogCancel>
-
-            <Button type="submit" variant="destructive" disabled={isPending}>
-              {isPending && <Spinner />}
-
-              {twoFactorLocalization.disableTwoFactor}
-            </Button>
-          </AlertDialogFooter>
-        </form>
+                {twoFactorLocalization.disableTwoFactor}
+              </form.AuthFormSubmitButton>
+            </AlertDialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </AlertDialogContent>
     </AlertDialog>
   )

--- a/examples/start-shadcn-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -15,9 +15,9 @@ import {
   useVerifyTotp
 } from "@better-auth-ui/react/plugins/two-factor"
 import { Check, Copy, ShieldCheck } from "lucide-react"
-import { type SyntheticEvent, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 import { toast } from "sonner"
-import { Button, buttonVariants } from "@/components/ui/button"
+import { buttonVariants } from "@/components/ui/button"
 import {
   Dialog,
   DialogClose,
@@ -39,6 +39,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { BackupCodes } from "./backup-codes"
 
@@ -79,7 +80,6 @@ export function EnableTwoFactorDialog({
   )
   const [totpUri, setTotpUri] = useState("")
   const [backupCodes, setBackupCodes] = useState<string[]>([])
-  const [code, setCode] = useState("")
   const {
     copied: setupKeyCopied,
     copy: copySetupKeyValue,
@@ -132,7 +132,7 @@ export function EnableTwoFactorDialog({
   const { mutate: verifyTotp, isPending: isVerifying } = useVerifyTotp(
     twoFactorClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
         toast.success(twoFactorLocalization.twoFactorEnabled)
         setStep("backupCodes")
@@ -141,6 +141,23 @@ export function EnableTwoFactorDialog({
   )
 
   const isPending = isEnabling || isVerifying || isResolvingPasswordRequirement
+
+  const form = useAuthForm({
+    defaultValues: { code: "", password: "" },
+    onSubmit: ({ value }) => {
+      if (step === "backupCodes") {
+        handleOpenChange(false)
+        return
+      }
+      if (step === "verify") {
+        verifyCode(value.code)
+        return
+      }
+      enableTwoFactor(
+        requiresPassword ? { method, password: value.password } : { method }
+      )
+    }
+  })
 
   const verifyCode = (completedCode: string) => {
     if (isPending || step !== "verify" || completedCode.length !== codeLength) {
@@ -158,30 +175,11 @@ export function EnableTwoFactorDialog({
       setMethod(enrollmentMethods[0] ?? "totp")
       setTotpUri("")
       setBackupCodes([])
-      setCode("")
+      form.reset()
       resetSetupKeyCopy()
       // Clears the resolved TOTP URI and backup codes from the mutation cache.
       resetEnrollment()
     }
-  }
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (step === "backupCodes") {
-      handleOpenChange(false)
-      return
-    }
-
-    if (step === "verify") {
-      verifyCode(code)
-      return
-    }
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-
-    enableTwoFactor(requiresPassword ? { method, password } : { method })
   }
 
   const submitLabel =
@@ -194,169 +192,189 @@ export function EnableTwoFactorDialog({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <ShieldCheck />
-              {twoFactorLocalization.twoFactor}
-            </DialogTitle>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-2">
+                <ShieldCheck />
+                {twoFactorLocalization.twoFactor}
+              </DialogTitle>
 
-            <DialogDescription>
-              {step === "password" && requiresPassword
-                ? twoFactorLocalization.passwordConfirmation
-                : step === "verify"
-                  ? twoFactorLocalization.scanQrCode
-                  : twoFactorLocalization.twoFactorDescription}
-            </DialogDescription>
-          </DialogHeader>
+              <DialogDescription>
+                {step === "password" && requiresPassword
+                  ? twoFactorLocalization.passwordConfirmation
+                  : step === "verify"
+                    ? twoFactorLocalization.scanQrCode
+                    : twoFactorLocalization.twoFactorDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          {step === "password" && (
-            <div className="flex flex-col gap-4">
-              {enrollmentMethods.length > 1 && (
-                <Tabs
-                  value={method}
-                  onValueChange={(value) => setMethod(value as TwoFactorMethod)}
-                >
-                  <TabsList
-                    aria-label={twoFactorLocalization.chooseEnrollmentMethod}
-                    className="w-full"
+            {step === "password" && (
+              <div className="flex flex-col gap-4">
+                {enrollmentMethods.length > 1 && (
+                  <Tabs
+                    value={method}
+                    onValueChange={(value) =>
+                      setMethod(value as TwoFactorMethod)
+                    }
                   >
-                    {enrollmentMethods.includes("totp") && (
-                      <TabsTrigger value="totp">
-                        {twoFactorLocalization.authenticatorApp}
-                      </TabsTrigger>
+                    <TabsList
+                      aria-label={twoFactorLocalization.chooseEnrollmentMethod}
+                      className="w-full"
+                    >
+                      {enrollmentMethods.includes("totp") && (
+                        <TabsTrigger value="totp">
+                          {twoFactorLocalization.authenticatorApp}
+                        </TabsTrigger>
+                      )}
+                      {enrollmentMethods.includes("otp") && (
+                        <TabsTrigger value="otp">
+                          {twoFactorLocalization.deliveredCode}
+                        </TabsTrigger>
+                      )}
+                    </TabsList>
+                  </Tabs>
+                )}
+
+                <p className="text-muted-foreground text-sm">
+                  {method === "totp"
+                    ? twoFactorLocalization.authenticatorAppDescription
+                    : twoFactorLocalization.deliveredCodeDescription}
+                </p>
+
+                {requiresPassword && (
+                  <form.AppField name="password">
+                    {(field) => (
+                      <Field>
+                        <FieldLabel htmlFor="two-factor-password">
+                          {localization.auth.password}
+                        </FieldLabel>
+
+                        <Input
+                          id="two-factor-password"
+                          name={field.name}
+                          type="password"
+                          autoComplete="current-password"
+                          autoFocus
+                          required
+                          placeholder={localization.auth.passwordPlaceholder}
+                          disabled={isPending}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(event) =>
+                            field.handleChange(event.target.value)
+                          }
+                        />
+
+                        <FieldError />
+                      </Field>
                     )}
-                    {enrollmentMethods.includes("otp") && (
-                      <TabsTrigger value="otp">
-                        {twoFactorLocalization.deliveredCode}
-                      </TabsTrigger>
-                    )}
-                  </TabsList>
-                </Tabs>
-              )}
-
-              <p className="text-muted-foreground text-sm">
-                {method === "totp"
-                  ? twoFactorLocalization.authenticatorAppDescription
-                  : twoFactorLocalization.deliveredCodeDescription}
-              </p>
-
-              {requiresPassword && (
-                <Field>
-                  <FieldLabel htmlFor="two-factor-password">
-                    {localization.auth.password}
-                  </FieldLabel>
-
-                  <Input
-                    id="two-factor-password"
-                    name="password"
-                    type="password"
-                    autoComplete="current-password"
-                    autoFocus
-                    required
-                    placeholder={localization.auth.passwordPlaceholder}
-                    disabled={isPending}
-                  />
-
-                  <FieldError />
-                </Field>
-              )}
-            </div>
-          )}
-
-          {step === "verify" && (
-            <div className="flex flex-col items-center gap-4">
-              {qrCode && (
-                <svg
-                  aria-hidden="true"
-                  className="size-44 rounded-md border"
-                  viewBox={`0 0 ${qrCode.size} ${qrCode.size}`}
-                >
-                  <path
-                    fill="white"
-                    d={`M0 0h${qrCode.size}v${qrCode.size}H0z`}
-                  />
-                  <path
-                    fill="black"
-                    d={qrCode.path}
-                    shapeRendering="crispEdges"
-                  />
-                </svg>
-              )}
-
-              {setupKey && (
-                <Field className="w-full gap-1">
-                  <FieldLabel
-                    className="text-muted-foreground text-xs"
-                    htmlFor="two-factor-setup-key"
-                  >
-                    {twoFactorLocalization.setupKey}
-                  </FieldLabel>
-
-                  <InputGroup>
-                    <InputGroupInput
-                      className="font-mono text-xs"
-                      id="two-factor-setup-key"
-                      readOnly
-                      value={setupKey}
-                    />
-
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        aria-label={
-                          setupKeyCopied
-                            ? twoFactorLocalization.setupKeyCopied
-                            : localization.settings.copyToClipboard
-                        }
-                        onClick={copySetupKey}
-                        size="icon-xs"
-                      >
-                        {setupKeyCopied ? <Check /> : <Copy />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                </Field>
-              )}
-
-              <OtpField
-                autoFocus
-                className="w-full"
-                disabled={isPending}
-                label={twoFactorLocalization.authenticatorCode}
-                length={codeLength}
-                name="code"
-                value={code}
-                onChange={setCode}
-                onComplete={verifyCode}
-              />
-            </div>
-          )}
-
-          {step === "backupCodes" && <BackupCodes codes={backupCodes} />}
-
-          <DialogFooter>
-            {step !== "backupCodes" && (
-              <DialogClose
-                className={buttonVariants({ variant: "outline" })}
-                disabled={isPending}
-                type="button"
-              >
-                {localization.settings.cancel}
-              </DialogClose>
+                  </form.AppField>
+                )}
+              </div>
             )}
 
-            <Button
-              type="submit"
-              disabled={
-                isPending || (step === "verify" && code.length !== codeLength)
-              }
-            >
-              {isPending && <Spinner />}
+            {step === "verify" && (
+              <div className="flex flex-col items-center gap-4">
+                {qrCode && (
+                  <svg
+                    aria-hidden="true"
+                    className="size-44 rounded-md border"
+                    viewBox={`0 0 ${qrCode.size} ${qrCode.size}`}
+                  >
+                    <path
+                      fill="white"
+                      d={`M0 0h${qrCode.size}v${qrCode.size}H0z`}
+                    />
+                    <path
+                      fill="black"
+                      d={qrCode.path}
+                      shapeRendering="crispEdges"
+                    />
+                  </svg>
+                )}
 
-              {submitLabel}
-            </Button>
-          </DialogFooter>
-        </form>
+                {setupKey && (
+                  <Field className="w-full gap-1">
+                    <FieldLabel
+                      className="text-muted-foreground text-xs"
+                      htmlFor="two-factor-setup-key"
+                    >
+                      {twoFactorLocalization.setupKey}
+                    </FieldLabel>
+
+                    <InputGroup>
+                      <InputGroupInput
+                        className="font-mono text-xs"
+                        id="two-factor-setup-key"
+                        readOnly
+                        value={setupKey}
+                      />
+
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          aria-label={
+                            setupKeyCopied
+                              ? twoFactorLocalization.setupKeyCopied
+                              : localization.settings.copyToClipboard
+                          }
+                          onClick={copySetupKey}
+                          size="icon-xs"
+                        >
+                          {setupKeyCopied ? <Check /> : <Copy />}
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  </Field>
+                )}
+
+                <form.AppField name="code">
+                  {(field) => (
+                    <OtpField
+                      autoFocus
+                      className="w-full"
+                      disabled={isPending}
+                      label={twoFactorLocalization.authenticatorCode}
+                      length={codeLength}
+                      name={field.name}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      onComplete={verifyCode}
+                    />
+                  )}
+                </form.AppField>
+              </div>
+            )}
+
+            {step === "backupCodes" && <BackupCodes codes={backupCodes} />}
+
+            <DialogFooter>
+              {step !== "backupCodes" && (
+                <DialogClose
+                  className={buttonVariants({ variant: "outline" })}
+                  disabled={isPending}
+                  type="button"
+                >
+                  {localization.settings.cancel}
+                </DialogClose>
+              )}
+
+              <form.Subscribe selector={(state) => state.values.code}>
+                {(code) => (
+                  <form.AuthFormSubmitButton
+                    disabled={
+                      isPending ||
+                      (step === "verify" && code.length !== codeLength)
+                    }
+                  >
+                    {isPending && <Spinner />}
+                    {submitLabel}
+                  </form.AuthFormSubmitButton>
+                )}
+              </form.Subscribe>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-shadcn-example/src/components/auth/two-factor/regenerate-backup-codes-dialog.tsx
+++ b/examples/start-shadcn-example/src/components/auth/two-factor/regenerate-backup-codes-dialog.tsx
@@ -4,7 +4,7 @@ import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-facto
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useGenerateBackupCodes } from "@better-auth-ui/react/plugins/two-factor"
 import { KeyRound } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import { toast } from "sonner"
 
 import {
@@ -17,12 +17,12 @@ import {
   AlertDialogMedia,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
-import { Button } from "@/components/ui/button"
 import { Field, FieldError, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
+import { useAuthForm } from "../auth-form"
 import { BackupCodes } from "./backup-codes"
 
 export type RegenerateBackupCodesDialogProps = {
@@ -63,91 +63,100 @@ export function RegenerateBackupCodesDialog({
 
   const isPending = isGenerating || isResolvingPasswordRequirement
 
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) => {
+      if (codes.length) {
+        handleOpenChange(false)
+        return
+      }
+      generateBackupCodes(requiresPassword ? { password: value.password } : {})
+    }
+  })
+
   const handleOpenChange = (nextOpen: boolean) => {
     onOpenChange(nextOpen)
 
     if (!nextOpen) {
       setCodes([])
+      form.reset()
       // Clears the resolved backup codes from the mutation cache.
       resetGeneration()
     }
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (codes.length) {
-      handleOpenChange(false)
-      return
-    }
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-
-    generateBackupCodes(requiresPassword ? { password } : {})
-  }
-
   return (
     <AlertDialog open={open} onOpenChange={handleOpenChange}>
       <AlertDialogContent>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-6">
-          <AlertDialogHeader>
-            <AlertDialogMedia>
-              <KeyRound />
-            </AlertDialogMedia>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-6">
+            <AlertDialogHeader>
+              <AlertDialogMedia>
+                <KeyRound />
+              </AlertDialogMedia>
 
-            <AlertDialogTitle>
-              {twoFactorLocalization.backupCodes}
-            </AlertDialogTitle>
+              <AlertDialogTitle>
+                {twoFactorLocalization.backupCodes}
+              </AlertDialogTitle>
 
-            <AlertDialogDescription>
-              {codes.length || !requiresPassword
-                ? twoFactorLocalization.backupCodesDescription
-                : twoFactorLocalization.passwordConfirmation}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+              <AlertDialogDescription>
+                {codes.length || !requiresPassword
+                  ? twoFactorLocalization.backupCodesDescription
+                  : twoFactorLocalization.passwordConfirmation}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
 
-          {codes.length ? (
-            <BackupCodes codes={codes} />
-          ) : (
-            requiresPassword && (
-              <Field>
-                <FieldLabel htmlFor="regenerate-backup-codes-password">
-                  {localization.auth.password}
-                </FieldLabel>
+            {codes.length ? (
+              <BackupCodes codes={codes} />
+            ) : (
+              requiresPassword && (
+                <form.AppField name="password">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="regenerate-backup-codes-password">
+                        {localization.auth.password}
+                      </FieldLabel>
 
-                <Input
-                  id="regenerate-backup-codes-password"
-                  name="password"
-                  type="password"
-                  autoComplete="current-password"
-                  autoFocus
-                  required
-                  placeholder={localization.auth.passwordPlaceholder}
-                  disabled={isPending}
-                />
+                      <Input
+                        id="regenerate-backup-codes-password"
+                        name={field.name}
+                        type="password"
+                        autoComplete="current-password"
+                        autoFocus
+                        required
+                        placeholder={localization.auth.passwordPlaceholder}
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
 
-                <FieldError />
-              </Field>
-            )
-          )}
-
-          <AlertDialogFooter>
-            {!codes.length && (
-              <AlertDialogCancel disabled={isPending}>
-                {localization.settings.cancel}
-              </AlertDialogCancel>
+                      <FieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              )
             )}
 
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Spinner />}
+            <AlertDialogFooter>
+              {!codes.length && (
+                <AlertDialogCancel disabled={isPending}>
+                  {localization.settings.cancel}
+                </AlertDialogCancel>
+              )}
 
-              {codes.length
-                ? twoFactorLocalization.done
-                : twoFactorLocalization.regenerateBackupCodes}
-            </Button>
-          </AlertDialogFooter>
-        </form>
+              <form.AuthFormSubmitButton disabled={isPending}>
+                {isPending && <Spinner />}
+
+                {codes.length
+                  ? twoFactorLocalization.done
+                  : twoFactorLocalization.regenerateBackupCodes}
+              </form.AuthFormSubmitButton>
+            </AlertDialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </AlertDialogContent>
     </AlertDialog>
   )

--- a/examples/start-shadcn-example/src/components/auth/two-factor/two-factor-challenge.tsx
+++ b/examples/start-shadcn-example/src/components/auth/two-factor/two-factor-challenge.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { authQueryKeys } from "@better-auth-ui/core"
+import { authQueryKeys, validateStringLength } from "@better-auth-ui/core"
 import type { TwoFactorAuthClient } from "@better-auth-ui/core/plugins/two-factor"
 import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
 import {
@@ -10,7 +10,7 @@ import {
   useVerifyTwoFactorOtp
 } from "@better-auth-ui/react/plugins/two-factor"
 import { useQueryClient } from "@tanstack/react-query"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -40,6 +40,7 @@ import {
   useResendCooldown
 } from "@/lib/auth/use-resend-cooldown"
 import { cn } from "@/lib/utils"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { useIsHydrated } from "../use-is-hydrated"
 
@@ -88,8 +89,6 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
   const [method, setMethod] = useState<ChallengeMethod>(
     () => methods[0] ?? "totp"
   )
-  const [code, setCode] = useState("")
-  const [trustDevice, setTrustDevice] = useState(false)
   const [otpRequested, setOtpRequested] = useState(false)
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
 
@@ -117,12 +116,15 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
 
   const { mutate: verifyTotp, isPending: isVerifyingTotp } = useVerifyTotp(
     twoFactorClient,
-    { onError: () => setCode(""), onSuccess: onVerified }
+    {
+      onError: () => form.setFieldValue("code", ""),
+      onSuccess: onVerified
+    }
   )
 
   const { mutate: verifyTwoFactorOtp, isPending: isVerifyingOtp } =
     useVerifyTwoFactorOtp(twoFactorClient, {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: onVerified
     })
 
@@ -133,8 +135,21 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
     isSendingOtp || isVerifyingTotp || isVerifyingOtp || isVerifyingBackupCode
   const needsOtpRequest = method === "otp" && !otpRequested
 
+  const form = useAuthForm({
+    defaultValues: { backupCode: "", code: "", trustDevice: false },
+    onSubmit: ({ value }) => {
+      const trust = trustDeviceEnabled ? { trustDevice: value.trustDevice } : {}
+      if (method === "backup") {
+        verifyBackupCode({ code: value.backupCode.trim(), ...trust })
+        return
+      }
+      verifyCode(value.code)
+    }
+  })
+
   const switchMethod = (next: ChallengeMethod) => {
-    setCode("")
+    form.setFieldValue("code", "")
+    form.setFieldValue("backupCode", "")
     setMethod(next)
   }
 
@@ -148,7 +163,9 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
       return
     }
 
-    const trust = trustDeviceEnabled ? { trustDevice } : {}
+    const trust = trustDeviceEnabled
+      ? { trustDevice: form.state.values.trustDevice }
+      : {}
 
     if (method === "otp") {
       verifyTwoFactorOtp({ code: completedCode, ...trust })
@@ -156,23 +173,6 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
     }
 
     verifyTotp({ code: completedCode, ...trust })
-  }
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const trust = trustDeviceEnabled ? { trustDevice } : {}
-
-    if (method === "backup") {
-      const formData = new FormData(e.currentTarget)
-      verifyBackupCode({
-        code: (formData.get("backupCode") as string).trim(),
-        ...trust
-      })
-      return
-    }
-
-    verifyCode(code)
   }
 
   const description =
@@ -210,113 +210,143 @@ export function TwoFactorChallenge({ className }: TwoFactorChallengeProps) {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit}>
-          <FieldGroup>
-            {method === "backup" ? (
-              <Field>
-                <FieldLabel htmlFor="backupCode">
-                  {twoFactorLocalization.backupCode}
-                </FieldLabel>
-
-                <Input
-                  id="backupCode"
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              {method === "backup" ? (
+                <form.AppField
                   name="backupCode"
-                  autoComplete="one-time-code"
-                  autoFocus
-                  required
-                  disabled={isPending}
-                />
-              </Field>
-            ) : (
-              <OtpField
-                autoFocus
-                disabled={isPending || needsOtpRequest}
-                label={
-                  method === "otp"
-                    ? twoFactorLocalization.emailedCode
-                    : twoFactorLocalization.authenticatorCode
-                }
-                length={codeLength}
-                name="code"
-                value={code}
-                onChange={setCode}
-                onComplete={verifyCode}
-              />
-            )}
-
-            {trustDeviceEnabled && (
-              <Field orientation="horizontal">
-                <Checkbox
-                  id="trustDevice"
-                  name="trustDevice"
-                  checked={trustDevice}
-                  disabled={isPending}
-                  onCheckedChange={(checked) =>
-                    setTrustDevice(checked === true)
-                  }
-                />
-
-                <FieldLabel htmlFor="trustDevice" className="font-normal">
-                  {twoFactorLocalization.trustDevice}
-                </FieldLabel>
-              </Field>
-            )}
-
-            <div className="flex flex-col gap-3">
-              {needsOtpRequest ? (
-                <Button
-                  type="button"
-                  disabled={isSendingOtp}
-                  onClick={() => sendTwoFactorOtp()}
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateStringLength(value, {
+                        requiredMessage: localization.auth.fieldRequired,
+                        trim: true
+                      })
+                  }}
                 >
-                  {isSendingOtp && <Spinner />}
+                  {(field) => (
+                    <Field>
+                      <FieldLabel htmlFor="backupCode">
+                        {twoFactorLocalization.backupCode}
+                      </FieldLabel>
 
-                  {twoFactorLocalization.sendEmailCode}
-                </Button>
+                      <Input
+                        id="backupCode"
+                        name={field.name}
+                        autoComplete="one-time-code"
+                        autoFocus
+                        required
+                        disabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                    </Field>
+                  )}
+                </form.AppField>
               ) : (
-                <Button
-                  type="submit"
-                  disabled={
-                    isPending ||
-                    (method !== "backup" && code.length !== codeLength)
-                  }
-                >
-                  {isPending && <Spinner />}
-
-                  {twoFactorLocalization.verify}
-                </Button>
+                <form.AppField name="code">
+                  {(field) => (
+                    <OtpField
+                      autoFocus
+                      disabled={isPending || needsOtpRequest}
+                      label={
+                        method === "otp"
+                          ? twoFactorLocalization.emailedCode
+                          : twoFactorLocalization.authenticatorCode
+                      }
+                      length={codeLength}
+                      name={field.name}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      onComplete={verifyCode}
+                    />
+                  )}
+                </form.AppField>
               )}
 
-              {method === "otp" && otpRequested && (
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={isPending || isCoolingDown}
-                  onClick={() => sendTwoFactorOtp()}
-                >
-                  {isCoolingDown
-                    ? localization.auth.resendIn.replace(
-                        "{{seconds}}",
-                        String(cooldown)
-                      )
-                    : localization.auth.resend}
-                </Button>
+              {trustDeviceEnabled && (
+                <form.AppField name="trustDevice">
+                  {(field) => (
+                    <Field orientation="horizontal">
+                      <Checkbox
+                        id="trustDevice"
+                        name={field.name}
+                        checked={field.state.value}
+                        disabled={isPending}
+                        onCheckedChange={(checked) =>
+                          field.handleChange(checked === true)
+                        }
+                      />
+
+                      <FieldLabel htmlFor="trustDevice" className="font-normal">
+                        {twoFactorLocalization.trustDevice}
+                      </FieldLabel>
+                    </Field>
+                  )}
+                </form.AppField>
               )}
 
-              {alternatives.map((alternative) => (
-                <Button
-                  type="button"
-                  variant="ghost"
-                  key={alternative.key}
-                  disabled={isPending}
-                  onClick={() => switchMethod(alternative.key)}
-                >
-                  {alternative.label}
-                </Button>
-              ))}
-            </div>
-          </FieldGroup>
-        </form>
+              <div className="flex flex-col gap-3">
+                {needsOtpRequest ? (
+                  <Button
+                    type="button"
+                    disabled={isSendingOtp}
+                    onClick={() => sendTwoFactorOtp()}
+                  >
+                    {isSendingOtp && <Spinner />}
+
+                    {twoFactorLocalization.sendEmailCode}
+                  </Button>
+                ) : (
+                  <form.Subscribe selector={(state) => state.values.code}>
+                    {(code) => (
+                      <form.AuthFormSubmitButton
+                        disabled={
+                          isPending ||
+                          (method !== "backup" && code.length !== codeLength)
+                        }
+                      >
+                        {isPending && <Spinner />}
+                        {twoFactorLocalization.verify}
+                      </form.AuthFormSubmitButton>
+                    )}
+                  </form.Subscribe>
+                )}
+
+                {method === "otp" && otpRequested && (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    disabled={isPending || isCoolingDown}
+                    onClick={() => sendTwoFactorOtp()}
+                  >
+                    {isCoolingDown
+                      ? localization.auth.resendIn.replace(
+                          "{{seconds}}",
+                          String(cooldown)
+                        )
+                      : localization.auth.resend}
+                  </Button>
+                )}
+
+                {alternatives.map((alternative) => (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    key={alternative.key}
+                    disabled={isPending}
+                    onClick={() => switchMethod(alternative.key)}
+                  >
+                    {alternative.label}
+                  </Button>
+                ))}
+              </div>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div className="flex flex-col gap-3 items-center w-full mt-4">
           <FieldDescription className="text-center">

--- a/examples/start-shadcn-example/src/components/auth/username/sign-in-username.tsx
+++ b/examples/start-shadcn-example/src/components/auth/username/sign-in-username.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import { authMutationKeys, validateStringLength } from "@better-auth-ui/core"
 import {
   isPasskeyAutoFillEnabled,
   withPasskeyAutoFill
@@ -16,18 +16,16 @@ import {
 import { useSignInUsername } from "@better-auth-ui/react/plugins/username"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import {
   ProviderButtons,
   type SocialLayout
 } from "@/components/auth/provider-buttons"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel,
   FieldSeparator
@@ -43,6 +41,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { usernamePlugin } from "@/lib/auth/username-plugin"
 import { cn } from "@/lib/utils"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 import { LastUsedBadge } from "../last-login-method/last-used-badge"
 
 export type SignInUsernameProps = {
@@ -82,12 +81,10 @@ export function SignInUsername({
 
   const { localization: usernameLocalization } = useAuthPlugin(usernamePlugin)
 
-  const [password, setPassword] = useState("")
-
   const { mutate: signInEmail, isPending: isSignInEmailPending } =
     useSignInEmail(authClient, {
       onError: (error, { email }) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
           sessionStorage.setItem("better-auth-ui.verify-email", email)
@@ -107,7 +104,7 @@ export function SignInUsername({
   const { mutate: signInUsername, isPending: isSignInUsernamePending } =
     useSignInUsername(authClient, {
       onError: (error) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
           sessionStorage.removeItem("better-auth-ui.verify-email")
@@ -141,35 +138,30 @@ export function SignInUsername({
   const passkeyAutoFill = isPasskeyAutoFillEnabled(plugins)
 
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
-
-  const [fieldErrors, setFieldErrors] = useState<{
-    email?: string
-    password?: string
-  }>({})
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const email = formData.get("email") as string
-    const rememberMe = formData.get("rememberMe") === "on"
-
-    if (isEmail(email)) {
-      signInEmail({
-        email,
-        password,
-        ...(emailAndPassword?.rememberMe ? { rememberMe } : {}),
-        fetchOptions
-      })
-    } else {
-      signInUsername({
-        username: email,
-        password,
-        ...(emailAndPassword?.rememberMe ? { rememberMe } : {}),
-        fetchOptions
-      })
+  const form = useAuthForm({
+    defaultValues: { identifier: "", password: "", rememberMe: false },
+    onSubmit: ({ value }) => {
+      if (isEmail(value.identifier)) {
+        signInEmail({
+          email: value.identifier,
+          password: value.password,
+          ...(emailAndPassword?.rememberMe
+            ? { rememberMe: value.rememberMe }
+            : {}),
+          fetchOptions
+        })
+      } else {
+        signInUsername({
+          username: value.identifier,
+          password: value.password,
+          ...(emailAndPassword?.rememberMe
+            ? { rememberMe: value.rememberMe }
+            : {}),
+          fetchOptions
+        })
+      }
     }
-  }
+  })
 
   const showSeparator =
     emailAndPassword?.enabled && socialProviders && socialProviders.length > 0
@@ -200,171 +192,187 @@ export function SignInUsername({
           )}
 
           {emailAndPassword?.enabled && (
-            <form onSubmit={handleSubmit}>
-              <FieldGroup>
-                <Field data-invalid={!!fieldErrors.email}>
-                  <FieldLabel htmlFor="email">
-                    {usernameLocalization.username}
-                  </FieldLabel>
-
-                  <Input
-                    id="email"
-                    name="email"
-                    type="text"
-                    autoComplete={withPasskeyAutoFill(
-                      "username",
-                      passkeyAutoFill
-                    )}
-                    placeholder={
-                      usernameLocalization.usernameOrEmailPlaceholder
-                    }
-                    required
-                    disabled={isPending}
-                    onChange={() => {
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: undefined
-                      }))
+            <form.AppForm>
+              <form.AuthFormRoot>
+                <FieldGroup>
+                  <form.AppField
+                    name="identifier"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          requiredMessage: localization.auth.fieldRequired,
+                          trim: true
+                        })
                     }}
-                    onInvalid={(e) => {
-                      e.preventDefault()
-
-                      setFieldErrors((prev) => ({
-                        ...prev,
-                        email: localization.auth.fieldRequired
-                      }))
-                    }}
-                    aria-invalid={!!fieldErrors.email}
-                  />
-
-                  <FieldError>{fieldErrors.email}</FieldError>
-                </Field>
-
-                <Field data-invalid={!!fieldErrors.password}>
-                  <FieldLabel htmlFor="password">
-                    {localization.auth.password}
-                  </FieldLabel>
-
-                  <InputGroup>
-                    <InputGroupInput
-                      id="password"
-                      name="password"
-                      type={isPasswordVisible ? "text" : "password"}
-                      autoComplete={withPasskeyAutoFill(
-                        "current-password",
-                        passkeyAutoFill
-                      )}
-                      value={password}
-                      onChange={(e) => {
-                        setPassword(e.target.value)
-
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: undefined
-                        }))
-                      }}
-                      placeholder={localization.auth.passwordPlaceholder}
-                      required
-                      minLength={emailAndPassword?.minPasswordLength}
-                      maxLength={emailAndPassword?.maxPasswordLength}
-                      disabled={isPending}
-                      onInvalid={(e) => {
-                        e.preventDefault()
-                        const el = e.target as HTMLInputElement
-                        const min = emailAndPassword?.minPasswordLength
-                        const max = emailAndPassword?.maxPasswordLength
-                        const msg = el.validity.valueMissing
-                          ? localization.auth.fieldRequired
-                          : el.validity.tooShort
-                            ? localization.auth.tooShort.replace(
-                                "{{min}}",
-                                String(min)
-                              )
-                            : localization.auth.tooLong.replace(
-                                "{{max}}",
-                                String(max)
-                              )
-
-                        setFieldErrors((prev) => ({
-                          ...prev,
-                          password: msg
-                        }))
-                      }}
-                      aria-invalid={!!fieldErrors.password}
-                    />
-
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        size="icon-xs"
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        title={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        onClick={() => {
-                          setIsPasswordVisible((visible) => !visible)
-                        }}
-                      >
-                        {isPasswordVisible ? <EyeOff /> : <Eye />}
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-
-                  <FieldError>{fieldErrors.password}</FieldError>
-                </Field>
-
-                {emailAndPassword.rememberMe && (
-                  <Field className="my-1">
-                    <div className="flex items-center gap-3">
-                      <Checkbox
-                        id="rememberMe"
-                        name="rememberMe"
-                        disabled={isPending}
-                      />
-
-                      <FieldLabel
-                        htmlFor="rememberMe"
-                        className="cursor-pointer text-sm font-normal"
-                      >
-                        {localization.auth.rememberMe}
-                      </FieldLabel>
-                    </div>
-                  </Field>
-                )}
-
-                {Captcha && (
-                  <div className="flex justify-center">{Captcha}</div>
-                )}
-
-                <div className="flex flex-col gap-3">
-                  <Button
-                    type="submit"
-                    className="relative overflow-visible"
-                    disabled={isPending}
                   >
-                    {isSignInPending && <Spinner />}
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="email">
+                            {usernameLocalization.username}
+                          </FieldLabel>
 
-                    {localization.auth.signIn}
+                          <Input
+                            id="email"
+                            name={field.name}
+                            type="text"
+                            autoComplete={withPasskeyAutoFill(
+                              "username",
+                              passkeyAutoFill
+                            )}
+                            placeholder={
+                              usernameLocalization.usernameOrEmailPlaceholder
+                            }
+                            required
+                            disabled={isPending}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={(event) =>
+                              field.handleChange(event.target.value)
+                            }
+                            aria-invalid={isInvalid}
+                          />
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
 
-                    <LastUsedBadge method={["email", "username"]} floating />
-                  </Button>
+                  <form.AppField
+                    name="password"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          maxLength: emailAndPassword?.maxPasswordLength,
+                          maxLengthMessage: localization.auth.tooLong.replace(
+                            "{{max}}",
+                            String(emailAndPassword?.maxPasswordLength)
+                          ),
+                          minLength: emailAndPassword?.minPasswordLength,
+                          minLengthMessage: localization.auth.tooShort.replace(
+                            "{{min}}",
+                            String(emailAndPassword?.minPasswordLength)
+                          ),
+                          requiredMessage: localization.auth.fieldRequired
+                        })
+                    }}
+                  >
+                    {(field) => {
+                      const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+                      return (
+                        <Field data-invalid={isInvalid}>
+                          <FieldLabel htmlFor="password">
+                            {localization.auth.password}
+                          </FieldLabel>
 
-                  {plugins.flatMap((plugin) =>
-                    (plugin.authButtons ?? []).map((AuthButton, index) => (
-                      <AuthButton
-                        key={`${plugin.id}-${index.toString()}`}
-                        view="signIn"
-                      />
-                    ))
+                          <InputGroup>
+                            <InputGroupInput
+                              id="password"
+                              name={field.name}
+                              type={isPasswordVisible ? "text" : "password"}
+                              autoComplete={withPasskeyAutoFill(
+                                "current-password",
+                                passkeyAutoFill
+                              )}
+                              value={field.state.value}
+                              onBlur={field.handleBlur}
+                              onChange={(event) =>
+                                field.handleChange(event.target.value)
+                              }
+                              placeholder={
+                                localization.auth.passwordPlaceholder
+                              }
+                              required
+                              minLength={emailAndPassword?.minPasswordLength}
+                              maxLength={emailAndPassword?.maxPasswordLength}
+                              disabled={isPending}
+                              aria-invalid={isInvalid}
+                            />
+
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                size="icon-xs"
+                                aria-label={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                title={
+                                  isPasswordVisible
+                                    ? localization.auth.hidePassword
+                                    : localization.auth.showPassword
+                                }
+                                onClick={() => {
+                                  setIsPasswordVisible((visible) => !visible)
+                                }}
+                              >
+                                {isPasswordVisible ? <EyeOff /> : <Eye />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )
+                    }}
+                  </form.AppField>
+
+                  {emailAndPassword.rememberMe && (
+                    <form.AppField name="rememberMe">
+                      {(field) => (
+                        <Field className="my-1">
+                          <div className="flex items-center gap-3">
+                            <Checkbox
+                              id="rememberMe"
+                              name={field.name}
+                              checked={field.state.value}
+                              disabled={isPending}
+                              onCheckedChange={(checked) =>
+                                field.handleChange(checked === true)
+                              }
+                            />
+
+                            <FieldLabel
+                              htmlFor="rememberMe"
+                              className="cursor-pointer text-sm font-normal"
+                            >
+                              {localization.auth.rememberMe}
+                            </FieldLabel>
+                          </div>
+                        </Field>
+                      )}
+                    </form.AppField>
                   )}
-                </div>
-              </FieldGroup>
-            </form>
+
+                  {Captcha && (
+                    <div className="flex justify-center">{Captcha}</div>
+                  )}
+
+                  <div className="flex flex-col gap-3">
+                    <form.AuthFormSubmitButton
+                      className="relative overflow-visible"
+                      disabled={isPending}
+                    >
+                      {isSignInPending && <Spinner />}
+
+                      {localization.auth.signIn}
+
+                      <LastUsedBadge method={["email", "username"]} floating />
+                    </form.AuthFormSubmitButton>
+
+                    {plugins.flatMap((plugin) =>
+                      (plugin.authButtons ?? []).map((AuthButton, index) => (
+                        <AuthButton
+                          key={`${plugin.id}-${index.toString()}`}
+                          view="signIn"
+                        />
+                      ))
+                    )}
+                  </div>
+                </FieldGroup>
+              </form.AuthFormRoot>
+            </form.AppForm>
           )}
 
           {socialPosition === "bottom" && (

--- a/packages/heroui/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/packages/heroui/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -9,7 +9,6 @@ import {
   AlertDialog,
   Button,
   FieldError,
-  Form,
   Input,
   Label,
   ListBox,
@@ -17,9 +16,10 @@ import {
   Spinner,
   TextField
 } from "@heroui/react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { apiKeyPlugin } from "../../../lib/auth/api-key-plugin"
+import { useAuthForm } from "../auth-form"
 
 import { NewApiKeyDialog } from "./new-api-key-dialog"
 
@@ -56,6 +56,7 @@ export function CreateApiKeyDialog({
     if (!open) {
       setKeyName(null)
       setSecretKey(null)
+      form.reset()
     }
 
     onOpenChange(open)
@@ -70,173 +71,210 @@ export function CreateApiKeyDialog({
     }
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.target as HTMLFormElement)
-    const name = (formData.get("name") as string)?.trim()
-    const expiration = formData.get("expiration")
-    const expirationDays =
-      typeof expiration === "string" && expiration !== "never"
-        ? Number(expiration)
+  const form = useAuthForm({
+    defaultValues: {
+      configId: availableConfigurations[0]?.id ?? "",
+      expiration:
+        keyExpiration && keyExpiration.defaultInterval === null
+          ? "never"
+          : String((keyExpiration && keyExpiration.defaultInterval) ?? "never"),
+      name: ""
+    },
+    onSubmit: ({ value }) => {
+      const name = value.name.trim()
+      const expirationDays =
+        value.expiration !== "never" ? Number(value.expiration) : undefined
+      const expiresIn = expirationDays
+        ? apiKeyExpirationDaysToSeconds(expirationDays)
         : undefined
-    const expiresIn = expirationDays
-      ? apiKeyExpirationDaysToSeconds(expirationDays)
-      : undefined
 
-    const selectedConfig = String(formData.get("configId") ?? "").trim()
-    const resolvedConfigId =
-      selectedConfig || (organizationId ? "organization" : undefined)
-    const payload = {
-      ...(name ? { name } : {}),
-      ...(expiresIn ? { expiresIn } : {}),
-      ...(resolvedConfigId ? { configId: resolvedConfigId } : {}),
-      ...(organizationId ? { organizationId } : {})
-    }
-
-    createApiKey(Object.keys(payload).length > 0 ? payload : undefined, {
-      onSuccess: (result) => {
-        handleOpenChange(false)
-        setKeyName(name)
-        setSecretKey(result.key)
-        setIsNewKeyDialogOpen(true)
+      const selectedConfig = value.configId.trim()
+      const resolvedConfigId =
+        selectedConfig || (organizationId ? "organization" : undefined)
+      const payload = {
+        ...(name ? { name } : {}),
+        ...(expiresIn ? { expiresIn } : {}),
+        ...(resolvedConfigId ? { configId: resolvedConfigId } : {}),
+        ...(organizationId ? { organizationId } : {})
       }
-    })
-  }
+
+      createApiKey(Object.keys(payload).length > 0 ? payload : undefined, {
+        onSuccess: (result) => {
+          handleOpenChange(false)
+          setKeyName(name)
+          setSecretKey(result.key)
+          setIsNewKeyDialogOpen(true)
+        }
+      })
+    }
+  })
 
   return (
     <>
       <AlertDialog.Backdrop isOpen={isOpen} onOpenChange={handleOpenChange}>
         <AlertDialog.Container>
           <AlertDialog.Dialog>
-            <Form onSubmit={handleSubmit}>
-              <AlertDialog.CloseTrigger />
+            <form.AppForm>
+              <form.AuthFormRoot>
+                <AlertDialog.CloseTrigger />
 
-              <AlertDialog.Header>
-                <AlertDialog.Icon status="default">
-                  <Key />
-                </AlertDialog.Icon>
+                <AlertDialog.Header>
+                  <AlertDialog.Icon status="default">
+                    <Key />
+                  </AlertDialog.Icon>
 
-                <AlertDialog.Heading>
-                  {apiKeyLocalization.createApiKey}
-                </AlertDialog.Heading>
-              </AlertDialog.Header>
+                  <AlertDialog.Heading>
+                    {apiKeyLocalization.createApiKey}
+                  </AlertDialog.Heading>
+                </AlertDialog.Header>
 
-              <AlertDialog.Body className="overflow-visible">
-                <p className="text-muted text-sm">
-                  {apiKeyLocalization.apiKeysDescription}
-                </p>
+                <AlertDialog.Body className="overflow-visible">
+                  <p className="text-muted text-sm">
+                    {apiKeyLocalization.apiKeysDescription}
+                  </p>
 
-                <div className="mt-4 flex flex-col gap-4">
-                  <TextField id="name" name="name" isDisabled={isCreating}>
-                    <Label>{apiKeyLocalization.name}</Label>
+                  <div className="mt-4 flex flex-col gap-4">
+                    <form.AppField name="name">
+                      {(field) => (
+                        <TextField
+                          id="name"
+                          name={field.name}
+                          isDisabled={isCreating}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={field.handleChange}
+                        >
+                          <Label>{apiKeyLocalization.name}</Label>
 
-                    <Input
-                      autoFocus
-                      placeholder={localization.settings.optional}
-                      variant="secondary"
-                    />
+                          <Input
+                            autoFocus
+                            placeholder={localization.settings.optional}
+                            variant="secondary"
+                          />
 
-                    <FieldError />
-                  </TextField>
+                          <FieldError />
+                        </TextField>
+                      )}
+                    </form.AppField>
 
-                  {availableConfigurations.length > 0 && (
-                    <Select
-                      defaultValue={availableConfigurations[0]?.id}
-                      fullWidth
-                      isDisabled={isCreating}
-                      name="configId"
-                      variant="secondary"
-                    >
-                      <Label>{apiKeyLocalization.configuration}</Label>
-                      <Select.Trigger>
-                        <Select.Value />
-                        <Select.Indicator />
-                      </Select.Trigger>
-                      <Select.Popover>
-                        <ListBox>
-                          {availableConfigurations.map((configuration) => (
-                            <ListBox.Item
-                              id={configuration.id}
-                              key={configuration.id}
-                              textValue={configuration.label}
-                            >
-                              {configuration.label}
-                              <ListBox.ItemIndicator />
-                            </ListBox.Item>
-                          ))}
-                        </ListBox>
-                      </Select.Popover>
-                    </Select>
-                  )}
+                    {availableConfigurations.length > 0 && (
+                      <form.AppField name="configId">
+                        {(field) => (
+                          <Select
+                            value={field.state.value}
+                            onChange={(value) =>
+                              field.handleChange(
+                                value == null ? "" : String(value)
+                              )
+                            }
+                            fullWidth
+                            isDisabled={isCreating}
+                            name={field.name}
+                            variant="secondary"
+                          >
+                            <Label>{apiKeyLocalization.configuration}</Label>
+                            <Select.Trigger>
+                              <Select.Value />
+                              <Select.Indicator />
+                            </Select.Trigger>
+                            <Select.Popover>
+                              <ListBox>
+                                {availableConfigurations.map(
+                                  (configuration) => (
+                                    <ListBox.Item
+                                      id={configuration.id}
+                                      key={configuration.id}
+                                      textValue={configuration.label}
+                                    >
+                                      {configuration.label}
+                                      <ListBox.ItemIndicator />
+                                    </ListBox.Item>
+                                  )
+                                )}
+                              </ListBox>
+                            </Select.Popover>
+                          </Select>
+                        )}
+                      </form.AppField>
+                    )}
 
-                  {keyExpiration ? (
-                    <Select
-                      defaultValue={
-                        keyExpiration.defaultInterval === null
-                          ? "never"
-                          : String(keyExpiration.defaultInterval)
-                      }
-                      fullWidth
-                      isDisabled={isCreating}
-                      name="expiration"
-                      variant="secondary"
-                    >
-                      <Label>{apiKeyLocalization.expiration}</Label>
+                    {keyExpiration ? (
+                      <form.AppField name="expiration">
+                        {(field) => (
+                          <Select
+                            value={field.state.value}
+                            onChange={(value) =>
+                              field.handleChange(
+                                value == null ? "" : String(value)
+                              )
+                            }
+                            fullWidth
+                            isDisabled={isCreating}
+                            name={field.name}
+                            variant="secondary"
+                          >
+                            <Label>{apiKeyLocalization.expiration}</Label>
 
-                      <Select.Trigger>
-                        <Select.Value />
-                        <Select.Indicator />
-                      </Select.Trigger>
+                            <Select.Trigger>
+                              <Select.Value />
+                              <Select.Indicator />
+                            </Select.Trigger>
 
-                      <Select.Popover>
-                        <ListBox>
-                          {keyExpiration.intervals.map((days) => (
-                            <ListBox.Item
-                              id={String(days)}
-                              key={days}
-                              textValue={`${days.toLocaleString(locale.languageTag)} ${
-                                days === 1
-                                  ? apiKeyLocalization.day
-                                  : apiKeyLocalization.days
-                              }`}
-                            >
-                              {days.toLocaleString(locale.languageTag)}{" "}
-                              {days === 1
-                                ? apiKeyLocalization.day
-                                : apiKeyLocalization.days}
-                              <ListBox.ItemIndicator />
-                            </ListBox.Item>
-                          ))}
+                            <Select.Popover>
+                              <ListBox>
+                                {keyExpiration.intervals.map((days) => (
+                                  <ListBox.Item
+                                    id={String(days)}
+                                    key={days}
+                                    textValue={`${days.toLocaleString(locale.languageTag)} ${
+                                      days === 1
+                                        ? apiKeyLocalization.day
+                                        : apiKeyLocalization.days
+                                    }`}
+                                  >
+                                    {days.toLocaleString(locale.languageTag)}{" "}
+                                    {days === 1
+                                      ? apiKeyLocalization.day
+                                      : apiKeyLocalization.days}
+                                    <ListBox.ItemIndicator />
+                                  </ListBox.Item>
+                                ))}
 
-                          {keyExpiration.allowNever ? (
-                            <ListBox.Item
-                              id="never"
-                              textValue={apiKeyLocalization.never}
-                            >
-                              {apiKeyLocalization.never}
-                              <ListBox.ItemIndicator />
-                            </ListBox.Item>
-                          ) : null}
-                        </ListBox>
-                      </Select.Popover>
-                    </Select>
-                  ) : null}
-                </div>
-              </AlertDialog.Body>
+                                {keyExpiration.allowNever ? (
+                                  <ListBox.Item
+                                    id="never"
+                                    textValue={apiKeyLocalization.never}
+                                  >
+                                    {apiKeyLocalization.never}
+                                    <ListBox.ItemIndicator />
+                                  </ListBox.Item>
+                                ) : null}
+                              </ListBox>
+                            </Select.Popover>
+                          </Select>
+                        )}
+                      </form.AppField>
+                    ) : null}
+                  </div>
+                </AlertDialog.Body>
 
-              <AlertDialog.Footer>
-                <Button slot="close" variant="tertiary" isDisabled={isCreating}>
-                  {localization.settings.cancel}
-                </Button>
+                <AlertDialog.Footer>
+                  <Button
+                    slot="close"
+                    variant="tertiary"
+                    isDisabled={isCreating}
+                  >
+                    {localization.settings.cancel}
+                  </Button>
 
-                <Button type="submit" isPending={isCreating}>
-                  {isCreating && <Spinner color="current" size="sm" />}
+                  <form.AuthFormSubmitButton isDisabled={isCreating}>
+                    {isCreating && <Spinner color="current" size="sm" />}
 
-                  {apiKeyLocalization.createApiKey}
-                </Button>
-              </AlertDialog.Footer>
-            </Form>
+                    {apiKeyLocalization.createApiKey}
+                  </form.AuthFormSubmitButton>
+                </AlertDialog.Footer>
+              </form.AuthFormRoot>
+            </form.AppForm>
           </AlertDialog.Dialog>
         </AlertDialog.Container>
       </AlertDialog.Backdrop>

--- a/packages/heroui/src/components/auth/api-key/edit-api-key-dialog.tsx
+++ b/packages/heroui/src/components/auth/api-key/edit-api-key-dialog.tsx
@@ -7,14 +7,14 @@ import { useUpdateApiKey } from "@better-auth-ui/react/plugins/api-key"
 import {
   AlertDialog,
   Button,
-  Form,
   Input,
   Label,
   Spinner,
   TextField
 } from "@heroui/react"
-import type { FormEvent } from "react"
+import { useEffect } from "react"
 import { apiKeyPlugin } from "../../../lib/auth/api-key-plugin"
+import { useAuthForm } from "../auth-form"
 
 export function EditApiKeyDialog({
   apiKey,
@@ -32,51 +32,66 @@ export function EditApiKeyDialog({
     onSuccess: () => onOpenChange(false)
   })
 
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    updateApiKey.mutate({
-      keyId: apiKey.id,
-      configId: apiKey.configId,
-      name: String(formData.get("name") ?? "").trim()
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { name: apiKey.name ?? "" },
+    onSubmit: ({ value }) => {
+      updateApiKey.mutate({
+        keyId: apiKey.id,
+        configId: apiKey.configId,
+        name: value.name.trim()
+      })
+    }
+  })
+  useEffect(() => {
+    if (isOpen) form.setFieldValue("name", apiKey.name ?? "")
+  }, [apiKey.name, form.setFieldValue, isOpen])
 
   return (
     <AlertDialog.Backdrop isOpen={isOpen} onOpenChange={onOpenChange}>
       <AlertDialog.Container>
         <AlertDialog.Dialog>
-          <Form onSubmit={submit}>
-            <AlertDialog.CloseTrigger />
-            <AlertDialog.Header>
-              <AlertDialog.Heading>{labels.editApiKey}</AlertDialog.Heading>
-            </AlertDialog.Header>
-            <AlertDialog.Body className="overflow-visible">
-              <div className="flex flex-col gap-4">
-                <TextField name="name">
-                  <Label>{labels.name}</Label>
-                  <Input defaultValue={apiKey.name ?? ""} variant="secondary" />
-                </TextField>
-              </div>
-              {updateApiKey.error && (
-                <p className="mt-3 text-sm text-danger" role="alert">
-                  {updateApiKey.error.error?.message ??
-                    updateApiKey.error?.message}
-                </p>
-              )}
-            </AlertDialog.Body>
-            <AlertDialog.Footer>
-              <Button slot="close" variant="tertiary">
-                {localization.settings.cancel}
-              </Button>
-              <Button isPending={updateApiKey.isPending} type="submit">
-                {updateApiKey.isPending && (
-                  <Spinner color="current" size="sm" />
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <AlertDialog.CloseTrigger />
+              <AlertDialog.Header>
+                <AlertDialog.Heading>{labels.editApiKey}</AlertDialog.Heading>
+              </AlertDialog.Header>
+              <AlertDialog.Body className="overflow-visible">
+                <div className="flex flex-col gap-4">
+                  <form.AppField name="name">
+                    {(field) => (
+                      <TextField
+                        name={field.name}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={field.handleChange}
+                      >
+                        <Label>{labels.name}</Label>
+                        <Input variant="secondary" />
+                      </TextField>
+                    )}
+                  </form.AppField>
+                </div>
+                {updateApiKey.error && (
+                  <p className="mt-3 text-sm text-danger" role="alert">
+                    {updateApiKey.error.error?.message ??
+                      updateApiKey.error?.message}
+                  </p>
                 )}
-                {localization.settings.saveChanges}
-              </Button>
-            </AlertDialog.Footer>
-          </Form>
+              </AlertDialog.Body>
+              <AlertDialog.Footer>
+                <Button slot="close" variant="tertiary">
+                  {localization.settings.cancel}
+                </Button>
+                <form.AuthFormSubmitButton isDisabled={updateApiKey.isPending}>
+                  {updateApiKey.isPending && (
+                    <Spinner color="current" size="sm" />
+                  )}
+                  {localization.settings.saveChanges}
+                </form.AuthFormSubmitButton>
+              </AlertDialog.Footer>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </AlertDialog.Dialog>
       </AlertDialog.Container>
     </AlertDialog.Backdrop>

--- a/packages/heroui/src/components/auth/delete-user/delete-account.tsx
+++ b/packages/heroui/src/components/auth/delete-user/delete-account.tsx
@@ -12,7 +12,6 @@ import {
   Card,
   type CardProps,
   FieldError,
-  Form,
   InputGroup,
   Label,
   Spinner,
@@ -20,9 +19,10 @@ import {
   toast
 } from "@heroui/react"
 import { useQueryClient } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { deleteUserPlugin } from "../../../lib/auth/delete-user-plugin"
+import { useAuthForm } from "../auth-form"
 
 export type DeleteAccountProps = {
   className?: string
@@ -49,7 +49,6 @@ export function DeleteAccount({
   const queryClient = useQueryClient()
 
   const [confirmOpen, setConfirmOpen] = useState(false)
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
 
   const hasCredentialAccount = accounts?.some(
@@ -61,36 +60,37 @@ export function DeleteAccount({
 
   const handleDialogOpenChange = (open: boolean) => {
     setConfirmOpen(open)
-    setPassword("")
+    form.setFieldValue("password", "")
     setIsPasswordVisible(false)
   }
 
-  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const params = {
-      ...(needsPassword ? { password } : {})
-    }
-
-    deleteUser(params, {
-      onSuccess: () => {
-        setConfirmOpen(false)
-        setPassword("")
-        setIsPasswordVisible(false)
-
-        if (sendDeleteAccountVerification) {
-          toast.success(deleteUserLocalization.deleteUserVerificationSent)
-        } else {
-          toast.success(deleteUserLocalization.deleteUserSuccess)
-          queryClient.removeQueries({ queryKey: authQueryKeys.all })
-          navigate({
-            to: `${basePaths.auth}/${viewPaths.auth.signIn}`,
-            replace: true
-          })
-        }
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) => {
+      const params = {
+        ...(needsPassword ? { password: value.password } : {})
       }
-    })
-  }
+
+      deleteUser(params, {
+        onSuccess: () => {
+          setConfirmOpen(false)
+          form.setFieldValue("password", "")
+          setIsPasswordVisible(false)
+
+          if (sendDeleteAccountVerification) {
+            toast.success(deleteUserLocalization.deleteUserVerificationSent)
+          } else {
+            toast.success(deleteUserLocalization.deleteUserSuccess)
+            queryClient.removeQueries({ queryKey: authQueryKeys.all })
+            navigate({
+              to: `${basePaths.auth}/${viewPaths.auth.signIn}`,
+              replace: true
+            })
+          }
+        }
+      })
+    }
+  })
 
   return (
     <Card className={className} variant={variant} {...props}>
@@ -121,87 +121,95 @@ export function DeleteAccount({
           >
             <AlertDialog.Container>
               <AlertDialog.Dialog>
-                <Form onSubmit={handleSubmit}>
-                  <AlertDialog.CloseTrigger />
+                <form.AppForm>
+                  <form.AuthFormRoot>
+                    <AlertDialog.CloseTrigger />
 
-                  <AlertDialog.Header>
-                    <AlertDialog.Icon status="danger">
-                      <TriangleExclamation />
-                    </AlertDialog.Icon>
+                    <AlertDialog.Header>
+                      <AlertDialog.Icon status="danger">
+                        <TriangleExclamation />
+                      </AlertDialog.Icon>
 
-                    <AlertDialog.Heading>
-                      {deleteUserLocalization.deleteAccount}
-                    </AlertDialog.Heading>
-                  </AlertDialog.Header>
+                      <AlertDialog.Heading>
+                        {deleteUserLocalization.deleteAccount}
+                      </AlertDialog.Heading>
+                    </AlertDialog.Header>
 
-                  <AlertDialog.Body className="overflow-visible">
-                    <p className="text-muted text-sm">
-                      {deleteUserLocalization.deleteAccountDescription}
-                    </p>
+                    <AlertDialog.Body className="overflow-visible">
+                      <p className="text-muted text-sm">
+                        {deleteUserLocalization.deleteAccountDescription}
+                      </p>
 
-                    {needsPassword && (
-                      <TextField
-                        className="mt-4"
-                        name="password"
-                        isDisabled={isPending}
-                        value={password}
-                        onChange={setPassword}
-                      >
-                        <Label>{localization.auth.password}</Label>
-
-                        <InputGroup variant="secondary">
-                          <InputGroup.Input
-                            autoComplete="current-password"
-                            placeholder={localization.auth.passwordPlaceholder}
-                            required
-                            type={isPasswordVisible ? "text" : "password"}
-                          />
-
-                          <InputGroup.Suffix className="px-0">
-                            <Button
-                              isIconOnly
-                              aria-label={
-                                isPasswordVisible
-                                  ? localization.auth.hidePassword
-                                  : localization.auth.showPassword
-                              }
+                      {needsPassword && (
+                        <form.AppField name="password">
+                          {(field) => (
+                            <TextField
+                              className="mt-4"
+                              name={field.name}
                               isDisabled={isPending}
-                              onPress={() =>
-                                setIsPasswordVisible(!isPasswordVisible)
-                              }
-                              size="sm"
-                              variant="ghost"
+                              value={field.state.value}
+                              onBlur={field.handleBlur}
+                              onChange={field.handleChange}
                             >
-                              {isPasswordVisible ? <EyeSlash /> : <Eye />}
-                            </Button>
-                          </InputGroup.Suffix>
-                        </InputGroup>
+                              <Label>{localization.auth.password}</Label>
 
-                        <FieldError />
-                      </TextField>
-                    )}
-                  </AlertDialog.Body>
+                              <InputGroup variant="secondary">
+                                <InputGroup.Input
+                                  autoComplete="current-password"
+                                  placeholder={
+                                    localization.auth.passwordPlaceholder
+                                  }
+                                  required
+                                  type={isPasswordVisible ? "text" : "password"}
+                                />
 
-                  <AlertDialog.Footer>
-                    <Button
-                      slot="close"
-                      variant="tertiary"
-                      isDisabled={isPending}
-                    >
-                      {localization.settings.cancel}
-                    </Button>
+                                <InputGroup.Suffix className="px-0">
+                                  <Button
+                                    isIconOnly
+                                    aria-label={
+                                      isPasswordVisible
+                                        ? localization.auth.hidePassword
+                                        : localization.auth.showPassword
+                                    }
+                                    isDisabled={isPending}
+                                    onPress={() =>
+                                      setIsPasswordVisible(!isPasswordVisible)
+                                    }
+                                    size="sm"
+                                    variant="ghost"
+                                  >
+                                    {isPasswordVisible ? <EyeSlash /> : <Eye />}
+                                  </Button>
+                                </InputGroup.Suffix>
+                              </InputGroup>
 
-                    <Button
-                      type="submit"
-                      variant="danger"
-                      isPending={isPending}
-                    >
-                      {isPending && <Spinner color="current" size="sm" />}
+                              <FieldError />
+                            </TextField>
+                          )}
+                        </form.AppField>
+                      )}
+                    </AlertDialog.Body>
 
-                      {deleteUserLocalization.deleteAccount}
-                    </Button>
-                  </AlertDialog.Footer>
-                </Form>
+                    <AlertDialog.Footer>
+                      <Button
+                        slot="close"
+                        variant="tertiary"
+                        isDisabled={isPending}
+                      >
+                        {localization.settings.cancel}
+                      </Button>
+
+                      <form.AuthFormSubmitButton
+                        variant="danger"
+                        isDisabled={isPending}
+                      >
+                        {isPending && <Spinner color="current" size="sm" />}
+
+                        {deleteUserLocalization.deleteAccount}
+                      </form.AuthFormSubmitButton>
+                    </AlertDialog.Footer>
+                  </form.AuthFormRoot>
+                </form.AppForm>
               </AlertDialog.Dialog>
             </AlertDialog.Container>
           </AlertDialog.Backdrop>

--- a/packages/heroui/src/components/auth/email-otp/email-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/email-otp.tsx
@@ -13,7 +13,6 @@ import {
   cn,
   Description,
   FieldError,
-  Form,
   Input,
   Label,
   Link,
@@ -21,11 +20,12 @@ import {
   TextField
 } from "@heroui/react"
 import { useIsMutating } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { emailOtpPlugin } from "../../../lib/auth/email-otp-plugin"
 import { useResendCooldown } from "../../../lib/auth/use-resend-cooldown"
 import { useSignInContinuation } from "../../../lib/auth/use-sign-in-continuation"
+import { useAuthForm } from "../auth-form"
 import { FieldSeparator } from "../field-separator"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
@@ -71,8 +71,6 @@ export function EmailOtp({
   const continueSignIn = useSignInContinuation()
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
 
-  const [email, setEmail] = useState(getSsoFallbackEmail)
-  const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
 
   const { mutate: sendVerificationOtp, isPending: isSending } =
@@ -86,7 +84,7 @@ export function EmailOtp({
   const { mutate: signInEmailOtp, isPending: isSigningIn } = useSignInEmailOtp(
     otpClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: (data) => continueSignIn(data)
     }
   )
@@ -99,27 +97,28 @@ export function EmailOtp({
   })
   const isPending = signInMutating + signUpMutating > 0 || isSending
 
-  const sendCode = () => sendVerificationOtp({ email, type: "sign-in" })
+  const sendCode = () =>
+    sendVerificationOtp({ email: form.state.values.email, type: "sign-in" })
   const verifyCode = (completedCode: string) => {
     if (isPending || isSigningIn) return
 
-    signInEmailOtp({ email, otp: completedCode })
+    signInEmailOtp({ email: form.state.values.email, otp: completedCode })
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (!codeSent) {
-      sendCode()
-      return
+  const form = useAuthForm({
+    defaultValues: { code: "", email: getSsoFallbackEmail() },
+    onSubmit: ({ value }) => {
+      if (!codeSent) {
+        sendVerificationOtp({ email: value.email, type: "sign-in" })
+        return
+      }
+      verifyCode(value.code)
     }
-
-    verifyCode(code)
-  }
+  })
 
   const startOver = () => {
     setCodeSent(false)
-    setCode("")
+    form.setFieldValue("code", "")
   }
 
   const showSeparator = !!socialProviders?.length
@@ -136,7 +135,10 @@ export function EmailOtp({
 
         {codeSent && (
           <Card.Description>
-            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
+            {emailOtpLocalization.codeSentTo.replace(
+              "{{email}}",
+              form.state.values.email
+            )}
           </Card.Description>
         )}
       </Card.Header>
@@ -154,100 +156,118 @@ export function EmailOtp({
           </>
         )}
 
-        <Form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          {codeSent ? (
-            <OtpField
-              autoFocus
-              isDisabled={isPending}
-              label={emailOtpLocalization.code}
-              length={otpLength}
-              name="otp"
-              value={code}
-              variant={variant}
-              onChange={setCode}
-              onComplete={verifyCode}
-            />
-          ) : (
-            <TextField
-              name="email"
-              type="email"
-              autoComplete="email"
-              isDisabled={isPending}
-              value={email}
-              onChange={setEmail}
-              validate={(value) => {
-                if (!value) return localization.auth.fieldRequired
-                if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
-                  return localization.auth.invalidEmail
-              }}
-            >
-              <Label>{localization.auth.email}</Label>
-
-              <Input
-                placeholder={localization.auth.emailPlaceholder}
-                required
-                variant={variant === "transparent" ? "primary" : "secondary"}
-              />
-
-              <FieldError />
-            </TextField>
-          )}
-
-          <div className="flex flex-col gap-3">
-            <Button
-              type="submit"
-              className="w-full"
-              isDisabled={codeSent && code.length !== otpLength}
-              isPending={isPending || isSigningIn}
-            >
-              {(isSending || isSigningIn) && (
-                <Spinner color="current" size="sm" />
-              )}
-
-              {codeSent
-                ? emailOtpLocalization.verifyCode
-                : emailOtpLocalization.sendCode}
-            </Button>
-
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-4">
             {codeSent ? (
-              <div className="flex flex-col gap-3">
-                <OpenEmailButton email={email} variant="secondary" />
-
-                <Button
-                  className="w-full"
-                  variant="tertiary"
-                  isDisabled={isPending || isSigningIn || isCoolingDown}
-                  onPress={sendCode}
-                >
-                  {isCoolingDown
-                    ? localization.auth.resendIn.replace(
-                        "{{seconds}}",
-                        String(cooldown)
-                      )
-                    : localization.auth.resend}
-                </Button>
-
-                <Button
-                  className="w-full"
-                  variant="ghost"
-                  isDisabled={isPending || isSigningIn}
-                  onPress={startOver}
-                >
-                  {emailOtpLocalization.useDifferentEmail}
-                </Button>
-              </div>
-            ) : (
-              plugins.flatMap((plugin) =>
-                (plugin.authButtons ?? []).map((AuthButton, index) => (
-                  <AuthButton
-                    key={`${plugin.id}-${index.toString()}`}
-                    view="emailOtp"
+              <form.AppField name="code">
+                {(field) => (
+                  <OtpField
+                    autoFocus
+                    isDisabled={isPending}
+                    label={emailOtpLocalization.code}
+                    length={otpLength}
+                    name={field.name}
+                    value={field.state.value}
+                    variant={variant}
+                    onChange={field.handleChange}
+                    onComplete={verifyCode}
                   />
-                ))
-              )
+                )}
+              </form.AppField>
+            ) : (
+              <form.AppField name="email">
+                {(field) => (
+                  <TextField
+                    name={field.name}
+                    type="email"
+                    autoComplete="email"
+                    isDisabled={isPending}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={field.handleChange}
+                    validate={(value) => {
+                      if (!value) return localization.auth.fieldRequired
+                      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
+                        return localization.auth.invalidEmail
+                    }}
+                  >
+                    <Label>{localization.auth.email}</Label>
+
+                    <Input
+                      placeholder={localization.auth.emailPlaceholder}
+                      required
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
+                      }
+                    />
+
+                    <FieldError />
+                  </TextField>
+                )}
+              </form.AppField>
             )}
-          </div>
-        </Form>
+
+            <div className="flex flex-col gap-3">
+              <form.AuthFormSubmitButton
+                className="w-full"
+                isDisabled={
+                  isPending ||
+                  isSigningIn ||
+                  (codeSent && form.state.values.code.length !== otpLength)
+                }
+              >
+                {(isSending || isSigningIn) && (
+                  <Spinner color="current" size="sm" />
+                )}
+
+                {codeSent
+                  ? emailOtpLocalization.verifyCode
+                  : emailOtpLocalization.sendCode}
+              </form.AuthFormSubmitButton>
+
+              {codeSent ? (
+                <div className="flex flex-col gap-3">
+                  <OpenEmailButton
+                    email={form.state.values.email}
+                    variant="secondary"
+                  />
+
+                  <Button
+                    className="w-full"
+                    variant="tertiary"
+                    isDisabled={isPending || isSigningIn || isCoolingDown}
+                    onPress={sendCode}
+                  >
+                    {isCoolingDown
+                      ? localization.auth.resendIn.replace(
+                          "{{seconds}}",
+                          String(cooldown)
+                        )
+                      : localization.auth.resend}
+                  </Button>
+
+                  <Button
+                    className="w-full"
+                    variant="ghost"
+                    isDisabled={isPending || isSigningIn}
+                    onPress={startOver}
+                  >
+                    {emailOtpLocalization.useDifferentEmail}
+                  </Button>
+                </div>
+              ) : (
+                plugins.flatMap((plugin) =>
+                  (plugin.authButtons ?? []).map((AuthButton, index) => (
+                    <AuthButton
+                      key={`${plugin.id}-${index.toString()}`}
+                      view="emailOtp"
+                    />
+                  ))
+                )
+              )}
+            </div>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         {socialPosition === "bottom" && !codeSent && (
           <>

--- a/packages/heroui/src/components/auth/email-otp/forgot-password-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/forgot-password-otp.tsx
@@ -3,22 +3,20 @@ import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin, useFetchOptions } from "@better-auth-ui/react"
 import { useRequestPasswordResetOtp } from "@better-auth-ui/react/plugins/email-otp"
 import {
-  Button,
   Card,
   type CardProps,
   cn,
   Description,
   FieldError,
-  Form,
   Input,
   Label,
   Link,
   Spinner,
   TextField
 } from "@heroui/react"
-import type { SyntheticEvent } from "react"
 
 import { emailOtpPlugin } from "../../../lib/auth/email-otp-plugin"
+import { useAuthForm } from "../auth-form"
 
 /** `sessionStorage` key the reset-code form reads the pending address from. */
 export const RESET_PASSWORD_OTP_STORAGE_KEY =
@@ -66,15 +64,14 @@ export function ForgotPasswordOtp({
       }
     })
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    requestPasswordResetOtp({
-      email: formData.get("email") as string,
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) =>
+      requestPasswordResetOtp({
+        email: value.email,
+        fetchOptions
+      })
+  })
 
   const Captcha = plugins.find(
     (plugin) => plugin.captchaComponent
@@ -92,37 +89,51 @@ export function ForgotPasswordOtp({
       </Card.Header>
 
       <Card.Content className="gap-4">
-        <Form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          <TextField
-            name="email"
-            type="email"
-            autoComplete="email"
-            isDisabled={isPending}
-            validate={(value) => {
-              if (!value) return localization.auth.fieldRequired
-              if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
-                return localization.auth.invalidEmail
-            }}
-          >
-            <Label>{localization.auth.email}</Label>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-4">
+            <form.AppField name="email">
+              {(field) => (
+                <TextField
+                  name={field.name}
+                  type="email"
+                  autoComplete="email"
+                  isDisabled={isPending}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={field.handleChange}
+                  validate={(value) => {
+                    if (!value) return localization.auth.fieldRequired
+                    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
+                      return localization.auth.invalidEmail
+                  }}
+                >
+                  <Label>{localization.auth.email}</Label>
 
-            <Input
-              placeholder={localization.auth.emailPlaceholder}
-              required
-              variant={variant === "transparent" ? "primary" : "secondary"}
-            />
+                  <Input
+                    placeholder={localization.auth.emailPlaceholder}
+                    required
+                    variant={
+                      variant === "transparent" ? "primary" : "secondary"
+                    }
+                  />
 
-            <FieldError />
-          </TextField>
+                  <FieldError />
+                </TextField>
+              )}
+            </form.AppField>
 
-          {Captcha && <div className="flex justify-center">{Captcha}</div>}
+            {Captcha && <div className="flex justify-center">{Captcha}</div>}
 
-          <Button type="submit" className="w-full" isPending={isPending}>
-            {isPending && <Spinner color="current" size="sm" />}
+            <form.AuthFormSubmitButton
+              className="w-full"
+              isDisabled={isPending}
+            >
+              {isPending && <Spinner color="current" size="sm" />}
 
-            {emailOtpLocalization.sendCode}
-          </Button>
-        </Form>
+              {emailOtpLocalization.sendCode}
+            </form.AuthFormSubmitButton>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </Card.Content>
 
       <Card.Footer className="flex-col gap-3">

--- a/packages/heroui/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/verify-email-otp.tsx
@@ -12,7 +12,6 @@ import {
   cn,
   Description,
   FieldError,
-  Form,
   Input,
   Label,
   Link,
@@ -21,13 +20,14 @@ import {
   toast,
   useIsHydrated
 } from "@heroui/react"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 
 import { emailOtpPlugin } from "../../../lib/auth/email-otp-plugin"
 import {
   RESEND_COOLDOWN_SECONDS,
   useResendCooldown
 } from "../../../lib/auth/use-resend-cooldown"
+import { useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 
@@ -69,7 +69,6 @@ export function VerifyEmailOtp({ className, variant }: VerifyEmailOtpProps) {
   const [email, setEmail] = useState(
     (isHydrated && sessionStorage.getItem(VERIFY_EMAIL_STORAGE_KEY)) || ""
   )
-  const [code, setCode] = useState("")
 
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
 
@@ -96,7 +95,7 @@ export function VerifyEmailOtp({ className, variant }: VerifyEmailOtpProps) {
   const { mutate: verifyEmailOtp, isPending: isVerifying } = useVerifyEmailOtp(
     otpClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
         sessionStorage.removeItem(VERIFY_EMAIL_STORAGE_KEY)
         toast.success(emailOtpLocalization.emailVerified)
@@ -113,20 +112,20 @@ export function VerifyEmailOtp({ className, variant }: VerifyEmailOtpProps) {
     verifyEmailOtp({ email, otp: completedCode })
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useAuthForm({
+    defaultValues: { code: "", email: "" },
+    onSubmit: ({ value }) => {
+      if (!email) {
+        sendVerificationOtp({
+          email: value.email,
+          type: "email-verification"
+        })
+        return
+      }
 
-    if (!email) {
-      const formData = new FormData(e.currentTarget)
-      sendVerificationOtp({
-        email: formData.get("email") as string,
-        type: "email-verification"
-      })
-      return
+      verifyCode(value.code)
     }
-
-    verifyCode(code)
-  }
+  })
 
   return (
     <Card
@@ -146,78 +145,95 @@ export function VerifyEmailOtp({ className, variant }: VerifyEmailOtpProps) {
       </Card.Header>
 
       <Card.Content className="gap-4">
-        <Form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          {email ? (
-            <OtpField
-              autoFocus
-              isDisabled={isPending}
-              label={emailOtpLocalization.code}
-              length={otpLength}
-              name="otp"
-              value={code}
-              variant={variant}
-              onChange={setCode}
-              onComplete={verifyCode}
-            />
-          ) : (
-            <TextField
-              name="email"
-              type="email"
-              autoComplete="email"
-              isDisabled={isPending}
-              validate={(value) => {
-                if (!value) return localization.auth.fieldRequired
-                if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
-                  return localization.auth.invalidEmail
-              }}
-            >
-              <Label>{localization.auth.email}</Label>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-4">
+            {email ? (
+              <form.AppField name="code">
+                {(field) => (
+                  <OtpField
+                    autoFocus
+                    isDisabled={isPending}
+                    label={emailOtpLocalization.code}
+                    length={otpLength}
+                    name={field.name}
+                    value={field.state.value}
+                    variant={variant}
+                    onChange={field.handleChange}
+                    onComplete={verifyCode}
+                  />
+                )}
+              </form.AppField>
+            ) : (
+              <form.AppField name="email">
+                {(field) => (
+                  <TextField
+                    name={field.name}
+                    type="email"
+                    autoComplete="email"
+                    isDisabled={isPending}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={field.handleChange}
+                    validate={(value) => {
+                      if (!value) return localization.auth.fieldRequired
+                      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
+                        return localization.auth.invalidEmail
+                    }}
+                  >
+                    <Label>{localization.auth.email}</Label>
 
-              <Input
-                placeholder={localization.auth.emailPlaceholder}
-                required
-                variant={variant === "transparent" ? "primary" : "secondary"}
-              />
+                    <Input
+                      placeholder={localization.auth.emailPlaceholder}
+                      required
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
+                      }
+                    />
 
-              <FieldError />
-            </TextField>
-          )}
+                    <FieldError />
+                  </TextField>
+                )}
+              </form.AppField>
+            )}
 
-          <div className="flex flex-col gap-3">
-            <Button
-              type="submit"
-              className="w-full"
-              isDisabled={Boolean(email) && code.length !== otpLength}
-              isPending={isPending}
-            >
-              {isPending && <Spinner color="current" size="sm" />}
-
-              {email
-                ? emailOtpLocalization.verifyCode
-                : emailOtpLocalization.sendCode}
-            </Button>
-
-            {email && <OpenEmailButton email={email} variant="secondary" />}
-
-            {email && (
-              <Button
+            <div className="flex flex-col gap-3">
+              <form.AuthFormSubmitButton
                 className="w-full"
-                variant="tertiary"
-                isDisabled={isPending || isCoolingDown}
-                onPress={() =>
-                  sendVerificationOtp({ email, type: "email-verification" })
+                isDisabled={
+                  isPending ||
+                  (Boolean(email) &&
+                    form.state.values.code.length !== otpLength)
                 }
               >
-                {isCoolingDown
-                  ? localization.auth.resendIn.replace(
-                      "{{seconds}}",
-                      String(cooldown)
-                    )
-                  : localization.auth.resend}
-              </Button>
-            )}
-          </div>
-        </Form>
+                {isPending && <Spinner color="current" size="sm" />}
+
+                {email
+                  ? emailOtpLocalization.verifyCode
+                  : emailOtpLocalization.sendCode}
+              </form.AuthFormSubmitButton>
+
+              {email && <OpenEmailButton email={email} variant="secondary" />}
+
+              {email && (
+                <Button
+                  className="w-full"
+                  variant="tertiary"
+                  isDisabled={isPending || isCoolingDown}
+                  onPress={() =>
+                    sendVerificationOtp({ email, type: "email-verification" })
+                  }
+                >
+                  {isCoolingDown
+                    ? localization.auth.resendIn.replace(
+                        "{{seconds}}",
+                        String(cooldown)
+                      )
+                    : localization.auth.resend}
+                </Button>
+              )}
+            </div>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </Card.Content>
 
       <Card.Footer className="flex-col gap-3">

--- a/packages/heroui/src/components/auth/forgot-password.tsx
+++ b/packages/heroui/src/components/auth/forgot-password.tsx
@@ -1,25 +1,21 @@
-import { getViewURL } from "@better-auth-ui/core"
+import { getViewURL, validateEmailAddress } from "@better-auth-ui/core"
 import {
   useAuth,
   useFetchOptions,
   useRequestPasswordReset
 } from "@better-auth-ui/react"
 import {
-  Button,
   Card,
   type CardProps,
   cn,
   Description,
-  FieldError,
-  Form,
   Input,
   Label,
   Link,
   Spinner,
   TextField
 } from "@heroui/react"
-import type { SyntheticEvent } from "react"
-
+import { isAuthFormFieldInvalid, useAuthForm } from "./auth-form"
 import { RESET_LINK_SENT_STORAGE_KEY } from "./reset-link-sent"
 
 export type ForgotPasswordProps = {
@@ -64,20 +60,19 @@ export function ForgotPassword({ className, variant }: ForgotPasswordProps) {
     }
   )
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    requestPasswordReset({
-      email: formData.get("email") as string,
-      redirectTo: getViewURL(
-        baseURL,
-        basePaths.auth,
-        viewPaths.auth.resetPassword
-      ),
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) =>
+      requestPasswordReset({
+        email: value.email,
+        redirectTo: getViewURL(
+          baseURL,
+          basePaths.auth,
+          viewPaths.auth.resetPassword
+        ),
+        fetchOptions
+      })
+  })
 
   const Captcha = plugins.find(
     (plugin) => plugin.captchaComponent
@@ -95,39 +90,58 @@ export function ForgotPassword({ className, variant }: ForgotPasswordProps) {
       </Card.Header>
 
       <Card.Content className="gap-4">
-        <Form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          <TextField
-            name="email"
-            type="email"
-            autoComplete="email"
-            isDisabled={isPending}
-            validate={(value) => {
-              if (!value) return localization.auth.fieldRequired
-              if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
-                return localization.auth.invalidEmail
-            }}
-          >
-            <Label>{localization.auth.email}</Label>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-4">
+            <form.AppField
+              name="email"
+              validators={{
+                onChange: ({ value }) =>
+                  validateEmailAddress(value, {
+                    invalidMessage: localization.auth.invalidEmail,
+                    requiredMessage: localization.auth.fieldRequired
+                  })
+              }}
+            >
+              {(field) => (
+                <TextField
+                  name={field.name}
+                  type="email"
+                  autoComplete="email"
+                  isDisabled={isPending}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={field.handleChange}
+                  isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                >
+                  <Label>{localization.auth.email}</Label>
 
-            <Input
-              placeholder={localization.auth.emailPlaceholder}
-              required
-              variant={variant === "transparent" ? "primary" : "secondary"}
-            />
+                  <Input
+                    placeholder={localization.auth.emailPlaceholder}
+                    required
+                    variant={
+                      variant === "transparent" ? "primary" : "secondary"
+                    }
+                  />
 
-            <FieldError />
-          </TextField>
+                  <field.AuthFormFieldError />
+                </TextField>
+              )}
+            </form.AppField>
 
-          {Captcha && <div className="flex justify-center">{Captcha}</div>}
+            {Captcha && <div className="flex justify-center">{Captcha}</div>}
 
-          <div className="flex flex-col gap-3">
-            <Button type="submit" className="w-full" isPending={isPending}>
-              {isPending && <Spinner color="current" size="sm" />}
+            <div className="flex flex-col gap-3">
+              <form.AuthFormSubmitButton
+                className="w-full"
+                isDisabled={isPending}
+              >
+                {isPending && <Spinner color="current" size="sm" />}
 
-              {localization.auth.sendResetLink}
-            </Button>
-          </div>
-        </Form>
+                {localization.auth.sendResetLink}
+              </form.AuthFormSubmitButton>
+            </div>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </Card.Content>
 
       <Card.Footer className="flex-col gap-3">

--- a/packages/heroui/src/components/auth/magic-link/magic-link.tsx
+++ b/packages/heroui/src/components/auth/magic-link/magic-link.tsx
@@ -4,13 +4,10 @@ import { getSsoFallbackEmail } from "@better-auth-ui/core/plugins/sso"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useSignInMagicLink } from "@better-auth-ui/react/plugins/magic-link"
 import {
-  Button,
   Card,
   type CardProps,
   cn,
   Description,
-  FieldError,
-  Form,
   Input,
   Label,
   Link,
@@ -18,9 +15,9 @@ import {
   TextField
 } from "@heroui/react"
 import { useIsMutating } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
 
 import { magicLinkPlugin } from "../../../lib/auth/magic-link-plugin"
+import { useAuthForm } from "../auth-form"
 import { FieldSeparator } from "../field-separator"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
 import { MAGIC_LINK_SENT_STORAGE_KEY } from "./magic-link-sent"
@@ -60,8 +57,6 @@ export function MagicLink({
   const { localization: magicLinkLocalization, viewPaths: magicLinkViewPaths } =
     useAuthPlugin(magicLinkPlugin)
 
-  const [email, setEmail] = useState(getSsoFallbackEmail)
-
   const { mutate: signInMagicLink, isPending: signInMagicLinkPending } =
     useSignInMagicLink(authClient as MagicLinkAuthClient, {
       onSuccess: (_data, variables) => {
@@ -80,10 +75,14 @@ export function MagicLink({
   })
   const isPending = signInMutating + signUpMutating > 0
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    signInMagicLink({ email, callbackURL: `${baseURL}${redirectTo}` })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: getSsoFallbackEmail() },
+    onSubmit: ({ value }) =>
+      signInMagicLink({
+        email: value.email,
+        callbackURL: `${baseURL}${redirectTo}`
+      })
+  })
 
   const showSeparator = !!socialProviders?.length
 
@@ -111,43 +110,57 @@ export function MagicLink({
           </>
         )}
 
-        <Form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          <TextField
-            name="email"
-            type="email"
-            autoComplete="email"
-            isDisabled={isPending}
-            value={email}
-            onChange={setEmail}
-          >
-            <Label>{localization.auth.email}</Label>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-4">
+            <form.AppField name="email">
+              {(field) => (
+                <TextField
+                  name={field.name}
+                  type="email"
+                  autoComplete="email"
+                  isDisabled={isPending}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={field.handleChange}
+                >
+                  <Label>{localization.auth.email}</Label>
 
-            <Input
-              placeholder={localization.auth.emailPlaceholder}
-              required
-              variant={variant === "transparent" ? "primary" : "secondary"}
-            />
+                  <Input
+                    placeholder={localization.auth.emailPlaceholder}
+                    required
+                    variant={
+                      variant === "transparent" ? "primary" : "secondary"
+                    }
+                  />
 
-            <FieldError />
-          </TextField>
+                  <field.AuthFormFieldError />
+                </TextField>
+              )}
+            </form.AppField>
 
-          <div className="flex flex-col gap-3">
-            <Button type="submit" className="w-full" isPending={isPending}>
-              {signInMagicLinkPending && <Spinner color="current" size="sm" />}
+            <div className="flex flex-col gap-3">
+              <form.AuthFormSubmitButton
+                className="w-full"
+                isDisabled={isPending}
+              >
+                {signInMagicLinkPending && (
+                  <Spinner color="current" size="sm" />
+                )}
 
-              {magicLinkLocalization.sendMagicLink}
-            </Button>
+                {magicLinkLocalization.sendMagicLink}
+              </form.AuthFormSubmitButton>
 
-            {plugins.flatMap((plugin) =>
-              (plugin.authButtons ?? []).map((AuthButton, index) => (
-                <AuthButton
-                  key={`${plugin.id}-${index.toString()}`}
-                  view="magicLink"
-                />
-              ))
-            )}
-          </div>
-        </Form>
+              {plugins.flatMap((plugin) =>
+                (plugin.authButtons ?? []).map((AuthButton, index) => (
+                  <AuthButton
+                    key={`${plugin.id}-${index.toString()}`}
+                    view="magicLink"
+                  />
+                ))
+              )}
+            </div>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         {socialPosition === "bottom" && (
           <>

--- a/packages/heroui/src/components/auth/organization/delete-organization-dialog.tsx
+++ b/packages/heroui/src/components/auth/organization/delete-organization-dialog.tsx
@@ -2,11 +2,11 @@ import type { OrganizationAuthClient } from "@better-auth-ui/core/plugins/organi
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useDeleteOrganization } from "@better-auth-ui/react/plugins/organization"
 import { TriangleExclamation } from "@gravity-ui/icons"
-import { AlertDialog, Button, Card, Form, Spinner, toast } from "@heroui/react"
+import { AlertDialog, Button, Card, Spinner, toast } from "@heroui/react"
 import type { Organization } from "better-auth/client"
-import type { SyntheticEvent } from "react"
 
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
+import { useAuthForm } from "../auth-form"
 import { OrganizationView } from "./organization-view"
 
 export type DeleteOrganizationDialogProps = {
@@ -41,52 +41,57 @@ export function DeleteOrganizationDialog({
     }
   )
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    deleteOrganization({ organizationId: organization.id })
-  }
+  const form = useAuthForm({
+    defaultValues: {},
+    onSubmit: () => deleteOrganization({ organizationId: organization.id })
+  })
 
   return (
     <AlertDialog.Backdrop isOpen={isOpen} onOpenChange={onOpenChange}>
       <AlertDialog.Container>
         <AlertDialog.Dialog>
-          <Form onSubmit={handleSubmit}>
-            <AlertDialog.CloseTrigger />
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <AlertDialog.CloseTrigger />
 
-            <AlertDialog.Header>
-              <AlertDialog.Icon status="danger">
-                <TriangleExclamation />
-              </AlertDialog.Icon>
+              <AlertDialog.Header>
+                <AlertDialog.Icon status="danger">
+                  <TriangleExclamation />
+                </AlertDialog.Icon>
 
-              <AlertDialog.Heading>
-                {organizationLocalization.deleteOrganization}
-              </AlertDialog.Heading>
-            </AlertDialog.Header>
+                <AlertDialog.Heading>
+                  {organizationLocalization.deleteOrganization}
+                </AlertDialog.Heading>
+              </AlertDialog.Header>
 
-            <AlertDialog.Body className="flex flex-col gap-4 overflow-visible">
-              <p className="text-muted text-sm">
-                {organizationLocalization.deleteOrganizationDescription}
-              </p>
+              <AlertDialog.Body className="flex flex-col gap-4 overflow-visible">
+                <p className="text-muted text-sm">
+                  {organizationLocalization.deleteOrganizationDescription}
+                </p>
 
-              <Card variant="secondary">
-                <Card.Content>
-                  <OrganizationView organization={organization} hideRole />
-                </Card.Content>
-              </Card>
-            </AlertDialog.Body>
+                <Card variant="secondary">
+                  <Card.Content>
+                    <OrganizationView organization={organization} hideRole />
+                  </Card.Content>
+                </Card>
+              </AlertDialog.Body>
 
-            <AlertDialog.Footer>
-              <Button slot="close" variant="tertiary" isDisabled={isPending}>
-                {localization.settings.cancel}
-              </Button>
+              <AlertDialog.Footer>
+                <Button slot="close" variant="tertiary" isDisabled={isPending}>
+                  {localization.settings.cancel}
+                </Button>
 
-              <Button type="submit" variant="danger" isPending={isPending}>
-                {isPending && <Spinner color="current" size="sm" />}
+                <form.AuthFormSubmitButton
+                  variant="danger"
+                  isDisabled={isPending}
+                >
+                  {isPending && <Spinner color="current" size="sm" />}
 
-                {organizationLocalization.deleteOrganization}
-              </Button>
-            </AlertDialog.Footer>
-          </Form>
+                  {organizationLocalization.deleteOrganization}
+                </form.AuthFormSubmitButton>
+              </AlertDialog.Footer>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </AlertDialog.Dialog>
       </AlertDialog.Container>
     </AlertDialog.Backdrop>

--- a/packages/heroui/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/packages/heroui/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -10,15 +10,15 @@ import {
   AlertDialog,
   Button,
   FieldError,
-  Form,
   Input,
   Label,
   Spinner,
   TextField
 } from "@heroui/react"
-import { type SyntheticEvent, useRef } from "react"
+import { useRef } from "react"
 
 import { passkeyPlugin } from "../../../lib/auth/passkey-plugin"
+import { useAuthForm } from "../auth-form"
 import { FreshSessionPrompt } from "../settings/security/fresh-session-prompt"
 
 export type AddPasskeyDialogProps = {
@@ -57,17 +57,16 @@ export function AddPasskeyDialog({
     addPasskey.mutate(requestWithCallbacks)
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.target as HTMLFormElement)
-    const name = (formData.get("name") as string)?.trim()
-
-    submitRequest({
-      ...(name ? { name } : {}),
-      ...(authenticatorAttachment ? { authenticatorAttachment } : {})
-    } as AddPasskeyParams<PasskeyAuthClient>)
-  }
+  const form = useAuthForm({
+    defaultValues: { name: "" },
+    onSubmit: ({ value }) => {
+      const name = value.name.trim()
+      submitRequest({
+        ...(name ? { name } : {}),
+        ...(authenticatorAttachment ? { authenticatorAttachment } : {})
+      } as AddPasskeyParams<PasskeyAuthClient>)
+    }
+  })
 
   const needsFreshSession = isSessionNotFreshError(addPasskey.error)
 
@@ -93,64 +92,73 @@ export function AddPasskeyDialog({
               </AlertDialog.Body>
             </>
           ) : (
-            <Form onSubmit={handleSubmit}>
-              <AlertDialog.CloseTrigger />
+            <form.AppForm>
+              <form.AuthFormRoot>
+                <AlertDialog.CloseTrigger />
 
-              <AlertDialog.Header>
-                <AlertDialog.Icon status="default">
-                  <Fingerprint />
-                </AlertDialog.Icon>
+                <AlertDialog.Header>
+                  <AlertDialog.Icon status="default">
+                    <Fingerprint />
+                  </AlertDialog.Icon>
 
-                <AlertDialog.Heading>
-                  {passkeyLocalization.addPasskey}
-                </AlertDialog.Heading>
-              </AlertDialog.Header>
+                  <AlertDialog.Heading>
+                    {passkeyLocalization.addPasskey}
+                  </AlertDialog.Heading>
+                </AlertDialog.Header>
 
-              <AlertDialog.Body className="overflow-visible">
-                <p className="text-muted text-sm">
-                  {passkeyLocalization.passkeysDescription}
-                </p>
+                <AlertDialog.Body className="overflow-visible">
+                  <p className="text-muted text-sm">
+                    {passkeyLocalization.passkeysDescription}
+                  </p>
 
-                <TextField
-                  className="mt-4"
-                  id="name"
-                  name="name"
-                  isDisabled={addPasskey.isPending}
-                  isInvalid={addPasskey.isError}
-                >
-                  <Label>{passkeyLocalization.name}</Label>
+                  <form.AppField name="name">
+                    {(field) => (
+                      <TextField
+                        className="mt-4"
+                        id="name"
+                        name={field.name}
+                        isDisabled={addPasskey.isPending}
+                        isInvalid={addPasskey.isError}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={field.handleChange}
+                      >
+                        <Label>{passkeyLocalization.name}</Label>
 
-                  <Input
-                    autoFocus
-                    placeholder={localization.settings.optional}
-                    variant="secondary"
-                  />
+                        <Input
+                          autoFocus
+                          placeholder={localization.settings.optional}
+                          variant="secondary"
+                        />
 
-                  <FieldError>
-                    {addPasskey.error?.error?.message ??
-                      addPasskey.error?.message}
-                  </FieldError>
-                </TextField>
-              </AlertDialog.Body>
+                        <FieldError>
+                          {addPasskey.error?.error?.message ??
+                            addPasskey.error?.message}
+                        </FieldError>
+                      </TextField>
+                    )}
+                  </form.AppField>
+                </AlertDialog.Body>
 
-              <AlertDialog.Footer>
-                <Button
-                  slot="close"
-                  variant="tertiary"
-                  isDisabled={addPasskey.isPending}
-                >
-                  {localization.settings.cancel}
-                </Button>
+                <AlertDialog.Footer>
+                  <Button
+                    slot="close"
+                    variant="tertiary"
+                    isDisabled={addPasskey.isPending}
+                  >
+                    {localization.settings.cancel}
+                  </Button>
 
-                <Button type="submit" isPending={addPasskey.isPending}>
-                  {addPasskey.isPending && (
-                    <Spinner color="current" size="sm" />
-                  )}
+                  <form.AuthFormSubmitButton isDisabled={addPasskey.isPending}>
+                    {addPasskey.isPending && (
+                      <Spinner color="current" size="sm" />
+                    )}
 
-                  {passkeyLocalization.addPasskey}
-                </Button>
-              </AlertDialog.Footer>
-            </Form>
+                    {passkeyLocalization.addPasskey}
+                  </form.AuthFormSubmitButton>
+                </AlertDialog.Footer>
+              </form.AuthFormRoot>
+            </form.AppForm>
           )}
         </AlertDialog.Dialog>
       </AlertDialog.Container>

--- a/packages/heroui/src/components/auth/passkey/rename-passkey-dialog.tsx
+++ b/packages/heroui/src/components/auth/passkey/rename-passkey-dialog.tsx
@@ -4,14 +4,14 @@ import { useUpdatePasskey } from "@better-auth-ui/react/plugins/passkey"
 import {
   AlertDialog,
   Button,
-  Form,
   Input,
   Label,
   Spinner,
   TextField
 } from "@heroui/react"
-import { type FormEvent, useEffect, useState } from "react"
+import { useEffect } from "react"
 import { passkeyPlugin } from "../../../lib/auth/passkey-plugin"
+import { useAuthForm } from "../auth-form"
 import type { ListedPasskey } from "./delete-passkey-dialog"
 
 export function RenamePasskeyDialog({
@@ -25,58 +25,64 @@ export function RenamePasskeyDialog({
 }) {
   const { authClient, localization } = useAuth()
   const { localization: labels } = useAuthPlugin(passkeyPlugin)
-  const [name, setName] = useState(passkey.name ?? "")
-
-  useEffect(() => {
-    if (isOpen) setName(passkey.name ?? "")
-  }, [isOpen, passkey.name])
-
   const updatePasskey = useUpdatePasskey(authClient as PasskeyAuthClient, {
     onSuccess: () => onOpenChange(false)
   })
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const nextName = name.trim()
-    if (nextName) updatePasskey.mutate({ id: passkey.id, name: nextName })
-  }
+  const form = useAuthForm({
+    defaultValues: { name: passkey.name ?? "" },
+    onSubmit: ({ value }) => {
+      const nextName = value.name.trim()
+      if (nextName) updatePasskey.mutate({ id: passkey.id, name: nextName })
+    }
+  })
+  useEffect(() => {
+    if (isOpen) form.setFieldValue("name", passkey.name ?? "")
+  }, [form.setFieldValue, isOpen, passkey.name])
 
   return (
     <AlertDialog.Backdrop isOpen={isOpen} onOpenChange={onOpenChange}>
       <AlertDialog.Container>
         <AlertDialog.Dialog>
-          <Form onSubmit={submit}>
-            <AlertDialog.CloseTrigger />
-            <AlertDialog.Header>
-              <AlertDialog.Heading>{labels.renamePasskey}</AlertDialog.Heading>
-            </AlertDialog.Header>
-            <AlertDialog.Body>
-              <TextField isDisabled={updatePasskey.isPending}>
-                <Label>{labels.name}</Label>
-                <Input
-                  autoFocus
-                  value={name}
-                  onChange={(event) => setName(event.target.value)}
-                  variant="secondary"
-                  required
-                />
-              </TextField>
-            </AlertDialog.Body>
-            <AlertDialog.Footer>
-              <Button slot="close" variant="tertiary">
-                {localization.settings.cancel}
-              </Button>
-              <Button
-                isDisabled={!name.trim()}
-                isPending={updatePasskey.isPending}
-                type="submit"
-              >
-                {updatePasskey.isPending && (
-                  <Spinner color="current" size="sm" />
-                )}
-                {localization.settings.saveChanges}
-              </Button>
-            </AlertDialog.Footer>
-          </Form>
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <AlertDialog.CloseTrigger />
+              <AlertDialog.Header>
+                <AlertDialog.Heading>
+                  {labels.renamePasskey}
+                </AlertDialog.Heading>
+              </AlertDialog.Header>
+              <AlertDialog.Body>
+                <form.AppField name="name">
+                  {(field) => (
+                    <TextField
+                      isDisabled={updatePasskey.isPending}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                      onBlur={field.handleBlur}
+                    >
+                      <Label>{labels.name}</Label>
+                      <Input autoFocus variant="secondary" required />
+                    </TextField>
+                  )}
+                </form.AppField>
+              </AlertDialog.Body>
+              <AlertDialog.Footer>
+                <Button slot="close" variant="tertiary">
+                  {localization.settings.cancel}
+                </Button>
+                <form.AuthFormSubmitButton
+                  isDisabled={
+                    !form.state.values.name.trim() || updatePasskey.isPending
+                  }
+                >
+                  {updatePasskey.isPending && (
+                    <Spinner color="current" size="sm" />
+                  )}
+                  {localization.settings.saveChanges}
+                </form.AuthFormSubmitButton>
+              </AlertDialog.Footer>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </AlertDialog.Dialog>
       </AlertDialog.Container>
     </AlertDialog.Backdrop>

--- a/packages/heroui/src/components/auth/phone-number/change-phone-number.tsx
+++ b/packages/heroui/src/components/auth/phone-number/change-phone-number.tsx
@@ -18,14 +18,14 @@ import {
   type CardProps,
   cn,
   Fieldset,
-  Form,
   Skeleton,
   Spinner,
   toast
 } from "@heroui/react"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 
 import { phoneNumberPlugin } from "../../../lib/auth/phone-number-plugin"
+import { useAuthForm } from "../auth-form"
 import { OtpField } from "../otp-field"
 import { InternationalPhoneField } from "./international-phone-field"
 import { RemovePhoneNumberDialog } from "./remove-phone-number-dialog"
@@ -58,18 +58,7 @@ export function ChangePhoneNumber({
   const { data: session } = useSession(phoneClient)
   const currentPhoneNumber =
     (session?.user as PhoneNumberUser | undefined)?.phoneNumber ?? ""
-  const [phoneNumber, setPhoneNumber] = useState(() =>
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [phoneError, setPhoneError] = useState<string>()
-  const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
-
-  useEffect(() => {
-    setPhoneNumber(
-      createPhoneNumberValue(currentPhoneNumber, defaultCountry, adapter)
-    )
-  }, [adapter, currentPhoneNumber, defaultCountry])
 
   const { mutate: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
     phoneClient,
@@ -78,9 +67,9 @@ export function ChangePhoneNumber({
   const { mutate: verify, isPending: isVerifying } = useVerifyPhoneNumber(
     phoneClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
-        setCode("")
+        form.setFieldValue("code", "")
         setCodeSent(false)
         toast.success(localization.phoneNumberUpdated)
       }
@@ -90,25 +79,40 @@ export function ChangePhoneNumber({
     phoneClient,
     {
       onSuccess: () => {
-        setPhoneNumber(createPhoneNumberValue("", defaultCountry, adapter))
+        form.setFieldValue(
+          "phoneNumber",
+          createPhoneNumberValue("", defaultCountry, adapter)
+        )
         toast.success(localization.phoneNumberRemoved)
       }
     }
   )
   const isPending = isSending || isVerifying || isRemoving
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!phoneNumber.e164) {
-      setPhoneError(localization.invalidPhoneNumber)
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter)
+    },
+    onSubmit: ({ value }) => {
+      if (!value.phoneNumber.e164) return
+      if (!codeSent) {
+        sendOtp({ phoneNumber: value.phoneNumber.e164 })
+        return
+      }
+      verify({
+        phoneNumber: value.phoneNumber.e164,
+        code: value.code,
+        updatePhoneNumber: true
+      })
     }
-    if (!codeSent) {
-      sendOtp({ phoneNumber: phoneNumber.e164 })
-      return
-    }
-    verify({ phoneNumber: phoneNumber.e164, code, updatePhoneNumber: true })
-  }
+  })
+  useEffect(() => {
+    form.setFieldValue(
+      "phoneNumber",
+      createPhoneNumberValue(currentPhoneNumber, defaultCountry, adapter)
+    )
+  }, [adapter, currentPhoneNumber, defaultCountry, form.setFieldValue])
   const removePhoneNumber = () =>
     updateUser({
       phoneNumber: null
@@ -121,102 +125,117 @@ export function ChangePhoneNumber({
       </h2>
       <Card className={cn("gap-4 p-4", className)} variant={variant} {...props}>
         <Card.Content>
-          <Form onSubmit={handleSubmit}>
-            <Fieldset className="w-full gap-4">
-              <Fieldset.Group>
-                {codeSent ? (
-                  <div className="flex flex-col gap-3">
-                    <p className="text-sm text-muted">
-                      {localization.codeSentTo.replace(
-                        "{{phoneNumber}}",
-                        phoneNumber.display
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <Fieldset className="w-full gap-4">
+                <Fieldset.Group>
+                  {codeSent ? (
+                    <div className="flex flex-col gap-3">
+                      <p className="text-sm text-muted">
+                        {localization.codeSentTo.replace(
+                          "{{phoneNumber}}",
+                          form.state.values.phoneNumber.display
+                        )}
+                      </p>
+                      <form.AppField name="code">
+                        {(field) => (
+                          <OtpField
+                            autoFocus
+                            isDisabled={isPending}
+                            label={localization.phoneCode}
+                            length={otpLength}
+                            name={field.name}
+                            value={field.state.value}
+                            variant={variant}
+                            onChange={field.handleChange}
+                          />
+                        )}
+                      </form.AppField>
+                    </div>
+                  ) : session ? (
+                    <form.AppField
+                      name="phoneNumber"
+                      validators={{
+                        onChange: ({ value }) =>
+                          value.e164
+                            ? undefined
+                            : localization.invalidPhoneNumber
+                      }}
+                    >
+                      {(field) => (
+                        <InternationalPhoneField
+                          adapter={adapter}
+                          countryCodes={countries}
+                          countryLabel={localization.country}
+                          error={field.state.meta.errors[0]?.toString()}
+                          isDisabled={isPending}
+                          locale={locale}
+                          phoneLabel={localization.phoneNumber}
+                          placeholder={localization.phoneNumberPlaceholder}
+                          value={field.state.value}
+                          variant={
+                            variant === "transparent" ? "primary" : "secondary"
+                          }
+                          onChange={field.handleChange}
+                        />
                       )}
-                    </p>
-                    <OtpField
-                      autoFocus
-                      isDisabled={isPending}
-                      label={localization.phoneCode}
-                      length={otpLength}
-                      name="otp"
-                      value={code}
-                      variant={variant}
-                      onChange={setCode}
-                    />
-                  </div>
-                ) : session ? (
-                  <InternationalPhoneField
-                    adapter={adapter}
-                    countryCodes={countries}
-                    countryLabel={localization.country}
-                    error={phoneError}
-                    isDisabled={isPending}
-                    locale={locale}
-                    phoneLabel={localization.phoneNumber}
-                    placeholder={localization.phoneNumberPlaceholder}
-                    value={phoneNumber}
-                    variant={
-                      variant === "transparent" ? "primary" : "secondary"
-                    }
-                    onChange={(value) => {
-                      setPhoneNumber(value)
-                      setPhoneError(undefined)
-                    }}
-                  />
-                ) : (
-                  <Skeleton className="h-14 w-full rounded-xl" />
-                )}
-              </Fieldset.Group>
-              <Fieldset.Actions>
-                {codeSent && (
-                  <Button
-                    size="sm"
-                    variant="tertiary"
-                    isDisabled={isPending}
-                    onPress={() => {
-                      setCode("")
-                      setCodeSent(false)
-                      setPhoneNumber(
-                        createPhoneNumberValue(
-                          currentPhoneNumber,
-                          defaultCountry,
-                          adapter
-                        )
-                      )
-                    }}
-                  >
-                    {localization.cancel}
-                  </Button>
-                )}
-                <Button
-                  size="sm"
-                  type="submit"
-                  isDisabled={
-                    !session ||
-                    isPending ||
-                    (codeSent && code.length !== otpLength)
-                  }
-                  isPending={isSending || isVerifying}
-                >
-                  {(isSending || isVerifying) && (
-                    <Spinner color="current" size="sm" />
+                    </form.AppField>
+                  ) : (
+                    <Skeleton className="h-14 w-full rounded-xl" />
                   )}
-                  {codeSent
-                    ? localization.verifyCode
-                    : localization.updatePhoneNumber}
-                </Button>
-                {!codeSent && currentPhoneNumber && (
-                  <RemovePhoneNumberDialog
-                    cancelLabel={localization.cancel}
-                    description={localization.removePhoneNumberDescription}
-                    isPending={isRemoving}
-                    label={localization.removePhoneNumber}
-                    title={localization.removePhoneNumberTitle}
-                    onConfirm={removePhoneNumber}
-                  />
-                )}
-              </Fieldset.Actions>
-            </Fieldset>
-          </Form>
+                </Fieldset.Group>
+                <Fieldset.Actions>
+                  {codeSent && (
+                    <Button
+                      size="sm"
+                      variant="tertiary"
+                      isDisabled={isPending}
+                      onPress={() => {
+                        form.setFieldValue("code", "")
+                        setCodeSent(false)
+                        form.setFieldValue(
+                          "phoneNumber",
+                          createPhoneNumberValue(
+                            currentPhoneNumber,
+                            defaultCountry,
+                            adapter
+                          )
+                        )
+                      }}
+                    >
+                      {localization.cancel}
+                    </Button>
+                  )}
+                  <form.AuthFormSubmitButton
+                    size="sm"
+                    type="submit"
+                    isDisabled={
+                      !session ||
+                      isPending ||
+                      (codeSent && form.state.values.code.length !== otpLength)
+                    }
+                  >
+                    {(isSending || isVerifying) && (
+                      <Spinner color="current" size="sm" />
+                    )}
+                    {codeSent
+                      ? localization.verifyCode
+                      : localization.updatePhoneNumber}
+                  </form.AuthFormSubmitButton>
+                  {!codeSent && currentPhoneNumber && (
+                    <RemovePhoneNumberDialog
+                      cancelLabel={localization.cancel}
+                      description={localization.removePhoneNumberDescription}
+                      isPending={isRemoving}
+                      label={localization.removePhoneNumber}
+                      title={localization.removePhoneNumberTitle}
+                      onConfirm={removePhoneNumber}
+                    />
+                  )}
+                </Fieldset.Actions>
+              </Fieldset>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </Card.Content>
       </Card>
     </div>

--- a/packages/heroui/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/packages/heroui/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -5,18 +5,16 @@ import {
 import { useAuth, useAuthPlugin, useFetchOptions } from "@better-auth-ui/react"
 import { useRequestPhoneNumberPasswordReset } from "@better-auth-ui/react/plugins/phone-number"
 import {
-  Button,
   Card,
   type CardProps,
   cn,
   Description,
-  Form,
   Link,
   Spinner
 } from "@heroui/react"
-import { type SyntheticEvent, useState } from "react"
 
 import { phoneNumberPlugin } from "../../../lib/auth/phone-number-plugin"
+import { useAuthForm } from "../auth-form"
 import { InternationalPhoneField } from "./international-phone-field"
 
 export const PHONE_NUMBER_RESET_STORAGE_KEY =
@@ -41,10 +39,6 @@ export function ForgotPhoneNumberPassword({
     localization: phoneLocalization,
     viewPaths: phoneNumberViewPaths
   } = useAuthPlugin(phoneNumberPlugin)
-  const [phoneNumber, setPhoneNumber] = useState(() =>
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [phoneError, setPhoneError] = useState<string>()
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
   const { mutate: requestReset, isPending } =
     useRequestPhoneNumberPasswordReset(authClient as PhoneNumberAuthClient, {
@@ -60,17 +54,18 @@ export function ForgotPhoneNumberPassword({
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    if (!phoneNumber.e164) {
-      setPhoneError(phoneLocalization.invalidPhoneNumber)
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter)
+    },
+    onSubmit: ({ value }) => {
+      if (!value.phoneNumber.e164) return
+      requestReset({
+        phoneNumber: value.phoneNumber.e164,
+        fetchOptions
+      })
     }
-    requestReset({
-      phoneNumber: phoneNumber.e164,
-      fetchOptions
-    })
-  }
+  })
 
   return (
     <Card
@@ -83,29 +78,41 @@ export function ForgotPhoneNumberPassword({
         </Card.Title>
       </Card.Header>
       <Card.Content className="gap-4">
-        <Form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-          <InternationalPhoneField
-            adapter={adapter}
-            countryCodes={countries}
-            countryLabel={phoneLocalization.country}
-            error={phoneError}
-            isDisabled={isPending}
-            locale={locale}
-            phoneLabel={phoneLocalization.phoneNumber}
-            placeholder={phoneLocalization.phoneNumberPlaceholder}
-            value={phoneNumber}
-            variant={variant === "transparent" ? "primary" : "secondary"}
-            onChange={(value) => {
-              setPhoneNumber(value)
-              setPhoneError(undefined)
-            }}
-          />
-          {Captcha && <div className="flex justify-center">{Captcha}</div>}
-          <Button className="w-full" type="submit" isPending={isPending}>
-            {isPending && <Spinner color="current" size="sm" />}
-            {phoneLocalization.sendCode}
-          </Button>
-        </Form>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-4">
+            <form.AppField
+              name="phoneNumber"
+              validators={{
+                onChange: ({ value }) =>
+                  value.e164 ? undefined : phoneLocalization.invalidPhoneNumber
+              }}
+            >
+              {(field) => (
+                <InternationalPhoneField
+                  adapter={adapter}
+                  countryCodes={countries}
+                  countryLabel={phoneLocalization.country}
+                  error={field.state.meta.errors[0]?.toString()}
+                  isDisabled={isPending}
+                  locale={locale}
+                  phoneLabel={phoneLocalization.phoneNumber}
+                  placeholder={phoneLocalization.phoneNumberPlaceholder}
+                  value={field.state.value}
+                  variant={variant === "transparent" ? "primary" : "secondary"}
+                  onChange={field.handleChange}
+                />
+              )}
+            </form.AppField>
+            {Captcha && <div className="flex justify-center">{Captcha}</div>}
+            <form.AuthFormSubmitButton
+              className="w-full"
+              isDisabled={isPending}
+            >
+              {isPending && <Spinner color="current" size="sm" />}
+              {phoneLocalization.sendCode}
+            </form.AuthFormSubmitButton>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </Card.Content>
       <Card.Footer className="flex-col gap-3">
         <Description className="text-sm">

--- a/packages/heroui/src/components/auth/settings/account/change-email.tsx
+++ b/packages/heroui/src/components/auth/settings/account/change-email.tsx
@@ -1,13 +1,11 @@
 import { getViewURL } from "@better-auth-ui/core"
 import { useAuth, useChangeEmail, useSession } from "@better-auth-ui/react"
 import {
-  Button,
   Card,
   type CardProps,
   cn,
   FieldError,
   Fieldset,
-  Form,
   Input,
   Label,
   Skeleton,
@@ -15,7 +13,8 @@ import {
   TextField,
   toast
 } from "@heroui/react"
-import type { SyntheticEvent } from "react"
+import { useEffect } from "react"
+import { useAuthForm } from "../../auth-form"
 
 export type ChangeEmailProps = {
   className?: string
@@ -43,19 +42,21 @@ export function ChangeEmail({
     onSuccess: () => toast.success(localization.settings.changeEmailSuccess)
   })
 
-  function handleSubmit(e: SyntheticEvent<HTMLFormElement>) {
-    e.preventDefault()
-    const formData = new FormData(e.currentTarget)
-
-    changeEmail({
-      newEmail: formData.get("email") as string,
-      callbackURL: getViewURL(
-        baseURL,
-        basePaths.settings,
-        viewPaths.settings.account
-      )
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) =>
+      changeEmail({
+        newEmail: value.email,
+        callbackURL: getViewURL(
+          baseURL,
+          basePaths.settings,
+          viewPaths.settings.account
+        )
+      })
+  })
+  useEffect(() => {
+    if (session) form.setFieldValue("email", session.user.email)
+  }, [form.setFieldValue, session])
 
   return (
     <div>
@@ -65,49 +66,57 @@ export function ChangeEmail({
 
       <Card className={cn("p-4 gap-4", className)} variant={variant} {...props}>
         <Card.Content>
-          <Form onSubmit={handleSubmit}>
-            <Fieldset className="w-full gap-4">
-              <Fieldset.Group>
-                <TextField
-                  key={`${session?.user.id}-${session?.user.email}-email`}
-                  name="email"
-                  type="email"
-                  defaultValue={session?.user.email}
-                  isDisabled={isPending || !session}
-                >
-                  <Label>{localization.auth.email}</Label>
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <Fieldset className="w-full gap-4">
+                <Fieldset.Group>
+                  <form.AppField name="email">
+                    {(field) => (
+                      <TextField
+                        key={`${session?.user.id}-${session?.user.email}-email`}
+                        name={field.name}
+                        type="email"
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={field.handleChange}
+                        isDisabled={isPending || !session}
+                      >
+                        <Label>{localization.auth.email}</Label>
 
-                  {session ? (
-                    <Input
-                      required
-                      variant={
-                        variant === "transparent" ? "primary" : "secondary"
-                      }
-                      autoComplete="email"
-                      placeholder={localization.auth.emailPlaceholder}
-                    />
-                  ) : (
-                    <Skeleton className="h-10 md:h-9 w-full rounded-xl" />
-                  )}
+                        {session ? (
+                          <Input
+                            required
+                            variant={
+                              variant === "transparent"
+                                ? "primary"
+                                : "secondary"
+                            }
+                            autoComplete="email"
+                            placeholder={localization.auth.emailPlaceholder}
+                          />
+                        ) : (
+                          <Skeleton className="h-10 md:h-9 w-full rounded-xl" />
+                        )}
 
-                  <FieldError />
-                </TextField>
-              </Fieldset.Group>
+                        <FieldError />
+                      </TextField>
+                    )}
+                  </form.AppField>
+                </Fieldset.Group>
 
-              <Fieldset.Actions>
-                <Button
-                  type="submit"
-                  isPending={isPending}
-                  isDisabled={!session}
-                  size="sm"
-                >
-                  {isPending && <Spinner color="current" size="sm" />}
+                <Fieldset.Actions>
+                  <form.AuthFormSubmitButton
+                    isDisabled={!session || isPending}
+                    size="sm"
+                  >
+                    {isPending && <Spinner color="current" size="sm" />}
 
-                  {localization.settings.updateEmail}
-                </Button>
-              </Fieldset.Actions>
-            </Fieldset>
-          </Form>
+                    {localization.settings.updateEmail}
+                  </form.AuthFormSubmitButton>
+                </Fieldset.Actions>
+              </Fieldset>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </Card.Content>
       </Card>
     </div>

--- a/packages/heroui/src/components/auth/settings/security/fresh-session-prompt.tsx
+++ b/packages/heroui/src/components/auth/settings/security/fresh-session-prompt.tsx
@@ -1,8 +1,8 @@
 import { isTwoFactorRedirect } from "@better-auth-ui/core/plugins/two-factor"
 import { useAuth, useSession, useSignInEmail } from "@better-auth-ui/react"
-import { Button, Form, Input, Label, Spinner, TextField } from "@heroui/react"
-import { type FormEvent, useState } from "react"
+import { Button, Input, Label, Spinner, TextField } from "@heroui/react"
 import { useSignInContinuation } from "../../../../lib/auth/use-sign-in-continuation"
+import { useAuthForm } from "../../auth-form"
 
 export interface FreshSessionPromptProps {
   onFresh: () => unknown | Promise<unknown>
@@ -20,27 +20,28 @@ export function FreshSessionPrompt({ onFresh }: FreshSessionPromptProps) {
   } = useAuth()
   const session = useSession(authClient)
   const continueSignIn = useSignInContinuation()
-  const [password, setPassword] = useState("")
   const signIn = useSignInEmail(authClient, {
     meta: { errorPresentation: "inline" },
-    onError: () => setPassword(""),
+    onError: () => form.setFieldValue("password", ""),
     onSuccess: async (data) => {
       if (isTwoFactorRedirect(data)) {
         continueSignIn(data)
         return
       }
 
-      setPassword("")
+      form.setFieldValue("password", "")
       await onFresh()
     }
   })
 
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const email = session.data?.user.email
-    if (!email) return
-    signIn.mutate({ email, password })
-  }
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) => {
+      const email = session.data?.user.email
+      if (!email) return
+      signIn.mutate({ email, password: value.password })
+    }
+  })
 
   return (
     <div className="flex flex-col gap-4 p-4">
@@ -54,32 +55,42 @@ export function FreshSessionPrompt({ onFresh }: FreshSessionPromptProps) {
       </div>
 
       {emailAndPassword?.enabled ? (
-        <Form className="flex flex-col gap-3" onSubmit={submit}>
-          <TextField
-            isDisabled={signIn.isPending}
-            isInvalid={signIn.isError}
-            value={password}
-            onChange={setPassword}
-          >
-            <Label>{localization.auth.password}</Label>
-            <Input
-              autoComplete="current-password"
-              name="password"
-              placeholder={localization.auth.passwordPlaceholder}
-              type="password"
-              required
-            />
-          </TextField>
-          {signIn.error && (
-            <p className="text-sm text-danger" role="alert">
-              {signIn.error.error?.message ?? signIn.error.message}
-            </p>
-          )}
-          <Button isDisabled={!password} type="submit" variant="primary">
-            {signIn.isPending && <Spinner color="current" size="sm" />}
-            {localization.settings.freshSessionSubmit}
-          </Button>
-        </Form>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-3">
+            <form.AppField name="password">
+              {(field) => (
+                <TextField
+                  isDisabled={signIn.isPending}
+                  isInvalid={signIn.isError}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={field.handleChange}
+                >
+                  <Label>{localization.auth.password}</Label>
+                  <Input
+                    autoComplete="current-password"
+                    name="password"
+                    placeholder={localization.auth.passwordPlaceholder}
+                    type="password"
+                    required
+                  />
+                </TextField>
+              )}
+            </form.AppField>
+            {signIn.error && (
+              <p className="text-sm text-danger" role="alert">
+                {signIn.error.error?.message ?? signIn.error.message}
+              </p>
+            )}
+            <form.AuthFormSubmitButton
+              isDisabled={!form.state.values.password}
+              variant="primary"
+            >
+              {signIn.isPending && <Spinner color="current" size="sm" />}
+              {localization.settings.freshSessionSubmit}
+            </form.AuthFormSubmitButton>
+          </form.AuthFormRoot>
+        </form.AppForm>
       ) : (
         <Button
           onPress={() =>

--- a/packages/heroui/src/components/auth/sign-in.tsx
+++ b/packages/heroui/src/components/auth/sign-in.tsx
@@ -18,7 +18,6 @@ import {
   cn,
   Description,
   FieldError,
-  Form,
   Input,
   InputGroup,
   Label,
@@ -27,9 +26,10 @@ import {
   TextField
 } from "@heroui/react"
 import { useIsMutating } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { useSignInContinuation } from "../../lib/auth/use-sign-in-continuation"
+import { useAuthForm } from "./auth-form"
 import { FieldSeparator } from "./field-separator"
 import { LastUsedBadge } from "./last-login-method/last-used-badge"
 import { ProviderButtons, type SocialLayout } from "./provider-buttons"
@@ -66,14 +66,13 @@ export function SignIn({
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
   const continueSignIn = useSignInContinuation()
 
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
 
   const { mutate: signInEmail, isPending: signInEmailPending } = useSignInEmail(
     authClient,
     {
       onError: (error, { email }) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
           sessionStorage.setItem("better-auth-ui.verify-email", email)
@@ -88,20 +87,18 @@ export function SignIn({
     }
   )
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const email = formData.get("email") as string
-    const rememberMe = formData.get("rememberMe") === "on"
-
-    signInEmail({
-      email,
-      password,
-      ...(emailAndPassword?.rememberMe ? { rememberMe } : {}),
-      fetchOptions
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "", password: "", rememberMe: false },
+    onSubmit: ({ value }) =>
+      signInEmail({
+        email: value.email,
+        password: value.password,
+        ...(emailAndPassword?.rememberMe
+          ? { rememberMe: value.rememberMe }
+          : {}),
+        fetchOptions
+      })
+  })
 
   const signInMutating = useIsMutating({
     mutationKey: authMutationKeys.signIn.all
@@ -145,129 +142,156 @@ export function SignIn({
         )}
 
         {emailAndPassword?.enabled && (
-          <Form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <TextField
-              name="email"
-              type="email"
-              autoComplete={withPasskeyAutoFill("email", passkeyAutoFill)}
-              isDisabled={isPending}
-              validate={(value) => {
-                if (!value) return localization.auth.fieldRequired
-                if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
-                  return localization.auth.invalidEmail
-              }}
-            >
-              <Label>{localization.auth.email}</Label>
-
-              <Input
-                placeholder={localization.auth.emailPlaceholder}
-                variant={variant === "transparent" ? "primary" : "secondary"}
-                required
-              />
-
-              <FieldError />
-            </TextField>
-
-            <TextField
-              minLength={emailAndPassword?.minPasswordLength}
-              maxLength={emailAndPassword?.maxPasswordLength}
-              name="password"
-              autoComplete={withPasskeyAutoFill(
-                "current-password",
-                passkeyAutoFill
-              )}
-              isDisabled={isPending}
-              value={password}
-              onChange={setPassword}
-              validate={(value) => {
-                if (!value) return localization.auth.fieldRequired
-                const min = emailAndPassword?.minPasswordLength
-                const max = emailAndPassword?.maxPasswordLength
-                if (min && value.length < min)
-                  return localization.auth.tooShort.replace(
-                    "{{min}}",
-                    String(min)
-                  )
-                if (max && value.length > max)
-                  return localization.auth.tooLong.replace(
-                    "{{max}}",
-                    String(max)
-                  )
-              }}
-            >
-              <Label>{localization.auth.password}</Label>
-
-              <InputGroup
-                variant={variant === "transparent" ? "primary" : "secondary"}
-              >
-                <InputGroup.Input
-                  placeholder={localization.auth.passwordPlaceholder}
-                  type={isPasswordVisible ? "text" : "password"}
-                  required
-                />
-
-                <InputGroup.Suffix className="px-0">
-                  <Button
-                    isIconOnly
-                    aria-label={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    size="sm"
-                    variant="ghost"
-                    onPress={() => setIsPasswordVisible(!isPasswordVisible)}
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-4">
+              <form.AppField name="email">
+                {(field) => (
+                  <TextField
+                    name={field.name}
+                    type="email"
+                    autoComplete={withPasskeyAutoFill("email", passkeyAutoFill)}
                     isDisabled={isPending}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={field.handleChange}
+                    validate={(value) => {
+                      if (!value) return localization.auth.fieldRequired
+                      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
+                        return localization.auth.invalidEmail
+                    }}
                   >
-                    {isPasswordVisible ? <EyeSlash /> : <Eye />}
-                  </Button>
-                </InputGroup.Suffix>
-              </InputGroup>
+                    <Label>{localization.auth.email}</Label>
 
-              <FieldError />
-            </TextField>
+                    <Input
+                      placeholder={localization.auth.emailPlaceholder}
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
+                      }
+                      required
+                    />
 
-            {emailAndPassword?.rememberMe && (
-              <Checkbox
-                name="rememberMe"
-                isDisabled={isPending}
-                variant={variant === "transparent" ? "primary" : "secondary"}
-              >
-                <Checkbox.Content>
-                  <Checkbox.Control>
-                    <Checkbox.Indicator />
-                  </Checkbox.Control>
+                    <FieldError />
+                  </TextField>
+                )}
+              </form.AppField>
 
-                  {localization.auth.rememberMe}
-                </Checkbox.Content>
-              </Checkbox>
-            )}
+              <form.AppField name="password">
+                {(field) => (
+                  <TextField
+                    minLength={emailAndPassword?.minPasswordLength}
+                    maxLength={emailAndPassword?.maxPasswordLength}
+                    name={field.name}
+                    autoComplete={withPasskeyAutoFill(
+                      "current-password",
+                      passkeyAutoFill
+                    )}
+                    isDisabled={isPending}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={field.handleChange}
+                    validate={(value) => {
+                      if (!value) return localization.auth.fieldRequired
+                      const min = emailAndPassword?.minPasswordLength
+                      const max = emailAndPassword?.maxPasswordLength
+                      if (min && value.length < min)
+                        return localization.auth.tooShort.replace(
+                          "{{min}}",
+                          String(min)
+                        )
+                      if (max && value.length > max)
+                        return localization.auth.tooLong.replace(
+                          "{{max}}",
+                          String(max)
+                        )
+                    }}
+                  >
+                    <Label>{localization.auth.password}</Label>
 
-            {Captcha && <div className="flex justify-center">{Captcha}</div>}
+                    <InputGroup
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
+                      }
+                    >
+                      <InputGroup.Input
+                        placeholder={localization.auth.passwordPlaceholder}
+                        type={isPasswordVisible ? "text" : "password"}
+                        required
+                      />
 
-            <div className="flex flex-col gap-3">
-              <Button
-                type="submit"
-                className="relative w-full overflow-visible"
-                isPending={isPending}
-              >
-                {signInEmailPending && <Spinner color="current" size="sm" />}
+                      <InputGroup.Suffix className="px-0">
+                        <Button
+                          isIconOnly
+                          aria-label={
+                            isPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          size="sm"
+                          variant="ghost"
+                          onPress={() =>
+                            setIsPasswordVisible(!isPasswordVisible)
+                          }
+                          isDisabled={isPending}
+                        >
+                          {isPasswordVisible ? <EyeSlash /> : <Eye />}
+                        </Button>
+                      </InputGroup.Suffix>
+                    </InputGroup>
 
-                {localization.auth.signIn}
+                    <FieldError />
+                  </TextField>
+                )}
+              </form.AppField>
 
-                <LastUsedBadge method="email" floating />
-              </Button>
+              {emailAndPassword?.rememberMe && (
+                <form.AppField name="rememberMe">
+                  {(field) => (
+                    <Checkbox
+                      name={field.name}
+                      isDisabled={isPending}
+                      isSelected={field.state.value}
+                      onChange={field.handleChange}
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
+                      }
+                    >
+                      <Checkbox.Content>
+                        <Checkbox.Control>
+                          <Checkbox.Indicator />
+                        </Checkbox.Control>
 
-              {plugins.flatMap((plugin) =>
-                plugin.authButtons?.map((AuthButton, index) => (
-                  <AuthButton
-                    key={`${plugin.id}-${index.toString()}`}
-                    view="signIn"
-                  />
-                ))
+                        {localization.auth.rememberMe}
+                      </Checkbox.Content>
+                    </Checkbox>
+                  )}
+                </form.AppField>
               )}
-            </div>
-          </Form>
+
+              {Captcha && <div className="flex justify-center">{Captcha}</div>}
+
+              <div className="flex flex-col gap-3">
+                <form.AuthFormSubmitButton
+                  className="relative w-full overflow-visible"
+                  isDisabled={isPending}
+                >
+                  {signInEmailPending && <Spinner color="current" size="sm" />}
+
+                  {localization.auth.signIn}
+
+                  <LastUsedBadge method="email" floating />
+                </form.AuthFormSubmitButton>
+
+                {plugins.flatMap((plugin) =>
+                  plugin.authButtons?.map((AuthButton, index) => (
+                    <AuthButton
+                      key={`${plugin.id}-${index.toString()}`}
+                      view="signIn"
+                    />
+                  ))
+                )}
+              </div>
+            </form.AuthFormRoot>
+          </form.AppForm>
         )}
 
         {socialPosition === "bottom" && (

--- a/packages/heroui/src/components/auth/siwe/sign-in-ethereum-button.tsx
+++ b/packages/heroui/src/components/auth/siwe/sign-in-ethereum-button.tsx
@@ -11,7 +11,6 @@ import { Wallet } from "@gravity-ui/icons"
 import {
   Button,
   FieldError,
-  Form,
   Input,
   Label,
   Modal,
@@ -19,9 +18,10 @@ import {
   TextField
 } from "@heroui/react"
 import { useIsMutating } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { siwePlugin } from "../../../lib/auth/siwe-plugin"
+import { useAuthForm } from "../auth-form"
 
 export type SignInEthereumButtonProps = {
   view?: AuthView
@@ -43,8 +43,6 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
       useIsMutating({ mutationKey: siweMutationKeys.all }) >
     0
 
-  if (view === "signUp") return null
-
   const completeSignIn = (email?: string) => {
     signIn.mutate(email ? { email } : undefined, {
       onSuccess: () => {
@@ -59,13 +57,15 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
     else setIsOpen(true)
   }
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const email = String(
-      new FormData(event.currentTarget).get("email") ?? ""
-    ).trim()
-    completeSignIn(email || undefined)
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) => {
+      const email = value.email.trim()
+      completeSignIn(email || undefined)
+    }
+  })
+
+  if (view === "signUp") return null
 
   return (
     <>
@@ -83,51 +83,60 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
       <Modal.Backdrop isOpen={isOpen} onOpenChange={setIsOpen}>
         <Modal.Container>
           <Modal.Dialog className="sm:max-w-md">
-            <Form onSubmit={handleSubmit}>
-              <Modal.CloseTrigger />
-              <Modal.Header>
-                <Modal.Icon className="bg-accent-soft text-accent-soft-foreground">
-                  <Wallet />
-                </Modal.Icon>
-                <Modal.Heading>
-                  {plugin.localization.continueWithEthereum}
-                </Modal.Heading>
-                <p className="mt-1.5 text-muted text-sm">
-                  {plugin.localization.emailDescription}
-                </p>
-              </Modal.Header>
-              <Modal.Body className="overflow-visible">
-                <TextField
-                  className="w-full"
-                  name="email"
-                  type="email"
-                  isRequired={plugin.email === "required"}
-                  isDisabled={signIn.isPending}
-                  variant="secondary"
-                >
-                  <Label>
-                    {plugin.email === "required"
-                      ? plugin.localization.email
-                      : plugin.localization.emailOptional}
-                  </Label>
-                  <Input autoFocus autoComplete="email" />
-                  <FieldError />
-                </TextField>
-              </Modal.Body>
-              <Modal.Footer>
-                <Button
-                  slot="close"
-                  variant="tertiary"
-                  isDisabled={signIn.isPending}
-                >
-                  {localization.settings.cancel}
-                </Button>
-                <Button type="submit" isPending={signIn.isPending}>
-                  {signIn.isPending && <Spinner color="current" size="sm" />}
-                  {plugin.localization.signMessage}
-                </Button>
-              </Modal.Footer>
-            </Form>
+            <form.AppForm>
+              <form.AuthFormRoot>
+                <Modal.CloseTrigger />
+                <Modal.Header>
+                  <Modal.Icon className="bg-accent-soft text-accent-soft-foreground">
+                    <Wallet />
+                  </Modal.Icon>
+                  <Modal.Heading>
+                    {plugin.localization.continueWithEthereum}
+                  </Modal.Heading>
+                  <p className="mt-1.5 text-muted text-sm">
+                    {plugin.localization.emailDescription}
+                  </p>
+                </Modal.Header>
+                <Modal.Body className="overflow-visible">
+                  <form.AppField name="email">
+                    {(field) => (
+                      <TextField
+                        className="w-full"
+                        name={field.name}
+                        type="email"
+                        isRequired={plugin.email === "required"}
+                        isDisabled={signIn.isPending}
+                        variant="secondary"
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={field.handleChange}
+                      >
+                        <Label>
+                          {plugin.email === "required"
+                            ? plugin.localization.email
+                            : plugin.localization.emailOptional}
+                        </Label>
+                        <Input autoFocus autoComplete="email" />
+                        <FieldError />
+                      </TextField>
+                    )}
+                  </form.AppField>
+                </Modal.Body>
+                <Modal.Footer>
+                  <Button
+                    slot="close"
+                    variant="tertiary"
+                    isDisabled={signIn.isPending}
+                  >
+                    {localization.settings.cancel}
+                  </Button>
+                  <form.AuthFormSubmitButton isDisabled={signIn.isPending}>
+                    {signIn.isPending && <Spinner color="current" size="sm" />}
+                    {plugin.localization.signMessage}
+                  </form.AuthFormSubmitButton>
+                </Modal.Footer>
+              </form.AuthFormRoot>
+            </form.AppForm>
           </Modal.Dialog>
         </Modal.Container>
       </Modal.Backdrop>

--- a/packages/heroui/src/components/auth/sso/sso-domain-verification.tsx
+++ b/packages/heroui/src/components/auth/sso/sso-domain-verification.tsx
@@ -18,7 +18,6 @@ import {
   type CardProps,
   cn,
   FieldError,
-  Form,
   Input,
   InputGroup,
   Label,
@@ -27,9 +26,10 @@ import {
   toast
 } from "@heroui/react"
 import type { BetterFetchError } from "better-auth/client"
-import { type FormEvent, useState } from "react"
+import { useState } from "react"
 
 import { ssoPlugin } from "../../../lib/auth/sso-plugin"
+import { useAuthForm } from "../auth-form"
 
 export type SsoDomainVerificationProps = {
   defaultProviderId?: string
@@ -53,7 +53,6 @@ export function SsoDomainVerification({
 }: SsoDomainVerificationProps) {
   const { authClient } = useAuth()
   const { localization } = useAuthPlugin(ssoPlugin)
-  const [providerId, setProviderId] = useState(defaultProviderId)
   const [token, setToken] = useState(defaultToken)
   const [verified, setVerified] = useState(false)
   const requestToken = useRequestSsoDomainVerification(
@@ -65,6 +64,14 @@ export function SsoDomainVerification({
   const verify = useVerifySsoDomain(authClient as SsoAuthClient, {
     onSuccess: () => setVerified(true)
   })
+  const form = useAuthForm({
+    defaultValues: { providerId: defaultProviderId },
+    onSubmit: ({ value }) => {
+      setVerified(false)
+      verify.mutate({ providerId: value.providerId })
+    }
+  })
+  const providerId = form.state.values.providerId
   const host = providerId ? `_${tokenPrefix}-${providerId}` : ""
   const hostCopy = useCopyToClipboard({
     onError: (error) =>
@@ -79,12 +86,6 @@ export function SsoDomainVerification({
       ? requestToken.error
       : verify.error
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setVerified(false)
-    verify.mutate({ providerId })
-  }
-
   return (
     <Card className={cn(className)} variant={variant} {...props}>
       <Card.Header>
@@ -94,110 +95,123 @@ export function SsoDomainVerification({
         </Card.Description>
       </Card.Header>
       <Card.Content>
-        <Form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-          <TextField
-            isRequired
-            name="providerId"
-            onChange={(value) => {
-              setProviderId(value.trim())
-              setToken("")
-              setVerified(false)
-            }}
-            value={providerId}
-          >
-            <Label>{localization.providerId}</Label>
-            <Input variant="secondary" />
-            <FieldError />
-          </TextField>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-4">
+            <form.AppField name="providerId">
+              {(field) => (
+                <TextField
+                  isRequired
+                  name={field.name}
+                  onChange={(value) => {
+                    field.handleChange(value.trim())
+                    setToken("")
+                    setVerified(false)
+                  }}
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                >
+                  <Label>{localization.providerId}</Label>
+                  <Input variant="secondary" />
+                  <FieldError />
+                </TextField>
+              )}
+            </form.AppField>
 
-          {token ? (
-            <div className="grid gap-3 rounded-lg border p-3">
-              <TextField isReadOnly value={host}>
-                <Label>{localization.txtRecordHost}</Label>
-                <InputGroup variant="secondary">
-                  <InputGroup.Input className="font-mono text-xs" />
-                  <InputGroup.Suffix className="px-0">
-                    <Button
-                      aria-label={localization.copyDnsHost}
-                      isIconOnly
-                      size="sm"
-                      variant="ghost"
-                      onPress={() => hostCopy.copy(host)}
-                    >
-                      {hostCopy.copied ? <Check /> : <Copy />}
-                    </Button>
-                  </InputGroup.Suffix>
-                </InputGroup>
-              </TextField>
-              <TextField isReadOnly value={token}>
-                <Label>{localization.txtRecordValue}</Label>
-                <InputGroup variant="secondary">
-                  <InputGroup.Input className="font-mono text-xs" />
-                  <InputGroup.Suffix className="px-0">
-                    <Button
-                      aria-label={localization.copyDnsValue}
-                      isIconOnly
-                      size="sm"
-                      variant="ghost"
-                      onPress={() => tokenCopy.copy(token)}
-                    >
-                      {tokenCopy.copied ? <Check /> : <Copy />}
-                    </Button>
-                  </InputGroup.Suffix>
-                </InputGroup>
-              </TextField>
+            {token ? (
+              <div className="grid gap-3 rounded-lg border p-3">
+                <TextField isReadOnly value={host}>
+                  <Label>{localization.txtRecordHost}</Label>
+                  <InputGroup variant="secondary">
+                    <InputGroup.Input className="font-mono text-xs" />
+                    <InputGroup.Suffix className="px-0">
+                      <Button
+                        aria-label={localization.copyDnsHost}
+                        isIconOnly
+                        size="sm"
+                        variant="ghost"
+                        onPress={() => hostCopy.copy(host)}
+                      >
+                        {hostCopy.copied ? <Check /> : <Copy />}
+                      </Button>
+                    </InputGroup.Suffix>
+                  </InputGroup>
+                </TextField>
+                <TextField isReadOnly value={token}>
+                  <Label>{localization.txtRecordValue}</Label>
+                  <InputGroup variant="secondary">
+                    <InputGroup.Input className="font-mono text-xs" />
+                    <InputGroup.Suffix className="px-0">
+                      <Button
+                        aria-label={localization.copyDnsValue}
+                        isIconOnly
+                        size="sm"
+                        variant="ghost"
+                        onPress={() => tokenCopy.copy(token)}
+                      >
+                        {tokenCopy.copied ? <Check /> : <Copy />}
+                      </Button>
+                    </InputGroup.Suffix>
+                  </InputGroup>
+                </TextField>
+              </div>
+            ) : null}
+
+            {error ? (
+              <Alert status="danger">
+                <Alert.Indicator />
+                <Alert.Content>
+                  <Alert.Description>
+                    {getErrorMessage(error)}
+                  </Alert.Description>
+                </Alert.Content>
+              </Alert>
+            ) : null}
+            {verified ? (
+              <Alert status="success">
+                <Alert.Indicator />
+                <Alert.Content>
+                  <Alert.Description>
+                    {localization.domainVerified}
+                  </Alert.Description>
+                </Alert.Content>
+              </Alert>
+            ) : null}
+
+            <div className="flex flex-wrap justify-end gap-2">
+              <Button
+                isDisabled={!providerId || verify.isPending}
+                isPending={requestToken.isPending}
+                type="button"
+                variant="outline"
+                onPress={() => {
+                  setVerified(false)
+                  requestToken.mutate({ providerId })
+                }}
+              >
+                {requestToken.isPending ? (
+                  <Spinner color="current" size="sm" />
+                ) : null}
+                {localization.requestNewToken}
+              </Button>
+              <form.AuthFormSubmitButton
+                isDisabled={
+                  !providerId || requestToken.isPending || verify.isPending
+                }
+              >
+                {verify.isPending ? (
+                  <Spinner color="current" size="sm" />
+                ) : null}
+                {localization.verifyDomain}
+              </form.AuthFormSubmitButton>
             </div>
-          ) : null}
 
-          {error ? (
-            <Alert status="danger">
-              <Alert.Indicator />
-              <Alert.Content>
-                <Alert.Description>{getErrorMessage(error)}</Alert.Description>
-              </Alert.Content>
-            </Alert>
-          ) : null}
-          {verified ? (
-            <Alert status="success">
-              <Alert.Indicator />
-              <Alert.Content>
-                <Alert.Description>
-                  {localization.domainVerified}
-                </Alert.Description>
-              </Alert.Content>
-            </Alert>
-          ) : null}
-
-          <div className="flex flex-wrap justify-end gap-2">
-            <Button
-              isDisabled={!providerId || verify.isPending}
-              isPending={requestToken.isPending}
-              type="button"
-              variant="outline"
-              onPress={() => {
-                setVerified(false)
-                requestToken.mutate({ providerId })
-              }}
-            >
-              {requestToken.isPending ? (
-                <Spinner color="current" size="sm" />
-              ) : null}
-              {localization.requestNewToken}
-            </Button>
-            <Button
-              isDisabled={!providerId || requestToken.isPending}
-              isPending={verify.isPending}
-              type="submit"
-            >
-              {verify.isPending ? <Spinner color="current" size="sm" /> : null}
-              {localization.verifyDomain}
-            </Button>
-          </div>
-
-          <span className="sr-only" aria-live="polite">
-            {token && !verified ? localization.domainVerificationRequested : ""}
-          </span>
-        </Form>
+            <span className="sr-only" aria-live="polite">
+              {token && !verified
+                ? localization.domainVerificationRequested
+                : ""}
+            </span>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </Card.Content>
     </Card>
   )

--- a/packages/heroui/src/components/auth/two-factor/disable-two-factor-dialog.tsx
+++ b/packages/heroui/src/components/auth/two-factor/disable-two-factor-dialog.tsx
@@ -6,17 +6,16 @@ import {
   AlertDialog,
   Button,
   FieldError,
-  Form,
   Input,
   Label,
   Spinner,
   TextField,
   toast
 } from "@heroui/react"
-import type { SyntheticEvent } from "react"
 
 import { twoFactorPlugin } from "../../../lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "../../../lib/auth/use-two-factor-password"
+import { useAuthForm } from "../auth-form"
 
 export type DisableTwoFactorDialogProps = {
   isOpen: boolean
@@ -48,73 +47,82 @@ export function DisableTwoFactorDialog({
 
   const isPending = isDisabling || isResolvingPasswordRequirement
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-
-    disableTwoFactor(requiresPassword ? { password } : {})
-  }
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) =>
+      disableTwoFactor(requiresPassword ? { password: value.password } : {})
+  })
 
   return (
     <AlertDialog.Backdrop isOpen={isOpen} onOpenChange={onOpenChange}>
       <AlertDialog.Container>
         <AlertDialog.Dialog>
-          <Form onSubmit={handleSubmit}>
-            <AlertDialog.CloseTrigger />
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <AlertDialog.CloseTrigger />
 
-            <AlertDialog.Header>
-              <AlertDialog.Icon status="danger">
-                <ShieldExclamation />
-              </AlertDialog.Icon>
+              <AlertDialog.Header>
+                <AlertDialog.Icon status="danger">
+                  <ShieldExclamation />
+                </AlertDialog.Icon>
 
-              <AlertDialog.Heading>
-                {twoFactorLocalization.disableTwoFactor}
-              </AlertDialog.Heading>
-            </AlertDialog.Header>
+                <AlertDialog.Heading>
+                  {twoFactorLocalization.disableTwoFactor}
+                </AlertDialog.Heading>
+              </AlertDialog.Header>
 
-            <AlertDialog.Body className="overflow-visible">
-              <p className="text-muted text-sm">
-                {requiresPassword
-                  ? twoFactorLocalization.passwordConfirmation
-                  : twoFactorLocalization.twoFactorDescription}
-              </p>
+              <AlertDialog.Body className="overflow-visible">
+                <p className="text-muted text-sm">
+                  {requiresPassword
+                    ? twoFactorLocalization.passwordConfirmation
+                    : twoFactorLocalization.twoFactorDescription}
+                </p>
 
-              {requiresPassword && (
-                <TextField
-                  className="mt-4"
-                  name="password"
-                  autoComplete="current-password"
+                {requiresPassword && (
+                  <form.AppField name="password">
+                    {(field) => (
+                      <TextField
+                        className="mt-4"
+                        name={field.name}
+                        autoComplete="current-password"
+                        isDisabled={isPending}
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={field.handleChange}
+                      >
+                        <Label>{localization.auth.password}</Label>
+
+                        <Input
+                          autoFocus
+                          required
+                          type="password"
+                          placeholder={localization.auth.passwordPlaceholder}
+                          variant="secondary"
+                        />
+
+                        <FieldError />
+                      </TextField>
+                    )}
+                  </form.AppField>
+                )}
+              </AlertDialog.Body>
+
+              <AlertDialog.Footer>
+                <Button slot="close" variant="tertiary" isDisabled={isPending}>
+                  {localization.settings.cancel}
+                </Button>
+
+                <form.AuthFormSubmitButton
+                  variant="danger"
                   isDisabled={isPending}
                 >
-                  <Label>{localization.auth.password}</Label>
+                  {isPending && <Spinner color="current" size="sm" />}
 
-                  <Input
-                    autoFocus
-                    required
-                    type="password"
-                    placeholder={localization.auth.passwordPlaceholder}
-                    variant="secondary"
-                  />
-
-                  <FieldError />
-                </TextField>
-              )}
-            </AlertDialog.Body>
-
-            <AlertDialog.Footer>
-              <Button slot="close" variant="tertiary" isDisabled={isPending}>
-                {localization.settings.cancel}
-              </Button>
-
-              <Button type="submit" variant="danger" isPending={isPending}>
-                {isPending && <Spinner color="current" size="sm" />}
-
-                {twoFactorLocalization.disableTwoFactor}
-              </Button>
-            </AlertDialog.Footer>
-          </Form>
+                  {twoFactorLocalization.disableTwoFactor}
+                </form.AuthFormSubmitButton>
+              </AlertDialog.Footer>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </AlertDialog.Dialog>
       </AlertDialog.Container>
     </AlertDialog.Backdrop>

--- a/packages/heroui/src/components/auth/two-factor/regenerate-backup-codes-dialog.tsx
+++ b/packages/heroui/src/components/auth/two-factor/regenerate-backup-codes-dialog.tsx
@@ -6,17 +6,17 @@ import {
   AlertDialog,
   Button,
   FieldError,
-  Form,
   Input,
   Label,
   Spinner,
   TextField,
   toast
 } from "@heroui/react"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { twoFactorPlugin } from "../../../lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "../../../lib/auth/use-two-factor-password"
+import { useAuthForm } from "../auth-form"
 import { BackupCodes } from "./backup-codes"
 
 export type RegenerateBackupCodesDialogProps = {
@@ -67,88 +67,101 @@ export function RegenerateBackupCodesDialog({
     }
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: ({ value }) => {
+      if (codes.length) {
+        handleOpenChange(false)
+        return
+      }
 
-    if (codes.length) {
-      handleOpenChange(false)
-      return
+      generateBackupCodes(requiresPassword ? { password: value.password } : {})
     }
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-
-    generateBackupCodes(requiresPassword ? { password } : {})
-  }
+  })
 
   return (
     <AlertDialog.Backdrop isOpen={isOpen} onOpenChange={handleOpenChange}>
       <AlertDialog.Container>
         <AlertDialog.Dialog>
-          <Form onSubmit={handleSubmit}>
-            <AlertDialog.CloseTrigger />
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <AlertDialog.CloseTrigger />
 
-            <AlertDialog.Header>
-              <AlertDialog.Icon status="default">
-                <Key />
-              </AlertDialog.Icon>
+              <AlertDialog.Header>
+                <AlertDialog.Icon status="default">
+                  <Key />
+                </AlertDialog.Icon>
 
-              <AlertDialog.Heading>
-                {twoFactorLocalization.backupCodes}
-              </AlertDialog.Heading>
-            </AlertDialog.Header>
+                <AlertDialog.Heading>
+                  {twoFactorLocalization.backupCodes}
+                </AlertDialog.Heading>
+              </AlertDialog.Header>
 
-            <AlertDialog.Body className="overflow-visible">
-              {codes.length ? (
-                <BackupCodes codes={codes} />
-              ) : (
-                <>
-                  <p className="text-muted text-sm">
-                    {requiresPassword
-                      ? twoFactorLocalization.passwordConfirmation
-                      : twoFactorLocalization.backupCodesDescription}
-                  </p>
+              <AlertDialog.Body className="overflow-visible">
+                {codes.length ? (
+                  <BackupCodes codes={codes} />
+                ) : (
+                  <>
+                    <p className="text-muted text-sm">
+                      {requiresPassword
+                        ? twoFactorLocalization.passwordConfirmation
+                        : twoFactorLocalization.backupCodesDescription}
+                    </p>
 
-                  {requiresPassword && (
-                    <TextField
-                      className="mt-4"
-                      name="password"
-                      autoComplete="current-password"
-                      isDisabled={isPending}
-                    >
-                      <Label>{localization.auth.password}</Label>
+                    {requiresPassword && (
+                      <form.AppField name="password">
+                        {(field) => (
+                          <TextField
+                            className="mt-4"
+                            name={field.name}
+                            autoComplete="current-password"
+                            isDisabled={isPending}
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={field.handleChange}
+                          >
+                            <Label>{localization.auth.password}</Label>
 
-                      <Input
-                        autoFocus
-                        required
-                        type="password"
-                        placeholder={localization.auth.passwordPlaceholder}
-                        variant="secondary"
-                      />
+                            <Input
+                              autoFocus
+                              required
+                              type="password"
+                              placeholder={
+                                localization.auth.passwordPlaceholder
+                              }
+                              variant="secondary"
+                            />
 
-                      <FieldError />
-                    </TextField>
-                  )}
-                </>
-              )}
-            </AlertDialog.Body>
+                            <FieldError />
+                          </TextField>
+                        )}
+                      </form.AppField>
+                    )}
+                  </>
+                )}
+              </AlertDialog.Body>
 
-            <AlertDialog.Footer>
-              {!codes.length && (
-                <Button slot="close" variant="tertiary" isDisabled={isPending}>
-                  {localization.settings.cancel}
-                </Button>
-              )}
+              <AlertDialog.Footer>
+                {!codes.length && (
+                  <Button
+                    slot="close"
+                    variant="tertiary"
+                    isDisabled={isPending}
+                  >
+                    {localization.settings.cancel}
+                  </Button>
+                )}
 
-              <Button type="submit" isPending={isPending}>
-                {isPending && <Spinner color="current" size="sm" />}
+                <form.AuthFormSubmitButton isDisabled={isPending}>
+                  {isPending && <Spinner color="current" size="sm" />}
 
-                {codes.length
-                  ? twoFactorLocalization.done
-                  : twoFactorLocalization.regenerateBackupCodes}
-              </Button>
-            </AlertDialog.Footer>
-          </Form>
+                  {codes.length
+                    ? twoFactorLocalization.done
+                    : twoFactorLocalization.regenerateBackupCodes}
+                </form.AuthFormSubmitButton>
+              </AlertDialog.Footer>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </AlertDialog.Dialog>
       </AlertDialog.Container>
     </AlertDialog.Backdrop>

--- a/packages/heroui/src/components/auth/username/sign-in-username.tsx
+++ b/packages/heroui/src/components/auth/username/sign-in-username.tsx
@@ -21,7 +21,6 @@ import {
   cn,
   Description,
   FieldError,
-  Form,
   Input,
   InputGroup,
   Label,
@@ -30,9 +29,10 @@ import {
   TextField
 } from "@heroui/react"
 import { useIsMutating } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 import { useSignInContinuation } from "../../../lib/auth/use-sign-in-continuation"
 import { usernamePlugin } from "../../../lib/auth/username-plugin"
+import { useAuthForm } from "../auth-form"
 import { FieldSeparator } from "../field-separator"
 import { LastUsedBadge } from "../last-login-method/last-used-badge"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
@@ -71,7 +71,6 @@ export function SignInUsername({
 
   const { localization: usernameLocalization } = useAuthPlugin(usernamePlugin)
 
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
 
   function isEmail(value: string): boolean {
@@ -81,7 +80,7 @@ export function SignInUsername({
   const { mutate: signInEmail, isPending: isSignInEmailPending } =
     useSignInEmail(authClient, {
       onError: (error, { email }) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
           sessionStorage.setItem("better-auth-ui.verify-email", email)
@@ -101,7 +100,7 @@ export function SignInUsername({
   const { mutate: signInUsername, isPending: isSignInUsernamePending } =
     useSignInUsername(authClient as UsernameAuthClient, {
       onError: (error) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
           sessionStorage.removeItem("better-auth-ui.verify-email")
@@ -119,29 +118,31 @@ export function SignInUsername({
       }
     })
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const formData = new FormData(e.currentTarget)
-    const email = formData.get("email") as string
-    const rememberMe = formData.get("rememberMe") === "on"
-
-    if (isEmail(email)) {
-      signInEmail({
-        email,
-        password,
-        ...(emailAndPassword?.rememberMe ? { rememberMe } : {}),
-        fetchOptions
-      })
-    } else {
-      signInUsername({
-        username: email,
-        password,
-        ...(emailAndPassword?.rememberMe ? { rememberMe } : {}),
-        fetchOptions
-      })
+  const form = useAuthForm({
+    defaultValues: { email: "", password: "", rememberMe: false },
+    onSubmit: ({ value }) => {
+      const email = value.email
+      if (isEmail(email)) {
+        signInEmail({
+          email,
+          password: value.password,
+          ...(emailAndPassword?.rememberMe
+            ? { rememberMe: value.rememberMe }
+            : {}),
+          fetchOptions
+        })
+      } else {
+        signInUsername({
+          username: email,
+          password: value.password,
+          ...(emailAndPassword?.rememberMe
+            ? { rememberMe: value.rememberMe }
+            : {}),
+          fetchOptions
+        })
+      }
     }
-  }
+  })
 
   const signInMutating = useIsMutating({
     mutationKey: authMutationKeys.signIn.all
@@ -186,127 +187,159 @@ export function SignInUsername({
         )}
 
         {emailAndPassword?.enabled && (
-          <Form onSubmit={handleSubmit} className="flex flex-col gap-4">
-            <TextField
-              name="email"
-              type="text"
-              autoComplete={withPasskeyAutoFill("username", passkeyAutoFill)}
-              isDisabled={isPending}
-              validate={(value) => {
-                if (!value) return localization.auth.fieldRequired
-              }}
-            >
-              <Label>{usernameLocalization.username}</Label>
-
-              <Input
-                placeholder={usernameLocalization.usernameOrEmailPlaceholder}
-                variant={variant === "transparent" ? "primary" : "secondary"}
-                required
-              />
-
-              <FieldError />
-            </TextField>
-
-            <TextField
-              minLength={emailAndPassword?.minPasswordLength}
-              maxLength={emailAndPassword?.maxPasswordLength}
-              name="password"
-              autoComplete={withPasskeyAutoFill(
-                "current-password",
-                passkeyAutoFill
-              )}
-              isDisabled={isPending}
-              value={password}
-              onChange={setPassword}
-              validate={(value) => {
-                if (!value) return localization.auth.fieldRequired
-                const min = emailAndPassword?.minPasswordLength
-                const max = emailAndPassword?.maxPasswordLength
-                if (min && value.length < min)
-                  return localization.auth.tooShort.replace(
-                    "{{min}}",
-                    String(min)
-                  )
-                if (max && value.length > max)
-                  return localization.auth.tooLong.replace(
-                    "{{max}}",
-                    String(max)
-                  )
-              }}
-            >
-              <Label>{localization.auth.password}</Label>
-
-              <InputGroup
-                variant={variant === "transparent" ? "primary" : "secondary"}
-              >
-                <InputGroup.Input
-                  placeholder={localization.auth.passwordPlaceholder}
-                  type={isPasswordVisible ? "text" : "password"}
-                  required
-                />
-
-                <InputGroup.Suffix className="px-0">
-                  <Button
-                    isIconOnly
-                    aria-label={
-                      isPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
-                    }
-                    size="sm"
-                    variant="ghost"
-                    onPress={() => setIsPasswordVisible(!isPasswordVisible)}
+          <form.AppForm>
+            <form.AuthFormRoot className="flex flex-col gap-4">
+              <form.AppField name="email">
+                {(field) => (
+                  <TextField
+                    name={field.name}
+                    type="text"
+                    autoComplete={withPasskeyAutoFill(
+                      "username",
+                      passkeyAutoFill
+                    )}
                     isDisabled={isPending}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={field.handleChange}
+                    validate={(value) => {
+                      if (!value) return localization.auth.fieldRequired
+                    }}
                   >
-                    {isPasswordVisible ? <EyeSlash /> : <Eye />}
-                  </Button>
-                </InputGroup.Suffix>
-              </InputGroup>
+                    <Label>{usernameLocalization.username}</Label>
 
-              <FieldError />
-            </TextField>
+                    <Input
+                      placeholder={
+                        usernameLocalization.usernameOrEmailPlaceholder
+                      }
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
+                      }
+                      required
+                    />
 
-            {emailAndPassword?.rememberMe && (
-              <Checkbox
-                name="rememberMe"
-                isDisabled={isPending}
-                variant={variant === "transparent" ? "primary" : "secondary"}
-              >
-                <Checkbox.Content>
-                  <Checkbox.Control>
-                    <Checkbox.Indicator />
-                  </Checkbox.Control>
+                    <FieldError />
+                  </TextField>
+                )}
+              </form.AppField>
 
-                  {localization.auth.rememberMe}
-                </Checkbox.Content>
-              </Checkbox>
-            )}
+              <form.AppField name="password">
+                {(field) => (
+                  <TextField
+                    minLength={emailAndPassword?.minPasswordLength}
+                    maxLength={emailAndPassword?.maxPasswordLength}
+                    name={field.name}
+                    autoComplete={withPasskeyAutoFill(
+                      "current-password",
+                      passkeyAutoFill
+                    )}
+                    isDisabled={isPending}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={field.handleChange}
+                    validate={(value) => {
+                      if (!value) return localization.auth.fieldRequired
+                      const min = emailAndPassword?.minPasswordLength
+                      const max = emailAndPassword?.maxPasswordLength
+                      if (min && value.length < min)
+                        return localization.auth.tooShort.replace(
+                          "{{min}}",
+                          String(min)
+                        )
+                      if (max && value.length > max)
+                        return localization.auth.tooLong.replace(
+                          "{{max}}",
+                          String(max)
+                        )
+                    }}
+                  >
+                    <Label>{localization.auth.password}</Label>
 
-            {Captcha && <div className="flex justify-center">{Captcha}</div>}
+                    <InputGroup
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
+                      }
+                    >
+                      <InputGroup.Input
+                        placeholder={localization.auth.passwordPlaceholder}
+                        type={isPasswordVisible ? "text" : "password"}
+                        required
+                      />
 
-            <div className="flex flex-col gap-3">
-              <Button
-                type="submit"
-                className="relative w-full overflow-visible"
-                isPending={isSignInPending || isPending}
-              >
-                {isSignInPending && <Spinner color="current" size="sm" />}
+                      <InputGroup.Suffix className="px-0">
+                        <Button
+                          isIconOnly
+                          aria-label={
+                            isPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          size="sm"
+                          variant="ghost"
+                          onPress={() =>
+                            setIsPasswordVisible(!isPasswordVisible)
+                          }
+                          isDisabled={isPending}
+                        >
+                          {isPasswordVisible ? <EyeSlash /> : <Eye />}
+                        </Button>
+                      </InputGroup.Suffix>
+                    </InputGroup>
 
-                {localization.auth.signIn}
+                    <FieldError />
+                  </TextField>
+                )}
+              </form.AppField>
 
-                <LastUsedBadge method={["email", "username"]} floating />
-              </Button>
+              {emailAndPassword?.rememberMe && (
+                <form.AppField name="rememberMe">
+                  {(field) => (
+                    <Checkbox
+                      name={field.name}
+                      isDisabled={isPending}
+                      isSelected={field.state.value}
+                      onChange={field.handleChange}
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
+                      }
+                    >
+                      <Checkbox.Content>
+                        <Checkbox.Control>
+                          <Checkbox.Indicator />
+                        </Checkbox.Control>
 
-              {plugins.flatMap((plugin) =>
-                plugin.authButtons?.map((AuthButton, index) => (
-                  <AuthButton
-                    key={`${plugin.id}-${index.toString()}`}
-                    view="signIn"
-                  />
-                ))
+                        {localization.auth.rememberMe}
+                      </Checkbox.Content>
+                    </Checkbox>
+                  )}
+                </form.AppField>
               )}
-            </div>
-          </Form>
+
+              {Captcha && <div className="flex justify-center">{Captcha}</div>}
+
+              <div className="flex flex-col gap-3">
+                <form.AuthFormSubmitButton
+                  className="relative w-full overflow-visible"
+                  isDisabled={isSignInPending || isPending}
+                >
+                  {isSignInPending && <Spinner color="current" size="sm" />}
+
+                  {localization.auth.signIn}
+
+                  <LastUsedBadge method={["email", "username"]} floating />
+                </form.AuthFormSubmitButton>
+
+                {plugins.flatMap((plugin) =>
+                  plugin.authButtons?.map((AuthButton, index) => (
+                    <AuthButton
+                      key={`${plugin.id}-${index.toString()}`}
+                      view="signIn"
+                    />
+                  ))
+                )}
+              </div>
+            </form.AuthFormRoot>
+          </form.AppForm>
         )}
 
         {socialPosition === "bottom" && (


### PR DESCRIPTION
## Summary

- migrate every requested auth input in the shadcn, Base UI, Next, and docs implementations to TanStack Form
- migrate the matching straightforward HeroUI credential, recovery, API-key, passkey, account-security, SSO-domain, SIWE, and organization-deletion forms
- replace per-view `FormData` parsing with typed form values and the shared TanStack submit lifecycle

## Stack

This PR is stacked on #553, which first migrates runtime-defined additional fields.

## Validation

- `bun nx run start-shadcn-example:typecheck`
- `bun nx run start-shadcn-baseui-example:typecheck`
- `bun nx run @better-auth-ui/heroui:typecheck`
- Biome pre-commit checks on all committed files

## Remaining parity work

The multi-step HeroUI flows and the Solid/Zaidan implementations still need their platform-parity migration. They are intentionally called out here so this ready-for-review PR does not imply that those surfaces are complete.
