### PR TITLE
refactor(ui): tighten TanStack form and table integrations

### DIFF
--- a/apps/docs/src/components/auth/auth-form.tsx
+++ b/apps/docs/src/components/auth/auth-form.tsx
@@ -3,6 +3,7 @@
 import {
   type AdditionalField as AdditionalFieldConfig,
   type AdditionalFieldFormValue,
+  DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS,
   getFormFieldErrors,
   validateAdditionalFieldRequired,
   validateAdditionalFieldValue
@@ -128,7 +129,12 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   )
 }
 
-export const { useAppForm: useAuthForm } = createFormHook({
+export const {
+  useAppForm: useAuthForm,
+  useTypedAppFormContext: useTypedAuthFormContext,
+  withFieldGroup: withAuthFieldGroup,
+  withForm: withAuthForm
+} = createFormHook({
   fieldComponents: { AuthFormAdditionalField, AuthFormFieldError },
   fieldContext,
   formComponents: { AuthFormRoot, AuthFormSubmitButton },
@@ -155,6 +161,10 @@ export function getAuthAdditionalFieldValidators(
     onChangeAsync: field.validate
       ? ({ value }: { value: AdditionalFieldFormValue }) =>
           validateAdditionalFieldValue(field, value)
+      : undefined,
+    onChangeAsyncDebounceMs: field.validate
+      ? (field.validateDebounceMs ??
+        DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS)
       : undefined
   }
 }

--- a/apps/docs/src/components/auth/device-authorization/device-authorization.tsx
+++ b/apps/docs/src/components/auth/device-authorization/device-authorization.tsx
@@ -10,6 +10,7 @@ import {
   useDenyDevice,
   useVerifyDeviceCode
 } from "@better-auth-ui/react/plugins/device-authorization"
+import { useSelector } from "@tanstack/react-form"
 import { REGEXP_ONLY_DIGITS_AND_CHARS } from "input-otp"
 import { CheckIcon, CircleCheckIcon, CircleXIcon, XIcon } from "lucide-react"
 import {
@@ -312,6 +313,10 @@ function DeviceCodeForm({
     defaultValues: { userCode: initialUserCode },
     onSubmit: ({ value }) => onSubmitCode(value.userCode)
   })
+  const userCodeComplete = useSelector(
+    form.store,
+    (state) => state.values.userCode.length === userCodeLength
+  )
 
   useEffect(() => {
     form.setFieldValue("userCode", initialUserCode)
@@ -390,11 +395,7 @@ function DeviceCodeForm({
 
               <form.AuthFormSubmitButton
                 className="w-full"
-                disabled={
-                  form.state.values.userCode.length !== userCodeLength ||
-                  isSessionPending ||
-                  isVerifying
-                }
+                disabled={!userCodeComplete || isSessionPending || isVerifying}
                 type="submit"
               >
                 {isVerifying ? <Spinner data-icon="inline-start" /> : null}

--- a/apps/docs/src/components/auth/email-otp/change-email-otp.tsx
+++ b/apps/docs/src/components/auth/email-otp/change-email-otp.tsx
@@ -7,6 +7,7 @@ import {
   useRequestEmailChangeOtp,
   useSendVerificationOtp
 } from "@better-auth-ui/react/plugins/email-otp"
+import { useSelector } from "@tanstack/react-form"
 import { useEffect, useReducer } from "react"
 import { toast } from "sonner"
 
@@ -150,6 +151,10 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
       submitCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (formState) => formState.values.code.length === otpLength
+  )
 
   const resetFlow = () => {
     form.reset()
@@ -261,8 +266,7 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
                 disabled={
                   isPending ||
                   !session ||
-                  (state.step !== "email" &&
-                    form.state.values.code.length !== otpLength)
+                  (state.step !== "email" && !codeComplete)
                 }
               >
                 {isPending && <Spinner />}

--- a/apps/docs/src/components/auth/email-otp/email-otp.tsx
+++ b/apps/docs/src/components/auth/email-otp/email-otp.tsx
@@ -8,6 +8,7 @@ import {
   useSendVerificationOtp,
   useSignInEmailOtp
 } from "@better-auth-ui/react/plugins/email-otp"
+import { useSelector } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { useState } from "react"
 
@@ -123,6 +124,11 @@ export function EmailOtp({
       verifyCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (state) => state.values.code.length === otpLength
+  )
+  const email = useSelector(form.store, (state) => state.values.email)
 
   const showSeparator = socialProviders && socialProviders.length > 0
 
@@ -133,10 +139,7 @@ export function EmailOtp({
 
         {codeSent && (
           <CardDescription>
-            {emailOtpLocalization.codeSentTo.replace(
-              "{{email}}",
-              form.state.values.email
-            )}
+            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
           </CardDescription>
         )}
       </CardHeader>
@@ -205,9 +208,7 @@ export function EmailOtp({
                 <div className="flex flex-col gap-3">
                   <form.AuthFormSubmitButton
                     disabled={
-                      isPending ||
-                      isSigningIn ||
-                      (codeSent && form.state.values.code.length !== otpLength)
+                      isPending || isSigningIn || (codeSent && !codeComplete)
                     }
                   >
                     {(isSending || isSigningIn) && <Spinner />}
@@ -219,10 +220,7 @@ export function EmailOtp({
 
                   {codeSent ? (
                     <>
-                      <OpenEmailButton
-                        email={form.state.values.email}
-                        variant="secondary"
-                      />
+                      <OpenEmailButton email={email} variant="secondary" />
 
                       <Button
                         type="button"

--- a/apps/docs/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/apps/docs/src/components/auth/email-otp/reset-password-otp.tsx
@@ -7,6 +7,7 @@ import {
 import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPasswordOtp } from "@better-auth-ui/react/plugins/email-otp"
+import { useSelector } from "@tanstack/react-form"
 import { Eye, EyeOff } from "lucide-react"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
@@ -128,6 +129,7 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
       })
     }
   })
+  const email = useSelector(form.store, (state) => state.values.email)
 
   useEffect(() => {
     const storedEmail =
@@ -143,12 +145,9 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
           {localization.auth.resetPassword}
         </CardTitle>
 
-        {hasStoredEmail && form.state.values.email && (
+        {hasStoredEmail && email && (
           <CardDescription>
-            {emailOtpLocalization.codeSentTo.replace(
-              "{{email}}",
-              form.state.values.email
-            )}
+            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
           </CardDescription>
         )}
       </CardHeader>
@@ -298,12 +297,7 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
                   {localization.auth.resetPassword}
                 </form.AuthFormSubmitButton>
 
-                {form.state.values.email && (
-                  <OpenEmailButton
-                    email={form.state.values.email}
-                    variant="secondary"
-                  />
-                )}
+                {email && <OpenEmailButton email={email} variant="secondary" />}
               </div>
             </FieldGroup>
           </form.AuthFormRoot>

--- a/apps/docs/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/apps/docs/src/components/auth/email-otp/verify-email-otp.tsx
@@ -7,6 +7,7 @@ import {
   useSendVerificationOtp,
   useVerifyEmailOtp
 } from "@better-auth-ui/react/plugins/email-otp"
+import { useSelector } from "@tanstack/react-form"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
@@ -130,6 +131,10 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
       verifyCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (state) => state.values.code.length === otpLength
+  )
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -195,11 +200,7 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
 
               <div className="flex flex-col gap-3">
                 <form.AuthFormSubmitButton
-                  disabled={
-                    isPending ||
-                    (Boolean(email) &&
-                      form.state.values.code.length !== otpLength)
-                  }
+                  disabled={isPending || (Boolean(email) && !codeComplete)}
                 >
                   {isPending && <Spinner />}
 

--- a/apps/docs/src/components/auth/organization/organization-invitation-row.tsx
+++ b/apps/docs/src/components/auth/organization/organization-invitation-row.tsx
@@ -22,11 +22,14 @@ import { TableCell, TableRow } from "@/components/ui/table"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
 import { OrganizationInvitationRowSkeleton } from "./organization-invitation-row-skeleton"
-import { OrganizationTableSelectRow } from "./organization-table-selection"
+import {
+  type OrganizationSelectableRow,
+  OrganizationTableSelectRow
+} from "./organization-table-selection"
 
 export type OrganizationInvitationRowProps = {
   invitation: Invitation
-  selectableRow?: Parameters<typeof OrganizationTableSelectRow>[0]["row"]
+  selectableRow?: OrganizationSelectableRow<Invitation>
   showCreatedAt?: boolean
   showEmail?: boolean
   showRole?: boolean

--- a/apps/docs/src/components/auth/organization/organization-member-row.tsx
+++ b/apps/docs/src/components/auth/organization/organization-member-row.tsx
@@ -26,7 +26,10 @@ import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { UserView } from "../user/user-view"
 import { EditMemberRolesDialog } from "./edit-member-roles-dialog"
 import { LeaveOrganizationDialog } from "./leave-organization-dialog"
-import { OrganizationTableSelectRow } from "./organization-table-selection"
+import {
+  type OrganizationSelectableRow,
+  OrganizationTableSelectRow
+} from "./organization-table-selection"
 import { RemoveMemberDialog } from "./remove-member-dialog"
 
 export type OrganizationMemberRowProps = {
@@ -34,7 +37,7 @@ export type OrganizationMemberRowProps = {
   isOwner?: boolean
   ownerCount?: number
   organization: Organization
-  selectableRow?: Parameters<typeof OrganizationTableSelectRow>[0]["row"]
+  selectableRow?: OrganizationSelectableRow<Member & { user: Partial<User> }>
   showRole?: boolean
   showTeams?: boolean
 }

--- a/apps/docs/src/components/auth/organization/organization-roles.tsx
+++ b/apps/docs/src/components/auth/organization/organization-roles.tsx
@@ -83,6 +83,7 @@ import {
 import { OrganizationTableBulkAction } from "./organization-table-bulk-action"
 import { OrganizationTablePagination } from "./organization-table-pagination"
 import {
+  type OrganizationSelectableRow,
   OrganizationTableSelectAll,
   OrganizationTableSelectRow
 } from "./organization-table-selection"
@@ -464,7 +465,7 @@ function OrganizationRoleRow({
   onEdit: () => void
   organizationId: string
   role: Role
-  selectableRow?: Parameters<typeof OrganizationTableSelectRow>[0]["row"]
+  selectableRow?: OrganizationSelectableRow<Role>
   showPermissions: boolean
 }) {
   const { localization: authLocalization } = useAuth()

--- a/apps/docs/src/components/auth/organization/organization-table-selection.tsx
+++ b/apps/docs/src/components/auth/organization/organization-table-selection.tsx
@@ -1,19 +1,16 @@
 "use client"
 
 import type { OrganizationLocalization } from "@better-auth-ui/core/plugins/organization"
+import { type Row, type RowData, Subscribe } from "@tanstack/react-table"
 import type { MouseEvent } from "react"
 
 import { Checkbox } from "@/components/ui/checkbox"
+import type { organizationTableFeatures } from "./organization-table"
 
-type SelectableRow = {
-  getCanSelect: () => boolean
-  getIsSelected: () => boolean
-  getToggleSelectedHandler: () => (event: {
-    nativeEvent: MouseEvent<HTMLButtonElement>["nativeEvent"]
-    shiftKey: boolean
-    target: { checked: boolean }
-  }) => void
-}
+export type OrganizationSelectableRow<TData extends RowData> = Row<
+  typeof organizationTableFeatures,
+  TData
+>
 
 export function OrganizationTableSelectAll({
   allSelected,
@@ -39,31 +36,34 @@ export function OrganizationTableSelectAll({
   )
 }
 
-export function OrganizationTableSelectRow({
+export function OrganizationTableSelectRow<TData extends RowData>({
   disabled,
   localization,
   row
 }: {
   disabled?: boolean
   localization: OrganizationLocalization
-  row: SelectableRow
+  row: OrganizationSelectableRow<TData>
 }) {
-  const selected = row.getIsSelected()
-
-  function toggle(event: MouseEvent<HTMLElement>) {
-    row.getToggleSelectedHandler()({
-      nativeEvent: event.nativeEvent,
-      shiftKey: event.shiftKey,
-      target: { checked: !selected }
-    })
-  }
-
   return (
-    <Checkbox
-      aria-label={localization.selectRow}
-      checked={selected}
-      disabled={disabled || !row.getCanSelect()}
-      onClick={toggle}
-    />
+    <Subscribe
+      source={row.table.atoms.rowSelection}
+      selector={(selection) => selection[row.id] === true}
+    >
+      {(selected) => (
+        <Checkbox
+          aria-label={localization.selectRow}
+          checked={selected}
+          disabled={disabled || !row.getCanSelect()}
+          onClick={(event: MouseEvent<HTMLElement>) =>
+            row.getToggleSelectedHandler()({
+              nativeEvent: event.nativeEvent,
+              shiftKey: event.shiftKey,
+              target: { checked: !selected }
+            })
+          }
+        />
+      )}
+    </Subscribe>
   )
 }

--- a/apps/docs/src/components/auth/organization/organization-table-state.ts
+++ b/apps/docs/src/components/auth/organization/organization-table-state.ts
@@ -2,12 +2,10 @@
 
 import {
   parseTableColumnVisibility,
-  parseTableFilterValue,
-  parseTablePage,
-  parseTablePageSize,
-  parseTableSorting,
+  parseTableUrlState,
   serializeTableColumnVisibility,
-  serializeTableFilterValue
+  serializeTableUrlState,
+  type TableUrlState
 } from "@better-auth-ui/core"
 import { useCreateAtom, useSelector } from "@tanstack/react-store"
 import {
@@ -35,38 +33,18 @@ function readUrlState(
   stateKey: string,
   defaultPageSize: number,
   allowedColumnIds?: readonly string[]
-): OrganizationTableUrlState {
+): TableUrlState {
   const params =
     typeof window === "undefined"
       ? new URLSearchParams()
       : new URLSearchParams(window.location.search)
-  const filterPrefix = `${stateKey}.filter.`
-  const columnFilters: ColumnFiltersState = []
-
-  for (const [key, value] of params) {
-    const id = key.slice(filterPrefix.length)
-    if (
-      key.startsWith(filterPrefix) &&
-      value &&
-      (!allowedColumnIds || allowedColumnIds.includes(id))
-    ) {
-      columnFilters.push({ id, value: parseTableFilterValue(value) })
-    }
-  }
-
-  return {
-    columnFilters,
-    globalFilter: params.get(`${stateKey}.search`) ?? "",
-    pagination: {
-      pageIndex: parseTablePage(params.get(`${stateKey}.page`), 1) - 1,
-      pageSize: parseTablePageSize(
-        params.get(`${stateKey}.pageSize`),
-        defaultPageSize,
-        ORGANIZATION_TABLE_PAGE_SIZE_OPTIONS
-      )
-    },
-    sorting: parseTableSorting(params.get(`${stateKey}.sort`), allowedColumnIds)
-  }
+  return parseTableUrlState(
+    params,
+    stateKey,
+    defaultPageSize,
+    ORGANIZATION_TABLE_PAGE_SIZE_OPTIONS,
+    allowedColumnIds
+  )
 }
 
 function readColumnVisibility(
@@ -85,16 +63,6 @@ function readColumnVisibility(
   }
 }
 
-function setOrDelete(
-  params: URLSearchParams,
-  key: string,
-  value: string,
-  defaultValue = ""
-) {
-  if (value === defaultValue) params.delete(key)
-  else params.set(key, value)
-}
-
 function writeUrlState(
   stateKey: string,
   defaultPageSize: number,
@@ -103,37 +71,12 @@ function writeUrlState(
   if (typeof window === "undefined") return
 
   const url = new URL(window.location.href)
-  const filterPrefix = `${stateKey}.filter.`
-
-  for (const key of Array.from(url.searchParams.keys())) {
-    if (key.startsWith(filterPrefix)) url.searchParams.delete(key)
-  }
-
-  for (const filter of state.columnFilters) {
-    const value = serializeTableFilterValue(filter.value)
-    if (value) url.searchParams.set(`${filterPrefix}${filter.id}`, value)
-  }
-
-  setOrDelete(url.searchParams, `${stateKey}.search`, state.globalFilter)
-  setOrDelete(
+  url.search = serializeTableUrlState(
     url.searchParams,
-    `${stateKey}.page`,
-    String(state.pagination.pageIndex + 1),
-    "1"
-  )
-  setOrDelete(
-    url.searchParams,
-    `${stateKey}.pageSize`,
-    String(state.pagination.pageSize),
-    String(defaultPageSize)
-  )
-  setOrDelete(
-    url.searchParams,
-    `${stateKey}.sort`,
-    state.sorting
-      .map(({ desc, id }) => `${id}.${desc ? "desc" : "asc"}`)
-      .join(",")
-  )
+    stateKey,
+    defaultPageSize,
+    state
+  ).toString()
 
   window.history.replaceState(window.history.state, "", url)
 }
@@ -144,6 +87,7 @@ export function useOrganizationTableState(
   allowedColumnIds?: readonly string[]
 ) {
   const columnFiltersAtom = useCreateAtom<ColumnFiltersState>([])
+  const columnVisibilityAtom = useCreateAtom<ColumnVisibilityState>({})
   const globalFilterAtom = useCreateAtom("")
   const paginationAtom = useCreateAtom<PaginationState>({
     pageIndex: 0,
@@ -152,12 +96,11 @@ export function useOrganizationTableState(
   const rowSelectionAtom = useCreateAtom<RowSelectionState>({})
   const sortingAtom = useCreateAtom<SortingState>([])
   const columnFilters = useSelector(columnFiltersAtom)
+  const columnVisibility = useSelector(columnVisibilityAtom)
   const globalFilter = useSelector(globalFilterAtom)
   const pagination = useSelector(paginationAtom)
   const rowSelection = useSelector(rowSelectionAtom)
   const sorting = useSelector(sortingAtom)
-  const [columnVisibility, setColumnVisibility] =
-    useState<ColumnVisibilityState>({})
   const [urlReady, setUrlReady] = useState(false)
   const [visibilityReady, setVisibilityReady] = useState(false)
   const atoms = useMemo(
@@ -180,47 +123,49 @@ export function useOrganizationTableState(
   const setPagination = useCallback(
     (updater: Updater<PaginationState>) => {
       paginationAtom.set((current) => functionalUpdate(updater, current))
-      rowSelectionAtom.set({})
     },
-    [paginationAtom, rowSelectionAtom]
+    [paginationAtom]
+  )
+
+  const setColumnVisibility = useCallback(
+    (updater: Updater<ColumnVisibilityState>) => {
+      columnVisibilityAtom.set((current) => functionalUpdate(updater, current))
+    },
+    [columnVisibilityAtom]
   )
 
   const setColumnFilters = useCallback(
     (updater: Updater<ColumnFiltersState>) => {
       columnFiltersAtom.set((current) => functionalUpdate(updater, current))
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
     },
-    [columnFiltersAtom, paginationAtom, rowSelectionAtom]
+    [columnFiltersAtom]
   )
 
   const setGlobalFilter = useCallback(
     (updater: Updater<string>) => {
       globalFilterAtom.set((current) => functionalUpdate(updater, current))
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
     },
-    [globalFilterAtom, paginationAtom, rowSelectionAtom]
+    [globalFilterAtom]
   )
 
   const setSorting = useCallback(
     (updater: Updater<SortingState>) => {
       sortingAtom.set((current) => functionalUpdate(updater, current))
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
     },
-    [paginationAtom, rowSelectionAtom, sortingAtom]
+    [sortingAtom]
   )
 
   useEffect(() => {
-    const resetPageAndSelection = () => {
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
+    const resetPage = () => {
+      const current = paginationAtom.get()
+      if (current.pageIndex === 0) rowSelectionAtom.set({})
+      else paginationAtom.set({ ...current, pageIndex: 0 })
     }
     const subscriptions = [
-      columnFiltersAtom.subscribe(resetPageAndSelection),
-      globalFilterAtom.subscribe(resetPageAndSelection),
-      sortingAtom.subscribe(resetPageAndSelection)
+      columnFiltersAtom.subscribe(resetPage),
+      globalFilterAtom.subscribe(resetPage),
+      sortingAtom.subscribe(resetPage),
+      paginationAtom.subscribe(() => rowSelectionAtom.set({}))
     ]
 
     return () => {
@@ -267,7 +212,7 @@ export function useOrganizationTableState(
   }, [columnVisibility, stateKey, visibilityReady])
 
   useEffect(() => {
-    setColumnVisibility(readColumnVisibility(stateKey, allowedColumnIds))
+    columnVisibilityAtom.set(readColumnVisibility(stateKey, allowedColumnIds))
     setVisibilityReady(true)
 
     const restoreUrlState = () => {
@@ -276,7 +221,6 @@ export function useOrganizationTableState(
       globalFilterAtom.set(next.globalFilter)
       sortingAtom.set(next.sorting)
       paginationAtom.set(next.pagination)
-      rowSelectionAtom.set({})
       setUrlReady(true)
     }
 
@@ -286,10 +230,10 @@ export function useOrganizationTableState(
   }, [
     allowedColumnIds,
     columnFiltersAtom,
+    columnVisibilityAtom,
     defaultPageSize,
     globalFilterAtom,
     paginationAtom,
-    rowSelectionAtom,
     sortingAtom,
     stateKey
   ])

--- a/apps/docs/src/components/auth/organization/organization-table.ts
+++ b/apps/docs/src/components/auth/organization/organization-table.ts
@@ -20,25 +20,27 @@ import {
 
 export const ORGANIZATION_TABLE_PAGE_SIZE = 10
 
+export const organizationTableFeatures = tableFeatures({
+  columnFilteringFeature,
+  globalFilteringFeature,
+  filteredRowModel: createFilteredRowModel(),
+  filterFns: { includesString: filterFn_includesString },
+  columnFacetingFeature,
+  facetedRowModel: createFacetedRowModel(),
+  facetedUniqueValues: createFacetedUniqueValues(),
+  columnVisibilityFeature,
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+  rowPaginationFeature,
+  paginatedRowModel: createPaginatedRowModel(),
+  rowSelectionFeature
+})
+
 export const {
   createAppColumnHelper: createOrganizationColumnHelper,
   useAppTable: useOrganizationTable
 } = createTableHook({
   enableMultiSort: true,
   sortDescFirst: false,
-  features: tableFeatures({
-    columnFilteringFeature,
-    globalFilteringFeature,
-    filteredRowModel: createFilteredRowModel(),
-    filterFns: { includesString: filterFn_includesString },
-    columnFacetingFeature,
-    facetedRowModel: createFacetedRowModel(),
-    facetedUniqueValues: createFacetedUniqueValues(),
-    columnVisibilityFeature,
-    rowSortingFeature,
-    sortedRowModel: createSortedRowModel(),
-    rowPaginationFeature,
-    paginatedRowModel: createPaginatedRowModel(),
-    rowSelectionFeature
-  })
+  features: organizationTableFeatures
 })

--- a/apps/docs/src/components/auth/phone-number/change-phone-number.tsx
+++ b/apps/docs/src/components/auth/phone-number/change-phone-number.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getFormFieldErrorMessage } from "@better-auth-ui/core"
 import {
   createPhoneNumberValue,
   type PhoneNumberAuthClient
@@ -14,6 +15,7 @@ import {
   useSendPhoneNumberOtp,
   useVerifyPhoneNumber
 } from "@better-auth-ui/react/plugins/phone-number"
+import { useSelector } from "@tanstack/react-form"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
@@ -101,6 +103,14 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
       })
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (formState) => formState.values.code.length === otpLength
+  )
+  const phoneNumberDisplay = useSelector(
+    form.store,
+    (formState) => formState.values.phoneNumber.display
+  )
 
   useEffect(() => {
     if (session) {
@@ -129,7 +139,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                   <FieldDescription>
                     {localization.codeSentTo.replace(
                       "{{phoneNumber}}",
-                      form.state.values.phoneNumber.display
+                      phoneNumberDisplay
                     )}
                   </FieldDescription>
                   <form.AppField name="code">
@@ -160,7 +170,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                       countryCodes={countries}
                       countryLabel={localization.country}
                       disabled={isPending}
-                      error={field.state.meta.errors[0]?.toString()}
+                      error={getFormFieldErrorMessage(field.state.meta.errors)}
                       locale={locale}
                       phoneLabel={localization.phoneNumber}
                       placeholder={localization.phoneNumberPlaceholder}
@@ -198,11 +208,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
               )}
               <form.AuthFormSubmitButton
                 size="sm"
-                disabled={
-                  isPending ||
-                  !session ||
-                  (codeSent && form.state.values.code.length !== otpLength)
-                }
+                disabled={isPending || !session || (codeSent && !codeComplete)}
               >
                 {(isSending || isVerifying) && <Spinner />}
                 {codeSent

--- a/apps/docs/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/apps/docs/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getFormFieldErrorMessage } from "@better-auth-ui/core"
 import {
   createPhoneNumberValue,
   type PhoneNumberAuthClient
@@ -87,7 +88,7 @@ export function ForgotPhoneNumberPassword({
                     countryCodes={countries}
                     countryLabel={phoneLocalization.country}
                     disabled={isPending}
-                    error={field.state.meta.errors[0]?.toString()}
+                    error={getFormFieldErrorMessage(field.state.meta.errors)}
                     locale={locale}
                     phoneLabel={phoneLocalization.phoneNumber}
                     placeholder={phoneLocalization.phoneNumberPlaceholder}

--- a/apps/docs/src/components/auth/phone-number/phone-number.tsx
+++ b/apps/docs/src/components/auth/phone-number/phone-number.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import {
+  authMutationKeys,
+  getFormFieldErrorMessage
+} from "@better-auth-ui/core"
 import {
   createPhoneNumberValue,
   type PhoneNumberAuthClient
@@ -16,6 +19,7 @@ import {
   useSignInPhoneNumber,
   useVerifyPhoneNumber
 } from "@better-auth-ui/react/plugins/phone-number"
+import { useSelector } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
 import { useState } from "react"
@@ -204,6 +208,14 @@ export function PhoneNumber({
       verifyCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (state) => state.values.code.length === otpLength
+  )
+  const phoneNumberDisplay = useSelector(
+    form.store,
+    (state) => state.values.phoneNumber.display
+  )
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -217,7 +229,7 @@ export function PhoneNumber({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              form.state.values.phoneNumber.display
+              phoneNumberDisplay
             )}
           </CardDescription>
         )}
@@ -271,7 +283,9 @@ export function PhoneNumber({
                           countryCodes={countries}
                           countryLabel={phoneLocalization.country}
                           disabled={isPending}
-                          error={field.state.meta.errors[0]?.toString()}
+                          error={getFormFieldErrorMessage(
+                            field.state.meta.errors
+                          )}
                           locale={locale}
                           phoneLabel={phoneLocalization.phoneNumber}
                           placeholder={phoneLocalization.phoneNumberPlaceholder}
@@ -367,10 +381,7 @@ export function PhoneNumber({
 
                 <div className="flex flex-col gap-3">
                   <form.AuthFormSubmitButton
-                    disabled={
-                      isPending ||
-                      (codeSent && form.state.values.code.length !== otpLength)
-                    }
+                    disabled={isPending || (codeSent && !codeComplete)}
                   >
                     {(isSending || isVerifying || isPasswordPending) && (
                       <Spinner />

--- a/apps/docs/src/components/auth/phone-number/reset-phone-number-password.tsx
+++ b/apps/docs/src/components/auth/phone-number/reset-phone-number-password.tsx
@@ -4,6 +4,7 @@ import { isPasswordCompromisedError } from "@better-auth-ui/core"
 import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPhoneNumberPassword } from "@better-auth-ui/react/plugins/phone-number"
+import { useSelector } from "@tanstack/react-form"
 import { Eye, EyeOff } from "lucide-react"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
@@ -115,6 +116,14 @@ export function ResetPhoneNumberPassword({
       })
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (formState) => formState.values.code.length === otpLength
+  )
+  const phoneNumber = useSelector(
+    form.store,
+    (formState) => formState.values.phoneNumber
+  )
 
   useEffect(() => {
     const stored = sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY) ?? ""
@@ -132,7 +141,7 @@ export function ResetPhoneNumberPassword({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              form.state.values.phoneNumber
+              phoneNumber
             )}
           </CardDescription>
         )}
@@ -261,11 +270,7 @@ export function ResetPhoneNumberPassword({
                 </form.AppField>
               )}
 
-              <form.AuthFormSubmitButton
-                disabled={
-                  isPending || form.state.values.code.length !== otpLength
-                }
-              >
+              <form.AuthFormSubmitButton disabled={isPending || !codeComplete}>
                 {isPending && <Spinner />}
                 {phoneLocalization.resetPassword}
               </form.AuthFormSubmitButton>

--- a/apps/docs/src/components/auth/sso/email-first-sign-in.tsx
+++ b/apps/docs/src/components/auth/sso/email-first-sign-in.tsx
@@ -22,6 +22,7 @@ import {
   useSignInEmail
 } from "@better-auth-ui/react"
 import { useSignInSso } from "@better-auth-ui/react/plugins/sso"
+import { useSelector } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
 import { useState } from "react"
@@ -163,6 +164,7 @@ export function EmailFirstSignIn({
       })
     }
   })
+  const email = useSelector(form.store, (state) => state.values.email)
 
   const startOver = () => {
     setStep("email")
@@ -178,9 +180,7 @@ export function EmailFirstSignIn({
           {localization.auth.signIn}
         </CardTitle>
         <CardDescription>
-          {step === "email"
-            ? ssoLocalization.emailFirstDescription
-            : form.state.values.email}
+          {step === "email" ? ssoLocalization.emailFirstDescription : email}
         </CardDescription>
       </CardHeader>
 

--- a/examples/next-shadcn-example/src/components/auth/auth-form.tsx
+++ b/examples/next-shadcn-example/src/components/auth/auth-form.tsx
@@ -3,6 +3,7 @@
 import {
   type AdditionalField as AdditionalFieldConfig,
   type AdditionalFieldFormValue,
+  DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS,
   getFormFieldErrors,
   validateAdditionalFieldRequired,
   validateAdditionalFieldValue
@@ -128,7 +129,12 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   )
 }
 
-export const { useAppForm: useAuthForm } = createFormHook({
+export const {
+  useAppForm: useAuthForm,
+  useTypedAppFormContext: useTypedAuthFormContext,
+  withFieldGroup: withAuthFieldGroup,
+  withForm: withAuthForm
+} = createFormHook({
   fieldComponents: { AuthFormAdditionalField, AuthFormFieldError },
   fieldContext,
   formComponents: { AuthFormRoot, AuthFormSubmitButton },
@@ -155,6 +161,10 @@ export function getAuthAdditionalFieldValidators(
     onChangeAsync: field.validate
       ? ({ value }: { value: AdditionalFieldFormValue }) =>
           validateAdditionalFieldValue(field, value)
+      : undefined,
+    onChangeAsyncDebounceMs: field.validate
+      ? (field.validateDebounceMs ??
+        DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS)
       : undefined
   }
 }

--- a/examples/next-shadcn-example/src/components/auth/device-authorization/device-authorization.tsx
+++ b/examples/next-shadcn-example/src/components/auth/device-authorization/device-authorization.tsx
@@ -10,6 +10,7 @@ import {
   useDenyDevice,
   useVerifyDeviceCode
 } from "@better-auth-ui/react/plugins/device-authorization"
+import { useSelector } from "@tanstack/react-form"
 import { REGEXP_ONLY_DIGITS_AND_CHARS } from "input-otp"
 import { CheckIcon, CircleCheckIcon, CircleXIcon, XIcon } from "lucide-react"
 import {
@@ -312,6 +313,10 @@ function DeviceCodeForm({
     defaultValues: { userCode: initialUserCode },
     onSubmit: ({ value }) => onSubmitCode(value.userCode)
   })
+  const userCodeComplete = useSelector(
+    form.store,
+    (state) => state.values.userCode.length === userCodeLength
+  )
 
   useEffect(() => {
     form.setFieldValue("userCode", initialUserCode)
@@ -390,11 +395,7 @@ function DeviceCodeForm({
 
               <form.AuthFormSubmitButton
                 className="w-full"
-                disabled={
-                  form.state.values.userCode.length !== userCodeLength ||
-                  isSessionPending ||
-                  isVerifying
-                }
+                disabled={!userCodeComplete || isSessionPending || isVerifying}
                 type="submit"
               >
                 {isVerifying ? <Spinner data-icon="inline-start" /> : null}

--- a/examples/next-shadcn-example/src/components/auth/email-otp/change-email-otp.tsx
+++ b/examples/next-shadcn-example/src/components/auth/email-otp/change-email-otp.tsx
@@ -7,6 +7,7 @@ import {
   useRequestEmailChangeOtp,
   useSendVerificationOtp
 } from "@better-auth-ui/react/plugins/email-otp"
+import { useSelector } from "@tanstack/react-form"
 import { useEffect, useReducer } from "react"
 import { toast } from "sonner"
 
@@ -150,6 +151,10 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
       submitCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (formState) => formState.values.code.length === otpLength
+  )
 
   const resetFlow = () => {
     form.reset()
@@ -261,8 +266,7 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
                 disabled={
                   isPending ||
                   !session ||
-                  (state.step !== "email" &&
-                    form.state.values.code.length !== otpLength)
+                  (state.step !== "email" && !codeComplete)
                 }
               >
                 {isPending && <Spinner />}

--- a/examples/next-shadcn-example/src/components/auth/email-otp/email-otp.tsx
+++ b/examples/next-shadcn-example/src/components/auth/email-otp/email-otp.tsx
@@ -8,6 +8,7 @@ import {
   useSendVerificationOtp,
   useSignInEmailOtp
 } from "@better-auth-ui/react/plugins/email-otp"
+import { useSelector } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { useState } from "react"
 
@@ -123,6 +124,11 @@ export function EmailOtp({
       verifyCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (state) => state.values.code.length === otpLength
+  )
+  const email = useSelector(form.store, (state) => state.values.email)
 
   const showSeparator = socialProviders && socialProviders.length > 0
 
@@ -133,10 +139,7 @@ export function EmailOtp({
 
         {codeSent && (
           <CardDescription>
-            {emailOtpLocalization.codeSentTo.replace(
-              "{{email}}",
-              form.state.values.email
-            )}
+            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
           </CardDescription>
         )}
       </CardHeader>
@@ -205,9 +208,7 @@ export function EmailOtp({
                 <div className="flex flex-col gap-3">
                   <form.AuthFormSubmitButton
                     disabled={
-                      isPending ||
-                      isSigningIn ||
-                      (codeSent && form.state.values.code.length !== otpLength)
+                      isPending || isSigningIn || (codeSent && !codeComplete)
                     }
                   >
                     {(isSending || isSigningIn) && <Spinner />}
@@ -219,10 +220,7 @@ export function EmailOtp({
 
                   {codeSent ? (
                     <>
-                      <OpenEmailButton
-                        email={form.state.values.email}
-                        variant="secondary"
-                      />
+                      <OpenEmailButton email={email} variant="secondary" />
 
                       <Button
                         type="button"

--- a/examples/next-shadcn-example/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/examples/next-shadcn-example/src/components/auth/email-otp/reset-password-otp.tsx
@@ -7,6 +7,7 @@ import {
 import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPasswordOtp } from "@better-auth-ui/react/plugins/email-otp"
+import { useSelector } from "@tanstack/react-form"
 import { Eye, EyeOff } from "lucide-react"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
@@ -128,6 +129,7 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
       })
     }
   })
+  const email = useSelector(form.store, (state) => state.values.email)
 
   useEffect(() => {
     const storedEmail =
@@ -143,12 +145,9 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
           {localization.auth.resetPassword}
         </CardTitle>
 
-        {hasStoredEmail && form.state.values.email && (
+        {hasStoredEmail && email && (
           <CardDescription>
-            {emailOtpLocalization.codeSentTo.replace(
-              "{{email}}",
-              form.state.values.email
-            )}
+            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
           </CardDescription>
         )}
       </CardHeader>
@@ -298,12 +297,7 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
                   {localization.auth.resetPassword}
                 </form.AuthFormSubmitButton>
 
-                {form.state.values.email && (
-                  <OpenEmailButton
-                    email={form.state.values.email}
-                    variant="secondary"
-                  />
-                )}
+                {email && <OpenEmailButton email={email} variant="secondary" />}
               </div>
             </FieldGroup>
           </form.AuthFormRoot>

--- a/examples/next-shadcn-example/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/examples/next-shadcn-example/src/components/auth/email-otp/verify-email-otp.tsx
@@ -7,6 +7,7 @@ import {
   useSendVerificationOtp,
   useVerifyEmailOtp
 } from "@better-auth-ui/react/plugins/email-otp"
+import { useSelector } from "@tanstack/react-form"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
@@ -130,6 +131,10 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
       verifyCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (state) => state.values.code.length === otpLength
+  )
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -195,11 +200,7 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
 
               <div className="flex flex-col gap-3">
                 <form.AuthFormSubmitButton
-                  disabled={
-                    isPending ||
-                    (Boolean(email) &&
-                      form.state.values.code.length !== otpLength)
-                  }
+                  disabled={isPending || (Boolean(email) && !codeComplete)}
                 >
                   {isPending && <Spinner />}
 

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-invitation-row.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-invitation-row.tsx
@@ -22,11 +22,14 @@ import { TableCell, TableRow } from "@/components/ui/table"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
 import { OrganizationInvitationRowSkeleton } from "./organization-invitation-row-skeleton"
-import { OrganizationTableSelectRow } from "./organization-table-selection"
+import {
+  type OrganizationSelectableRow,
+  OrganizationTableSelectRow
+} from "./organization-table-selection"
 
 export type OrganizationInvitationRowProps = {
   invitation: Invitation
-  selectableRow?: Parameters<typeof OrganizationTableSelectRow>[0]["row"]
+  selectableRow?: OrganizationSelectableRow<Invitation>
   showCreatedAt?: boolean
   showEmail?: boolean
   showRole?: boolean

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-member-row.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-member-row.tsx
@@ -26,7 +26,10 @@ import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { UserView } from "../user/user-view"
 import { EditMemberRolesDialog } from "./edit-member-roles-dialog"
 import { LeaveOrganizationDialog } from "./leave-organization-dialog"
-import { OrganizationTableSelectRow } from "./organization-table-selection"
+import {
+  type OrganizationSelectableRow,
+  OrganizationTableSelectRow
+} from "./organization-table-selection"
 import { RemoveMemberDialog } from "./remove-member-dialog"
 
 export type OrganizationMemberRowProps = {
@@ -34,7 +37,7 @@ export type OrganizationMemberRowProps = {
   isOwner?: boolean
   ownerCount?: number
   organization: Organization
-  selectableRow?: Parameters<typeof OrganizationTableSelectRow>[0]["row"]
+  selectableRow?: OrganizationSelectableRow<Member & { user: Partial<User> }>
   showRole?: boolean
   showTeams?: boolean
 }

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-roles.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-roles.tsx
@@ -83,6 +83,7 @@ import {
 import { OrganizationTableBulkAction } from "./organization-table-bulk-action"
 import { OrganizationTablePagination } from "./organization-table-pagination"
 import {
+  type OrganizationSelectableRow,
   OrganizationTableSelectAll,
   OrganizationTableSelectRow
 } from "./organization-table-selection"
@@ -464,7 +465,7 @@ function OrganizationRoleRow({
   onEdit: () => void
   organizationId: string
   role: Role
-  selectableRow?: Parameters<typeof OrganizationTableSelectRow>[0]["row"]
+  selectableRow?: OrganizationSelectableRow<Role>
   showPermissions: boolean
 }) {
   const { localization: authLocalization } = useAuth()

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-table-selection.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-table-selection.tsx
@@ -1,19 +1,16 @@
 "use client"
 
 import type { OrganizationLocalization } from "@better-auth-ui/core/plugins/organization"
+import { type Row, type RowData, Subscribe } from "@tanstack/react-table"
 import type { MouseEvent } from "react"
 
 import { Checkbox } from "@/components/ui/checkbox"
+import type { organizationTableFeatures } from "./organization-table"
 
-type SelectableRow = {
-  getCanSelect: () => boolean
-  getIsSelected: () => boolean
-  getToggleSelectedHandler: () => (event: {
-    nativeEvent: MouseEvent<HTMLButtonElement>["nativeEvent"]
-    shiftKey: boolean
-    target: { checked: boolean }
-  }) => void
-}
+export type OrganizationSelectableRow<TData extends RowData> = Row<
+  typeof organizationTableFeatures,
+  TData
+>
 
 export function OrganizationTableSelectAll({
   allSelected,
@@ -39,31 +36,34 @@ export function OrganizationTableSelectAll({
   )
 }
 
-export function OrganizationTableSelectRow({
+export function OrganizationTableSelectRow<TData extends RowData>({
   disabled,
   localization,
   row
 }: {
   disabled?: boolean
   localization: OrganizationLocalization
-  row: SelectableRow
+  row: OrganizationSelectableRow<TData>
 }) {
-  const selected = row.getIsSelected()
-
-  function toggle(event: MouseEvent<HTMLElement>) {
-    row.getToggleSelectedHandler()({
-      nativeEvent: event.nativeEvent,
-      shiftKey: event.shiftKey,
-      target: { checked: !selected }
-    })
-  }
-
   return (
-    <Checkbox
-      aria-label={localization.selectRow}
-      checked={selected}
-      disabled={disabled || !row.getCanSelect()}
-      onClick={toggle}
-    />
+    <Subscribe
+      source={row.table.atoms.rowSelection}
+      selector={(selection) => selection[row.id] === true}
+    >
+      {(selected) => (
+        <Checkbox
+          aria-label={localization.selectRow}
+          checked={selected}
+          disabled={disabled || !row.getCanSelect()}
+          onClick={(event: MouseEvent<HTMLElement>) =>
+            row.getToggleSelectedHandler()({
+              nativeEvent: event.nativeEvent,
+              shiftKey: event.shiftKey,
+              target: { checked: !selected }
+            })
+          }
+        />
+      )}
+    </Subscribe>
   )
 }

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-table-state.ts
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-table-state.ts
@@ -2,12 +2,10 @@
 
 import {
   parseTableColumnVisibility,
-  parseTableFilterValue,
-  parseTablePage,
-  parseTablePageSize,
-  parseTableSorting,
+  parseTableUrlState,
   serializeTableColumnVisibility,
-  serializeTableFilterValue
+  serializeTableUrlState,
+  type TableUrlState
 } from "@better-auth-ui/core"
 import { useCreateAtom, useSelector } from "@tanstack/react-store"
 import {
@@ -35,38 +33,18 @@ function readUrlState(
   stateKey: string,
   defaultPageSize: number,
   allowedColumnIds?: readonly string[]
-): OrganizationTableUrlState {
+): TableUrlState {
   const params =
     typeof window === "undefined"
       ? new URLSearchParams()
       : new URLSearchParams(window.location.search)
-  const filterPrefix = `${stateKey}.filter.`
-  const columnFilters: ColumnFiltersState = []
-
-  for (const [key, value] of params) {
-    const id = key.slice(filterPrefix.length)
-    if (
-      key.startsWith(filterPrefix) &&
-      value &&
-      (!allowedColumnIds || allowedColumnIds.includes(id))
-    ) {
-      columnFilters.push({ id, value: parseTableFilterValue(value) })
-    }
-  }
-
-  return {
-    columnFilters,
-    globalFilter: params.get(`${stateKey}.search`) ?? "",
-    pagination: {
-      pageIndex: parseTablePage(params.get(`${stateKey}.page`), 1) - 1,
-      pageSize: parseTablePageSize(
-        params.get(`${stateKey}.pageSize`),
-        defaultPageSize,
-        ORGANIZATION_TABLE_PAGE_SIZE_OPTIONS
-      )
-    },
-    sorting: parseTableSorting(params.get(`${stateKey}.sort`), allowedColumnIds)
-  }
+  return parseTableUrlState(
+    params,
+    stateKey,
+    defaultPageSize,
+    ORGANIZATION_TABLE_PAGE_SIZE_OPTIONS,
+    allowedColumnIds
+  )
 }
 
 function readColumnVisibility(
@@ -85,16 +63,6 @@ function readColumnVisibility(
   }
 }
 
-function setOrDelete(
-  params: URLSearchParams,
-  key: string,
-  value: string,
-  defaultValue = ""
-) {
-  if (value === defaultValue) params.delete(key)
-  else params.set(key, value)
-}
-
 function writeUrlState(
   stateKey: string,
   defaultPageSize: number,
@@ -103,37 +71,12 @@ function writeUrlState(
   if (typeof window === "undefined") return
 
   const url = new URL(window.location.href)
-  const filterPrefix = `${stateKey}.filter.`
-
-  for (const key of Array.from(url.searchParams.keys())) {
-    if (key.startsWith(filterPrefix)) url.searchParams.delete(key)
-  }
-
-  for (const filter of state.columnFilters) {
-    const value = serializeTableFilterValue(filter.value)
-    if (value) url.searchParams.set(`${filterPrefix}${filter.id}`, value)
-  }
-
-  setOrDelete(url.searchParams, `${stateKey}.search`, state.globalFilter)
-  setOrDelete(
+  url.search = serializeTableUrlState(
     url.searchParams,
-    `${stateKey}.page`,
-    String(state.pagination.pageIndex + 1),
-    "1"
-  )
-  setOrDelete(
-    url.searchParams,
-    `${stateKey}.pageSize`,
-    String(state.pagination.pageSize),
-    String(defaultPageSize)
-  )
-  setOrDelete(
-    url.searchParams,
-    `${stateKey}.sort`,
-    state.sorting
-      .map(({ desc, id }) => `${id}.${desc ? "desc" : "asc"}`)
-      .join(",")
-  )
+    stateKey,
+    defaultPageSize,
+    state
+  ).toString()
 
   window.history.replaceState(window.history.state, "", url)
 }
@@ -144,6 +87,7 @@ export function useOrganizationTableState(
   allowedColumnIds?: readonly string[]
 ) {
   const columnFiltersAtom = useCreateAtom<ColumnFiltersState>([])
+  const columnVisibilityAtom = useCreateAtom<ColumnVisibilityState>({})
   const globalFilterAtom = useCreateAtom("")
   const paginationAtom = useCreateAtom<PaginationState>({
     pageIndex: 0,
@@ -152,12 +96,11 @@ export function useOrganizationTableState(
   const rowSelectionAtom = useCreateAtom<RowSelectionState>({})
   const sortingAtom = useCreateAtom<SortingState>([])
   const columnFilters = useSelector(columnFiltersAtom)
+  const columnVisibility = useSelector(columnVisibilityAtom)
   const globalFilter = useSelector(globalFilterAtom)
   const pagination = useSelector(paginationAtom)
   const rowSelection = useSelector(rowSelectionAtom)
   const sorting = useSelector(sortingAtom)
-  const [columnVisibility, setColumnVisibility] =
-    useState<ColumnVisibilityState>({})
   const [urlReady, setUrlReady] = useState(false)
   const [visibilityReady, setVisibilityReady] = useState(false)
   const atoms = useMemo(
@@ -180,47 +123,49 @@ export function useOrganizationTableState(
   const setPagination = useCallback(
     (updater: Updater<PaginationState>) => {
       paginationAtom.set((current) => functionalUpdate(updater, current))
-      rowSelectionAtom.set({})
     },
-    [paginationAtom, rowSelectionAtom]
+    [paginationAtom]
+  )
+
+  const setColumnVisibility = useCallback(
+    (updater: Updater<ColumnVisibilityState>) => {
+      columnVisibilityAtom.set((current) => functionalUpdate(updater, current))
+    },
+    [columnVisibilityAtom]
   )
 
   const setColumnFilters = useCallback(
     (updater: Updater<ColumnFiltersState>) => {
       columnFiltersAtom.set((current) => functionalUpdate(updater, current))
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
     },
-    [columnFiltersAtom, paginationAtom, rowSelectionAtom]
+    [columnFiltersAtom]
   )
 
   const setGlobalFilter = useCallback(
     (updater: Updater<string>) => {
       globalFilterAtom.set((current) => functionalUpdate(updater, current))
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
     },
-    [globalFilterAtom, paginationAtom, rowSelectionAtom]
+    [globalFilterAtom]
   )
 
   const setSorting = useCallback(
     (updater: Updater<SortingState>) => {
       sortingAtom.set((current) => functionalUpdate(updater, current))
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
     },
-    [paginationAtom, rowSelectionAtom, sortingAtom]
+    [sortingAtom]
   )
 
   useEffect(() => {
-    const resetPageAndSelection = () => {
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
+    const resetPage = () => {
+      const current = paginationAtom.get()
+      if (current.pageIndex === 0) rowSelectionAtom.set({})
+      else paginationAtom.set({ ...current, pageIndex: 0 })
     }
     const subscriptions = [
-      columnFiltersAtom.subscribe(resetPageAndSelection),
-      globalFilterAtom.subscribe(resetPageAndSelection),
-      sortingAtom.subscribe(resetPageAndSelection)
+      columnFiltersAtom.subscribe(resetPage),
+      globalFilterAtom.subscribe(resetPage),
+      sortingAtom.subscribe(resetPage),
+      paginationAtom.subscribe(() => rowSelectionAtom.set({}))
     ]
 
     return () => {
@@ -267,7 +212,7 @@ export function useOrganizationTableState(
   }, [columnVisibility, stateKey, visibilityReady])
 
   useEffect(() => {
-    setColumnVisibility(readColumnVisibility(stateKey, allowedColumnIds))
+    columnVisibilityAtom.set(readColumnVisibility(stateKey, allowedColumnIds))
     setVisibilityReady(true)
 
     const restoreUrlState = () => {
@@ -276,7 +221,6 @@ export function useOrganizationTableState(
       globalFilterAtom.set(next.globalFilter)
       sortingAtom.set(next.sorting)
       paginationAtom.set(next.pagination)
-      rowSelectionAtom.set({})
       setUrlReady(true)
     }
 
@@ -286,10 +230,10 @@ export function useOrganizationTableState(
   }, [
     allowedColumnIds,
     columnFiltersAtom,
+    columnVisibilityAtom,
     defaultPageSize,
     globalFilterAtom,
     paginationAtom,
-    rowSelectionAtom,
     sortingAtom,
     stateKey
   ])

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-table.ts
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-table.ts
@@ -20,25 +20,27 @@ import {
 
 export const ORGANIZATION_TABLE_PAGE_SIZE = 10
 
+export const organizationTableFeatures = tableFeatures({
+  columnFilteringFeature,
+  globalFilteringFeature,
+  filteredRowModel: createFilteredRowModel(),
+  filterFns: { includesString: filterFn_includesString },
+  columnFacetingFeature,
+  facetedRowModel: createFacetedRowModel(),
+  facetedUniqueValues: createFacetedUniqueValues(),
+  columnVisibilityFeature,
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+  rowPaginationFeature,
+  paginatedRowModel: createPaginatedRowModel(),
+  rowSelectionFeature
+})
+
 export const {
   createAppColumnHelper: createOrganizationColumnHelper,
   useAppTable: useOrganizationTable
 } = createTableHook({
   enableMultiSort: true,
   sortDescFirst: false,
-  features: tableFeatures({
-    columnFilteringFeature,
-    globalFilteringFeature,
-    filteredRowModel: createFilteredRowModel(),
-    filterFns: { includesString: filterFn_includesString },
-    columnFacetingFeature,
-    facetedRowModel: createFacetedRowModel(),
-    facetedUniqueValues: createFacetedUniqueValues(),
-    columnVisibilityFeature,
-    rowSortingFeature,
-    sortedRowModel: createSortedRowModel(),
-    rowPaginationFeature,
-    paginatedRowModel: createPaginatedRowModel(),
-    rowSelectionFeature
-  })
+  features: organizationTableFeatures
 })

--- a/examples/next-shadcn-example/src/components/auth/phone-number/change-phone-number.tsx
+++ b/examples/next-shadcn-example/src/components/auth/phone-number/change-phone-number.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getFormFieldErrorMessage } from "@better-auth-ui/core"
 import {
   createPhoneNumberValue,
   type PhoneNumberAuthClient
@@ -14,6 +15,7 @@ import {
   useSendPhoneNumberOtp,
   useVerifyPhoneNumber
 } from "@better-auth-ui/react/plugins/phone-number"
+import { useSelector } from "@tanstack/react-form"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
@@ -101,6 +103,14 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
       })
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (formState) => formState.values.code.length === otpLength
+  )
+  const phoneNumberDisplay = useSelector(
+    form.store,
+    (formState) => formState.values.phoneNumber.display
+  )
 
   useEffect(() => {
     if (session) {
@@ -129,7 +139,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                   <FieldDescription>
                     {localization.codeSentTo.replace(
                       "{{phoneNumber}}",
-                      form.state.values.phoneNumber.display
+                      phoneNumberDisplay
                     )}
                   </FieldDescription>
                   <form.AppField name="code">
@@ -160,7 +170,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                       countryCodes={countries}
                       countryLabel={localization.country}
                       disabled={isPending}
-                      error={field.state.meta.errors[0]?.toString()}
+                      error={getFormFieldErrorMessage(field.state.meta.errors)}
                       locale={locale}
                       phoneLabel={localization.phoneNumber}
                       placeholder={localization.phoneNumberPlaceholder}
@@ -198,11 +208,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
               )}
               <form.AuthFormSubmitButton
                 size="sm"
-                disabled={
-                  isPending ||
-                  !session ||
-                  (codeSent && form.state.values.code.length !== otpLength)
-                }
+                disabled={isPending || !session || (codeSent && !codeComplete)}
               >
                 {(isSending || isVerifying) && <Spinner />}
                 {codeSent

--- a/examples/next-shadcn-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/examples/next-shadcn-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getFormFieldErrorMessage } from "@better-auth-ui/core"
 import {
   createPhoneNumberValue,
   type PhoneNumberAuthClient
@@ -87,7 +88,7 @@ export function ForgotPhoneNumberPassword({
                     countryCodes={countries}
                     countryLabel={phoneLocalization.country}
                     disabled={isPending}
-                    error={field.state.meta.errors[0]?.toString()}
+                    error={getFormFieldErrorMessage(field.state.meta.errors)}
                     locale={locale}
                     phoneLabel={phoneLocalization.phoneNumber}
                     placeholder={phoneLocalization.phoneNumberPlaceholder}

--- a/examples/next-shadcn-example/src/components/auth/phone-number/phone-number.tsx
+++ b/examples/next-shadcn-example/src/components/auth/phone-number/phone-number.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import {
+  authMutationKeys,
+  getFormFieldErrorMessage
+} from "@better-auth-ui/core"
 import {
   createPhoneNumberValue,
   type PhoneNumberAuthClient
@@ -16,6 +19,7 @@ import {
   useSignInPhoneNumber,
   useVerifyPhoneNumber
 } from "@better-auth-ui/react/plugins/phone-number"
+import { useSelector } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
 import { useState } from "react"
@@ -204,6 +208,14 @@ export function PhoneNumber({
       verifyCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (state) => state.values.code.length === otpLength
+  )
+  const phoneNumberDisplay = useSelector(
+    form.store,
+    (state) => state.values.phoneNumber.display
+  )
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -217,7 +229,7 @@ export function PhoneNumber({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              form.state.values.phoneNumber.display
+              phoneNumberDisplay
             )}
           </CardDescription>
         )}
@@ -271,7 +283,9 @@ export function PhoneNumber({
                           countryCodes={countries}
                           countryLabel={phoneLocalization.country}
                           disabled={isPending}
-                          error={field.state.meta.errors[0]?.toString()}
+                          error={getFormFieldErrorMessage(
+                            field.state.meta.errors
+                          )}
                           locale={locale}
                           phoneLabel={phoneLocalization.phoneNumber}
                           placeholder={phoneLocalization.phoneNumberPlaceholder}
@@ -367,10 +381,7 @@ export function PhoneNumber({
 
                 <div className="flex flex-col gap-3">
                   <form.AuthFormSubmitButton
-                    disabled={
-                      isPending ||
-                      (codeSent && form.state.values.code.length !== otpLength)
-                    }
+                    disabled={isPending || (codeSent && !codeComplete)}
                   >
                     {(isSending || isVerifying || isPasswordPending) && (
                       <Spinner />

--- a/examples/next-shadcn-example/src/components/auth/phone-number/reset-phone-number-password.tsx
+++ b/examples/next-shadcn-example/src/components/auth/phone-number/reset-phone-number-password.tsx
@@ -4,6 +4,7 @@ import { isPasswordCompromisedError } from "@better-auth-ui/core"
 import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPhoneNumberPassword } from "@better-auth-ui/react/plugins/phone-number"
+import { useSelector } from "@tanstack/react-form"
 import { Eye, EyeOff } from "lucide-react"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
@@ -115,6 +116,14 @@ export function ResetPhoneNumberPassword({
       })
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (formState) => formState.values.code.length === otpLength
+  )
+  const phoneNumber = useSelector(
+    form.store,
+    (formState) => formState.values.phoneNumber
+  )
 
   useEffect(() => {
     const stored = sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY) ?? ""
@@ -132,7 +141,7 @@ export function ResetPhoneNumberPassword({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              form.state.values.phoneNumber
+              phoneNumber
             )}
           </CardDescription>
         )}
@@ -261,11 +270,7 @@ export function ResetPhoneNumberPassword({
                 </form.AppField>
               )}
 
-              <form.AuthFormSubmitButton
-                disabled={
-                  isPending || form.state.values.code.length !== otpLength
-                }
-              >
+              <form.AuthFormSubmitButton disabled={isPending || !codeComplete}>
                 {isPending && <Spinner />}
                 {phoneLocalization.resetPassword}
               </form.AuthFormSubmitButton>

--- a/examples/next-shadcn-example/src/components/auth/sso/email-first-sign-in.tsx
+++ b/examples/next-shadcn-example/src/components/auth/sso/email-first-sign-in.tsx
@@ -22,6 +22,7 @@ import {
   useSignInEmail
 } from "@better-auth-ui/react"
 import { useSignInSso } from "@better-auth-ui/react/plugins/sso"
+import { useSelector } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
 import { useState } from "react"
@@ -163,6 +164,7 @@ export function EmailFirstSignIn({
       })
     }
   })
+  const email = useSelector(form.store, (state) => state.values.email)
 
   const startOver = () => {
     setStep("email")
@@ -178,9 +180,7 @@ export function EmailFirstSignIn({
           {localization.auth.signIn}
         </CardTitle>
         <CardDescription>
-          {step === "email"
-            ? ssoLocalization.emailFirstDescription
-            : form.state.values.email}
+          {step === "email" ? ssoLocalization.emailFirstDescription : email}
         </CardDescription>
       </CardHeader>
 

--- a/examples/start-shadcn-baseui-example/src/components/auth/auth-form.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/auth-form.tsx
@@ -3,6 +3,7 @@
 import {
   type AdditionalField as AdditionalFieldConfig,
   type AdditionalFieldFormValue,
+  DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS,
   getFormFieldErrors,
   validateAdditionalFieldRequired,
   validateAdditionalFieldValue
@@ -128,7 +129,12 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   )
 }
 
-export const { useAppForm: useAuthForm } = createFormHook({
+export const {
+  useAppForm: useAuthForm,
+  useTypedAppFormContext: useTypedAuthFormContext,
+  withFieldGroup: withAuthFieldGroup,
+  withForm: withAuthForm
+} = createFormHook({
   fieldComponents: { AuthFormAdditionalField, AuthFormFieldError },
   fieldContext,
   formComponents: { AuthFormRoot, AuthFormSubmitButton },
@@ -155,6 +161,10 @@ export function getAuthAdditionalFieldValidators(
     onChangeAsync: field.validate
       ? ({ value }: { value: AdditionalFieldFormValue }) =>
           validateAdditionalFieldValue(field, value)
+      : undefined,
+    onChangeAsyncDebounceMs: field.validate
+      ? (field.validateDebounceMs ??
+        DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS)
       : undefined
   }
 }

--- a/examples/start-shadcn-baseui-example/src/components/auth/device-authorization/device-authorization.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/device-authorization/device-authorization.tsx
@@ -10,6 +10,7 @@ import {
   useDenyDevice,
   useVerifyDeviceCode
 } from "@better-auth-ui/react/plugins/device-authorization"
+import { useSelector } from "@tanstack/react-form"
 import { REGEXP_ONLY_DIGITS_AND_CHARS } from "input-otp"
 import { CheckIcon, CircleCheckIcon, CircleXIcon, XIcon } from "lucide-react"
 import {
@@ -312,6 +313,10 @@ function DeviceCodeForm({
     defaultValues: { userCode: initialUserCode },
     onSubmit: ({ value }) => onSubmitCode(value.userCode)
   })
+  const userCodeComplete = useSelector(
+    form.store,
+    (state) => state.values.userCode.length === userCodeLength
+  )
 
   useEffect(() => {
     form.setFieldValue("userCode", initialUserCode)
@@ -390,11 +395,7 @@ function DeviceCodeForm({
 
               <form.AuthFormSubmitButton
                 className="w-full"
-                disabled={
-                  form.state.values.userCode.length !== userCodeLength ||
-                  isSessionPending ||
-                  isVerifying
-                }
+                disabled={!userCodeComplete || isSessionPending || isVerifying}
                 type="submit"
               >
                 {isVerifying ? <Spinner data-icon="inline-start" /> : null}

--- a/examples/start-shadcn-baseui-example/src/components/auth/email-otp/change-email-otp.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/email-otp/change-email-otp.tsx
@@ -7,6 +7,7 @@ import {
   useRequestEmailChangeOtp,
   useSendVerificationOtp
 } from "@better-auth-ui/react/plugins/email-otp"
+import { useSelector } from "@tanstack/react-form"
 import { useEffect, useReducer } from "react"
 import { toast } from "sonner"
 
@@ -150,6 +151,10 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
       submitCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (formState) => formState.values.code.length === otpLength
+  )
 
   const resetFlow = () => {
     form.reset()
@@ -261,8 +266,7 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
                 disabled={
                   isPending ||
                   !session ||
-                  (state.step !== "email" &&
-                    form.state.values.code.length !== otpLength)
+                  (state.step !== "email" && !codeComplete)
                 }
               >
                 {isPending && <Spinner />}

--- a/examples/start-shadcn-baseui-example/src/components/auth/email-otp/email-otp.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/email-otp/email-otp.tsx
@@ -8,6 +8,7 @@ import {
   useSendVerificationOtp,
   useSignInEmailOtp
 } from "@better-auth-ui/react/plugins/email-otp"
+import { useSelector } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { useState } from "react"
 
@@ -123,6 +124,11 @@ export function EmailOtp({
       verifyCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (state) => state.values.code.length === otpLength
+  )
+  const email = useSelector(form.store, (state) => state.values.email)
 
   const showSeparator = socialProviders && socialProviders.length > 0
 
@@ -133,10 +139,7 @@ export function EmailOtp({
 
         {codeSent && (
           <CardDescription>
-            {emailOtpLocalization.codeSentTo.replace(
-              "{{email}}",
-              form.state.values.email
-            )}
+            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
           </CardDescription>
         )}
       </CardHeader>
@@ -205,9 +208,7 @@ export function EmailOtp({
                 <div className="flex flex-col gap-3">
                   <form.AuthFormSubmitButton
                     disabled={
-                      isPending ||
-                      isSigningIn ||
-                      (codeSent && form.state.values.code.length !== otpLength)
+                      isPending || isSigningIn || (codeSent && !codeComplete)
                     }
                   >
                     {(isSending || isSigningIn) && <Spinner />}
@@ -219,10 +220,7 @@ export function EmailOtp({
 
                   {codeSent ? (
                     <>
-                      <OpenEmailButton
-                        email={form.state.values.email}
-                        variant="secondary"
-                      />
+                      <OpenEmailButton email={email} variant="secondary" />
 
                       <Button
                         type="button"

--- a/examples/start-shadcn-baseui-example/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/email-otp/reset-password-otp.tsx
@@ -7,6 +7,7 @@ import {
 import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPasswordOtp } from "@better-auth-ui/react/plugins/email-otp"
+import { useSelector } from "@tanstack/react-form"
 import { Eye, EyeOff } from "lucide-react"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
@@ -128,6 +129,7 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
       })
     }
   })
+  const email = useSelector(form.store, (state) => state.values.email)
 
   useEffect(() => {
     const storedEmail =
@@ -143,12 +145,9 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
           {localization.auth.resetPassword}
         </CardTitle>
 
-        {hasStoredEmail && form.state.values.email && (
+        {hasStoredEmail && email && (
           <CardDescription>
-            {emailOtpLocalization.codeSentTo.replace(
-              "{{email}}",
-              form.state.values.email
-            )}
+            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
           </CardDescription>
         )}
       </CardHeader>
@@ -298,12 +297,7 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
                   {localization.auth.resetPassword}
                 </form.AuthFormSubmitButton>
 
-                {form.state.values.email && (
-                  <OpenEmailButton
-                    email={form.state.values.email}
-                    variant="secondary"
-                  />
-                )}
+                {email && <OpenEmailButton email={email} variant="secondary" />}
               </div>
             </FieldGroup>
           </form.AuthFormRoot>

--- a/examples/start-shadcn-baseui-example/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/email-otp/verify-email-otp.tsx
@@ -7,6 +7,7 @@ import {
   useSendVerificationOtp,
   useVerifyEmailOtp
 } from "@better-auth-ui/react/plugins/email-otp"
+import { useSelector } from "@tanstack/react-form"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
@@ -130,6 +131,10 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
       verifyCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (state) => state.values.code.length === otpLength
+  )
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -195,11 +200,7 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
 
               <div className="flex flex-col gap-3">
                 <form.AuthFormSubmitButton
-                  disabled={
-                    isPending ||
-                    (Boolean(email) &&
-                      form.state.values.code.length !== otpLength)
-                  }
+                  disabled={isPending || (Boolean(email) && !codeComplete)}
                 >
                   {isPending && <Spinner />}
 

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-invitation-row.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-invitation-row.tsx
@@ -22,11 +22,14 @@ import { TableCell, TableRow } from "@/components/ui/table"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
 import { OrganizationInvitationRowSkeleton } from "./organization-invitation-row-skeleton"
-import { OrganizationTableSelectRow } from "./organization-table-selection"
+import {
+  type OrganizationSelectableRow,
+  OrganizationTableSelectRow
+} from "./organization-table-selection"
 
 export type OrganizationInvitationRowProps = {
   invitation: Invitation
-  selectableRow?: Parameters<typeof OrganizationTableSelectRow>[0]["row"]
+  selectableRow?: OrganizationSelectableRow<Invitation>
   showCreatedAt?: boolean
   showEmail?: boolean
   showRole?: boolean

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-member-row.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-member-row.tsx
@@ -26,7 +26,10 @@ import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { UserView } from "../user/user-view"
 import { EditMemberRolesDialog } from "./edit-member-roles-dialog"
 import { LeaveOrganizationDialog } from "./leave-organization-dialog"
-import { OrganizationTableSelectRow } from "./organization-table-selection"
+import {
+  type OrganizationSelectableRow,
+  OrganizationTableSelectRow
+} from "./organization-table-selection"
 import { RemoveMemberDialog } from "./remove-member-dialog"
 
 export type OrganizationMemberRowProps = {
@@ -34,7 +37,7 @@ export type OrganizationMemberRowProps = {
   isOwner?: boolean
   ownerCount?: number
   organization: Organization
-  selectableRow?: Parameters<typeof OrganizationTableSelectRow>[0]["row"]
+  selectableRow?: OrganizationSelectableRow<Member & { user: Partial<User> }>
   showRole?: boolean
   showTeams?: boolean
 }

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-roles.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-roles.tsx
@@ -83,6 +83,7 @@ import {
 import { OrganizationTableBulkAction } from "./organization-table-bulk-action"
 import { OrganizationTablePagination } from "./organization-table-pagination"
 import {
+  type OrganizationSelectableRow,
   OrganizationTableSelectAll,
   OrganizationTableSelectRow
 } from "./organization-table-selection"
@@ -464,7 +465,7 @@ function OrganizationRoleRow({
   onEdit: () => void
   organizationId: string
   role: Role
-  selectableRow?: Parameters<typeof OrganizationTableSelectRow>[0]["row"]
+  selectableRow?: OrganizationSelectableRow<Role>
   showPermissions: boolean
 }) {
   const { localization: authLocalization } = useAuth()

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-table-selection.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-table-selection.tsx
@@ -1,19 +1,16 @@
 "use client"
 
 import type { OrganizationLocalization } from "@better-auth-ui/core/plugins/organization"
+import { type Row, type RowData, Subscribe } from "@tanstack/react-table"
 import type { MouseEvent } from "react"
 
 import { Checkbox } from "@/components/ui/checkbox"
+import type { organizationTableFeatures } from "./organization-table"
 
-type SelectableRow = {
-  getCanSelect: () => boolean
-  getIsSelected: () => boolean
-  getToggleSelectedHandler: () => (event: {
-    nativeEvent: MouseEvent<HTMLButtonElement>["nativeEvent"]
-    shiftKey: boolean
-    target: { checked: boolean }
-  }) => void
-}
+export type OrganizationSelectableRow<TData extends RowData> = Row<
+  typeof organizationTableFeatures,
+  TData
+>
 
 export function OrganizationTableSelectAll({
   allSelected,
@@ -39,31 +36,34 @@ export function OrganizationTableSelectAll({
   )
 }
 
-export function OrganizationTableSelectRow({
+export function OrganizationTableSelectRow<TData extends RowData>({
   disabled,
   localization,
   row
 }: {
   disabled?: boolean
   localization: OrganizationLocalization
-  row: SelectableRow
+  row: OrganizationSelectableRow<TData>
 }) {
-  const selected = row.getIsSelected()
-
-  function toggle(event: MouseEvent<HTMLElement>) {
-    row.getToggleSelectedHandler()({
-      nativeEvent: event.nativeEvent,
-      shiftKey: event.shiftKey,
-      target: { checked: !selected }
-    })
-  }
-
   return (
-    <Checkbox
-      aria-label={localization.selectRow}
-      checked={selected}
-      disabled={disabled || !row.getCanSelect()}
-      onClick={toggle}
-    />
+    <Subscribe
+      source={row.table.atoms.rowSelection}
+      selector={(selection) => selection[row.id] === true}
+    >
+      {(selected) => (
+        <Checkbox
+          aria-label={localization.selectRow}
+          checked={selected}
+          disabled={disabled || !row.getCanSelect()}
+          onClick={(event: MouseEvent<HTMLElement>) =>
+            row.getToggleSelectedHandler()({
+              nativeEvent: event.nativeEvent,
+              shiftKey: event.shiftKey,
+              target: { checked: !selected }
+            })
+          }
+        />
+      )}
+    </Subscribe>
   )
 }

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-table-state.ts
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-table-state.ts
@@ -2,12 +2,10 @@
 
 import {
   parseTableColumnVisibility,
-  parseTableFilterValue,
-  parseTablePage,
-  parseTablePageSize,
-  parseTableSorting,
+  parseTableUrlState,
   serializeTableColumnVisibility,
-  serializeTableFilterValue
+  serializeTableUrlState,
+  type TableUrlState
 } from "@better-auth-ui/core"
 import { useCreateAtom, useSelector } from "@tanstack/react-store"
 import {
@@ -35,38 +33,18 @@ function readUrlState(
   stateKey: string,
   defaultPageSize: number,
   allowedColumnIds?: readonly string[]
-): OrganizationTableUrlState {
+): TableUrlState {
   const params =
     typeof window === "undefined"
       ? new URLSearchParams()
       : new URLSearchParams(window.location.search)
-  const filterPrefix = `${stateKey}.filter.`
-  const columnFilters: ColumnFiltersState = []
-
-  for (const [key, value] of params) {
-    const id = key.slice(filterPrefix.length)
-    if (
-      key.startsWith(filterPrefix) &&
-      value &&
-      (!allowedColumnIds || allowedColumnIds.includes(id))
-    ) {
-      columnFilters.push({ id, value: parseTableFilterValue(value) })
-    }
-  }
-
-  return {
-    columnFilters,
-    globalFilter: params.get(`${stateKey}.search`) ?? "",
-    pagination: {
-      pageIndex: parseTablePage(params.get(`${stateKey}.page`), 1) - 1,
-      pageSize: parseTablePageSize(
-        params.get(`${stateKey}.pageSize`),
-        defaultPageSize,
-        ORGANIZATION_TABLE_PAGE_SIZE_OPTIONS
-      )
-    },
-    sorting: parseTableSorting(params.get(`${stateKey}.sort`), allowedColumnIds)
-  }
+  return parseTableUrlState(
+    params,
+    stateKey,
+    defaultPageSize,
+    ORGANIZATION_TABLE_PAGE_SIZE_OPTIONS,
+    allowedColumnIds
+  )
 }
 
 function readColumnVisibility(
@@ -85,16 +63,6 @@ function readColumnVisibility(
   }
 }
 
-function setOrDelete(
-  params: URLSearchParams,
-  key: string,
-  value: string,
-  defaultValue = ""
-) {
-  if (value === defaultValue) params.delete(key)
-  else params.set(key, value)
-}
-
 function writeUrlState(
   stateKey: string,
   defaultPageSize: number,
@@ -103,37 +71,12 @@ function writeUrlState(
   if (typeof window === "undefined") return
 
   const url = new URL(window.location.href)
-  const filterPrefix = `${stateKey}.filter.`
-
-  for (const key of Array.from(url.searchParams.keys())) {
-    if (key.startsWith(filterPrefix)) url.searchParams.delete(key)
-  }
-
-  for (const filter of state.columnFilters) {
-    const value = serializeTableFilterValue(filter.value)
-    if (value) url.searchParams.set(`${filterPrefix}${filter.id}`, value)
-  }
-
-  setOrDelete(url.searchParams, `${stateKey}.search`, state.globalFilter)
-  setOrDelete(
+  url.search = serializeTableUrlState(
     url.searchParams,
-    `${stateKey}.page`,
-    String(state.pagination.pageIndex + 1),
-    "1"
-  )
-  setOrDelete(
-    url.searchParams,
-    `${stateKey}.pageSize`,
-    String(state.pagination.pageSize),
-    String(defaultPageSize)
-  )
-  setOrDelete(
-    url.searchParams,
-    `${stateKey}.sort`,
-    state.sorting
-      .map(({ desc, id }) => `${id}.${desc ? "desc" : "asc"}`)
-      .join(",")
-  )
+    stateKey,
+    defaultPageSize,
+    state
+  ).toString()
 
   window.history.replaceState(window.history.state, "", url)
 }
@@ -144,6 +87,7 @@ export function useOrganizationTableState(
   allowedColumnIds?: readonly string[]
 ) {
   const columnFiltersAtom = useCreateAtom<ColumnFiltersState>([])
+  const columnVisibilityAtom = useCreateAtom<ColumnVisibilityState>({})
   const globalFilterAtom = useCreateAtom("")
   const paginationAtom = useCreateAtom<PaginationState>({
     pageIndex: 0,
@@ -152,12 +96,11 @@ export function useOrganizationTableState(
   const rowSelectionAtom = useCreateAtom<RowSelectionState>({})
   const sortingAtom = useCreateAtom<SortingState>([])
   const columnFilters = useSelector(columnFiltersAtom)
+  const columnVisibility = useSelector(columnVisibilityAtom)
   const globalFilter = useSelector(globalFilterAtom)
   const pagination = useSelector(paginationAtom)
   const rowSelection = useSelector(rowSelectionAtom)
   const sorting = useSelector(sortingAtom)
-  const [columnVisibility, setColumnVisibility] =
-    useState<ColumnVisibilityState>({})
   const [urlReady, setUrlReady] = useState(false)
   const [visibilityReady, setVisibilityReady] = useState(false)
   const atoms = useMemo(
@@ -180,47 +123,49 @@ export function useOrganizationTableState(
   const setPagination = useCallback(
     (updater: Updater<PaginationState>) => {
       paginationAtom.set((current) => functionalUpdate(updater, current))
-      rowSelectionAtom.set({})
     },
-    [paginationAtom, rowSelectionAtom]
+    [paginationAtom]
+  )
+
+  const setColumnVisibility = useCallback(
+    (updater: Updater<ColumnVisibilityState>) => {
+      columnVisibilityAtom.set((current) => functionalUpdate(updater, current))
+    },
+    [columnVisibilityAtom]
   )
 
   const setColumnFilters = useCallback(
     (updater: Updater<ColumnFiltersState>) => {
       columnFiltersAtom.set((current) => functionalUpdate(updater, current))
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
     },
-    [columnFiltersAtom, paginationAtom, rowSelectionAtom]
+    [columnFiltersAtom]
   )
 
   const setGlobalFilter = useCallback(
     (updater: Updater<string>) => {
       globalFilterAtom.set((current) => functionalUpdate(updater, current))
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
     },
-    [globalFilterAtom, paginationAtom, rowSelectionAtom]
+    [globalFilterAtom]
   )
 
   const setSorting = useCallback(
     (updater: Updater<SortingState>) => {
       sortingAtom.set((current) => functionalUpdate(updater, current))
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
     },
-    [paginationAtom, rowSelectionAtom, sortingAtom]
+    [sortingAtom]
   )
 
   useEffect(() => {
-    const resetPageAndSelection = () => {
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
+    const resetPage = () => {
+      const current = paginationAtom.get()
+      if (current.pageIndex === 0) rowSelectionAtom.set({})
+      else paginationAtom.set({ ...current, pageIndex: 0 })
     }
     const subscriptions = [
-      columnFiltersAtom.subscribe(resetPageAndSelection),
-      globalFilterAtom.subscribe(resetPageAndSelection),
-      sortingAtom.subscribe(resetPageAndSelection)
+      columnFiltersAtom.subscribe(resetPage),
+      globalFilterAtom.subscribe(resetPage),
+      sortingAtom.subscribe(resetPage),
+      paginationAtom.subscribe(() => rowSelectionAtom.set({}))
     ]
 
     return () => {
@@ -267,7 +212,7 @@ export function useOrganizationTableState(
   }, [columnVisibility, stateKey, visibilityReady])
 
   useEffect(() => {
-    setColumnVisibility(readColumnVisibility(stateKey, allowedColumnIds))
+    columnVisibilityAtom.set(readColumnVisibility(stateKey, allowedColumnIds))
     setVisibilityReady(true)
 
     const restoreUrlState = () => {
@@ -276,7 +221,6 @@ export function useOrganizationTableState(
       globalFilterAtom.set(next.globalFilter)
       sortingAtom.set(next.sorting)
       paginationAtom.set(next.pagination)
-      rowSelectionAtom.set({})
       setUrlReady(true)
     }
 
@@ -286,10 +230,10 @@ export function useOrganizationTableState(
   }, [
     allowedColumnIds,
     columnFiltersAtom,
+    columnVisibilityAtom,
     defaultPageSize,
     globalFilterAtom,
     paginationAtom,
-    rowSelectionAtom,
     sortingAtom,
     stateKey
   ])

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-table.ts
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-table.ts
@@ -20,25 +20,27 @@ import {
 
 export const ORGANIZATION_TABLE_PAGE_SIZE = 10
 
+export const organizationTableFeatures = tableFeatures({
+  columnFilteringFeature,
+  globalFilteringFeature,
+  filteredRowModel: createFilteredRowModel(),
+  filterFns: { includesString: filterFn_includesString },
+  columnFacetingFeature,
+  facetedRowModel: createFacetedRowModel(),
+  facetedUniqueValues: createFacetedUniqueValues(),
+  columnVisibilityFeature,
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+  rowPaginationFeature,
+  paginatedRowModel: createPaginatedRowModel(),
+  rowSelectionFeature
+})
+
 export const {
   createAppColumnHelper: createOrganizationColumnHelper,
   useAppTable: useOrganizationTable
 } = createTableHook({
   enableMultiSort: true,
   sortDescFirst: false,
-  features: tableFeatures({
-    columnFilteringFeature,
-    globalFilteringFeature,
-    filteredRowModel: createFilteredRowModel(),
-    filterFns: { includesString: filterFn_includesString },
-    columnFacetingFeature,
-    facetedRowModel: createFacetedRowModel(),
-    facetedUniqueValues: createFacetedUniqueValues(),
-    columnVisibilityFeature,
-    rowSortingFeature,
-    sortedRowModel: createSortedRowModel(),
-    rowPaginationFeature,
-    paginatedRowModel: createPaginatedRowModel(),
-    rowSelectionFeature
-  })
+  features: organizationTableFeatures
 })

--- a/examples/start-shadcn-baseui-example/src/components/auth/phone-number/change-phone-number.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/phone-number/change-phone-number.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getFormFieldErrorMessage } from "@better-auth-ui/core"
 import {
   createPhoneNumberValue,
   type PhoneNumberAuthClient
@@ -14,6 +15,7 @@ import {
   useSendPhoneNumberOtp,
   useVerifyPhoneNumber
 } from "@better-auth-ui/react/plugins/phone-number"
+import { useSelector } from "@tanstack/react-form"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
@@ -101,6 +103,14 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
       })
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (formState) => formState.values.code.length === otpLength
+  )
+  const phoneNumberDisplay = useSelector(
+    form.store,
+    (formState) => formState.values.phoneNumber.display
+  )
 
   useEffect(() => {
     if (session) {
@@ -129,7 +139,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                   <FieldDescription>
                     {localization.codeSentTo.replace(
                       "{{phoneNumber}}",
-                      form.state.values.phoneNumber.display
+                      phoneNumberDisplay
                     )}
                   </FieldDescription>
                   <form.AppField name="code">
@@ -160,7 +170,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                       countryCodes={countries}
                       countryLabel={localization.country}
                       disabled={isPending}
-                      error={field.state.meta.errors[0]?.toString()}
+                      error={getFormFieldErrorMessage(field.state.meta.errors)}
                       locale={locale}
                       phoneLabel={localization.phoneNumber}
                       placeholder={localization.phoneNumberPlaceholder}
@@ -198,11 +208,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
               )}
               <form.AuthFormSubmitButton
                 size="sm"
-                disabled={
-                  isPending ||
-                  !session ||
-                  (codeSent && form.state.values.code.length !== otpLength)
-                }
+                disabled={isPending || !session || (codeSent && !codeComplete)}
               >
                 {(isSending || isVerifying) && <Spinner />}
                 {codeSent

--- a/examples/start-shadcn-baseui-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getFormFieldErrorMessage } from "@better-auth-ui/core"
 import {
   createPhoneNumberValue,
   type PhoneNumberAuthClient
@@ -87,7 +88,7 @@ export function ForgotPhoneNumberPassword({
                     countryCodes={countries}
                     countryLabel={phoneLocalization.country}
                     disabled={isPending}
-                    error={field.state.meta.errors[0]?.toString()}
+                    error={getFormFieldErrorMessage(field.state.meta.errors)}
                     locale={locale}
                     phoneLabel={phoneLocalization.phoneNumber}
                     placeholder={phoneLocalization.phoneNumberPlaceholder}

--- a/examples/start-shadcn-baseui-example/src/components/auth/phone-number/phone-number.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/phone-number/phone-number.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import {
+  authMutationKeys,
+  getFormFieldErrorMessage
+} from "@better-auth-ui/core"
 import {
   createPhoneNumberValue,
   type PhoneNumberAuthClient
@@ -16,6 +19,7 @@ import {
   useSignInPhoneNumber,
   useVerifyPhoneNumber
 } from "@better-auth-ui/react/plugins/phone-number"
+import { useSelector } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
 import { useState } from "react"
@@ -204,6 +208,14 @@ export function PhoneNumber({
       verifyCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (state) => state.values.code.length === otpLength
+  )
+  const phoneNumberDisplay = useSelector(
+    form.store,
+    (state) => state.values.phoneNumber.display
+  )
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -217,7 +229,7 @@ export function PhoneNumber({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              form.state.values.phoneNumber.display
+              phoneNumberDisplay
             )}
           </CardDescription>
         )}
@@ -271,7 +283,9 @@ export function PhoneNumber({
                           countryCodes={countries}
                           countryLabel={phoneLocalization.country}
                           disabled={isPending}
-                          error={field.state.meta.errors[0]?.toString()}
+                          error={getFormFieldErrorMessage(
+                            field.state.meta.errors
+                          )}
                           locale={locale}
                           phoneLabel={phoneLocalization.phoneNumber}
                           placeholder={phoneLocalization.phoneNumberPlaceholder}
@@ -367,10 +381,7 @@ export function PhoneNumber({
 
                 <div className="flex flex-col gap-3">
                   <form.AuthFormSubmitButton
-                    disabled={
-                      isPending ||
-                      (codeSent && form.state.values.code.length !== otpLength)
-                    }
+                    disabled={isPending || (codeSent && !codeComplete)}
                   >
                     {(isSending || isVerifying || isPasswordPending) && (
                       <Spinner />

--- a/examples/start-shadcn-baseui-example/src/components/auth/phone-number/reset-phone-number-password.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/phone-number/reset-phone-number-password.tsx
@@ -4,6 +4,7 @@ import { isPasswordCompromisedError } from "@better-auth-ui/core"
 import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPhoneNumberPassword } from "@better-auth-ui/react/plugins/phone-number"
+import { useSelector } from "@tanstack/react-form"
 import { Eye, EyeOff } from "lucide-react"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
@@ -115,6 +116,14 @@ export function ResetPhoneNumberPassword({
       })
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (formState) => formState.values.code.length === otpLength
+  )
+  const phoneNumber = useSelector(
+    form.store,
+    (formState) => formState.values.phoneNumber
+  )
 
   useEffect(() => {
     const stored = sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY) ?? ""
@@ -132,7 +141,7 @@ export function ResetPhoneNumberPassword({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              form.state.values.phoneNumber
+              phoneNumber
             )}
           </CardDescription>
         )}
@@ -261,11 +270,7 @@ export function ResetPhoneNumberPassword({
                 </form.AppField>
               )}
 
-              <form.AuthFormSubmitButton
-                disabled={
-                  isPending || form.state.values.code.length !== otpLength
-                }
-              >
+              <form.AuthFormSubmitButton disabled={isPending || !codeComplete}>
                 {isPending && <Spinner />}
                 {phoneLocalization.resetPassword}
               </form.AuthFormSubmitButton>

--- a/examples/start-shadcn-baseui-example/src/components/auth/sso/email-first-sign-in.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/sso/email-first-sign-in.tsx
@@ -22,6 +22,7 @@ import {
   useSignInEmail
 } from "@better-auth-ui/react"
 import { useSignInSso } from "@better-auth-ui/react/plugins/sso"
+import { useSelector } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
 import { useState } from "react"
@@ -163,6 +164,7 @@ export function EmailFirstSignIn({
       })
     }
   })
+  const email = useSelector(form.store, (state) => state.values.email)
 
   const startOver = () => {
     setStep("email")
@@ -178,9 +180,7 @@ export function EmailFirstSignIn({
           {localization.auth.signIn}
         </CardTitle>
         <CardDescription>
-          {step === "email"
-            ? ssoLocalization.emailFirstDescription
-            : form.state.values.email}
+          {step === "email" ? ssoLocalization.emailFirstDescription : email}
         </CardDescription>
       </CardHeader>
 

--- a/examples/start-shadcn-example/src/components/auth/auth-form.tsx
+++ b/examples/start-shadcn-example/src/components/auth/auth-form.tsx
@@ -3,6 +3,7 @@
 import {
   type AdditionalField as AdditionalFieldConfig,
   type AdditionalFieldFormValue,
+  DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS,
   getFormFieldErrors,
   validateAdditionalFieldRequired,
   validateAdditionalFieldValue
@@ -128,7 +129,12 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   )
 }
 
-export const { useAppForm: useAuthForm } = createFormHook({
+export const {
+  useAppForm: useAuthForm,
+  useTypedAppFormContext: useTypedAuthFormContext,
+  withFieldGroup: withAuthFieldGroup,
+  withForm: withAuthForm
+} = createFormHook({
   fieldComponents: { AuthFormAdditionalField, AuthFormFieldError },
   fieldContext,
   formComponents: { AuthFormRoot, AuthFormSubmitButton },
@@ -155,6 +161,10 @@ export function getAuthAdditionalFieldValidators(
     onChangeAsync: field.validate
       ? ({ value }: { value: AdditionalFieldFormValue }) =>
           validateAdditionalFieldValue(field, value)
+      : undefined,
+    onChangeAsyncDebounceMs: field.validate
+      ? (field.validateDebounceMs ??
+        DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS)
       : undefined
   }
 }

--- a/examples/start-shadcn-example/src/components/auth/device-authorization/device-authorization.tsx
+++ b/examples/start-shadcn-example/src/components/auth/device-authorization/device-authorization.tsx
@@ -10,6 +10,7 @@ import {
   useDenyDevice,
   useVerifyDeviceCode
 } from "@better-auth-ui/react/plugins/device-authorization"
+import { useSelector } from "@tanstack/react-form"
 import { REGEXP_ONLY_DIGITS_AND_CHARS } from "input-otp"
 import { CheckIcon, CircleCheckIcon, CircleXIcon, XIcon } from "lucide-react"
 import {
@@ -312,6 +313,10 @@ function DeviceCodeForm({
     defaultValues: { userCode: initialUserCode },
     onSubmit: ({ value }) => onSubmitCode(value.userCode)
   })
+  const userCodeComplete = useSelector(
+    form.store,
+    (state) => state.values.userCode.length === userCodeLength
+  )
 
   useEffect(() => {
     form.setFieldValue("userCode", initialUserCode)
@@ -390,11 +395,7 @@ function DeviceCodeForm({
 
               <form.AuthFormSubmitButton
                 className="w-full"
-                disabled={
-                  form.state.values.userCode.length !== userCodeLength ||
-                  isSessionPending ||
-                  isVerifying
-                }
+                disabled={!userCodeComplete || isSessionPending || isVerifying}
                 type="submit"
               >
                 {isVerifying ? <Spinner data-icon="inline-start" /> : null}

--- a/examples/start-shadcn-example/src/components/auth/email-otp/change-email-otp.tsx
+++ b/examples/start-shadcn-example/src/components/auth/email-otp/change-email-otp.tsx
@@ -7,6 +7,7 @@ import {
   useRequestEmailChangeOtp,
   useSendVerificationOtp
 } from "@better-auth-ui/react/plugins/email-otp"
+import { useSelector } from "@tanstack/react-form"
 import { useEffect, useReducer } from "react"
 import { toast } from "sonner"
 
@@ -150,6 +151,10 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
       submitCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (formState) => formState.values.code.length === otpLength
+  )
 
   const resetFlow = () => {
     form.reset()
@@ -261,8 +266,7 @@ export function ChangeEmailOtp({ className }: ChangeEmailOtpProps) {
                 disabled={
                   isPending ||
                   !session ||
-                  (state.step !== "email" &&
-                    form.state.values.code.length !== otpLength)
+                  (state.step !== "email" && !codeComplete)
                 }
               >
                 {isPending && <Spinner />}

--- a/examples/start-shadcn-example/src/components/auth/email-otp/email-otp.tsx
+++ b/examples/start-shadcn-example/src/components/auth/email-otp/email-otp.tsx
@@ -8,6 +8,7 @@ import {
   useSendVerificationOtp,
   useSignInEmailOtp
 } from "@better-auth-ui/react/plugins/email-otp"
+import { useSelector } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { useState } from "react"
 
@@ -123,6 +124,11 @@ export function EmailOtp({
       verifyCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (state) => state.values.code.length === otpLength
+  )
+  const email = useSelector(form.store, (state) => state.values.email)
 
   const showSeparator = socialProviders && socialProviders.length > 0
 
@@ -133,10 +139,7 @@ export function EmailOtp({
 
         {codeSent && (
           <CardDescription>
-            {emailOtpLocalization.codeSentTo.replace(
-              "{{email}}",
-              form.state.values.email
-            )}
+            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
           </CardDescription>
         )}
       </CardHeader>
@@ -205,9 +208,7 @@ export function EmailOtp({
                 <div className="flex flex-col gap-3">
                   <form.AuthFormSubmitButton
                     disabled={
-                      isPending ||
-                      isSigningIn ||
-                      (codeSent && form.state.values.code.length !== otpLength)
+                      isPending || isSigningIn || (codeSent && !codeComplete)
                     }
                   >
                     {(isSending || isSigningIn) && <Spinner />}
@@ -219,10 +220,7 @@ export function EmailOtp({
 
                   {codeSent ? (
                     <>
-                      <OpenEmailButton
-                        email={form.state.values.email}
-                        variant="secondary"
-                      />
+                      <OpenEmailButton email={email} variant="secondary" />
 
                       <Button
                         type="button"

--- a/examples/start-shadcn-example/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/examples/start-shadcn-example/src/components/auth/email-otp/reset-password-otp.tsx
@@ -7,6 +7,7 @@ import {
 import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPasswordOtp } from "@better-auth-ui/react/plugins/email-otp"
+import { useSelector } from "@tanstack/react-form"
 import { Eye, EyeOff } from "lucide-react"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
@@ -128,6 +129,7 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
       })
     }
   })
+  const email = useSelector(form.store, (state) => state.values.email)
 
   useEffect(() => {
     const storedEmail =
@@ -143,12 +145,9 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
           {localization.auth.resetPassword}
         </CardTitle>
 
-        {hasStoredEmail && form.state.values.email && (
+        {hasStoredEmail && email && (
           <CardDescription>
-            {emailOtpLocalization.codeSentTo.replace(
-              "{{email}}",
-              form.state.values.email
-            )}
+            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
           </CardDescription>
         )}
       </CardHeader>
@@ -298,12 +297,7 @@ export function ResetPasswordOtp({ className }: ResetPasswordOtpProps) {
                   {localization.auth.resetPassword}
                 </form.AuthFormSubmitButton>
 
-                {form.state.values.email && (
-                  <OpenEmailButton
-                    email={form.state.values.email}
-                    variant="secondary"
-                  />
-                )}
+                {email && <OpenEmailButton email={email} variant="secondary" />}
               </div>
             </FieldGroup>
           </form.AuthFormRoot>

--- a/examples/start-shadcn-example/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/examples/start-shadcn-example/src/components/auth/email-otp/verify-email-otp.tsx
@@ -7,6 +7,7 @@ import {
   useSendVerificationOtp,
   useVerifyEmailOtp
 } from "@better-auth-ui/react/plugins/email-otp"
+import { useSelector } from "@tanstack/react-form"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
@@ -130,6 +131,10 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
       verifyCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (state) => state.values.code.length === otpLength
+  )
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -195,11 +200,7 @@ export function VerifyEmailOtp({ className }: VerifyEmailOtpProps) {
 
               <div className="flex flex-col gap-3">
                 <form.AuthFormSubmitButton
-                  disabled={
-                    isPending ||
-                    (Boolean(email) &&
-                      form.state.values.code.length !== otpLength)
-                  }
+                  disabled={isPending || (Boolean(email) && !codeComplete)}
                 >
                   {isPending && <Spinner />}
 

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-invitation-row.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-invitation-row.tsx
@@ -22,11 +22,14 @@ import { TableCell, TableRow } from "@/components/ui/table"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
 import { OrganizationInvitationRowSkeleton } from "./organization-invitation-row-skeleton"
-import { OrganizationTableSelectRow } from "./organization-table-selection"
+import {
+  type OrganizationSelectableRow,
+  OrganizationTableSelectRow
+} from "./organization-table-selection"
 
 export type OrganizationInvitationRowProps = {
   invitation: Invitation
-  selectableRow?: Parameters<typeof OrganizationTableSelectRow>[0]["row"]
+  selectableRow?: OrganizationSelectableRow<Invitation>
   showCreatedAt?: boolean
   showEmail?: boolean
   showRole?: boolean

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-member-row.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-member-row.tsx
@@ -26,7 +26,10 @@ import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { UserView } from "../user/user-view"
 import { EditMemberRolesDialog } from "./edit-member-roles-dialog"
 import { LeaveOrganizationDialog } from "./leave-organization-dialog"
-import { OrganizationTableSelectRow } from "./organization-table-selection"
+import {
+  type OrganizationSelectableRow,
+  OrganizationTableSelectRow
+} from "./organization-table-selection"
 import { RemoveMemberDialog } from "./remove-member-dialog"
 
 export type OrganizationMemberRowProps = {
@@ -34,7 +37,7 @@ export type OrganizationMemberRowProps = {
   isOwner?: boolean
   ownerCount?: number
   organization: Organization
-  selectableRow?: Parameters<typeof OrganizationTableSelectRow>[0]["row"]
+  selectableRow?: OrganizationSelectableRow<Member & { user: Partial<User> }>
   showRole?: boolean
   showTeams?: boolean
 }

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-roles.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-roles.tsx
@@ -83,6 +83,7 @@ import {
 import { OrganizationTableBulkAction } from "./organization-table-bulk-action"
 import { OrganizationTablePagination } from "./organization-table-pagination"
 import {
+  type OrganizationSelectableRow,
   OrganizationTableSelectAll,
   OrganizationTableSelectRow
 } from "./organization-table-selection"
@@ -464,7 +465,7 @@ function OrganizationRoleRow({
   onEdit: () => void
   organizationId: string
   role: Role
-  selectableRow?: Parameters<typeof OrganizationTableSelectRow>[0]["row"]
+  selectableRow?: OrganizationSelectableRow<Role>
   showPermissions: boolean
 }) {
   const { localization: authLocalization } = useAuth()

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-table-selection.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-table-selection.tsx
@@ -1,19 +1,16 @@
 "use client"
 
 import type { OrganizationLocalization } from "@better-auth-ui/core/plugins/organization"
+import { type Row, type RowData, Subscribe } from "@tanstack/react-table"
 import type { MouseEvent } from "react"
 
 import { Checkbox } from "@/components/ui/checkbox"
+import type { organizationTableFeatures } from "./organization-table"
 
-type SelectableRow = {
-  getCanSelect: () => boolean
-  getIsSelected: () => boolean
-  getToggleSelectedHandler: () => (event: {
-    nativeEvent: MouseEvent<HTMLButtonElement>["nativeEvent"]
-    shiftKey: boolean
-    target: { checked: boolean }
-  }) => void
-}
+export type OrganizationSelectableRow<TData extends RowData> = Row<
+  typeof organizationTableFeatures,
+  TData
+>
 
 export function OrganizationTableSelectAll({
   allSelected,
@@ -39,31 +36,34 @@ export function OrganizationTableSelectAll({
   )
 }
 
-export function OrganizationTableSelectRow({
+export function OrganizationTableSelectRow<TData extends RowData>({
   disabled,
   localization,
   row
 }: {
   disabled?: boolean
   localization: OrganizationLocalization
-  row: SelectableRow
+  row: OrganizationSelectableRow<TData>
 }) {
-  const selected = row.getIsSelected()
-
-  function toggle(event: MouseEvent<HTMLElement>) {
-    row.getToggleSelectedHandler()({
-      nativeEvent: event.nativeEvent,
-      shiftKey: event.shiftKey,
-      target: { checked: !selected }
-    })
-  }
-
   return (
-    <Checkbox
-      aria-label={localization.selectRow}
-      checked={selected}
-      disabled={disabled || !row.getCanSelect()}
-      onClick={toggle}
-    />
+    <Subscribe
+      source={row.table.atoms.rowSelection}
+      selector={(selection) => selection[row.id] === true}
+    >
+      {(selected) => (
+        <Checkbox
+          aria-label={localization.selectRow}
+          checked={selected}
+          disabled={disabled || !row.getCanSelect()}
+          onClick={(event: MouseEvent<HTMLElement>) =>
+            row.getToggleSelectedHandler()({
+              nativeEvent: event.nativeEvent,
+              shiftKey: event.shiftKey,
+              target: { checked: !selected }
+            })
+          }
+        />
+      )}
+    </Subscribe>
   )
 }

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-table-state.ts
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-table-state.ts
@@ -2,12 +2,10 @@
 
 import {
   parseTableColumnVisibility,
-  parseTableFilterValue,
-  parseTablePage,
-  parseTablePageSize,
-  parseTableSorting,
+  parseTableUrlState,
   serializeTableColumnVisibility,
-  serializeTableFilterValue
+  serializeTableUrlState,
+  type TableUrlState
 } from "@better-auth-ui/core"
 import { useCreateAtom, useSelector } from "@tanstack/react-store"
 import {
@@ -35,38 +33,18 @@ function readUrlState(
   stateKey: string,
   defaultPageSize: number,
   allowedColumnIds?: readonly string[]
-): OrganizationTableUrlState {
+): TableUrlState {
   const params =
     typeof window === "undefined"
       ? new URLSearchParams()
       : new URLSearchParams(window.location.search)
-  const filterPrefix = `${stateKey}.filter.`
-  const columnFilters: ColumnFiltersState = []
-
-  for (const [key, value] of params) {
-    const id = key.slice(filterPrefix.length)
-    if (
-      key.startsWith(filterPrefix) &&
-      value &&
-      (!allowedColumnIds || allowedColumnIds.includes(id))
-    ) {
-      columnFilters.push({ id, value: parseTableFilterValue(value) })
-    }
-  }
-
-  return {
-    columnFilters,
-    globalFilter: params.get(`${stateKey}.search`) ?? "",
-    pagination: {
-      pageIndex: parseTablePage(params.get(`${stateKey}.page`), 1) - 1,
-      pageSize: parseTablePageSize(
-        params.get(`${stateKey}.pageSize`),
-        defaultPageSize,
-        ORGANIZATION_TABLE_PAGE_SIZE_OPTIONS
-      )
-    },
-    sorting: parseTableSorting(params.get(`${stateKey}.sort`), allowedColumnIds)
-  }
+  return parseTableUrlState(
+    params,
+    stateKey,
+    defaultPageSize,
+    ORGANIZATION_TABLE_PAGE_SIZE_OPTIONS,
+    allowedColumnIds
+  )
 }
 
 function readColumnVisibility(
@@ -85,16 +63,6 @@ function readColumnVisibility(
   }
 }
 
-function setOrDelete(
-  params: URLSearchParams,
-  key: string,
-  value: string,
-  defaultValue = ""
-) {
-  if (value === defaultValue) params.delete(key)
-  else params.set(key, value)
-}
-
 function writeUrlState(
   stateKey: string,
   defaultPageSize: number,
@@ -103,37 +71,12 @@ function writeUrlState(
   if (typeof window === "undefined") return
 
   const url = new URL(window.location.href)
-  const filterPrefix = `${stateKey}.filter.`
-
-  for (const key of Array.from(url.searchParams.keys())) {
-    if (key.startsWith(filterPrefix)) url.searchParams.delete(key)
-  }
-
-  for (const filter of state.columnFilters) {
-    const value = serializeTableFilterValue(filter.value)
-    if (value) url.searchParams.set(`${filterPrefix}${filter.id}`, value)
-  }
-
-  setOrDelete(url.searchParams, `${stateKey}.search`, state.globalFilter)
-  setOrDelete(
+  url.search = serializeTableUrlState(
     url.searchParams,
-    `${stateKey}.page`,
-    String(state.pagination.pageIndex + 1),
-    "1"
-  )
-  setOrDelete(
-    url.searchParams,
-    `${stateKey}.pageSize`,
-    String(state.pagination.pageSize),
-    String(defaultPageSize)
-  )
-  setOrDelete(
-    url.searchParams,
-    `${stateKey}.sort`,
-    state.sorting
-      .map(({ desc, id }) => `${id}.${desc ? "desc" : "asc"}`)
-      .join(",")
-  )
+    stateKey,
+    defaultPageSize,
+    state
+  ).toString()
 
   window.history.replaceState(window.history.state, "", url)
 }
@@ -144,6 +87,7 @@ export function useOrganizationTableState(
   allowedColumnIds?: readonly string[]
 ) {
   const columnFiltersAtom = useCreateAtom<ColumnFiltersState>([])
+  const columnVisibilityAtom = useCreateAtom<ColumnVisibilityState>({})
   const globalFilterAtom = useCreateAtom("")
   const paginationAtom = useCreateAtom<PaginationState>({
     pageIndex: 0,
@@ -152,12 +96,11 @@ export function useOrganizationTableState(
   const rowSelectionAtom = useCreateAtom<RowSelectionState>({})
   const sortingAtom = useCreateAtom<SortingState>([])
   const columnFilters = useSelector(columnFiltersAtom)
+  const columnVisibility = useSelector(columnVisibilityAtom)
   const globalFilter = useSelector(globalFilterAtom)
   const pagination = useSelector(paginationAtom)
   const rowSelection = useSelector(rowSelectionAtom)
   const sorting = useSelector(sortingAtom)
-  const [columnVisibility, setColumnVisibility] =
-    useState<ColumnVisibilityState>({})
   const [urlReady, setUrlReady] = useState(false)
   const [visibilityReady, setVisibilityReady] = useState(false)
   const atoms = useMemo(
@@ -180,47 +123,49 @@ export function useOrganizationTableState(
   const setPagination = useCallback(
     (updater: Updater<PaginationState>) => {
       paginationAtom.set((current) => functionalUpdate(updater, current))
-      rowSelectionAtom.set({})
     },
-    [paginationAtom, rowSelectionAtom]
+    [paginationAtom]
+  )
+
+  const setColumnVisibility = useCallback(
+    (updater: Updater<ColumnVisibilityState>) => {
+      columnVisibilityAtom.set((current) => functionalUpdate(updater, current))
+    },
+    [columnVisibilityAtom]
   )
 
   const setColumnFilters = useCallback(
     (updater: Updater<ColumnFiltersState>) => {
       columnFiltersAtom.set((current) => functionalUpdate(updater, current))
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
     },
-    [columnFiltersAtom, paginationAtom, rowSelectionAtom]
+    [columnFiltersAtom]
   )
 
   const setGlobalFilter = useCallback(
     (updater: Updater<string>) => {
       globalFilterAtom.set((current) => functionalUpdate(updater, current))
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
     },
-    [globalFilterAtom, paginationAtom, rowSelectionAtom]
+    [globalFilterAtom]
   )
 
   const setSorting = useCallback(
     (updater: Updater<SortingState>) => {
       sortingAtom.set((current) => functionalUpdate(updater, current))
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
     },
-    [paginationAtom, rowSelectionAtom, sortingAtom]
+    [sortingAtom]
   )
 
   useEffect(() => {
-    const resetPageAndSelection = () => {
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
+    const resetPage = () => {
+      const current = paginationAtom.get()
+      if (current.pageIndex === 0) rowSelectionAtom.set({})
+      else paginationAtom.set({ ...current, pageIndex: 0 })
     }
     const subscriptions = [
-      columnFiltersAtom.subscribe(resetPageAndSelection),
-      globalFilterAtom.subscribe(resetPageAndSelection),
-      sortingAtom.subscribe(resetPageAndSelection)
+      columnFiltersAtom.subscribe(resetPage),
+      globalFilterAtom.subscribe(resetPage),
+      sortingAtom.subscribe(resetPage),
+      paginationAtom.subscribe(() => rowSelectionAtom.set({}))
     ]
 
     return () => {
@@ -267,7 +212,7 @@ export function useOrganizationTableState(
   }, [columnVisibility, stateKey, visibilityReady])
 
   useEffect(() => {
-    setColumnVisibility(readColumnVisibility(stateKey, allowedColumnIds))
+    columnVisibilityAtom.set(readColumnVisibility(stateKey, allowedColumnIds))
     setVisibilityReady(true)
 
     const restoreUrlState = () => {
@@ -276,7 +221,6 @@ export function useOrganizationTableState(
       globalFilterAtom.set(next.globalFilter)
       sortingAtom.set(next.sorting)
       paginationAtom.set(next.pagination)
-      rowSelectionAtom.set({})
       setUrlReady(true)
     }
 
@@ -286,10 +230,10 @@ export function useOrganizationTableState(
   }, [
     allowedColumnIds,
     columnFiltersAtom,
+    columnVisibilityAtom,
     defaultPageSize,
     globalFilterAtom,
     paginationAtom,
-    rowSelectionAtom,
     sortingAtom,
     stateKey
   ])

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-table.ts
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-table.ts
@@ -20,25 +20,27 @@ import {
 
 export const ORGANIZATION_TABLE_PAGE_SIZE = 10
 
+export const organizationTableFeatures = tableFeatures({
+  columnFilteringFeature,
+  globalFilteringFeature,
+  filteredRowModel: createFilteredRowModel(),
+  filterFns: { includesString: filterFn_includesString },
+  columnFacetingFeature,
+  facetedRowModel: createFacetedRowModel(),
+  facetedUniqueValues: createFacetedUniqueValues(),
+  columnVisibilityFeature,
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+  rowPaginationFeature,
+  paginatedRowModel: createPaginatedRowModel(),
+  rowSelectionFeature
+})
+
 export const {
   createAppColumnHelper: createOrganizationColumnHelper,
   useAppTable: useOrganizationTable
 } = createTableHook({
   enableMultiSort: true,
   sortDescFirst: false,
-  features: tableFeatures({
-    columnFilteringFeature,
-    globalFilteringFeature,
-    filteredRowModel: createFilteredRowModel(),
-    filterFns: { includesString: filterFn_includesString },
-    columnFacetingFeature,
-    facetedRowModel: createFacetedRowModel(),
-    facetedUniqueValues: createFacetedUniqueValues(),
-    columnVisibilityFeature,
-    rowSortingFeature,
-    sortedRowModel: createSortedRowModel(),
-    rowPaginationFeature,
-    paginatedRowModel: createPaginatedRowModel(),
-    rowSelectionFeature
-  })
+  features: organizationTableFeatures
 })

--- a/examples/start-shadcn-example/src/components/auth/phone-number/change-phone-number.tsx
+++ b/examples/start-shadcn-example/src/components/auth/phone-number/change-phone-number.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getFormFieldErrorMessage } from "@better-auth-ui/core"
 import {
   createPhoneNumberValue,
   type PhoneNumberAuthClient
@@ -14,6 +15,7 @@ import {
   useSendPhoneNumberOtp,
   useVerifyPhoneNumber
 } from "@better-auth-ui/react/plugins/phone-number"
+import { useSelector } from "@tanstack/react-form"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
 
@@ -101,6 +103,14 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
       })
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (formState) => formState.values.code.length === otpLength
+  )
+  const phoneNumberDisplay = useSelector(
+    form.store,
+    (formState) => formState.values.phoneNumber.display
+  )
 
   useEffect(() => {
     if (session) {
@@ -129,7 +139,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                   <FieldDescription>
                     {localization.codeSentTo.replace(
                       "{{phoneNumber}}",
-                      form.state.values.phoneNumber.display
+                      phoneNumberDisplay
                     )}
                   </FieldDescription>
                   <form.AppField name="code">
@@ -160,7 +170,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
                       countryCodes={countries}
                       countryLabel={localization.country}
                       disabled={isPending}
-                      error={field.state.meta.errors[0]?.toString()}
+                      error={getFormFieldErrorMessage(field.state.meta.errors)}
                       locale={locale}
                       phoneLabel={localization.phoneNumber}
                       placeholder={localization.phoneNumberPlaceholder}
@@ -198,11 +208,7 @@ export function ChangePhoneNumber({ className }: ChangePhoneNumberProps) {
               )}
               <form.AuthFormSubmitButton
                 size="sm"
-                disabled={
-                  isPending ||
-                  !session ||
-                  (codeSent && form.state.values.code.length !== otpLength)
-                }
+                disabled={isPending || !session || (codeSent && !codeComplete)}
               >
                 {(isSending || isVerifying) && <Spinner />}
                 {codeSent

--- a/examples/start-shadcn-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/examples/start-shadcn-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getFormFieldErrorMessage } from "@better-auth-ui/core"
 import {
   createPhoneNumberValue,
   type PhoneNumberAuthClient
@@ -87,7 +88,7 @@ export function ForgotPhoneNumberPassword({
                     countryCodes={countries}
                     countryLabel={phoneLocalization.country}
                     disabled={isPending}
-                    error={field.state.meta.errors[0]?.toString()}
+                    error={getFormFieldErrorMessage(field.state.meta.errors)}
                     locale={locale}
                     phoneLabel={phoneLocalization.phoneNumber}
                     placeholder={phoneLocalization.phoneNumberPlaceholder}

--- a/examples/start-shadcn-example/src/components/auth/phone-number/phone-number.tsx
+++ b/examples/start-shadcn-example/src/components/auth/phone-number/phone-number.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import { authMutationKeys } from "@better-auth-ui/core"
+import {
+  authMutationKeys,
+  getFormFieldErrorMessage
+} from "@better-auth-ui/core"
 import {
   createPhoneNumberValue,
   type PhoneNumberAuthClient
@@ -16,6 +19,7 @@ import {
   useSignInPhoneNumber,
   useVerifyPhoneNumber
 } from "@better-auth-ui/react/plugins/phone-number"
+import { useSelector } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
 import { useState } from "react"
@@ -204,6 +208,14 @@ export function PhoneNumber({
       verifyCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (state) => state.values.code.length === otpLength
+  )
+  const phoneNumberDisplay = useSelector(
+    form.store,
+    (state) => state.values.phoneNumber.display
+  )
 
   return (
     <Card className={cn("w-full max-w-sm", className)}>
@@ -217,7 +229,7 @@ export function PhoneNumber({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              form.state.values.phoneNumber.display
+              phoneNumberDisplay
             )}
           </CardDescription>
         )}
@@ -271,7 +283,9 @@ export function PhoneNumber({
                           countryCodes={countries}
                           countryLabel={phoneLocalization.country}
                           disabled={isPending}
-                          error={field.state.meta.errors[0]?.toString()}
+                          error={getFormFieldErrorMessage(
+                            field.state.meta.errors
+                          )}
                           locale={locale}
                           phoneLabel={phoneLocalization.phoneNumber}
                           placeholder={phoneLocalization.phoneNumberPlaceholder}
@@ -367,10 +381,7 @@ export function PhoneNumber({
 
                 <div className="flex flex-col gap-3">
                   <form.AuthFormSubmitButton
-                    disabled={
-                      isPending ||
-                      (codeSent && form.state.values.code.length !== otpLength)
-                    }
+                    disabled={isPending || (codeSent && !codeComplete)}
                   >
                     {(isSending || isVerifying || isPasswordPending) && (
                       <Spinner />

--- a/examples/start-shadcn-example/src/components/auth/phone-number/reset-phone-number-password.tsx
+++ b/examples/start-shadcn-example/src/components/auth/phone-number/reset-phone-number-password.tsx
@@ -4,6 +4,7 @@ import { isPasswordCompromisedError } from "@better-auth-ui/core"
 import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPhoneNumberPassword } from "@better-auth-ui/react/plugins/phone-number"
+import { useSelector } from "@tanstack/react-form"
 import { Eye, EyeOff } from "lucide-react"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
@@ -115,6 +116,14 @@ export function ResetPhoneNumberPassword({
       })
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (formState) => formState.values.code.length === otpLength
+  )
+  const phoneNumber = useSelector(
+    form.store,
+    (formState) => formState.values.phoneNumber
+  )
 
   useEffect(() => {
     const stored = sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY) ?? ""
@@ -132,7 +141,7 @@ export function ResetPhoneNumberPassword({
           <CardDescription>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              form.state.values.phoneNumber
+              phoneNumber
             )}
           </CardDescription>
         )}
@@ -261,11 +270,7 @@ export function ResetPhoneNumberPassword({
                 </form.AppField>
               )}
 
-              <form.AuthFormSubmitButton
-                disabled={
-                  isPending || form.state.values.code.length !== otpLength
-                }
-              >
+              <form.AuthFormSubmitButton disabled={isPending || !codeComplete}>
                 {isPending && <Spinner />}
                 {phoneLocalization.resetPassword}
               </form.AuthFormSubmitButton>

--- a/examples/start-shadcn-example/src/components/auth/sso/email-first-sign-in.tsx
+++ b/examples/start-shadcn-example/src/components/auth/sso/email-first-sign-in.tsx
@@ -22,6 +22,7 @@ import {
   useSignInEmail
 } from "@better-auth-ui/react"
 import { useSignInSso } from "@better-auth-ui/react/plugins/sso"
+import { useSelector } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { Eye, EyeOff } from "lucide-react"
 import { useState } from "react"
@@ -163,6 +164,7 @@ export function EmailFirstSignIn({
       })
     }
   })
+  const email = useSelector(form.store, (state) => state.values.email)
 
   const startOver = () => {
     setStep("email")
@@ -178,9 +180,7 @@ export function EmailFirstSignIn({
           {localization.auth.signIn}
         </CardTitle>
         <CardDescription>
-          {step === "email"
-            ? ssoLocalization.emailFirstDescription
-            : form.state.values.email}
+          {step === "email" ? ssoLocalization.emailFirstDescription : email}
         </CardDescription>
       </CardHeader>
 

--- a/examples/start-solid-zaidan-example/src/components/auth/auth-form.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/auth-form.tsx
@@ -1,6 +1,7 @@
 import {
   type AdditionalField as AdditionalFieldConfig,
   type AdditionalFieldFormValue,
+  DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS,
   getFormFieldErrors,
   validateAdditionalFieldRequired,
   validateAdditionalFieldValue
@@ -135,7 +136,11 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   )
 }
 
-export const { useAppForm: createAuthForm } = createFormHook({
+export const {
+  useAppForm: createAuthForm,
+  withFieldGroup: withAuthFieldGroup,
+  withForm: withAuthForm
+} = createFormHook({
   fieldComponents: { AuthFormAdditionalField, AuthFormFieldError },
   fieldContext,
   formComponents: { AuthFormRoot, AuthFormSubmitButton },
@@ -152,6 +157,10 @@ export function getAuthAdditionalFieldValidators(
     onChangeAsync: field.validate
       ? ({ value }: { value: AdditionalFieldFormValue }) =>
           validateAdditionalFieldValue(field, value)
+      : undefined,
+    onChangeAsyncDebounceMs: field.validate
+      ? (field.validateDebounceMs ??
+        DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS)
       : undefined
   }
 }

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-table-state.ts
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-table-state.ts
@@ -1,11 +1,8 @@
 import {
   parseTableColumnVisibility,
-  parseTableFilterValue,
-  parseTablePage,
-  parseTablePageSize,
-  parseTableSorting,
+  parseTableUrlState,
   serializeTableColumnVisibility,
-  serializeTableFilterValue
+  serializeTableUrlState
 } from "@better-auth-ui/core"
 import { createAtom, useSelector } from "@tanstack/solid-store"
 import {
@@ -27,41 +24,13 @@ function readUrl(
   defaultPageSize: number,
   allowedColumnIds?: readonly string[]
 ) {
-  const params = new URLSearchParams(window.location.search)
-  const prefix = `${stateKey}.filter.`
-  const filters: ColumnFiltersState = []
-  for (const [key, value] of params) {
-    const id = key.slice(prefix.length)
-    if (
-      key.startsWith(prefix) &&
-      value &&
-      (!allowedColumnIds || allowedColumnIds.includes(id))
-    )
-      filters.push({ id, value: parseTableFilterValue(value) })
-  }
-  return {
-    columnFilters: filters,
-    globalFilter: params.get(`${stateKey}.search`) ?? "",
-    pagination: {
-      pageIndex: parseTablePage(params.get(`${stateKey}.page`), 1) - 1,
-      pageSize: parseTablePageSize(
-        params.get(`${stateKey}.pageSize`),
-        defaultPageSize,
-        ORGANIZATION_TABLE_PAGE_SIZE_OPTIONS
-      )
-    },
-    sorting: parseTableSorting(params.get(`${stateKey}.sort`), allowedColumnIds)
-  }
-}
-
-function setOrDelete(
-  params: URLSearchParams,
-  key: string,
-  value: string,
-  fallback = ""
-) {
-  if (value === fallback) params.delete(key)
-  else params.set(key, value)
+  return parseTableUrlState(
+    new URLSearchParams(window.location.search),
+    stateKey,
+    defaultPageSize,
+    ORGANIZATION_TABLE_PAGE_SIZE_OPTIONS,
+    allowedColumnIds
+  )
 }
 
 export function createOrganizationTableState(
@@ -70,6 +39,7 @@ export function createOrganizationTableState(
   allowedColumnIds?: readonly string[]
 ) {
   const columnFiltersAtom = createAtom<ColumnFiltersState>([])
+  const columnVisibilityAtom = createAtom<ColumnVisibilityState>({})
   const globalFilterAtom = createAtom("")
   const paginationAtom = createAtom<PaginationState>({
     pageIndex: 0,
@@ -78,12 +48,11 @@ export function createOrganizationTableState(
   const rowSelectionAtom = createAtom<RowSelectionState>({})
   const sortingAtom = createAtom<SortingState>([])
   const columnFilters = useSelector(columnFiltersAtom)
+  const columnVisibility = useSelector(columnVisibilityAtom)
   const globalFilter = useSelector(globalFilterAtom)
   const pagination = useSelector(paginationAtom)
   const rowSelection = useSelector(rowSelectionAtom)
   const sorting = useSelector(sortingAtom)
-  const [columnVisibility, setColumnVisibility] =
-    createSignal<ColumnVisibilityState>({})
   const [ready, setReady] = createSignal(false)
   const atoms = {
     columnFilters: columnFiltersAtom,
@@ -95,40 +64,40 @@ export function createOrganizationTableState(
 
   const setPagination = (updater: Updater<PaginationState>) => {
     paginationAtom.set((current) => functionalUpdate(updater, current))
-    rowSelectionAtom.set({})
+  }
+  const setColumnVisibility = (updater: Updater<ColumnVisibilityState>) => {
+    columnVisibilityAtom.set((current) => functionalUpdate(updater, current))
   }
   const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
     columnFiltersAtom.set((current) => functionalUpdate(updater, current))
-    paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-    rowSelectionAtom.set({})
   }
   const setGlobalFilter = (updater: Updater<string>) => {
     globalFilterAtom.set((current) => functionalUpdate(updater, current))
-    paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-    rowSelectionAtom.set({})
   }
   const setSorting = (updater: Updater<SortingState>) => {
     sortingAtom.set((current) => functionalUpdate(updater, current))
-    paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-    rowSelectionAtom.set({})
   }
 
   onMount(() => {
-    const resetPageAndSelection = () => {
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
+    const resetPage = () => {
+      const current = paginationAtom.get()
+      if (current.pageIndex === 0) rowSelectionAtom.set({})
+      else paginationAtom.set({ ...current, pageIndex: 0 })
     }
     const subscriptions = [
-      columnFiltersAtom.subscribe(resetPageAndSelection),
-      globalFilterAtom.subscribe(resetPageAndSelection),
-      sortingAtom.subscribe(resetPageAndSelection)
+      columnFiltersAtom.subscribe(resetPage),
+      globalFilterAtom.subscribe(resetPage),
+      sortingAtom.subscribe(resetPage),
+      paginationAtom.subscribe(() => rowSelectionAtom.set({}))
     ]
 
     try {
       const saved = window.localStorage.getItem(
         `${STORAGE_PREFIX}:${stateKey}:columns`
       )
-      setColumnVisibility(parseTableColumnVisibility(saved, allowedColumnIds))
+      columnVisibilityAtom.set(
+        parseTableColumnVisibility(saved, allowedColumnIds)
+      )
     } catch {
       // Storage is optional.
     }
@@ -138,7 +107,6 @@ export function createOrganizationTableState(
       globalFilterAtom.set(next.globalFilter)
       sortingAtom.set(next.sorting)
       paginationAtom.set(next.pagination)
-      rowSelectionAtom.set({})
       setReady(true)
     }
     restore()
@@ -171,33 +139,12 @@ export function createOrganizationTableState(
     }
     if (!ready()) return
     const url = new URL(window.location.href)
-    const prefix = `${stateKey}.filter.`
-    for (const key of Array.from(url.searchParams.keys()))
-      if (key.startsWith(prefix)) url.searchParams.delete(key)
-    for (const filter of state.columnFilters) {
-      const value = serializeTableFilterValue(filter.value)
-      if (value) url.searchParams.set(`${prefix}${filter.id}`, value)
-    }
-    setOrDelete(url.searchParams, `${stateKey}.search`, state.globalFilter)
-    setOrDelete(
+    url.search = serializeTableUrlState(
       url.searchParams,
-      `${stateKey}.page`,
-      String(state.pagination.pageIndex + 1),
-      "1"
-    )
-    setOrDelete(
-      url.searchParams,
-      `${stateKey}.pageSize`,
-      String(state.pagination.pageSize),
-      String(defaultPageSize)
-    )
-    setOrDelete(
-      url.searchParams,
-      `${stateKey}.sort`,
-      state.sorting
-        .map(({ desc, id }) => `${id}.${desc ? "desc" : "asc"}`)
-        .join(",")
-    )
+      stateKey,
+      defaultPageSize,
+      state
+    ).toString()
     window.history.replaceState(window.history.state, "", url)
   })
 

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-table.ts
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-table.ts
@@ -18,25 +18,27 @@ import {
 
 export const ORGANIZATION_TABLE_PAGE_SIZE = 10
 
+export const organizationTableFeatures = tableFeatures({
+  columnFilteringFeature,
+  globalFilteringFeature,
+  filteredRowModel: createFilteredRowModel(),
+  filterFns: { includesString: filterFn_includesString },
+  columnFacetingFeature,
+  facetedRowModel: createFacetedRowModel(),
+  facetedUniqueValues: createFacetedUniqueValues(),
+  columnVisibilityFeature,
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+  rowPaginationFeature,
+  paginatedRowModel: createPaginatedRowModel(),
+  rowSelectionFeature
+})
+
 export const {
   createAppColumnHelper: createOrganizationColumnHelper,
   createAppTable: createOrganizationTable
 } = createTableHook({
   enableMultiSort: true,
   sortDescFirst: false,
-  features: tableFeatures({
-    columnFilteringFeature,
-    globalFilteringFeature,
-    filteredRowModel: createFilteredRowModel(),
-    filterFns: { includesString: filterFn_includesString },
-    columnFacetingFeature,
-    facetedRowModel: createFacetedRowModel(),
-    facetedUniqueValues: createFacetedUniqueValues(),
-    columnVisibilityFeature,
-    rowSortingFeature,
-    sortedRowModel: createSortedRowModel(),
-    rowPaginationFeature,
-    paginatedRowModel: createPaginatedRowModel(),
-    rowSelectionFeature
-  })
+  features: organizationTableFeatures
 })

--- a/packages/core/src/config/additional-fields-config.ts
+++ b/packages/core/src/config/additional-fields-config.ts
@@ -7,6 +7,9 @@ export type AdditionalFieldValue = string | number | boolean | Date
 /** Value stored for an additional field while it is owned by a form. */
 export type AdditionalFieldFormValue = AdditionalFieldValue | null
 
+/** Default delay for custom additional-field validation after a value changes. */
+export const DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS = 300
+
 /** Runtime additional-field values keyed by their configured model names. */
 export type AdditionalFieldFormValues = Record<string, AdditionalFieldFormValue>
 
@@ -128,6 +131,12 @@ export interface AdditionalField {
   validate?: (
     value: AdditionalFieldValue | null | undefined
   ) => void | Promise<void>
+  /**
+   * Delay custom validation after a value changes. Set to `0` to validate
+   * immediately.
+   * @default 300
+   */
+  validateDebounceMs?: number
   /**
    * Render on the sign-up form. Pass `"above"` to render between the `email`
    * and `password` fields; otherwise the field renders below the password

--- a/packages/core/src/lib/table-state.ts
+++ b/packages/core/src/lib/table-state.ts
@@ -11,6 +11,13 @@ export type TableFilterValue =
   | null
   | readonly (boolean | number | string | null)[]
 
+export type TableUrlState = {
+  columnFilters: { id: string; value: TableFilterValue }[]
+  globalFilter: string
+  pagination: { pageIndex: number; pageSize: number }
+  sorting: TableSortingEntry[]
+}
+
 const TABLE_STATE_VERSION = 1
 const TABLE_FILTER_VALUE_PREFIX = "~"
 
@@ -121,6 +128,91 @@ export function serializeTableFilterValue(value: unknown): string | undefined {
   return `${TABLE_FILTER_VALUE_PREFIX}${JSON.stringify(value)}`
 }
 
+/** Parse one namespaced table state from URL search parameters. */
+export function parseTableUrlState(
+  params: URLSearchParams,
+  stateKey: string,
+  defaultPageSize: number,
+  allowedPageSizes: readonly number[],
+  allowedColumnIds?: readonly string[]
+): TableUrlState {
+  const filterPrefix = `${stateKey}.filter.`
+  const columnFilters: TableUrlState["columnFilters"] = []
+
+  for (const [key, value] of params) {
+    const id = key.slice(filterPrefix.length)
+    if (
+      key.startsWith(filterPrefix) &&
+      value &&
+      (!allowedColumnIds || allowedColumnIds.includes(id))
+    ) {
+      columnFilters.push({ id, value: parseTableFilterValue(value) })
+    }
+  }
+
+  return {
+    columnFilters,
+    globalFilter: params.get(`${stateKey}.search`) ?? "",
+    pagination: {
+      pageIndex: parseTablePage(params.get(`${stateKey}.page`), 1) - 1,
+      pageSize: parseTablePageSize(
+        params.get(`${stateKey}.pageSize`),
+        defaultPageSize,
+        allowedPageSizes
+      )
+    },
+    sorting: parseTableSorting(params.get(`${stateKey}.sort`), allowedColumnIds)
+  }
+}
+
+/** Write one namespaced table state without changing unrelated parameters. */
+export function serializeTableUrlState(
+  source: URLSearchParams,
+  stateKey: string,
+  defaultPageSize: number,
+  state: {
+    columnFilters: readonly { id: string; value: unknown }[]
+    globalFilter: string
+    pagination: { pageIndex: number; pageSize: number }
+    sorting: readonly TableSortingEntry[]
+  }
+) {
+  const params = new URLSearchParams(source)
+  const filterPrefix = `${stateKey}.filter.`
+
+  for (const key of Array.from(params.keys())) {
+    if (key.startsWith(filterPrefix)) params.delete(key)
+  }
+
+  for (const filter of state.columnFilters) {
+    const value = serializeTableFilterValue(filter.value)
+    if (value) params.set(`${filterPrefix}${filter.id}`, value)
+  }
+
+  setOrDelete(params, `${stateKey}.search`, state.globalFilter)
+  setOrDelete(
+    params,
+    `${stateKey}.page`,
+    String(state.pagination.pageIndex + 1),
+    "1"
+  )
+  setOrDelete(
+    params,
+    `${stateKey}.pageSize`,
+    String(state.pagination.pageSize),
+    String(defaultPageSize)
+  )
+  setOrDelete(
+    params,
+    `${stateKey}.sort`,
+    state.sorting
+      .map(({ desc, id }) => `${id}.${desc ? "desc" : "asc"}`)
+      .join(",")
+  )
+
+  return params
+}
+
 export function getLookaheadPage<T>(items: readonly T[], pageSize: number) {
   const normalizedPageSize = Math.max(1, Math.floor(pageSize))
   return {
@@ -155,6 +247,16 @@ export function getClampedTablePageIndex(
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function setOrDelete(
+  params: URLSearchParams,
+  key: string,
+  value: string,
+  defaultValue = ""
+) {
+  if (value === defaultValue) params.delete(key)
+  else params.set(key, value)
 }
 
 function isTableFilterPrimitive(

--- a/packages/core/tests/table-state.test.ts
+++ b/packages/core/tests/table-state.test.ts
@@ -7,8 +7,10 @@ import {
   parseTablePage,
   parseTablePageSize,
   parseTableSorting,
+  parseTableUrlState,
   serializeTableColumnVisibility,
-  serializeTableFilterValue
+  serializeTableFilterValue,
+  serializeTableUrlState
 } from "../src/lib/table-state"
 
 describe("table state", () => {
@@ -87,5 +89,42 @@ describe("table state", () => {
         )
       )
     ).toBe(true)
+  })
+
+  it("round trips namespaced URL state without changing unrelated parameters", () => {
+    const params = serializeTableUrlState(
+      new URLSearchParams("other=kept&members.filter.stale=value"),
+      "members",
+      10,
+      {
+        columnFilters: [{ id: "role", value: ["admin", "owner"] }],
+        globalFilter: "Ada",
+        pagination: { pageIndex: 2, pageSize: 20 },
+        sorting: [
+          { desc: false, id: "name" },
+          { desc: true, id: "createdAt" }
+        ]
+      }
+    )
+
+    expect(params.get("other")).toBe("kept")
+    expect(params.has("members.filter.stale")).toBe(false)
+    expect(
+      parseTableUrlState(
+        params,
+        "members",
+        10,
+        [10, 20, 50],
+        ["role", "name", "createdAt"]
+      )
+    ).toEqual({
+      columnFilters: [{ id: "role", value: ["admin", "owner"] }],
+      globalFilter: "Ada",
+      pagination: { pageIndex: 2, pageSize: 20 },
+      sorting: [
+        { desc: false, id: "name" },
+        { desc: true, id: "createdAt" }
+      ]
+    })
   })
 })

--- a/packages/heroui/src/components/auth/auth-form.tsx
+++ b/packages/heroui/src/components/auth/auth-form.tsx
@@ -1,6 +1,7 @@
 import {
   type AdditionalField as AdditionalFieldConfig,
   type AdditionalFieldFormValue,
+  DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS,
   getFormFieldErrorMessage,
   getFormFieldErrors,
   validateAdditionalFieldRequired,
@@ -128,7 +129,12 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   )
 }
 
-export const { useAppForm: useAuthForm } = createFormHook({
+export const {
+  useAppForm: useAuthForm,
+  useTypedAppFormContext: useTypedAuthFormContext,
+  withFieldGroup: withAuthFieldGroup,
+  withForm: withAuthForm
+} = createFormHook({
   fieldComponents: { AuthFormAdditionalField, AuthFormFieldError },
   fieldContext,
   formComponents: { AuthFormRoot, AuthFormSubmitButton },
@@ -155,6 +161,10 @@ export function getAuthAdditionalFieldValidators(
     onChangeAsync: field.validate
       ? ({ value }: { value: AdditionalFieldFormValue }) =>
           validateAdditionalFieldValue(field, value)
+      : undefined,
+    onChangeAsyncDebounceMs: field.validate
+      ? (field.validateDebounceMs ??
+        DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS)
       : undefined
   }
 }

--- a/packages/heroui/src/components/auth/email-otp/email-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/email-otp.tsx
@@ -19,6 +19,7 @@ import {
   Spinner,
   TextField
 } from "@heroui/react"
+import { useSelector } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
 import { useState } from "react"
 
@@ -115,6 +116,11 @@ export function EmailOtp({
       verifyCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (state) => state.values.code.length === otpLength
+  )
+  const email = useSelector(form.store, (state) => state.values.email)
 
   const startOver = () => {
     setCodeSent(false)
@@ -135,10 +141,7 @@ export function EmailOtp({
 
         {codeSent && (
           <Card.Description>
-            {emailOtpLocalization.codeSentTo.replace(
-              "{{email}}",
-              form.state.values.email
-            )}
+            {emailOtpLocalization.codeSentTo.replace("{{email}}", email)}
           </Card.Description>
         )}
       </Card.Header>
@@ -211,9 +214,7 @@ export function EmailOtp({
               <form.AuthFormSubmitButton
                 className="w-full"
                 isDisabled={
-                  isPending ||
-                  isSigningIn ||
-                  (codeSent && form.state.values.code.length !== otpLength)
+                  isPending || isSigningIn || (codeSent && !codeComplete)
                 }
               >
                 {(isSending || isSigningIn) && (
@@ -227,10 +228,7 @@ export function EmailOtp({
 
               {codeSent ? (
                 <div className="flex flex-col gap-3">
-                  <OpenEmailButton
-                    email={form.state.values.email}
-                    variant="secondary"
-                  />
+                  <OpenEmailButton email={email} variant="secondary" />
 
                   <Button
                     className="w-full"

--- a/packages/heroui/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/verify-email-otp.tsx
@@ -20,6 +20,7 @@ import {
   toast,
   useIsHydrated
 } from "@heroui/react"
+import { useSelector } from "@tanstack/react-form"
 import { useEffect, useState } from "react"
 
 import { emailOtpPlugin } from "../../../lib/auth/email-otp-plugin"
@@ -126,6 +127,10 @@ export function VerifyEmailOtp({ className, variant }: VerifyEmailOtpProps) {
       verifyCode(value.code)
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (state) => state.values.code.length === otpLength
+  )
 
   return (
     <Card
@@ -199,11 +204,7 @@ export function VerifyEmailOtp({ className, variant }: VerifyEmailOtpProps) {
             <div className="flex flex-col gap-3">
               <form.AuthFormSubmitButton
                 className="w-full"
-                isDisabled={
-                  isPending ||
-                  (Boolean(email) &&
-                    form.state.values.code.length !== otpLength)
-                }
+                isDisabled={isPending || (Boolean(email) && !codeComplete)}
               >
                 {isPending && <Spinner color="current" size="sm" />}
 

--- a/packages/heroui/src/components/auth/organization/organization-invitation-row.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-invitation-row.tsx
@@ -16,11 +16,14 @@ import type { Invitation } from "better-auth/client"
 
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
 import { OrganizationInvitationRowSkeleton } from "./organization-invitation-row-skeleton"
-import { OrganizationTableSelectRow } from "./organization-table-selection"
+import {
+  type OrganizationSelectableRow,
+  OrganizationTableSelectRow
+} from "./organization-table-selection"
 
 export type OrganizationInvitationTableRowProps = {
   invitation: Invitation
-  selectableRow?: Parameters<typeof OrganizationTableSelectRow>[0]["row"]
+  selectableRow?: OrganizationSelectableRow<Invitation>
   showCreatedAt?: boolean
   showRole?: boolean
   showStatus?: boolean
@@ -84,7 +87,7 @@ export function OrganizationInvitationTableRow({
   const isPending = invitation.status === "pending"
 
   return (
-    <Table.Row>
+    <Table.Row id={invitation.id}>
       {selectableRow && (
         <Table.Cell>
           <OrganizationTableSelectRow

--- a/packages/heroui/src/components/auth/organization/organization-member-row.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-member-row.tsx
@@ -22,7 +22,10 @@ import { organizationPlugin } from "../../../lib/auth/organization-plugin"
 import { UserView } from "../user/user-view"
 import { EditMemberRolesDialog } from "./edit-member-roles-dialog"
 import { LeaveOrganizationDialog } from "./leave-organization-dialog"
-import { OrganizationTableSelectRow } from "./organization-table-selection"
+import {
+  type OrganizationSelectableRow,
+  OrganizationTableSelectRow
+} from "./organization-table-selection"
 import { RemoveMemberDialog } from "./remove-member-dialog"
 
 export type OrganizationMemberRowProps = {
@@ -30,7 +33,7 @@ export type OrganizationMemberRowProps = {
   isOwner?: boolean
   ownerCount?: number
   organization: Organization
-  selectableRow?: Parameters<typeof OrganizationTableSelectRow>[0]["row"]
+  selectableRow?: OrganizationSelectableRow<Member & { user: Partial<User> }>
   showRole?: boolean
   showTeams?: boolean
 }
@@ -106,7 +109,7 @@ export function OrganizationMemberRow({
   const [roleEditorOpen, setRoleEditorOpen] = useState(false)
 
   return (
-    <Table.Row>
+    <Table.Row id={member.id}>
       {selectableRow && (
         <Table.Cell>
           <OrganizationTableSelectRow

--- a/packages/heroui/src/components/auth/organization/organization-roles.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-roles.tsx
@@ -50,6 +50,7 @@ import {
 import { OrganizationTableBulkAction } from "./organization-table-bulk-action"
 import { OrganizationTablePagination } from "./organization-table-pagination"
 import {
+  type OrganizationSelectableRow,
   OrganizationTableSelectAll,
   OrganizationTableSelectRow
 } from "./organization-table-selection"
@@ -433,7 +434,7 @@ function OrganizationRoleRow({
   onEdit: () => void
   organizationId: string
   role: Role
-  selectableRow?: Parameters<typeof OrganizationTableSelectRow>[0]["row"]
+  selectableRow?: OrganizationSelectableRow<Role>
   showPermissions: boolean
 }) {
   const { localization: authLocalization } = useAuth()

--- a/packages/heroui/src/components/auth/organization/organization-table-selection.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-table-selection.tsx
@@ -1,15 +1,13 @@
 import type { OrganizationLocalization } from "@better-auth-ui/core/plugins/organization"
 import { Checkbox } from "@heroui/react"
+import { type Row, type RowData, Subscribe } from "@tanstack/react-table"
 import { useRef } from "react"
+import type { organizationTableFeatures } from "./organization-table"
 
-type SelectableRow = {
-  getCanSelect: () => boolean
-  getIsSelected: () => boolean
-  getToggleSelectedHandler: () => (event: {
-    shiftKey: boolean
-    target: { checked: boolean }
-  }) => void
-}
+export type OrganizationSelectableRow<TData extends RowData> = Row<
+  typeof organizationTableFeatures,
+  TData
+>
 
 function SelectionCheckbox({
   ariaLabel,
@@ -77,27 +75,33 @@ export function OrganizationTableSelectAll({
   )
 }
 
-export function OrganizationTableSelectRow({
+export function OrganizationTableSelectRow<TData extends RowData>({
   disabled,
   localization,
   row
 }: {
   disabled?: boolean
   localization: OrganizationLocalization
-  row: SelectableRow
+  row: OrganizationSelectableRow<TData>
 }) {
-  const selected = row.getIsSelected()
   return (
-    <SelectionCheckbox
-      ariaLabel={localization.selectRow}
-      disabled={disabled || !row.getCanSelect()}
-      selected={selected}
-      onChange={(next, shiftKey) =>
-        row.getToggleSelectedHandler()({
-          shiftKey,
-          target: { checked: next }
-        })
-      }
-    />
+    <Subscribe
+      source={row.table.atoms.rowSelection}
+      selector={(selection) => selection[row.id] === true}
+    >
+      {(selected) => (
+        <SelectionCheckbox
+          ariaLabel={localization.selectRow}
+          disabled={disabled || !row.getCanSelect()}
+          selected={selected}
+          onChange={(next, shiftKey) =>
+            row.getToggleSelectedHandler()({
+              shiftKey,
+              target: { checked: next }
+            })
+          }
+        />
+      )}
+    </Subscribe>
   )
 }

--- a/packages/heroui/src/components/auth/organization/organization-table-state.ts
+++ b/packages/heroui/src/components/auth/organization/organization-table-state.ts
@@ -1,11 +1,9 @@
 import {
   parseTableColumnVisibility,
-  parseTableFilterValue,
-  parseTablePage,
-  parseTablePageSize,
-  parseTableSorting,
+  parseTableUrlState,
   serializeTableColumnVisibility,
-  serializeTableFilterValue
+  serializeTableUrlState,
+  type TableUrlState
 } from "@better-auth-ui/core"
 import { useCreateAtom, useSelector } from "@tanstack/react-store"
 import {
@@ -33,35 +31,18 @@ function readUrlState(
   stateKey: string,
   defaultPageSize: number,
   allowedColumnIds?: readonly string[]
-): OrganizationTableUrlState {
+): TableUrlState {
   const params =
     typeof window === "undefined"
       ? new URLSearchParams()
       : new URLSearchParams(window.location.search)
-  const filterPrefix = `${stateKey}.filter.`
-  const columnFilters: ColumnFiltersState = []
-  for (const [key, value] of params) {
-    const id = key.slice(filterPrefix.length)
-    if (
-      key.startsWith(filterPrefix) &&
-      value &&
-      (!allowedColumnIds || allowedColumnIds.includes(id))
-    )
-      columnFilters.push({ id, value: parseTableFilterValue(value) })
-  }
-  return {
-    columnFilters,
-    globalFilter: params.get(`${stateKey}.search`) ?? "",
-    pagination: {
-      pageIndex: parseTablePage(params.get(`${stateKey}.page`), 1) - 1,
-      pageSize: parseTablePageSize(
-        params.get(`${stateKey}.pageSize`),
-        defaultPageSize,
-        ORGANIZATION_TABLE_PAGE_SIZE_OPTIONS
-      )
-    },
-    sorting: parseTableSorting(params.get(`${stateKey}.sort`), allowedColumnIds)
-  }
+  return parseTableUrlState(
+    params,
+    stateKey,
+    defaultPageSize,
+    ORGANIZATION_TABLE_PAGE_SIZE_OPTIONS,
+    allowedColumnIds
+  )
 }
 
 function readColumnVisibility(
@@ -79,16 +60,6 @@ function readColumnVisibility(
   }
 }
 
-function setOrDelete(
-  params: URLSearchParams,
-  key: string,
-  value: string,
-  defaultValue = ""
-) {
-  if (value === defaultValue) params.delete(key)
-  else params.set(key, value)
-}
-
 function writeUrlState(
   stateKey: string,
   defaultPageSize: number,
@@ -96,34 +67,12 @@ function writeUrlState(
 ) {
   if (typeof window === "undefined") return
   const url = new URL(window.location.href)
-  const filterPrefix = `${stateKey}.filter.`
-  for (const key of Array.from(url.searchParams.keys())) {
-    if (key.startsWith(filterPrefix)) url.searchParams.delete(key)
-  }
-  for (const filter of state.columnFilters) {
-    const value = serializeTableFilterValue(filter.value)
-    if (value) url.searchParams.set(`${filterPrefix}${filter.id}`, value)
-  }
-  setOrDelete(url.searchParams, `${stateKey}.search`, state.globalFilter)
-  setOrDelete(
+  url.search = serializeTableUrlState(
     url.searchParams,
-    `${stateKey}.page`,
-    String(state.pagination.pageIndex + 1),
-    "1"
-  )
-  setOrDelete(
-    url.searchParams,
-    `${stateKey}.pageSize`,
-    String(state.pagination.pageSize),
-    String(defaultPageSize)
-  )
-  setOrDelete(
-    url.searchParams,
-    `${stateKey}.sort`,
-    state.sorting
-      .map(({ desc, id }) => `${id}.${desc ? "desc" : "asc"}`)
-      .join(",")
-  )
+    stateKey,
+    defaultPageSize,
+    state
+  ).toString()
   window.history.replaceState(window.history.state, "", url)
 }
 
@@ -133,6 +82,7 @@ export function useOrganizationTableState(
   allowedColumnIds?: readonly string[]
 ) {
   const columnFiltersAtom = useCreateAtom<ColumnFiltersState>([])
+  const columnVisibilityAtom = useCreateAtom<ColumnVisibilityState>({})
   const globalFilterAtom = useCreateAtom("")
   const paginationAtom = useCreateAtom<PaginationState>({
     pageIndex: 0,
@@ -141,12 +91,11 @@ export function useOrganizationTableState(
   const rowSelectionAtom = useCreateAtom<RowSelectionState>({})
   const sortingAtom = useCreateAtom<SortingState>([])
   const columnFilters = useSelector(columnFiltersAtom)
+  const columnVisibility = useSelector(columnVisibilityAtom)
   const globalFilter = useSelector(globalFilterAtom)
   const pagination = useSelector(paginationAtom)
   const rowSelection = useSelector(rowSelectionAtom)
   const sorting = useSelector(sortingAtom)
-  const [columnVisibility, setColumnVisibility] =
-    useState<ColumnVisibilityState>({})
   const [urlReady, setUrlReady] = useState(false)
   const [visibilityReady, setVisibilityReady] = useState(false)
   const atoms = useMemo(
@@ -169,44 +118,45 @@ export function useOrganizationTableState(
   const setPagination = useCallback(
     (updater: Updater<PaginationState>) => {
       paginationAtom.set((current) => functionalUpdate(updater, current))
-      rowSelectionAtom.set({})
     },
-    [paginationAtom, rowSelectionAtom]
+    [paginationAtom]
+  )
+  const setColumnVisibility = useCallback(
+    (updater: Updater<ColumnVisibilityState>) => {
+      columnVisibilityAtom.set((current) => functionalUpdate(updater, current))
+    },
+    [columnVisibilityAtom]
   )
   const setColumnFilters = useCallback(
     (updater: Updater<ColumnFiltersState>) => {
       columnFiltersAtom.set((current) => functionalUpdate(updater, current))
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
     },
-    [columnFiltersAtom, paginationAtom, rowSelectionAtom]
+    [columnFiltersAtom]
   )
   const setGlobalFilter = useCallback(
     (updater: Updater<string>) => {
       globalFilterAtom.set((current) => functionalUpdate(updater, current))
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
     },
-    [globalFilterAtom, paginationAtom, rowSelectionAtom]
+    [globalFilterAtom]
   )
   const setSorting = useCallback(
     (updater: Updater<SortingState>) => {
       sortingAtom.set((current) => functionalUpdate(updater, current))
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
     },
-    [paginationAtom, rowSelectionAtom, sortingAtom]
+    [sortingAtom]
   )
 
   useEffect(() => {
-    const resetPageAndSelection = () => {
-      paginationAtom.set((current) => ({ ...current, pageIndex: 0 }))
-      rowSelectionAtom.set({})
+    const resetPage = () => {
+      const current = paginationAtom.get()
+      if (current.pageIndex === 0) rowSelectionAtom.set({})
+      else paginationAtom.set({ ...current, pageIndex: 0 })
     }
     const subscriptions = [
-      columnFiltersAtom.subscribe(resetPageAndSelection),
-      globalFilterAtom.subscribe(resetPageAndSelection),
-      sortingAtom.subscribe(resetPageAndSelection)
+      columnFiltersAtom.subscribe(resetPage),
+      globalFilterAtom.subscribe(resetPage),
+      sortingAtom.subscribe(resetPage),
+      paginationAtom.subscribe(() => rowSelectionAtom.set({}))
     ]
 
     return () => {
@@ -251,7 +201,7 @@ export function useOrganizationTableState(
   }, [columnVisibility, stateKey, visibilityReady])
 
   useEffect(() => {
-    setColumnVisibility(readColumnVisibility(stateKey, allowedColumnIds))
+    columnVisibilityAtom.set(readColumnVisibility(stateKey, allowedColumnIds))
     setVisibilityReady(true)
     const restoreUrlState = () => {
       const next = readUrlState(stateKey, defaultPageSize, allowedColumnIds)
@@ -259,7 +209,6 @@ export function useOrganizationTableState(
       globalFilterAtom.set(next.globalFilter)
       sortingAtom.set(next.sorting)
       paginationAtom.set(next.pagination)
-      rowSelectionAtom.set({})
       setUrlReady(true)
     }
     restoreUrlState()
@@ -268,10 +217,10 @@ export function useOrganizationTableState(
   }, [
     allowedColumnIds,
     columnFiltersAtom,
+    columnVisibilityAtom,
     defaultPageSize,
     globalFilterAtom,
     paginationAtom,
-    rowSelectionAtom,
     sortingAtom,
     stateKey
   ])

--- a/packages/heroui/src/components/auth/organization/organization-table.ts
+++ b/packages/heroui/src/components/auth/organization/organization-table.ts
@@ -18,25 +18,27 @@ import {
 
 export const ORGANIZATION_TABLE_PAGE_SIZE = 10
 
+export const organizationTableFeatures = tableFeatures({
+  columnFilteringFeature,
+  globalFilteringFeature,
+  filteredRowModel: createFilteredRowModel(),
+  filterFns: { includesString: filterFn_includesString },
+  columnFacetingFeature,
+  facetedRowModel: createFacetedRowModel(),
+  facetedUniqueValues: createFacetedUniqueValues(),
+  columnVisibilityFeature,
+  rowSortingFeature,
+  sortedRowModel: createSortedRowModel(),
+  rowPaginationFeature,
+  paginatedRowModel: createPaginatedRowModel(),
+  rowSelectionFeature
+})
+
 export const {
   createAppColumnHelper: createOrganizationColumnHelper,
   useAppTable: useOrganizationTable
 } = createTableHook({
   enableMultiSort: true,
   sortDescFirst: false,
-  features: tableFeatures({
-    columnFilteringFeature,
-    globalFilteringFeature,
-    filteredRowModel: createFilteredRowModel(),
-    filterFns: { includesString: filterFn_includesString },
-    columnFacetingFeature,
-    facetedRowModel: createFacetedRowModel(),
-    facetedUniqueValues: createFacetedUniqueValues(),
-    columnVisibilityFeature,
-    rowSortingFeature,
-    sortedRowModel: createSortedRowModel(),
-    rowPaginationFeature,
-    paginatedRowModel: createPaginatedRowModel(),
-    rowSelectionFeature
-  })
+  features: organizationTableFeatures
 })

--- a/packages/heroui/src/components/auth/passkey/rename-passkey-dialog.tsx
+++ b/packages/heroui/src/components/auth/passkey/rename-passkey-dialog.tsx
@@ -9,6 +9,7 @@ import {
   Spinner,
   TextField
 } from "@heroui/react"
+import { useSelector } from "@tanstack/react-form"
 import { useEffect } from "react"
 import { passkeyPlugin } from "../../../lib/auth/passkey-plugin"
 import { useAuthForm } from "../auth-form"
@@ -35,6 +36,10 @@ export function RenamePasskeyDialog({
       if (nextName) updatePasskey.mutate({ id: passkey.id, name: nextName })
     }
   })
+  const nameIsEmpty = useSelector(
+    form.store,
+    (state) => state.values.name.trim().length === 0
+  )
   useEffect(() => {
     if (isOpen) form.setFieldValue("name", passkey.name ?? "")
   }, [form.setFieldValue, isOpen, passkey.name])
@@ -71,9 +76,7 @@ export function RenamePasskeyDialog({
                   {localization.settings.cancel}
                 </Button>
                 <form.AuthFormSubmitButton
-                  isDisabled={
-                    !form.state.values.name.trim() || updatePasskey.isPending
-                  }
+                  isDisabled={nameIsEmpty || updatePasskey.isPending}
                 >
                   {updatePasskey.isPending && (
                     <Spinner color="current" size="sm" />

--- a/packages/heroui/src/components/auth/phone-number/change-phone-number.tsx
+++ b/packages/heroui/src/components/auth/phone-number/change-phone-number.tsx
@@ -1,3 +1,4 @@
+import { getFormFieldErrorMessage } from "@better-auth-ui/core"
 import {
   createPhoneNumberValue,
   type PhoneNumberAuthClient
@@ -22,6 +23,7 @@ import {
   Spinner,
   toast
 } from "@heroui/react"
+import { useSelector } from "@tanstack/react-form"
 import { useEffect, useState } from "react"
 
 import { phoneNumberPlugin } from "../../../lib/auth/phone-number-plugin"
@@ -107,6 +109,14 @@ export function ChangePhoneNumber({
       })
     }
   })
+  const codeComplete = useSelector(
+    form.store,
+    (formState) => formState.values.code.length === otpLength
+  )
+  const phoneNumberDisplay = useSelector(
+    form.store,
+    (formState) => formState.values.phoneNumber.display
+  )
   useEffect(() => {
     form.setFieldValue(
       "phoneNumber",
@@ -134,7 +144,7 @@ export function ChangePhoneNumber({
                       <p className="text-sm text-muted">
                         {localization.codeSentTo.replace(
                           "{{phoneNumber}}",
-                          form.state.values.phoneNumber.display
+                          phoneNumberDisplay
                         )}
                       </p>
                       <form.AppField name="code">
@@ -167,7 +177,9 @@ export function ChangePhoneNumber({
                           adapter={adapter}
                           countryCodes={countries}
                           countryLabel={localization.country}
-                          error={field.state.meta.errors[0]?.toString()}
+                          error={getFormFieldErrorMessage(
+                            field.state.meta.errors
+                          )}
                           isDisabled={isPending}
                           locale={locale}
                           phoneLabel={localization.phoneNumber}
@@ -210,9 +222,7 @@ export function ChangePhoneNumber({
                     size="sm"
                     type="submit"
                     isDisabled={
-                      !session ||
-                      isPending ||
-                      (codeSent && form.state.values.code.length !== otpLength)
+                      !session || isPending || (codeSent && !codeComplete)
                     }
                   >
                     {(isSending || isVerifying) && (

--- a/packages/heroui/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/packages/heroui/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -1,3 +1,4 @@
+import { getFormFieldErrorMessage } from "@better-auth-ui/core"
 import {
   createPhoneNumberValue,
   type PhoneNumberAuthClient
@@ -92,7 +93,7 @@ export function ForgotPhoneNumberPassword({
                   adapter={adapter}
                   countryCodes={countries}
                   countryLabel={phoneLocalization.country}
-                  error={field.state.meta.errors[0]?.toString()}
+                  error={getFormFieldErrorMessage(field.state.meta.errors)}
                   isDisabled={isPending}
                   locale={locale}
                   phoneLabel={phoneLocalization.phoneNumber}

--- a/packages/heroui/src/components/auth/settings/security/fresh-session-prompt.tsx
+++ b/packages/heroui/src/components/auth/settings/security/fresh-session-prompt.tsx
@@ -1,6 +1,7 @@
 import { isTwoFactorRedirect } from "@better-auth-ui/core/plugins/two-factor"
 import { useAuth, useSession, useSignInEmail } from "@better-auth-ui/react"
 import { Button, Input, Label, Spinner, TextField } from "@heroui/react"
+import { useSelector } from "@tanstack/react-form"
 import { useSignInContinuation } from "../../../../lib/auth/use-sign-in-continuation"
 import { useAuthForm } from "../../auth-form"
 
@@ -42,6 +43,10 @@ export function FreshSessionPrompt({ onFresh }: FreshSessionPromptProps) {
       signIn.mutate({ email, password: value.password })
     }
   })
+  const passwordIsEmpty = useSelector(
+    form.store,
+    (state) => state.values.password.length === 0
+  )
 
   return (
     <div className="flex flex-col gap-4 p-4">
@@ -83,7 +88,7 @@ export function FreshSessionPrompt({ onFresh }: FreshSessionPromptProps) {
               </p>
             )}
             <form.AuthFormSubmitButton
-              isDisabled={!form.state.values.password}
+              isDisabled={passwordIsEmpty}
               variant="primary"
             >
               {signIn.isPending && <Spinner color="current" size="sm" />}

--- a/packages/heroui/src/components/auth/sso/sso-domain-verification.tsx
+++ b/packages/heroui/src/components/auth/sso/sso-domain-verification.tsx
@@ -25,6 +25,7 @@ import {
   TextField,
   toast
 } from "@heroui/react"
+import { useSelector } from "@tanstack/react-form"
 import type { BetterFetchError } from "better-auth/client"
 import { useState } from "react"
 
@@ -71,7 +72,7 @@ export function SsoDomainVerification({
       verify.mutate({ providerId: value.providerId })
     }
   })
-  const providerId = form.state.values.providerId
+  const providerId = useSelector(form.store, (state) => state.values.providerId)
   const host = providerId ? `_${tokenPrefix}-${providerId}` : ""
   const hostCopy = useCopyToClipboard({
     onError: (error) =>

--- a/packages/heroui/tests/auth-form.test.tsx
+++ b/packages/heroui/tests/auth-form.test.tsx
@@ -1,7 +1,14 @@
+import {
+  type AdditionalField,
+  DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS
+} from "@better-auth-ui/core"
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
-import { useAuthForm } from "../src/components/auth/auth-form"
+import {
+  getAuthAdditionalFieldValidators,
+  useAuthForm
+} from "../src/components/auth/auth-form"
 
 function TestAuthForm({ onSubmit }: { onSubmit: () => Promise<void> }) {
   const form = useAuthForm({ defaultValues: {}, onSubmit })
@@ -35,5 +42,31 @@ describe("AuthFormRoot", () => {
 
     finishSubmission()
     await waitFor(() => expect(submitButton).toBeEnabled())
+  })
+})
+
+describe("additional field validation", () => {
+  it("debounces custom validation and allows an explicit override", async () => {
+    const validate = vi.fn()
+    const field: AdditionalField = {
+      label: "Handle",
+      name: "handle",
+      type: "string",
+      validate
+    }
+
+    const validators = getAuthAdditionalFieldValidators(field, "Required")
+    expect(validators.onChangeAsyncDebounceMs).toBe(
+      DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS
+    )
+    await validators.onChangeAsync?.({ value: "ada" })
+    expect(validate).toHaveBeenCalledWith("ada")
+
+    expect(
+      getAuthAdditionalFieldValidators(
+        { ...field, validateDebounceMs: 0 },
+        "Required"
+      ).onChangeAsyncDebounceMs
+    ).toBe(0)
   })
 })

--- a/packages/heroui/tests/organization-table.test.tsx
+++ b/packages/heroui/tests/organization-table.test.tsx
@@ -42,14 +42,20 @@ afterEach(() => {
 describe("organization table state", () => {
   it("preserves Shift for keyboard range selection", () => {
     const toggleSelected = vi.fn()
+    const { result } = renderHook(() =>
+      useOrganizationTable({
+        columns,
+        data: rows,
+        getRowId: (row) => row.id
+      })
+    )
+    const row = result.current.getRow("1")
+    vi.spyOn(row, "getToggleSelectedHandler").mockReturnValue(toggleSelected)
+
     render(
       <OrganizationTableSelectRow
         localization={organizationLocalization}
-        row={{
-          getCanSelect: () => true,
-          getIsSelected: () => false,
-          getToggleSelectedHandler: () => toggleSelected
-        }}
+        row={row}
       />
     )
 


### PR DESCRIPTION
## Summary

- expose typed TanStack Form composition helpers and debounce custom async additional-field validation
- subscribe React render paths and row selection to narrow TanStack state slices
- centralize namespaced table URL state and coordinate pagination, filtering, sorting, visibility, and selection through TanStack atoms
- keep React, Solid, shadcn Radix, shadcn Base UI, HeroUI, Zaidan, Next.js, and docs consumers in sync
- add focused coverage for URL state, async validation, and table selection behavior

## Validation

- bun nx run-many -t typecheck -p @better-auth-ui/core,@better-auth-ui/heroui,start-shadcn-example,start-shadcn-baseui-example,start-solid-zaidan-example,docs
- bun nx run-many -t lint -p workspace,docs,next-shadcn-example,next-heroui-example
- bun nx run-many -t test -p @better-auth-ui/core,@better-auth-ui/heroui
- bun nx run start-solid-zaidan-example:test -- --run tests/auth-form.browser.test.tsx --project browser
- bun nx run start-shadcn-example:registry:build
- bun nx run start-shadcn-example:registry:test

## Note

The full Solid example suite still has seven unrelated documentation-content assertions failing on the current docs structure. The focused Solid browser integration suite and all affected type checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable debouncing for custom additional-field validation, with a 300 ms default and optional immediate validation.
  - Improved organization table state synchronization with URL filters, sorting, pagination, and column visibility.
- **Bug Fixes**
  - Organization table selection now updates reliably as rows are selected.
  - Improved phone-number validation error display.
  - Form controls now respond more consistently to changing email, phone, code, password, and passkey values.
- **Tests**
  - Added coverage for validation debounce behavior and organization table selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->