### PR TITLE
feat(auth): unify TanStack form and table integrations

### DIFF
--- a/apps/docs/src/components/auth/auth-form.tsx
+++ b/apps/docs/src/components/auth/auth-form.tsx
@@ -5,14 +5,30 @@ import {
   type AdditionalFieldFormValue,
   DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS,
   getFormFieldErrors,
+  normalizeAuthFormServerError,
   validateAdditionalFieldRequired,
   validateAdditionalFieldValue
 } from "@better-auth-ui/core"
-import { createFormHook, createFormHookContexts } from "@tanstack/react-form"
-import { type ComponentProps, type FormEvent, useRef } from "react"
+import {
+  type AnyFormApi,
+  createFormHook,
+  createFormHookContexts
+} from "@tanstack/react-form"
+import {
+  type ComponentProps,
+  type FormEvent,
+  type ReactNode,
+  useRef
+} from "react"
 
 import { Button } from "@/components/ui/button"
-import { FieldError } from "@/components/ui/field"
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel
+} from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { AdditionalField, type AdditionalFieldProps } from "./additional-field"
 
@@ -40,13 +56,64 @@ function AuthFormFieldError() {
   return errors.length > 0 ? <FieldError errors={errors} /> : null
 }
 
+function AuthFormServerError() {
+  const form = useFormContext()
+
+  return (
+    <form.Subscribe selector={(state) => state.errorMap.onServer}>
+      {(error) => {
+        const formError =
+          error && typeof error === "object" && "form" in error
+            ? error.form
+            : error
+        const errors = getFormFieldErrors(formError ? [formError] : [])
+        return errors.length > 0 ? <FieldError errors={errors} /> : null
+      }}
+    </form.Subscribe>
+  )
+}
+
+export function setAuthFormServerError(
+  form: AnyFormApi,
+  error: unknown,
+  fallbackMessage: string
+) {
+  const normalized = normalizeAuthFormServerError(error, fallbackMessage)
+  form.setErrorMap({
+    onServer: {
+      fields: normalized.fields ?? {},
+      form: normalized.form
+    }
+  })
+}
+
+export function clearAuthFormServerError(form: AnyFormApi) {
+  form.setErrorMap({ onServer: undefined })
+}
+
+export async function submitAuthForm(
+  form: AnyFormApi,
+  serverErrorMessage = "Unable to submit this form. Try again."
+) {
+  clearAuthFormServerError(form)
+  try {
+    await form.handleSubmit()
+    return form.state.isValid
+  } catch (error) {
+    setAuthFormServerError(form, error, serverErrorMessage)
+    return false
+  }
+}
+
 type AuthFormRootProps = Omit<ComponentProps<"form">, "onSubmit"> & {
   onBeforeSubmit?: () => void
+  serverErrorMessage?: string
 }
 
 function AuthFormRoot({
   children,
   onBeforeSubmit,
+  serverErrorMessage = "Unable to submit this form. Try again.",
   ...props
 }: AuthFormRootProps) {
   const form = useFormContext()
@@ -60,8 +127,8 @@ function AuthFormRoot({
     onBeforeSubmit?.()
     submittingRef.current = true
     try {
-      await form.handleSubmit()
-      if (!form.state.isValid) focusFirstInvalidAuthFormControl(formElement)
+      const isValid = await submitAuthForm(form, serverErrorMessage)
+      if (!isValid) focusFirstInvalidAuthFormControl(formElement)
     } finally {
       submittingRef.current = false
     }
@@ -77,6 +144,42 @@ function AuthFormRoot({
     >
       {children}
     </form>
+  )
+}
+
+type AuthFormTextFieldProps = Omit<
+  ComponentProps<typeof Input>,
+  "name" | "onBlur" | "onChange" | "value"
+> & {
+  description?: ReactNode
+  label: ReactNode
+}
+
+function AuthFormTextField({
+  description,
+  id,
+  label,
+  ...props
+}: AuthFormTextFieldProps) {
+  const field = useFieldContext<string>()
+  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+  const inputId = id ?? field.name
+
+  return (
+    <Field data-invalid={isInvalid}>
+      <FieldLabel htmlFor={inputId}>{label}</FieldLabel>
+      <Input
+        {...props}
+        aria-invalid={isInvalid}
+        id={inputId}
+        name={field.name}
+        onBlur={field.handleBlur}
+        onChange={(event) => field.handleChange(event.target.value)}
+        value={field.state.value}
+      />
+      {description ? <FieldDescription>{description}</FieldDescription> : null}
+      <AuthFormFieldError />
+    </Field>
   )
 }
 
@@ -135,9 +238,17 @@ export const {
   withFieldGroup: withAuthFieldGroup,
   withForm: withAuthForm
 } = createFormHook({
-  fieldComponents: { AuthFormAdditionalField, AuthFormFieldError },
+  fieldComponents: {
+    AuthFormAdditionalField,
+    AuthFormFieldError,
+    AuthFormTextField
+  },
   fieldContext,
-  formComponents: { AuthFormRoot, AuthFormSubmitButton },
+  formComponents: {
+    AuthFormRoot,
+    AuthFormServerError,
+    AuthFormSubmitButton
+  },
   formContext
 })
 

--- a/apps/docs/src/components/auth/organization/organization-table-renderer.tsx
+++ b/apps/docs/src/components/auth/organization/organization-table-renderer.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import type { ReactNode } from "react"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@/components/ui/table"
+import { useOrganizationTableContext } from "./organization-table"
+
+export function OrganizationTableRenderer({ empty }: { empty: ReactNode }) {
+  const table = useOrganizationTableContext()
+  const rows = table.getRowModel().rows
+
+  return (
+    <Table>
+      <TableHeader>
+        {table.getHeaderGroups().map((headerGroup) => (
+          <TableRow key={headerGroup.id}>
+            {headerGroup.headers.map((header) => (
+              <TableHead colSpan={header.colSpan} key={header.id}>
+                {header.isPlaceholder ? null : (
+                  <table.FlexRender header={header} />
+                )}
+              </TableHead>
+            ))}
+          </TableRow>
+        ))}
+      </TableHeader>
+      <TableBody>
+        {rows.length ? (
+          rows.map((row) => (
+            <TableRow
+              data-state={row.getIsSelected() ? "selected" : undefined}
+              key={row.id}
+            >
+              {row.getVisibleCells().map((cell) => (
+                <TableCell key={cell.id}>
+                  <table.FlexRender cell={cell} />
+                </TableCell>
+              ))}
+            </TableRow>
+          ))
+        ) : (
+          <TableRow>
+            <TableCell colSpan={table.getVisibleLeafColumns().length}>
+              {empty}
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  )
+}

--- a/apps/docs/src/components/auth/organization/organization-table-state.ts
+++ b/apps/docs/src/components/auth/organization/organization-table-state.ts
@@ -1,10 +1,12 @@
 "use client"
 
 import {
+  createBrowserTablePersistenceAdapters,
   parseTableColumnVisibility,
   parseTableUrlState,
   serializeTableColumnVisibility,
   serializeTableUrlState,
+  type TablePersistenceAdapters,
   type TableUrlState
 } from "@better-auth-ui/core"
 import { useCreateAtom, useSelector } from "@tanstack/react-store"
@@ -17,7 +19,7 @@ import {
   type SortingState,
   type Updater
 } from "@tanstack/react-table"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { ORGANIZATION_TABLE_PAGE_SIZE } from "./organization-table"
 
 const TABLE_STATE_STORAGE_PREFIX = "better-auth-ui:organization-table"
@@ -30,16 +32,13 @@ type OrganizationTableUrlState = {
 }
 
 function readUrlState(
+  adapters: TablePersistenceAdapters,
   stateKey: string,
   defaultPageSize: number,
   allowedColumnIds?: readonly string[]
 ): TableUrlState {
-  const params =
-    typeof window === "undefined"
-      ? new URLSearchParams()
-      : new URLSearchParams(window.location.search)
   return parseTableUrlState(
-    params,
+    adapters.search.read(),
     stateKey,
     defaultPageSize,
     ORGANIZATION_TABLE_PAGE_SIZE_OPTIONS,
@@ -48,15 +47,15 @@ function readUrlState(
 }
 
 function readColumnVisibility(
+  adapters: TablePersistenceAdapters,
   stateKey: string,
   allowedColumnIds?: readonly string[]
 ): ColumnVisibilityState {
-  if (typeof window === "undefined") return {}
-
   try {
-    const value = window.localStorage.getItem(
-      `${TABLE_STATE_STORAGE_PREFIX}:${stateKey}:columns`
-    )
+    const value =
+      adapters.storage?.read(
+        `${TABLE_STATE_STORAGE_PREFIX}:${stateKey}:columns`
+      ) ?? null
     return parseTableColumnVisibility(value, allowedColumnIds)
   } catch {
     return {}
@@ -64,28 +63,31 @@ function readColumnVisibility(
 }
 
 function writeUrlState(
+  adapters: TablePersistenceAdapters,
   stateKey: string,
   defaultPageSize: number,
   state: OrganizationTableUrlState
 ) {
-  if (typeof window === "undefined") return
-
-  const url = new URL(window.location.href)
-  url.search = serializeTableUrlState(
-    url.searchParams,
-    stateKey,
-    defaultPageSize,
-    state
-  ).toString()
-
-  window.history.replaceState(window.history.state, "", url)
+  adapters.search.replace(
+    serializeTableUrlState(
+      adapters.search.read(),
+      stateKey,
+      defaultPageSize,
+      state
+    )
+  )
 }
 
 export function useOrganizationTableState(
   stateKey: string,
   defaultPageSize = ORGANIZATION_TABLE_PAGE_SIZE,
-  allowedColumnIds?: readonly string[]
+  allowedColumnIds?: readonly string[],
+  persistenceAdapters?: TablePersistenceAdapters
 ) {
+  const adapters = useMemo(
+    () => persistenceAdapters ?? createBrowserTablePersistenceAdapters(),
+    [persistenceAdapters]
+  )
   const columnFiltersAtom = useCreateAtom<ColumnFiltersState>([])
   const columnVisibilityAtom = useCreateAtom<ColumnVisibilityState>({})
   const globalFilterAtom = useCreateAtom("")
@@ -103,6 +105,7 @@ export function useOrganizationTableState(
   const sorting = useSelector(sortingAtom)
   const [urlReady, setUrlReady] = useState(false)
   const [visibilityReady, setVisibilityReady] = useState(false)
+  const restoringUrlState = useRef(false)
   const atoms = useMemo(
     () => ({
       columnFilters: columnFiltersAtom,
@@ -157,6 +160,7 @@ export function useOrganizationTableState(
 
   useEffect(() => {
     const resetPage = () => {
+      if (restoringUrlState.current) return
       const current = paginationAtom.get()
       if (current.pageIndex === 0) rowSelectionAtom.set({})
       else paginationAtom.set({ ...current, pageIndex: 0 })
@@ -182,13 +186,14 @@ export function useOrganizationTableState(
   useEffect(() => {
     if (!urlReady) return
 
-    writeUrlState(stateKey, defaultPageSize, {
+    writeUrlState(adapters, stateKey, defaultPageSize, {
       columnFilters,
       globalFilter,
       pagination,
       sorting
     })
   }, [
+    adapters,
     columnFilters,
     defaultPageSize,
     globalFilter,
@@ -202,32 +207,41 @@ export function useOrganizationTableState(
     if (!visibilityReady) return
 
     try {
-      window.localStorage.setItem(
+      adapters.storage?.write(
         `${TABLE_STATE_STORAGE_PREFIX}:${stateKey}:columns`,
         serializeTableColumnVisibility(columnVisibility)
       )
     } catch {
       // Browsers can disable storage while still allowing the table to work.
     }
-  }, [columnVisibility, stateKey, visibilityReady])
+  }, [adapters, columnVisibility, stateKey, visibilityReady])
 
   useEffect(() => {
-    columnVisibilityAtom.set(readColumnVisibility(stateKey, allowedColumnIds))
+    columnVisibilityAtom.set(
+      readColumnVisibility(adapters, stateKey, allowedColumnIds)
+    )
     setVisibilityReady(true)
 
     const restoreUrlState = () => {
-      const next = readUrlState(stateKey, defaultPageSize, allowedColumnIds)
+      restoringUrlState.current = true
+      const next = readUrlState(
+        adapters,
+        stateKey,
+        defaultPageSize,
+        allowedColumnIds
+      )
       columnFiltersAtom.set(next.columnFilters)
       globalFilterAtom.set(next.globalFilter)
       sortingAtom.set(next.sorting)
       paginationAtom.set(next.pagination)
+      restoringUrlState.current = false
       setUrlReady(true)
     }
 
     restoreUrlState()
-    window.addEventListener("popstate", restoreUrlState)
-    return () => window.removeEventListener("popstate", restoreUrlState)
+    return adapters.search.subscribe(restoreUrlState)
   }, [
+    adapters,
     allowedColumnIds,
     columnFiltersAtom,
     columnVisibilityAtom,

--- a/apps/docs/src/components/auth/organization/organization-table.ts
+++ b/apps/docs/src/components/auth/organization/organization-table.ts
@@ -38,7 +38,8 @@ export const organizationTableFeatures = tableFeatures({
 
 export const {
   createAppColumnHelper: createOrganizationColumnHelper,
-  useAppTable: useOrganizationTable
+  useAppTable: useOrganizationTable,
+  useTableContext: useOrganizationTableContext
 } = createTableHook({
   enableMultiSort: true,
   sortDescFirst: false,

--- a/examples/start-solid-zaidan-example/registry.manifest.ts
+++ b/examples/start-solid-zaidan-example/registry.manifest.ts
@@ -117,11 +117,7 @@ const zaidanFormSupportFiles = [
   libFile("src/lib/utils.ts")
 ] satisfies SolidRegistryFile[]
 
-const zaidanInteractiveSupportFiles = [
-  componentFile("src/components/auth/auth-form.tsx"),
-  componentFile("src/components/auth/additional-field.tsx"),
-  libFile("src/lib/utils.ts")
-] satisfies SolidRegistryFile[]
+const zaidanInteractiveSupportFiles = zaidanFormSupportFiles
 
 /** Every form that picks a new password renders the strength meter. */
 const passwordStrengthFiles = [
@@ -429,7 +425,7 @@ const solidRegistryBaseManifest = {
       title: "Solid SSO",
       description:
         "Solid email-first sign-in and organization provider management for Better Auth SSO.",
-      dependencies: [...solidAuthDependencies, "@tanstack/solid-form"],
+      dependencies: solidAuthDependencies,
       registryDependencies: [
         betterAuthSolidRegistryDependency("auth-provider"),
         betterAuthSolidRegistryDependency("sign-in")

--- a/examples/start-solid-zaidan-example/registry.manifest.ts
+++ b/examples/start-solid-zaidan-example/registry.manifest.ts
@@ -23,6 +23,7 @@ export type SolidRegistryManifest = {
 const solidDependencies = [
   "@better-auth-ui/solid@latest",
   "@better-auth-ui/core@latest",
+  "@tanstack/solid-form",
   "@tanstack/solid-query",
   "@tanstack/solid-router",
   "better-auth",
@@ -111,10 +112,14 @@ const uiFile = (path: SolidRegistryFile["path"]) =>
   ({ path, type: "registry:ui" }) satisfies SolidRegistryFile
 
 const zaidanFormSupportFiles = [
+  componentFile("src/components/auth/auth-form.tsx"),
+  componentFile("src/components/auth/additional-field.tsx"),
   libFile("src/lib/utils.ts")
 ] satisfies SolidRegistryFile[]
 
 const zaidanInteractiveSupportFiles = [
+  componentFile("src/components/auth/auth-form.tsx"),
+  componentFile("src/components/auth/additional-field.tsx"),
   libFile("src/lib/utils.ts")
 ] satisfies SolidRegistryFile[]
 
@@ -172,11 +177,7 @@ const solidRegistryBaseManifest = {
       title: "Solid Additional Field",
       description:
         "Additional field renderer used by Solid sign-up and profile surfaces.",
-      files: [
-        componentFile("src/components/auth/auth-form.tsx"),
-        componentFile("src/components/auth/additional-field.tsx"),
-        ...zaidanFormSupportFiles
-      ]
+      files: [...zaidanFormSupportFiles]
     }),
     item({
       name: "sign-in",
@@ -718,7 +719,6 @@ const solidRegistryBaseManifest = {
       files: [
         componentFile("src/components/auth/settings/account/user-profile.tsx"),
         componentFile("src/components/auth/settings/account/change-avatar.tsx"),
-        componentFile("src/components/auth/additional-field.tsx"),
         componentFile("src/components/auth/settings/shared/helpers.ts"),
         ...zaidanInteractiveSupportFiles
       ]

--- a/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
@@ -1798,8 +1798,7 @@ function PasswordDialog(props: {
         userId: props.userId,
         newPassword: value.password
       })
-      setPasswordMutation.reset()
-      props.onOpenChange(false)
+      close()
     }
   }))
   const close = () => {

--- a/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
@@ -1788,27 +1788,24 @@ function PasswordDialog(props: {
   const config = () =>
     (auth.plugins.find((plugin) => plugin.id === adminPlugin.id) ??
       adminPlugin()) as ReturnType<typeof adminPlugin>
-  const [password, setPassword] = createSignal("")
-  const [errorMessage, setErrorMessage] = createSignal<string>()
   const setPasswordMutation = useSetAdminUserPassword(authClient)
 
+  const form = createAuthForm(() => ({
+    defaultValues: { password: "" },
+    onSubmit: async ({ value }) => {
+      if (!props.userId) return
+      await setPasswordMutation.mutateAsync({
+        userId: props.userId,
+        newPassword: value.password
+      })
+      setPasswordMutation.reset()
+      props.onOpenChange(false)
+    }
+  }))
   const close = () => {
-    setPassword("")
-    setErrorMessage(undefined)
+    form.reset()
     setPasswordMutation.reset()
     props.onOpenChange(false)
-  }
-  const submit = (event: SubmitEvent) => {
-    event.preventDefault()
-    setErrorMessage(undefined)
-    if (props.userId)
-      setPasswordMutation.mutate(
-        { userId: props.userId, newPassword: password() },
-        {
-          onError: (error) => setErrorMessage(getAdminErrorMessage(error)),
-          onSuccess: close
-        }
-      )
   }
 
   return (
@@ -1817,40 +1814,43 @@ function PasswordDialog(props: {
       onOpenChange={(open) => (open ? props.onOpenChange(true) : close())}
     >
       <DialogContent>
-        <form class="flex flex-col gap-4" onSubmit={submit}>
-          <DialogHeader>
-            <DialogTitle>{config().localization.setPassword}</DialogTitle>
-            <DialogDescription>
-              {config().localization.userDetails}
-            </DialogDescription>
-          </DialogHeader>
-          <Field data-invalid={Boolean(errorMessage())}>
-            <FieldLabel for="solid-admin-new-password">
-              {config().localization.password}
-            </FieldLabel>
-            <Input
-              aria-invalid={Boolean(errorMessage())}
-              autocomplete="new-password"
-              id="solid-admin-new-password"
-              required
-              type="password"
-              value={password()}
-              onInput={(event) => setPassword(event.currentTarget.value)}
-            />
-            <FieldError>{errorMessage()}</FieldError>
-          </Field>
-          <DialogFooter>
-            <Button onClick={close} type="button" variant="outline">
-              {config().localization.cancel}
-            </Button>
-            <Button
-              disabled={!password() || setPasswordMutation.isPending}
-              type="submit"
+        <form.AppForm>
+          <form.AuthFormRoot class="flex flex-col gap-4">
+            <DialogHeader>
+              <DialogTitle>{config().localization.setPassword}</DialogTitle>
+              <DialogDescription>
+                {config().localization.userDetails}
+              </DialogDescription>
+            </DialogHeader>
+            <form.AppField
+              name="password"
+              validators={{
+                onChange: ({ value }) =>
+                  value ? undefined : config().localization.password
+              }}
             >
-              {config().localization.setPassword}
-            </Button>
-          </DialogFooter>
-        </form>
+              {(field) => (
+                <field.AuthFormTextField
+                  autocomplete="new-password"
+                  id="solid-admin-new-password"
+                  label={config().localization.password}
+                  type="password"
+                />
+              )}
+            </form.AppField>
+            <form.AuthFormServerError />
+            <DialogFooter>
+              <Button onClick={close} type="button" variant="outline">
+                {config().localization.cancel}
+              </Button>
+              <form.AuthFormSubmitButton
+                disabled={setPasswordMutation.isPending || !props.userId}
+              >
+                {config().localization.setPassword}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
     </Dialog>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -18,7 +18,6 @@ import {
   DialogTitle
 } from "@/components/ui/dialog"
 import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
 import {
   Select,
   SelectContent,
@@ -27,6 +26,7 @@ import {
   SelectValue
 } from "@/components/ui/select"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
+import { createAuthForm } from "../auth-form"
 
 type ExpirationOption = {
   id: string
@@ -109,134 +109,138 @@ export function CreateApiKeyDialog(props: {
     }
   }
 
-  const submitCreateApiKey = (event: SubmitEvent) => {
-    event.preventDefault()
-
-    const formData = new FormData(event.currentTarget as HTMLFormElement)
-    const name = String(formData.get("name") ?? "").trim()
-    const expirationDays = expiration()?.days
-    const expiresIn = expirationDays
-      ? apiKeyExpirationDaysToSeconds(expirationDays)
-      : undefined
-    const configId =
-      configuration()?.id || (props.organizationId ? "organization" : undefined)
-    const payload = {
-      ...(name ? { name } : {}),
-      ...(expiresIn ? { expiresIn } : {}),
-      ...(configId ? { configId } : {}),
-      ...(props.organizationId ? { organizationId: props.organizationId } : {})
+  const form = createAuthForm(() => ({
+    defaultValues: { name: "" },
+    onSubmit: async ({ value }) => {
+      const name = value.name.trim()
+      const expirationDays = expiration()?.days
+      const expiresIn = expirationDays
+        ? apiKeyExpirationDaysToSeconds(expirationDays)
+        : undefined
+      const configId =
+        configuration()?.id ||
+        (props.organizationId ? "organization" : undefined)
+      const payload = {
+        ...(name ? { name } : {}),
+        ...(expiresIn ? { expiresIn } : {}),
+        ...(configId ? { configId } : {}),
+        ...(props.organizationId
+          ? { organizationId: props.organizationId }
+          : {})
+      }
+      await createApiKey.mutateAsync(
+        Object.keys(payload).length > 0 ? payload : undefined
+      )
     }
-
-    createApiKey.mutate(Object.keys(payload).length > 0 ? payload : undefined)
-  }
+  }))
 
   return (
     <>
       <DialogContent>
-        <form class="flex flex-col gap-6" onSubmit={submitCreateApiKey}>
-          <DialogHeader>
-            <div class="flex size-10 items-center justify-center rounded-md bg-muted">
-              <Key class="size-4.5" />
-            </div>
-            <DialogTitle>{apiKeyLocalization.createApiKey}</DialogTitle>
-            <DialogDescription>
-              {apiKeyLocalization.apiKeysDescription}
-            </DialogDescription>
-          </DialogHeader>
+        <form.AppForm>
+          <form.AuthFormRoot class="flex flex-col gap-6">
+            <DialogHeader>
+              <div class="flex size-10 items-center justify-center rounded-md bg-muted">
+                <Key class="size-4.5" />
+              </div>
+              <DialogTitle>{apiKeyLocalization.createApiKey}</DialogTitle>
+              <DialogDescription>
+                {apiKeyLocalization.apiKeysDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <FieldGroup>
-            <Field>
-              <FieldLabel for="api-key-name">
-                {apiKeyLocalization.name}
-              </FieldLabel>
-              <Input
-                autofocus
+            <FieldGroup>
+              <form.AppField name="name">
+                {(field) => (
+                  <field.AuthFormTextField
+                    autofocus
+                    disabled={createApiKey.isPending}
+                    id="api-key-name"
+                    label={apiKeyLocalization.name}
+                    placeholder={auth.localization.settings.optional}
+                  />
+                )}
+              </form.AppField>
+
+              <Show when={configurationOptions.length > 0}>
+                <Field>
+                  <FieldLabel for="api-key-configuration">
+                    {apiKeyLocalization.configuration}
+                  </FieldLabel>
+                  <Select<ConfigurationOption>
+                    disabled={createApiKey.isPending}
+                    itemComponent={(itemProps) => (
+                      <SelectItem item={itemProps.item}>
+                        {itemProps.item.rawValue.label}
+                      </SelectItem>
+                    )}
+                    onChange={(option) => setConfiguration(option ?? undefined)}
+                    options={configurationOptions}
+                    optionTextValue="label"
+                    optionValue="id"
+                    value={configuration()}
+                  >
+                    <SelectTrigger id="api-key-configuration" class="w-full">
+                      <SelectValue<ConfigurationOption>>
+                        {(state) =>
+                          (
+                            state.selectedOption() as
+                              | ConfigurationOption
+                              | undefined
+                          )?.label
+                        }
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent />
+                  </Select>
+                </Field>
+              </Show>
+
+              <Show when={keyExpiration}>
+                <Field>
+                  <FieldLabel for="api-key-expiration">
+                    {apiKeyLocalization.expiration}
+                  </FieldLabel>
+                  <Select<ExpirationOption>
+                    disabled={createApiKey.isPending}
+                    itemComponent={(itemProps) => (
+                      <SelectItem item={itemProps.item}>
+                        {itemProps.item.rawValue.label}
+                      </SelectItem>
+                    )}
+                    onChange={(option) => setExpiration(option ?? undefined)}
+                    options={expirationOptions}
+                    optionTextValue="label"
+                    optionValue="id"
+                    value={expiration()}
+                  >
+                    <SelectTrigger id="api-key-expiration" class="w-full">
+                      <SelectValue<ExpirationOption>>
+                        {(state) => state.selectedOption().label}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent />
+                  </Select>
+                </Field>
+              </Show>
+              <form.AuthFormServerError />
+            </FieldGroup>
+
+            <DialogFooter>
+              <DialogClose
+                as={Button}
                 disabled={createApiKey.isPending}
-                id="api-key-name"
-                name="name"
-                placeholder={auth.localization.settings.optional}
-              />
-            </Field>
-
-            <Show when={configurationOptions.length > 0}>
-              <Field>
-                <FieldLabel for="api-key-configuration">
-                  {apiKeyLocalization.configuration}
-                </FieldLabel>
-                <Select<ConfigurationOption>
-                  disabled={createApiKey.isPending}
-                  itemComponent={(itemProps) => (
-                    <SelectItem item={itemProps.item}>
-                      {itemProps.item.rawValue.label}
-                    </SelectItem>
-                  )}
-                  onChange={(option) => setConfiguration(option ?? undefined)}
-                  options={configurationOptions}
-                  optionTextValue="label"
-                  optionValue="id"
-                  value={configuration()}
-                >
-                  <SelectTrigger id="api-key-configuration" class="w-full">
-                    <SelectValue<ConfigurationOption>>
-                      {(state) =>
-                        (
-                          state.selectedOption() as
-                            | ConfigurationOption
-                            | undefined
-                        )?.label
-                      }
-                    </SelectValue>
-                  </SelectTrigger>
-                  <SelectContent />
-                </Select>
-              </Field>
-            </Show>
-
-            <Show when={keyExpiration}>
-              <Field>
-                <FieldLabel for="api-key-expiration">
-                  {apiKeyLocalization.expiration}
-                </FieldLabel>
-                <Select<ExpirationOption>
-                  disabled={createApiKey.isPending}
-                  itemComponent={(itemProps) => (
-                    <SelectItem item={itemProps.item}>
-                      {itemProps.item.rawValue.label}
-                    </SelectItem>
-                  )}
-                  onChange={(option) => setExpiration(option ?? undefined)}
-                  options={expirationOptions}
-                  optionTextValue="label"
-                  optionValue="id"
-                  value={expiration()}
-                >
-                  <SelectTrigger id="api-key-expiration" class="w-full">
-                    <SelectValue<ExpirationOption>>
-                      {(state) => state.selectedOption().label}
-                    </SelectValue>
-                  </SelectTrigger>
-                  <SelectContent />
-                </Select>
-              </Field>
-            </Show>
-          </FieldGroup>
-
-          <DialogFooter>
-            <DialogClose
-              as={Button}
-              disabled={createApiKey.isPending}
-              type="button"
-              variant="outline"
-            >
-              {auth.localization.settings.cancel}
-            </DialogClose>
-            <Button disabled={createApiKey.isPending} type="submit">
-              {createApiKey.isPending
-                ? `${apiKeyLocalization.createApiKey}…`
-                : apiKeyLocalization.createApiKey}
-            </Button>
-          </DialogFooter>
-        </form>
+                type="button"
+                variant="outline"
+              >
+                {auth.localization.settings.cancel}
+              </DialogClose>
+              <form.AuthFormSubmitButton disabled={createApiKey.isPending}>
+                {apiKeyLocalization.createApiKey}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </DialogContent>
 
       <Dialog

--- a/examples/start-solid-zaidan-example/src/components/auth/api-key/edit-api-key-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/api-key/edit-api-key-dialog.tsx
@@ -1,7 +1,6 @@
 import type { ApiKeyAuthClient } from "@better-auth-ui/core/plugins/api-key"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import { useUpdateApiKey } from "@better-auth-ui/solid/plugins/api-key"
-import { Show } from "solid-js"
 import type { ListedApiKey } from "@/components/auth/settings/shared/types"
 import { Button } from "@/components/ui/button"
 import {
@@ -11,14 +10,10 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import {
-  Field,
-  FieldError,
-  FieldGroup,
-  FieldLabel
-} from "@/components/ui/field"
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
+import { createAuthForm } from "../auth-form"
 
 export function EditApiKeyDialog(props: {
   apiKey: ListedApiKey
@@ -32,47 +27,54 @@ export function EditApiKeyDialog(props: {
   const updateApiKey = useUpdateApiKey(auth.authClient, () => ({
     onSuccess: () => props.onOpenChange(false)
   }))
-  const submit = (event: SubmitEvent) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget as HTMLFormElement)
-    updateApiKey.mutate({
-      keyId: props.apiKey.id,
-      configId: props.apiKey.configId,
-      name: String(formData.get("name") ?? "").trim()
-    })
-  }
-  const updateErrorMessage = () =>
-    updateApiKey.error?.error?.message ?? updateApiKey.error?.message
+  const form = createAuthForm(() => ({
+    defaultValues: { name: props.apiKey.name ?? "" },
+    onSubmit: async ({ value }) => {
+      await updateApiKey.mutateAsync({
+        keyId: props.apiKey.id,
+        configId: props.apiKey.configId,
+        name: value.name.trim()
+      })
+    }
+  }))
   return (
     <DialogContent>
-      <form class="flex flex-col gap-6" onSubmit={submit}>
-        <DialogHeader>
-          <DialogTitle>{labels.editApiKey}</DialogTitle>
-        </DialogHeader>
-        <FieldGroup>
-          <Field>
-            <FieldLabel for={`api-key-name-${props.apiKey.id}`}>
-              {labels.name}
-            </FieldLabel>
-            <Input
-              id={`api-key-name-${props.apiKey.id}`}
-              name="name"
-              value={props.apiKey.name ?? ""}
-            />
-          </Field>
-          <Show when={updateErrorMessage()}>
-            <FieldError>{updateErrorMessage()}</FieldError>
-          </Show>
-        </FieldGroup>
-        <DialogFooter>
-          <DialogClose as={Button} variant="outline">
-            {auth.localization.settings.cancel}
-          </DialogClose>
-          <Button disabled={updateApiKey.isPending} type="submit">
-            {auth.localization.settings.saveChanges}
-          </Button>
-        </DialogFooter>
-      </form>
+      <form.AppForm>
+        <form.AuthFormRoot class="flex flex-col gap-6">
+          <DialogHeader>
+            <DialogTitle>{labels.editApiKey}</DialogTitle>
+          </DialogHeader>
+          <FieldGroup>
+            <form.AppField name="name">
+              {(field) => (
+                <Field>
+                  <FieldLabel for={`api-key-name-${props.apiKey.id}`}>
+                    {labels.name}
+                  </FieldLabel>
+                  <Input
+                    id={`api-key-name-${props.apiKey.id}`}
+                    name={field().name}
+                    value={field().state.value}
+                    onBlur={field().handleBlur}
+                    onInput={(event) =>
+                      field().handleChange(event.currentTarget.value)
+                    }
+                  />
+                </Field>
+              )}
+            </form.AppField>
+            <form.AuthFormServerError />
+          </FieldGroup>
+          <DialogFooter>
+            <DialogClose as={Button} variant="outline">
+              {auth.localization.settings.cancel}
+            </DialogClose>
+            <form.AuthFormSubmitButton disabled={updateApiKey.isPending}>
+              {auth.localization.settings.saveChanges}
+            </form.AuthFormSubmitButton>
+          </DialogFooter>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </DialogContent>
   )
 }

--- a/examples/start-solid-zaidan-example/src/components/auth/auth-form.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/auth-form.tsx
@@ -3,14 +3,25 @@ import {
   type AdditionalFieldFormValue,
   DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS,
   getFormFieldErrors,
+  normalizeAuthFormServerError,
   validateAdditionalFieldRequired,
   validateAdditionalFieldValue
 } from "@better-auth-ui/core"
-import { createFormHook, createFormHookContexts } from "@tanstack/solid-form"
-import { type ComponentProps, Show, splitProps } from "solid-js"
+import {
+  type AnyFormApi,
+  createFormHook,
+  createFormHookContexts
+} from "@tanstack/solid-form"
+import { type ComponentProps, type JSX, Show, splitProps } from "solid-js"
 
 import { Button } from "@/components/ui/button"
-import { FieldError } from "@/components/ui/field"
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldLabel
+} from "@/components/ui/field"
+import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { AdditionalField, type AdditionalFieldProps } from "./additional-field"
 
@@ -49,13 +60,73 @@ function AuthFormFieldError() {
   )
 }
 
+function AuthFormServerError() {
+  const form = useFormContext()
+
+  return (
+    <form.Subscribe selector={(state) => state.errorMap.onServer}>
+      {(error) => {
+        const errors = () => {
+          const current = error()
+          const formError =
+            current && typeof current === "object" && "form" in current
+              ? current.form
+              : current
+          return getFormFieldErrors(formError ? [formError] : [])
+        }
+        return (
+          <Show when={errors().length > 0}>
+            <FieldError errors={errors()} />
+          </Show>
+        )
+      }}
+    </form.Subscribe>
+  )
+}
+
+export function setAuthFormServerError(
+  form: AnyFormApi,
+  error: unknown,
+  fallbackMessage: string
+) {
+  const normalized = normalizeAuthFormServerError(error, fallbackMessage)
+  form.setErrorMap({
+    onServer: {
+      fields: normalized.fields ?? {},
+      form: normalized.form
+    }
+  })
+}
+
+export function clearAuthFormServerError(form: AnyFormApi) {
+  form.setErrorMap({ onServer: undefined })
+}
+
+export async function submitAuthForm(
+  form: AnyFormApi,
+  serverErrorMessage = "Unable to submit this form. Try again."
+) {
+  clearAuthFormServerError(form)
+  try {
+    await form.handleSubmit()
+    return form.state.isValid
+  } catch (error) {
+    setAuthFormServerError(form, error, serverErrorMessage)
+    return false
+  }
+}
+
 type AuthFormRootProps = Omit<ComponentProps<"form">, "onSubmit"> & {
   onBeforeSubmit?: () => void
+  serverErrorMessage?: string
 }
 
 function AuthFormRoot(props: AuthFormRootProps) {
   const form = useFormContext()
-  const [local, formProps] = splitProps(props, ["onBeforeSubmit"])
+  const [local, formProps] = splitProps(props, [
+    "onBeforeSubmit",
+    "serverErrorMessage"
+  ])
   let submitting = false
 
   const submit = async (event: SubmitEvent) => {
@@ -66,8 +137,11 @@ function AuthFormRoot(props: AuthFormRootProps) {
     local.onBeforeSubmit?.()
     submitting = true
     try {
-      await form.handleSubmit()
-      if (!form.state.isValid) focusFirstInvalidAuthFormControl(formElement)
+      const isValid = await submitAuthForm(
+        form,
+        local.serverErrorMessage ?? "Unable to submit this form. Try again."
+      )
+      if (!isValid) focusFirstInvalidAuthFormControl(formElement)
     } finally {
       submitting = false
     }
@@ -83,6 +157,40 @@ function AuthFormRoot(props: AuthFormRootProps) {
       }}
       onSubmit={submit}
     />
+  )
+}
+
+type AuthFormTextFieldProps = Omit<
+  ComponentProps<typeof Input>,
+  "name" | "onBlur" | "onInput" | "value"
+> & {
+  description?: JSX.Element
+  label: JSX.Element
+}
+
+function AuthFormTextField(props: AuthFormTextFieldProps) {
+  const field = useFieldContext<string>()
+  const [local, inputProps] = splitProps(props, ["description", "id", "label"])
+  const isInvalid = () => isAuthFormFieldInvalid(field().state.meta)
+  const inputId = () => local.id ?? field().name
+
+  return (
+    <Field data-invalid={isInvalid()}>
+      <FieldLabel for={inputId()}>{local.label}</FieldLabel>
+      <Input
+        {...inputProps}
+        aria-invalid={isInvalid()}
+        id={inputId()}
+        name={field().name}
+        onBlur={field().handleBlur}
+        onInput={(event) => field().handleChange(event.currentTarget.value)}
+        value={field().state.value}
+      />
+      <Show when={local.description}>
+        <FieldDescription>{local.description}</FieldDescription>
+      </Show>
+      <AuthFormFieldError />
+    </Field>
   )
 }
 
@@ -141,9 +249,17 @@ export const {
   withFieldGroup: withAuthFieldGroup,
   withForm: withAuthForm
 } = createFormHook({
-  fieldComponents: { AuthFormAdditionalField, AuthFormFieldError },
+  fieldComponents: {
+    AuthFormAdditionalField,
+    AuthFormFieldError,
+    AuthFormTextField
+  },
   fieldContext,
-  formComponents: { AuthFormRoot, AuthFormSubmitButton },
+  formComponents: {
+    AuthFormRoot,
+    AuthFormServerError,
+    AuthFormSubmitButton
+  },
   formContext
 })
 

--- a/examples/start-solid-zaidan-example/src/components/auth/auth-form.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/auth-form.tsx
@@ -28,6 +28,8 @@ import { AdditionalField, type AdditionalFieldProps } from "./additional-field"
 const { fieldContext, formContext, useFieldContext, useFormContext } =
   createFormHookContexts()
 
+const DEFAULT_AUTH_FORM_SERVER_ERROR = "Unable to submit this form. Try again."
+
 export function focusFirstInvalidAuthFormControl(form: HTMLFormElement) {
   requestAnimationFrame(() => {
     form
@@ -104,14 +106,16 @@ export function clearAuthFormServerError(form: AnyFormApi) {
 
 export async function submitAuthForm(
   form: AnyFormApi,
-  serverErrorMessage = "Unable to submit this form. Try again."
+  serverErrorMessage = DEFAULT_AUTH_FORM_SERVER_ERROR
 ) {
   clearAuthFormServerError(form)
   try {
     await form.handleSubmit()
     return form.state.isValid
   } catch (error) {
-    setAuthFormServerError(form, error, serverErrorMessage)
+    if (!form.state.errorMap.onServer) {
+      setAuthFormServerError(form, error, serverErrorMessage)
+    }
     return false
   }
 }
@@ -139,7 +143,7 @@ function AuthFormRoot(props: AuthFormRootProps) {
     try {
       const isValid = await submitAuthForm(
         form,
-        local.serverErrorMessage ?? "Unable to submit this form. Try again."
+        local.serverErrorMessage ?? DEFAULT_AUTH_FORM_SERVER_ERROR
       )
       if (!isValid) focusFirstInvalidAuthFormControl(formElement)
     } finally {

--- a/examples/start-solid-zaidan-example/src/components/auth/delete-user/delete-account.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/delete-user/delete-account.tsx
@@ -27,6 +27,7 @@ import {
   InputGroupInput
 } from "@/components/ui/input-group"
 import { cn } from "@/lib/utils"
+import { createAuthForm, isAuthFormFieldInvalid } from "../auth-form"
 
 const defaultDeleteAccountLabel = "Delete account"
 
@@ -38,7 +39,6 @@ export function DeleteAccount(props: DeleteAccountProps = {}) {
   const auth = useAuth()
   const queryClient = useQueryClient()
   const [confirmOpen, setConfirmOpen] = createSignal(false)
-  const [password, setPassword] = createSignal("")
   const [isPasswordVisible, setIsPasswordVisible] = createSignal(false)
   const deleteUserPluginConfig = () =>
     auth.plugins.find((plugin) => plugin.id === "deleteUser") as
@@ -75,7 +75,7 @@ export function DeleteAccount(props: DeleteAccountProps = {}) {
   const deleteUser = useDeleteUser(auth.authClient, () => ({
     onSuccess: () => {
       setConfirmOpen(false)
-      setPassword("")
+      form.reset()
       setIsPasswordVisible(false)
 
       if (sendDeleteAccountVerification()) {
@@ -94,19 +94,20 @@ export function DeleteAccount(props: DeleteAccountProps = {}) {
 
   const handleDialogOpenChange = (open: boolean) => {
     setConfirmOpen(open)
-    setPassword("")
+    form.reset()
     setIsPasswordVisible(false)
   }
 
-  const submitDeleteUser = (event: SubmitEvent) => {
-    event.preventDefault()
-
-    deleteUser.mutate(
-      (needsPassword() ? { password: password() } : {}) as Parameters<
-        typeof deleteUser.mutate
-      >[0]
-    )
-  }
+  const form = createAuthForm(() => ({
+    defaultValues: { password: "" },
+    onSubmit: async ({ value }) => {
+      await deleteUser.mutateAsync(
+        (needsPassword() ? { password: value.password } : {}) as Parameters<
+          typeof deleteUser.mutateAsync
+        >[0]
+      )
+    }
+  }))
 
   return (
     <Card class={cn("z-card-padding-none border-destructive", props.class)}>
@@ -131,86 +132,106 @@ export function DeleteAccount(props: DeleteAccountProps = {}) {
           </AlertDialogTrigger>
 
           <AlertDialogContent>
-            <form class="flex flex-col gap-6" onSubmit={submitDeleteUser}>
-              <AlertDialogHeader>
-                <AlertDialogMedia class="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
-                  <TriangleAlert />
-                </AlertDialogMedia>
-                <AlertDialogTitle>
-                  {deleteUserLabels().deleteUser}
-                </AlertDialogTitle>
-                <AlertDialogDescription>
-                  {deleteUserLabels().deleteUserDescription}
-                </AlertDialogDescription>
-              </AlertDialogHeader>
+            <form.AppForm>
+              <form.AuthFormRoot class="flex flex-col gap-6">
+                <AlertDialogHeader>
+                  <AlertDialogMedia class="bg-destructive/10 text-destructive dark:bg-destructive/20 dark:text-destructive">
+                    <TriangleAlert />
+                  </AlertDialogMedia>
+                  <AlertDialogTitle>
+                    {deleteUserLabels().deleteUser}
+                  </AlertDialogTitle>
+                  <AlertDialogDescription>
+                    {deleteUserLabels().deleteUserDescription}
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
 
-              <Show when={needsPassword()}>
-                <Field>
-                  <FieldLabel for="delete-password">
-                    {auth.localization.auth.password}
-                  </FieldLabel>
-                  <InputGroup>
-                    <InputGroupInput
-                      autocomplete="current-password"
-                      disabled={deleteUser.isPending}
-                      id="delete-password"
-                      name="password"
-                      onInput={(event) =>
-                        setPassword(event.currentTarget.value)
-                      }
-                      placeholder={auth.localization.auth.passwordPlaceholder}
-                      required
-                      type={isPasswordVisible() ? "text" : "password"}
-                      value={password()}
-                    />
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        aria-label={
-                          isPasswordVisible()
-                            ? auth.localization.auth.hidePassword
-                            : auth.localization.auth.showPassword
-                        }
-                        disabled={deleteUser.isPending}
-                        onClick={() =>
-                          setIsPasswordVisible((visible) => !visible)
-                        }
-                        size="icon-sm"
-                        title={
-                          isPasswordVisible()
-                            ? auth.localization.auth.hidePassword
-                            : auth.localization.auth.showPassword
-                        }
+                <Show when={needsPassword()}>
+                  <form.AppField
+                    name="password"
+                    validators={{
+                      onChange: ({ value }) =>
+                        value ? undefined : auth.localization.auth.fieldRequired
+                    }}
+                  >
+                    {(field) => (
+                      <Field
+                        data-invalid={isAuthFormFieldInvalid(
+                          field().state.meta
+                        )}
                       >
-                        <Show
-                          when={isPasswordVisible()}
-                          fallback={<Eye aria-hidden class="size-4" />}
-                        >
-                          <EyeOff aria-hidden class="size-4" />
-                        </Show>
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                </Field>
-              </Show>
+                        <FieldLabel for="delete-password">
+                          {auth.localization.auth.password}
+                        </FieldLabel>
+                        <InputGroup>
+                          <InputGroupInput
+                            aria-invalid={isAuthFormFieldInvalid(
+                              field().state.meta
+                            )}
+                            autocomplete="current-password"
+                            disabled={deleteUser.isPending}
+                            id="delete-password"
+                            name={field().name}
+                            onBlur={field().handleBlur}
+                            onInput={(event) =>
+                              field().handleChange(event.currentTarget.value)
+                            }
+                            placeholder={
+                              auth.localization.auth.passwordPlaceholder
+                            }
+                            type={isPasswordVisible() ? "text" : "password"}
+                            value={field().state.value}
+                          />
+                          <InputGroupAddon align="inline-end">
+                            <InputGroupButton
+                              aria-label={
+                                isPasswordVisible()
+                                  ? auth.localization.auth.hidePassword
+                                  : auth.localization.auth.showPassword
+                              }
+                              disabled={deleteUser.isPending}
+                              onClick={() =>
+                                setIsPasswordVisible((visible) => !visible)
+                              }
+                              size="icon-sm"
+                              title={
+                                isPasswordVisible()
+                                  ? auth.localization.auth.hidePassword
+                                  : auth.localization.auth.showPassword
+                              }
+                            >
+                              <Show
+                                when={isPasswordVisible()}
+                                fallback={<Eye aria-hidden class="size-4" />}
+                              >
+                                <EyeOff aria-hidden class="size-4" />
+                              </Show>
+                            </InputGroupButton>
+                          </InputGroupAddon>
+                        </InputGroup>
+                        <field.AuthFormFieldError />
+                      </Field>
+                    )}
+                  </form.AppField>
+                </Show>
+                <form.AuthFormServerError />
 
-              <AlertDialogFooter>
-                <AlertDialogCancel
-                  disabled={deleteUser.isPending}
-                  type="button"
-                >
-                  {auth.localization.settings.cancel}
-                </AlertDialogCancel>
-                <Button
-                  disabled={deleteUser.isPending}
-                  type="submit"
-                  variant="destructive"
-                >
-                  {deleteUser.isPending
-                    ? `${deleteUserLabels().deleteUser}…`
-                    : deleteUserLabels().deleteUser}
-                </Button>
-              </AlertDialogFooter>
-            </form>
+                <AlertDialogFooter>
+                  <AlertDialogCancel
+                    disabled={deleteUser.isPending}
+                    type="button"
+                  >
+                    {auth.localization.settings.cancel}
+                  </AlertDialogCancel>
+                  <form.AuthFormSubmitButton
+                    disabled={deleteUser.isPending}
+                    variant="destructive"
+                  >
+                    {deleteUserLabels().deleteUser}
+                  </form.AuthFormSubmitButton>
+                </AlertDialogFooter>
+              </form.AuthFormRoot>
+            </form.AppForm>
           </AlertDialogContent>
         </AlertDialog>
       </CardContent>

--- a/examples/start-solid-zaidan-example/src/components/auth/device-authorization/device-authorization.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/device-authorization/device-authorization.tsx
@@ -200,7 +200,7 @@ export function DeviceAuthorization(props: DeviceAuthorizationProps) {
     const currentCode = normalizedUserCode()
 
     if (currentCode.length === userCodeLength) {
-      void submitCode(currentCode)
+      void submitCode(currentCode).catch(() => undefined)
     }
   })
 
@@ -244,7 +244,9 @@ export function DeviceAuthorization(props: DeviceAuthorizationProps) {
           userCode={userCode()}
           userCodeLength={userCodeLength}
           onCodeChange={handleCodeChange}
-          onCodeComplete={(value) => void submitCode(value)}
+          onCodeComplete={(value) =>
+            void submitCode(value).catch(() => undefined)
+          }
           onSubmit={submitCode}
         />
       </Match>

--- a/examples/start-solid-zaidan-example/src/components/auth/device-authorization/device-authorization.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/device-authorization/device-authorization.tsx
@@ -44,6 +44,7 @@ import { Separator } from "@/components/ui/separator"
 import { Spinner } from "@/components/ui/spinner"
 import { deviceAuthorizationPlugin } from "@/lib/auth/device-authorization-plugin"
 import { cn } from "@/lib/utils"
+import { createAuthForm, isAuthFormFieldInvalid } from "../auth-form"
 
 type DeviceAuthorizationStep = "code" | "approval" | "approved" | "denied"
 
@@ -169,7 +170,7 @@ export function DeviceAuthorization(props: DeviceAuthorizationProps) {
     setCodeError("")
   }
 
-  const submitCode = (completedCode: string) => {
+  const submitCode = async (completedCode: string) => {
     const normalizedCode = normalizeDeviceCode(completedCode)
 
     if (
@@ -190,7 +191,7 @@ export function DeviceAuthorization(props: DeviceAuthorizationProps) {
       return
     }
 
-    verifyDeviceCode.mutate({
+    await verifyDeviceCode.mutateAsync({
       query: { user_code: normalizedCode }
     })
   }
@@ -199,20 +200,9 @@ export function DeviceAuthorization(props: DeviceAuthorizationProps) {
     const currentCode = normalizedUserCode()
 
     if (currentCode.length === userCodeLength) {
-      submitCode(currentCode)
+      void submitCode(currentCode)
     }
   })
-
-  const handleSubmit = (event: SubmitEvent) => {
-    event.preventDefault()
-
-    if (normalizedUserCode().length !== userCodeLength) {
-      handleAuthorizationError()
-      return
-    }
-
-    submitCode(normalizedUserCode())
-  }
 
   const cardClass = () => cn("w-full max-w-sm", props.class)
 
@@ -254,8 +244,8 @@ export function DeviceAuthorization(props: DeviceAuthorizationProps) {
           userCode={userCode()}
           userCodeLength={userCodeLength}
           onCodeChange={handleCodeChange}
-          onCodeComplete={submitCode}
-          onSubmit={handleSubmit}
+          onCodeComplete={(value) => void submitCode(value)}
+          onSubmit={submitCode}
         />
       </Match>
     </Switch>
@@ -272,7 +262,7 @@ type DeviceCodeFormProps = {
   userCodeLength: number
   onCodeChange: (value: string) => void
   onCodeComplete: (value: string) => void
-  onSubmit: (event: SubmitEvent) => void
+  onSubmit: (value: string) => Promise<void>
 }
 
 function DeviceCodeForm(props: DeviceCodeFormProps) {
@@ -281,6 +271,15 @@ function DeviceCodeForm(props: DeviceCodeFormProps) {
   const firstGroup = slots.slice(0, groupBreak)
   const secondGroup = slots.slice(groupBreak)
   const errorId = "device-code-error"
+  const form = createAuthForm(() => ({
+    defaultValues: { userCode: props.userCode },
+    onSubmit: async ({ value }) => props.onSubmit(value.userCode)
+  }))
+  createEffect(() => {
+    if (form.state.values.userCode !== props.userCode) {
+      form.setFieldValue("userCode", props.userCode)
+    }
+  })
 
   return (
     <Card class={props.class}>
@@ -294,69 +293,91 @@ function DeviceCodeForm(props: DeviceCodeFormProps) {
       </CardHeader>
 
       <CardContent>
-        <form
-          aria-label={props.localization.deviceAuthorization}
-          onSubmit={props.onSubmit}
-        >
-          <FieldGroup>
-            <Field data-invalid={Boolean(props.codeError)}>
-              <FieldLabel for="device-code">
-                {props.localization.deviceCode}
-              </FieldLabel>
-
-              <InputOTP
-                maxLength={props.userCodeLength}
-                id="device-code"
-                aria-describedby={props.codeError ? errorId : undefined}
-                aria-invalid={Boolean(props.codeError)}
-                aria-label={props.localization.deviceCode}
-                autocomplete="one-time-code"
-                containerClass="w-full justify-center"
-                disabled={props.isVerifying}
-                inputmode="text"
+        <form.AppForm>
+          <form.AuthFormRoot
+            aria-label={props.localization.deviceAuthorization}
+          >
+            <FieldGroup>
+              <form.AppField
                 name="userCode"
-                pattern="^[A-Za-z0-9]*$"
-                value={props.userCode}
-                onValueChange={props.onCodeChange}
-                onComplete={props.onCodeComplete}
+                validators={{
+                  onChange: ({ value }) =>
+                    normalizeDeviceCode(value).length === props.userCodeLength
+                      ? undefined
+                      : props.localization.invalidDeviceCode
+                }}
               >
-                <InputOTPGroup>
-                  <For each={firstGroup}>
-                    {(slot) => <InputOTPSlot index={slot.index} />}
-                  </For>
-                </InputOTPGroup>
+                {(field) => (
+                  <Field
+                    data-invalid={
+                      Boolean(props.codeError) ||
+                      isAuthFormFieldInvalid(field().state.meta)
+                    }
+                  >
+                    <FieldLabel for="device-code">
+                      {props.localization.deviceCode}
+                    </FieldLabel>
 
-                <Show when={secondGroup.length > 0}>
-                  <InputOTPSeparator />
-                  <InputOTPGroup>
-                    <For each={secondGroup}>
-                      {(slot) => <InputOTPSlot index={slot.index} />}
-                    </For>
-                  </InputOTPGroup>
-                </Show>
-              </InputOTP>
+                    <InputOTP
+                      maxLength={props.userCodeLength}
+                      id="device-code"
+                      aria-describedby={props.codeError ? errorId : undefined}
+                      aria-invalid={Boolean(props.codeError)}
+                      aria-label={props.localization.deviceCode}
+                      autocomplete="one-time-code"
+                      containerClass="w-full justify-center"
+                      disabled={props.isVerifying}
+                      inputmode="text"
+                      name="userCode"
+                      pattern="^[A-Za-z0-9]*$"
+                      value={field().state.value}
+                      onValueChange={(value) => {
+                        field().handleChange(value)
+                        props.onCodeChange(value)
+                      }}
+                      onComplete={(value) => {
+                        field().handleChange(value)
+                        props.onCodeComplete(value)
+                      }}
+                    >
+                      <InputOTPGroup>
+                        <For each={firstGroup}>
+                          {(slot) => <InputOTPSlot index={slot.index} />}
+                        </For>
+                      </InputOTPGroup>
 
-              <Show when={props.codeError}>
-                <FieldError id={errorId}>{props.codeError}</FieldError>
-              </Show>
-            </Field>
+                      <Show when={secondGroup.length > 0}>
+                        <InputOTPSeparator />
+                        <InputOTPGroup>
+                          <For each={secondGroup}>
+                            {(slot) => <InputOTPSlot index={slot.index} />}
+                          </For>
+                        </InputOTPGroup>
+                      </Show>
+                    </InputOTP>
 
-            <Button
-              class="w-full"
-              disabled={
-                props.userCode.length !== props.userCodeLength ||
-                props.isSessionPending ||
-                props.isVerifying
-              }
-              type="submit"
-            >
-              <Show when={props.isVerifying}>
-                <Spinner />
-              </Show>
-              {props.localization.continue}
-            </Button>
-          </FieldGroup>
-        </form>
+                    <Show when={props.codeError}>
+                      <FieldError id={errorId}>{props.codeError}</FieldError>
+                    </Show>
+                    <field.AuthFormFieldError />
+                  </Field>
+                )}
+              </form.AppField>
+
+              <form.AuthFormSubmitButton
+                class="w-full"
+                disabled={
+                  props.userCode.length !== props.userCodeLength ||
+                  props.isSessionPending ||
+                  props.isVerifying
+                }
+              >
+                {props.localization.continue}
+              </form.AuthFormSubmitButton>
+              <form.AuthFormServerError />
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
     </Card>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/change-email-otp.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/change-email-otp.tsx
@@ -1,3 +1,4 @@
+import { validateEmailAddress } from "@better-auth-ui/core"
 import {
   changeEmailOtpOptions,
   type EmailOtpAuthClient,
@@ -13,11 +14,9 @@ import { OpenEmailButton } from "@/components/auth/open-email-button"
 import { OtpField } from "@/components/auth/otp-field"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Field, FieldLabel } from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
-import { Spinner } from "@/components/ui/spinner"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { cn } from "@/lib/utils"
+import { createAuthForm, submitAuthForm } from "../auth-form"
 
 type ChangeEmailStep = "email" | "currentCode" | "newCode"
 
@@ -25,14 +24,7 @@ export type ChangeEmailOtpProps = {
   class?: string
 }
 
-/**
- * Change the account email with codes instead of a confirmation link.
- *
- * Replaces the built-in `<ChangeEmail />` card when the email-OTP plugin runs
- * with `changeEmail: true`. With `verifyCurrentEmail` on it is a three-step
- * flow — confirm the current address, then the new one — and two steps
- * otherwise.
- */
+/** Change the account email with verification codes. */
 export function ChangeEmailOtp(props: ChangeEmailOtpProps = {}) {
   const auth = useAuth()
   const {
@@ -40,96 +32,75 @@ export function ChangeEmailOtp(props: ChangeEmailOtpProps = {}) {
     otpLength,
     verifyCurrentEmail
   } = useAuthPlugin(emailOtpPlugin)
-
   const otpClient = () => auth.authClient as EmailOtpAuthClient
   const session = useSession(otpClient())
   const currentEmail = () => session.data?.user.email
-
   const [step, setStep] = createSignal<ChangeEmailStep>("email")
-  const [newEmail, setNewEmail] = createSignal("")
-  const [code, setCode] = createSignal("")
 
   const resetFlow = () => {
-    setCode("")
-    setNewEmail("")
+    form.reset()
     setStep("email")
   }
-
-  // The step transition is attached per call: the code goes to the current
-  // address while the pending change targets the new one, so the address to
-  // remember isn't in this mutation's variables.
   const sendCode = createMutation(() => ({
     ...sendVerificationOtpOptions(otpClient())
   }))
-
   const requestChange = createMutation(() => ({
     ...requestEmailChangeOtpOptions(otpClient()),
-    onError: () => setCode(""),
+    onError: () => form.setFieldValue("code", ""),
     onSuccess: () => {
-      setCode("")
+      form.setFieldValue("code", "")
       setStep("newCode")
     }
   }))
-
   const changeEmail = createMutation(() => ({
     ...changeEmailOtpOptions(otpClient()),
-    onError: () => setCode(""),
+    onError: () => form.setFieldValue("code", ""),
     onSuccess: () => {
       toast.success(auth.localization.settings.changeEmailSuccess)
       resetFlow()
     }
   }))
-
   const isPending = () =>
     sendCode.isPending || requestChange.isPending || changeEmail.isPending
 
-  const codeTarget = () =>
-    step() === "currentCode" ? currentEmail() : newEmail()
-
-  const submitCode = (completedCode: string) => {
-    if (isPending() || step() === "email") return
-
-    if (step() === "currentCode") {
-      requestChange.mutate({
-        newEmail: newEmail(),
-        otp: completedCode
-      } as Parameters<typeof requestChange.mutate>[0])
-      return
-    }
-
-    changeEmail.mutate({
-      newEmail: newEmail(),
-      otp: completedCode
-    } as Parameters<typeof changeEmail.mutate>[0])
-  }
-
-  const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
-    event.preventDefault()
-
-    if (step() === "email") {
-      const formData = new FormData(event.currentTarget)
-      const target = String(formData.get("email") ?? "")
-      setNewEmail(target)
-
-      const current = currentEmail()
-
-      if (verifyCurrentEmail && current) {
-        sendCode.mutate(
-          { email: current, type: "change-email" } as Parameters<
-            typeof sendCode.mutate
-          >[0],
-          { onSuccess: () => setStep("currentCode") }
-        )
+  const form = createAuthForm(() => ({
+    defaultValues: { code: "", email: "" },
+    onSubmit: async ({ value }) => {
+      if (step() === "email") {
+        const current = currentEmail()
+        if (verifyCurrentEmail && current) {
+          await sendCode.mutateAsync({
+            email: current,
+            type: "change-email"
+          } as Parameters<typeof sendCode.mutateAsync>[0])
+          setStep("currentCode")
+          return
+        }
+        await requestChange.mutateAsync({ newEmail: value.email } as Parameters<
+          typeof requestChange.mutateAsync
+        >[0])
         return
       }
-
-      requestChange.mutate({ newEmail: target } as Parameters<
-        typeof requestChange.mutate
-      >[0])
-      return
+      if (step() === "currentCode") {
+        await requestChange.mutateAsync({
+          newEmail: value.email,
+          otp: value.code
+        } as Parameters<typeof requestChange.mutateAsync>[0])
+        return
+      }
+      await changeEmail.mutateAsync({
+        newEmail: value.email,
+        otp: value.code
+      } as Parameters<typeof changeEmail.mutateAsync>[0])
     }
-
-    submitCode(code())
+  }))
+  const code = () => form.state.values.code
+  const codeTarget = () =>
+    step() === "currentCode" ? currentEmail() : form.state.values.email
+  const submitCode = async (completedCode: string) => {
+    if (isPending() || step() === "email") return
+    form.setFieldValue("code", completedCode)
+    await submitAuthForm(form)
   }
 
   return (
@@ -137,97 +108,110 @@ export function ChangeEmailOtp(props: ChangeEmailOtpProps = {}) {
       <h2 class="mb-3 text-sm font-semibold">
         {auth.localization.settings.changeEmail}
       </h2>
-
-      <form onSubmit={submit}>
-        <Card>
-          <CardContent class="flex flex-col gap-6">
-            <Show
-              when={step() === "email"}
-              fallback={
-                <div class="flex flex-col gap-3">
-                  <p class="text-muted-foreground text-sm">
-                    {emailOtpLocalization.confirmEmailDescription.replace(
-                      "{{email}}",
-                      codeTarget() ?? ""
-                    )}
-                  </p>
-
-                  <OtpField
-                    autofocus
-                    disabled={isPending()}
-                    id="change-email-code"
-                    label={
-                      step() === "currentCode"
-                        ? emailOtpLocalization.confirmCurrentEmail
-                        : emailOtpLocalization.confirmNewEmail
-                    }
-                    length={otpLength}
-                    name="otp"
-                    onInput={setCode}
-                    onComplete={submitCode}
-                    value={code()}
-                  />
-
-                  <Show when={codeTarget()}>
-                    {(target) => (
-                      <OpenEmailButton email={target()} variant="secondary" />
-                    )}
-                  </Show>
-                </div>
-              }
-            >
-              <Field>
-                <FieldLabel for="settings-email">
-                  {auth.localization.auth.email}
-                </FieldLabel>
-
-                <Input
-                  autocomplete="email"
-                  disabled={isPending() || !session.data}
-                  id="settings-email"
-                  name="email"
-                  placeholder={auth.localization.auth.emailPlaceholder}
-                  required
-                  type="email"
-                  value={currentEmail() ?? ""}
-                />
-              </Field>
-            </Show>
-          </CardContent>
-
-          <CardFooter class="gap-3">
-            <Show when={step() !== "email"}>
-              <Button
-                disabled={isPending()}
-                onClick={resetFlow}
-                size="sm"
-                type="button"
-                variant="outline"
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card>
+            <CardContent class="flex flex-col gap-6">
+              <Show
+                when={step() === "email"}
+                fallback={
+                  <div class="flex flex-col gap-3">
+                    <p class="text-muted-foreground text-sm">
+                      {emailOtpLocalization.confirmEmailDescription.replace(
+                        "{{email}}",
+                        codeTarget() ?? ""
+                      )}
+                    </p>
+                    <form.AppField
+                      name="code"
+                      validators={{
+                        onChange: ({ value }) =>
+                          value.length === otpLength
+                            ? undefined
+                            : emailOtpLocalization.codeLengthMismatch.replace(
+                                "{{length}}",
+                                String(otpLength)
+                              )
+                      }}
+                    >
+                      {(field) => (
+                        <OtpField
+                          autofocus
+                          disabled={isPending()}
+                          id="change-email-code"
+                          label={
+                            step() === "currentCode"
+                              ? emailOtpLocalization.confirmCurrentEmail
+                              : emailOtpLocalization.confirmNewEmail
+                          }
+                          length={otpLength}
+                          name={field().name}
+                          onInput={field().handleChange}
+                          onComplete={(value) => void submitCode(value)}
+                          value={field().state.value}
+                        />
+                      )}
+                    </form.AppField>
+                    <Show when={codeTarget()}>
+                      {(target) => (
+                        <OpenEmailButton email={target()} variant="secondary" />
+                      )}
+                    </Show>
+                  </div>
+                }
               >
-                {auth.localization.settings.cancel}
-              </Button>
-            </Show>
-
-            <Button
-              disabled={
-                isPending() ||
-                !session.data ||
-                (step() !== "email" && code().length !== otpLength)
-              }
-              size="sm"
-              type="submit"
-            >
-              <Show when={isPending()}>
-                <Spinner />
+                <form.AppField
+                  name="email"
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateEmailAddress(value, {
+                        invalidMessage: auth.localization.auth.invalidEmail,
+                        requiredMessage: auth.localization.auth.fieldRequired
+                      })
+                  }}
+                >
+                  {(field) => (
+                    <field.AuthFormTextField
+                      autocomplete="email"
+                      disabled={isPending() || !session.data}
+                      id="settings-email"
+                      label={auth.localization.auth.email}
+                      placeholder={auth.localization.auth.emailPlaceholder}
+                      type="email"
+                    />
+                  )}
+                </form.AppField>
               </Show>
-
-              {step() === "email"
-                ? auth.localization.settings.updateEmail
-                : emailOtpLocalization.verifyCode}
-            </Button>
-          </CardFooter>
-        </Card>
-      </form>
+            </CardContent>
+            <CardFooter class="gap-3">
+              <Show when={step() !== "email"}>
+                <Button
+                  disabled={isPending()}
+                  onClick={resetFlow}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  {auth.localization.settings.cancel}
+                </Button>
+              </Show>
+              <form.AuthFormSubmitButton
+                disabled={
+                  isPending() ||
+                  !session.data ||
+                  (step() !== "email" && code().length !== otpLength)
+                }
+                size="sm"
+              >
+                {step() === "email"
+                  ? auth.localization.settings.updateEmail
+                  : emailOtpLocalization.verifyCode}
+              </form.AuthFormSubmitButton>
+              <form.AuthFormServerError />
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/email-otp.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/email-otp.tsx
@@ -1,3 +1,4 @@
+import { validateEmailAddress } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   sendVerificationOtpOptions,
@@ -21,18 +22,17 @@ import {
   CardHeader,
   CardTitle
 } from "@/components/ui/card"
-import {
-  Field,
-  FieldError,
-  FieldGroup,
-  FieldLabel
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
+import { FieldGroup } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { useResendCooldown } from "@/lib/auth/use-resend-cooldown"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import {
+  createAuthForm,
+  setAuthFormServerError,
+  submitAuthForm
+} from "../auth-form"
 
 export type EmailOtpProps = {
   class?: string
@@ -54,9 +54,6 @@ export function EmailOtp(props: EmailOtpProps) {
   const continueSignIn = useSignInContinuation()
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
 
-  const [email, setEmail] = createSignal("")
-  const [emailError, setEmailError] = createSignal<string>()
-  const [code, setCode] = createSignal("")
   const [codeSent, setCodeSent] = createSignal(false)
 
   const otpClient = () => auth.authClient as EmailOtpAuthClient
@@ -71,34 +68,46 @@ export function EmailOtp(props: EmailOtpProps) {
 
   const signIn = createMutation(() => ({
     ...signInEmailOtpOptions(otpClient()),
-    onError: () => setCode(""),
+    onError: () => form.setFieldValue("code", ""),
     onSuccess: (data) => continueSignIn(data)
   }))
 
   const isPending = () => sendCode.isPending || signIn.isPending
 
-  const requestCode = () =>
-    sendCode.mutate({ email: email(), type: "sign-in" } as Parameters<
-      typeof sendCode.mutate
-    >[0])
+  const form = createAuthForm(() => ({
+    defaultValues: { code: "", email: "" },
+    onSubmit: async ({ value }) => {
+      if (!codeSent()) {
+        await sendCode.mutateAsync({
+          email: value.email,
+          type: "sign-in"
+        } as Parameters<typeof sendCode.mutateAsync>[0])
+        return
+      }
+      await signIn.mutateAsync({
+        email: value.email,
+        otp: value.code
+      } as Parameters<typeof signIn.mutateAsync>[0])
+    }
+  }))
+  const email = () => form.state.values.email
+  const code = () => form.state.values.code
 
-  const verifyCode = (completedCode: string) => {
-    if (isPending()) return
-
-    signIn.mutate({ email: email(), otp: completedCode } as Parameters<
-      typeof signIn.mutate
-    >[0])
+  const requestCode = async () => {
+    try {
+      await sendCode.mutateAsync({
+        email: email(),
+        type: "sign-in"
+      } as Parameters<typeof sendCode.mutateAsync>[0])
+    } catch (error) {
+      setAuthFormServerError(form, error, "Unable to send a code. Try again.")
+    }
   }
 
-  const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
-    event.preventDefault()
-
-    if (!codeSent()) {
-      requestCode()
-      return
-    }
-
-    verifyCode(code())
+  const verifyCode = async (completedCode: string) => {
+    if (isPending()) return
+    form.setFieldValue("code", completedCode)
+    await submitAuthForm(form)
   }
 
   const socialPosition = () => props.socialPosition ?? "bottom"
@@ -136,106 +145,102 @@ export function EmailOtp(props: EmailOtpProps) {
             </Show>
           </Show>
 
-          <form aria-label={auth.localization.auth.signIn} onSubmit={submit}>
-            <FieldGroup>
-              <Show
-                when={codeSent()}
-                fallback={
-                  <Field data-invalid={Boolean(emailError())}>
-                    <FieldLabel for="email-otp-email">
-                      {auth.localization.auth.email}
-                    </FieldLabel>
-
-                    <Input
-                      aria-invalid={Boolean(emailError())}
-                      autocomplete="email"
-                      disabled={isPending()}
-                      id="email-otp-email"
+          <form.AppForm>
+            <form.AuthFormRoot aria-label={auth.localization.auth.signIn}>
+              <FieldGroup>
+                <Show
+                  when={codeSent()}
+                  fallback={
+                    <form.AppField
                       name="email"
-                      onInput={(event) => {
-                        setEmail(event.currentTarget.value)
-                        setEmailError(undefined)
+                      validators={{
+                        onChange: ({ value }) =>
+                          validateEmailAddress(value, {
+                            invalidMessage: auth.localization.auth.invalidEmail,
+                            requiredMessage:
+                              auth.localization.auth.fieldRequired
+                          })
                       }}
-                      onInvalid={(event) => {
-                        event.preventDefault()
-                        setEmailError(event.currentTarget.validationMessage)
-                      }}
-                      placeholder={auth.localization.auth.emailPlaceholder}
-                      required
-                      type="email"
-                      value={email()}
-                    />
-
-                    <Show when={emailError()}>
-                      {(message) => <FieldError>{message()}</FieldError>}
-                    </Show>
-                  </Field>
-                }
-              >
-                <OtpField
-                  autofocus
-                  disabled={isPending()}
-                  id="email-otp-code"
-                  label={emailOtpLocalization.code}
-                  length={otpLength}
-                  name="otp"
-                  onInput={setCode}
-                  onComplete={verifyCode}
-                  value={code()}
-                />
-              </Show>
-
-              <div class="flex flex-col gap-3">
-                <Button
-                  class="w-full"
-                  disabled={
-                    isPending() || (codeSent() && code().length !== otpLength)
+                    >
+                      {(field) => (
+                        <field.AuthFormTextField
+                          autocomplete="email"
+                          disabled={isPending()}
+                          id="email-otp-email"
+                          label={auth.localization.auth.email}
+                          placeholder={auth.localization.auth.emailPlaceholder}
+                          type="email"
+                        />
+                      )}
+                    </form.AppField>
                   }
-                  type="submit"
                 >
-                  <Show when={isPending()}>
-                    <Spinner />
-                  </Show>
-
-                  {codeSent()
-                    ? emailOtpLocalization.verifyCode
-                    : emailOtpLocalization.sendCode}
-                </Button>
-
-                <Show when={codeSent()}>
-                  <OpenEmailButton email={email()} variant="secondary" />
-
-                  <Button
-                    class="w-full"
-                    disabled={isPending() || isCoolingDown()}
-                    onClick={requestCode}
-                    type="button"
-                    variant="outline"
-                  >
-                    {isCoolingDown()
-                      ? auth.localization.auth.resendIn.replace(
-                          "{{seconds}}",
-                          String(cooldown())
-                        )
-                      : auth.localization.auth.resend}
-                  </Button>
-
-                  <Button
-                    class="w-full"
+                  <OtpField
+                    autofocus
                     disabled={isPending()}
-                    onClick={() => {
-                      setCodeSent(false)
-                      setCode("")
-                    }}
-                    type="button"
-                    variant="ghost"
-                  >
-                    {emailOtpLocalization.useDifferentEmail}
-                  </Button>
+                    id="email-otp-code"
+                    label={emailOtpLocalization.code}
+                    length={otpLength}
+                    name="otp"
+                    onInput={(value) => form.setFieldValue("code", value)}
+                    onComplete={verifyCode}
+                    value={code()}
+                  />
                 </Show>
-              </div>
-            </FieldGroup>
-          </form>
+
+                <div class="flex flex-col gap-3">
+                  <Button
+                    class="w-full"
+                    disabled={
+                      isPending() || (codeSent() && code().length !== otpLength)
+                    }
+                    type="submit"
+                  >
+                    <Show when={isPending()}>
+                      <Spinner />
+                    </Show>
+
+                    {codeSent()
+                      ? emailOtpLocalization.verifyCode
+                      : emailOtpLocalization.sendCode}
+                  </Button>
+
+                  <Show when={codeSent()}>
+                    <OpenEmailButton email={email()} variant="secondary" />
+
+                    <Button
+                      class="w-full"
+                      disabled={isPending() || isCoolingDown()}
+                      onClick={() => void requestCode()}
+                      type="button"
+                      variant="outline"
+                    >
+                      {isCoolingDown()
+                        ? auth.localization.auth.resendIn.replace(
+                            "{{seconds}}",
+                            String(cooldown())
+                          )
+                        : auth.localization.auth.resend}
+                    </Button>
+
+                    <Button
+                      class="w-full"
+                      disabled={isPending()}
+                      onClick={() => {
+                        setCodeSent(false)
+                        form.setFieldValue("code", "")
+                      }}
+                      type="button"
+                      variant="ghost"
+                    >
+                      {emailOtpLocalization.useDifferentEmail}
+                    </Button>
+                  </Show>
+                </div>
+                <form.AuthFormServerError />
+              </FieldGroup>
+            </form.AuthFormRoot>
+          </form.AppForm>
 
           <Show
             when={

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/forgot-password-otp.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/forgot-password-otp.tsx
@@ -1,4 +1,4 @@
-import { getAuthLinkURL } from "@better-auth-ui/core"
+import { getAuthLinkURL, validateEmailAddress } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   requestPasswordResetOtpOptions
@@ -10,9 +10,7 @@ import {
   useFetchOptions
 } from "@better-auth-ui/solid"
 import { createMutation } from "@tanstack/solid-query"
-import { createSignal, Show } from "solid-js"
 
-import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -20,16 +18,9 @@ import {
   CardHeader,
   CardTitle
 } from "@/components/ui/card"
-import {
-  Field,
-  FieldError,
-  FieldGroup,
-  FieldLabel
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
-import { Spinner } from "@/components/ui/spinner"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { cn } from "@/lib/utils"
+import { createAuthForm } from "../auth-form"
 
 /** `sessionStorage` key the reset-code form reads the pending address from. */
 export const RESET_PASSWORD_OTP_STORAGE_KEY =
@@ -52,8 +43,6 @@ export function ForgotPasswordOtp(props: ForgotPasswordOtpProps) {
   const { localization: emailOtpLocalization } = useAuthPlugin(emailOtpPlugin)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
 
-  const [emailError, setEmailError] = createSignal<string>()
-
   const requestReset = createMutation(() => ({
     ...requestPasswordResetOtpOptions(auth.authClient as EmailOtpAuthClient),
     onError: () => resetFetchOptions(),
@@ -68,15 +57,15 @@ export function ForgotPasswordOtp(props: ForgotPasswordOtpProps) {
     }
   }))
 
-  const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
-    event.preventDefault()
-
-    const formData = new FormData(event.currentTarget)
-    requestReset.mutate({
-      email: formData.get("email") as string,
-      fetchOptions
-    } as Parameters<typeof requestReset.mutate>[0])
-  }
+  const form = createAuthForm(() => ({
+    defaultValues: { email: "" },
+    onSubmit: async ({ value }) => {
+      await requestReset.mutateAsync({
+        email: value.email,
+        fetchOptions: fetchOptions()
+      } as Parameters<typeof requestReset.mutateAsync>[0])
+    }
+  }))
 
   return (
     <Card class={cn("w-full max-w-sm", props.class)}>
@@ -87,50 +76,40 @@ export function ForgotPasswordOtp(props: ForgotPasswordOtpProps) {
       </CardHeader>
 
       <CardContent>
-        <form
-          aria-label={auth.localization.auth.forgotPassword}
-          onSubmit={submit}
-        >
-          <FieldGroup>
-            <Field data-invalid={Boolean(emailError())}>
-              <FieldLabel for="forgot-password-email">
-                {auth.localization.auth.email}
-              </FieldLabel>
-
-              <Input
-                aria-invalid={Boolean(emailError())}
-                autocomplete="email"
-                disabled={requestReset.isPending}
-                id="forgot-password-email"
+        <form.AppForm>
+          <form.AuthFormRoot aria-label={auth.localization.auth.forgotPassword}>
+            <div class="flex flex-col gap-6">
+              <form.AppField
                 name="email"
-                onInput={() => setEmailError(undefined)}
-                onInvalid={(event) => {
-                  event.preventDefault()
-                  setEmailError(event.currentTarget.validationMessage)
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: auth.localization.auth.invalidEmail,
+                      requiredMessage: auth.localization.auth.fieldRequired
+                    })
                 }}
-                placeholder={auth.localization.auth.emailPlaceholder}
-                required
-                type="email"
-              />
-
-              <Show when={emailError()}>
-                {(message) => <FieldError>{message()}</FieldError>}
-              </Show>
-            </Field>
-
-            <Button
-              class="w-full"
-              disabled={requestReset.isPending}
-              type="submit"
-            >
-              <Show when={requestReset.isPending}>
-                <Spinner />
-              </Show>
-
-              {emailOtpLocalization.sendCode}
-            </Button>
-          </FieldGroup>
-        </form>
+              >
+                {(field) => (
+                  <field.AuthFormTextField
+                    autocomplete="email"
+                    disabled={requestReset.isPending}
+                    id="forgot-password-email"
+                    label={auth.localization.auth.email}
+                    placeholder={auth.localization.auth.emailPlaceholder}
+                    type="email"
+                  />
+                )}
+              </form.AppField>
+              <form.AuthFormSubmitButton
+                class="w-full"
+                disabled={requestReset.isPending}
+              >
+                {emailOtpLocalization.sendCode}
+              </form.AuthFormSubmitButton>
+              <form.AuthFormServerError />
+            </div>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
 
       <CardFooter class="justify-center">

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/reset-password-otp.tsx
@@ -1,6 +1,8 @@
 import {
   getAuthLinkURL,
-  isPasswordCompromisedError
+  isPasswordCompromisedError,
+  validateEmailAddress,
+  validateStringLength
 } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
@@ -8,12 +10,11 @@ import {
 } from "@better-auth-ui/core/plugins/email-otp"
 import { AuthLink, useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import { createMutation } from "@tanstack/solid-query"
-import { createSignal, Show } from "solid-js"
+import { Show } from "solid-js"
 import { toast } from "solid-sonner"
 
 import { OpenEmailButton } from "@/components/auth/open-email-button"
 import { OtpField } from "@/components/auth/otp-field"
-import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -22,16 +23,14 @@ import {
   CardHeader,
   CardTitle
 } from "@/components/ui/card"
-import {
-  Field,
-  FieldError,
-  FieldGroup,
-  FieldLabel
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
-import { Spinner } from "@/components/ui/spinner"
+import { FieldGroup } from "@/components/ui/field"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import { cn } from "@/lib/utils"
+import {
+  createAuthForm,
+  setAuthFormServerError,
+  submitAuthForm
+} from "../auth-form"
 import { PasswordStrengthMeter } from "../password-strength-meter"
 import { RESET_PASSWORD_OTP_STORAGE_KEY } from "./forgot-password-otp"
 
@@ -59,24 +58,19 @@ export function ResetPasswordOtp(props: ResetPasswordOtpProps) {
       : (sessionStorage.getItem(RESET_PASSWORD_OTP_STORAGE_KEY) ?? "")
 
   const hasStoredEmail = Boolean(storedEmail)
-  const [email, setEmail] = createSignal(storedEmail)
-  const [code, setCode] = createSignal("")
-  const [password, setPassword] = createSignal("")
-  const [passwordError, setPasswordError] = createSignal<string>()
-  let formRef: HTMLFormElement | undefined
-  let submissionLocked = false
-
   const resetPassword = createMutation(() => ({
     ...resetPasswordOtpOptions(auth.authClient as EmailOtpAuthClient),
     onError: (error) => {
       // The haveIBeenPwned plugin rejects on the password itself, so it
       // belongs against the field rather than in a toast.
       if (isPasswordCompromisedError(error)) {
-        setPasswordError(auth.localization.auth.passwordCompromised)
+        setAuthFormServerError(
+          form,
+          { fields: { password: auth.localization.auth.passwordCompromised } },
+          auth.localization.auth.passwordCompromised
+        )
       }
-
-      submissionLocked = false
-      setCode("")
+      form.setFieldValue("code", "")
     },
     onSuccess: () => {
       sessionStorage.removeItem(RESET_PASSWORD_OTP_STORAGE_KEY)
@@ -87,60 +81,37 @@ export function ResetPasswordOtp(props: ResetPasswordOtpProps) {
     }
   }))
 
-  const submitReset = (
-    form: HTMLFormElement,
-    submittedCode: string,
-    reportErrors: boolean
-  ) => {
-    if (resetPassword.isPending || submissionLocked) return
-
-    const formData = new FormData(form)
-    const password = formData.get("password") as string
-    const confirmPassword = formData.get("confirmPassword") as string
-
-    if (
-      auth.emailAndPassword?.confirmPassword &&
-      password !== confirmPassword
-    ) {
-      if (reportErrors) {
-        toast.error(auth.localization.auth.passwordsDoNotMatch)
-      }
-      return
+  const validatePassword = (value: string) =>
+    validateStringLength(value, {
+      maxLength: auth.emailAndPassword?.maxPasswordLength,
+      maxLengthMessage: auth.localization.auth.tooLong.replace(
+        "{{max}}",
+        String(auth.emailAndPassword?.maxPasswordLength)
+      ),
+      minLength: auth.emailAndPassword?.minPasswordLength,
+      minLengthMessage: auth.localization.auth.tooShort.replace(
+        "{{min}}",
+        String(auth.emailAndPassword?.minPasswordLength)
+      ),
+      requiredMessage: auth.localization.auth.fieldRequired
+    })
+  const form = createAuthForm(() => ({
+    defaultValues: {
+      code: "",
+      confirmPassword: "",
+      email: storedEmail,
+      password: ""
+    },
+    onSubmit: async ({ value }) => {
+      await resetPassword.mutateAsync({
+        email: value.email,
+        otp: value.code,
+        password: value.password
+      } as Parameters<typeof resetPassword.mutateAsync>[0])
     }
-
-    if (submittedCode.length !== otpLength) {
-      if (reportErrors) {
-        toast.error(
-          emailOtpLocalization.codeLengthMismatch.replace(
-            "{{length}}",
-            String(otpLength)
-          )
-        )
-      }
-      return
-    }
-
-    submissionLocked = true
-    resetPassword.mutate({
-      email: hasStoredEmail ? email() : (formData.get("email") as string),
-      otp: submittedCode,
-      password
-    } as Parameters<typeof resetPassword.mutate>[0])
-  }
-
-  const tryAutoSubmit = (completedCode?: string) => {
-    if (!formRef?.matches(":valid")) return
-
-    const formData = new FormData(formRef)
-    const submittedCode = completedCode ?? String(formData.get("otp") ?? "")
-
-    submitReset(formRef, submittedCode, false)
-  }
-
-  const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
-    event.preventDefault()
-    submitReset(event.currentTarget, code(), true)
-  }
+  }))
+  const email = () => form.state.values.email
+  const password = () => form.state.values.password
 
   return (
     <Card class={cn("w-full max-w-sm", props.class)}>
@@ -157,116 +128,122 @@ export function ResetPasswordOtp(props: ResetPasswordOtpProps) {
       </CardHeader>
 
       <CardContent>
-        <form
-          ref={formRef}
-          aria-label={auth.localization.auth.resetPassword}
-          onSubmit={submit}
-        >
-          <FieldGroup>
-            <Show when={!hasStoredEmail}>
-              <Field>
-                <FieldLabel for="reset-password-email">
-                  {auth.localization.auth.email}
-                </FieldLabel>
-
-                <Input
-                  autocomplete="email"
-                  disabled={resetPassword.isPending}
-                  id="reset-password-email"
+        <form.AppForm>
+          <form.AuthFormRoot aria-label={auth.localization.auth.resetPassword}>
+            <FieldGroup>
+              <Show when={!hasStoredEmail}>
+                <form.AppField
                   name="email"
-                  onInput={(event) => setEmail(event.currentTarget.value)}
-                  placeholder={auth.localization.auth.emailPlaceholder}
-                  required
-                  type="email"
-                  value={email()}
-                />
-              </Field>
-            </Show>
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateEmailAddress(value, {
+                        invalidMessage: auth.localization.auth.invalidEmail,
+                        requiredMessage: auth.localization.auth.fieldRequired
+                      })
+                  }}
+                >
+                  {(field) => (
+                    <field.AuthFormTextField
+                      autocomplete="email"
+                      disabled={resetPassword.isPending}
+                      id="reset-password-email"
+                      label={auth.localization.auth.email}
+                      placeholder={auth.localization.auth.emailPlaceholder}
+                      type="email"
+                    />
+                  )}
+                </form.AppField>
+              </Show>
 
-            <OtpField
-              autofocus={hasStoredEmail}
-              disabled={resetPassword.isPending}
-              id="reset-password-code"
-              label={emailOtpLocalization.code}
-              length={otpLength}
-              name="otp"
-              onInput={setCode}
-              onComplete={tryAutoSubmit}
-              value={code()}
-            />
+              <form.AppField
+                name="code"
+                validators={{
+                  onChange: ({ value }) =>
+                    value.length === otpLength
+                      ? undefined
+                      : emailOtpLocalization.codeLengthMismatch.replace(
+                          "{{length}}",
+                          String(otpLength)
+                        )
+                }}
+              >
+                {(field) => (
+                  <OtpField
+                    autofocus={hasStoredEmail}
+                    disabled={resetPassword.isPending}
+                    id="reset-password-code"
+                    label={emailOtpLocalization.code}
+                    length={otpLength}
+                    name={field().name}
+                    onInput={field().handleChange}
+                    onComplete={() => void submitAuthForm(form)}
+                    value={field().state.value}
+                  />
+                )}
+              </form.AppField>
 
-            <Field data-invalid={Boolean(passwordError())}>
-              <FieldLabel for="reset-password-password">
-                {auth.localization.auth.newPassword}
-              </FieldLabel>
-
-              <Input
-                aria-invalid={Boolean(passwordError())}
-                autocomplete="new-password"
-                disabled={resetPassword.isPending}
-                id="reset-password-password"
-                maxLength={auth.emailAndPassword?.maxPasswordLength}
-                minLength={auth.emailAndPassword?.minPasswordLength}
+              <form.AppField
                 name="password"
-                onInput={(event) => {
-                  setPassword(event.currentTarget.value)
-                  setPasswordError(undefined)
+                validators={{
+                  onChange: ({ value }) => validatePassword(value)
                 }}
-                onInvalid={(event) => {
-                  event.preventDefault()
-                  setPasswordError(event.currentTarget.validationMessage)
-                }}
-                placeholder={auth.localization.auth.newPasswordPlaceholder}
-                required
-                type="password"
-              />
+              >
+                {(field) => (
+                  <>
+                    <field.AuthFormTextField
+                      autocomplete="new-password"
+                      disabled={resetPassword.isPending}
+                      id="reset-password-password"
+                      label={auth.localization.auth.newPassword}
+                      placeholder={
+                        auth.localization.auth.newPasswordPlaceholder
+                      }
+                      type="password"
+                    />
+                    <PasswordStrengthMeter password={password()} />
+                  </>
+                )}
+              </form.AppField>
 
-              <Show when={passwordError()}>
-                {(message) => <FieldError>{message()}</FieldError>}
-              </Show>
-
-              <PasswordStrengthMeter password={password()} />
-            </Field>
-
-            <Show when={auth.emailAndPassword?.confirmPassword}>
-              <Field>
-                <FieldLabel for="reset-password-confirm">
-                  {auth.localization.auth.confirmPassword}
-                </FieldLabel>
-
-                <Input
-                  autocomplete="new-password"
-                  disabled={resetPassword.isPending}
-                  id="reset-password-confirm"
-                  maxLength={auth.emailAndPassword?.maxPasswordLength}
-                  minLength={auth.emailAndPassword?.minPasswordLength}
+              <Show when={auth.emailAndPassword?.confirmPassword}>
+                <form.AppField
                   name="confirmPassword"
-                  placeholder={
-                    auth.localization.auth.confirmPasswordPlaceholder
-                  }
-                  required
-                  type="password"
-                />
-              </Field>
-            </Show>
-
-            <Button
-              class="w-full"
-              disabled={resetPassword.isPending}
-              type="submit"
-            >
-              <Show when={resetPassword.isPending}>
-                <Spinner />
+                  validators={{
+                    onChange: ({ value }) =>
+                      value === password()
+                        ? undefined
+                        : auth.localization.auth.passwordsDoNotMatch
+                  }}
+                >
+                  {(field) => (
+                    <field.AuthFormTextField
+                      autocomplete="new-password"
+                      disabled={resetPassword.isPending}
+                      id="reset-password-confirm"
+                      label={auth.localization.auth.confirmPassword}
+                      placeholder={
+                        auth.localization.auth.confirmPasswordPlaceholder
+                      }
+                      type="password"
+                    />
+                  )}
+                </form.AppField>
               </Show>
 
-              {auth.localization.auth.resetPassword}
-            </Button>
+              <form.AuthFormSubmitButton
+                class="w-full"
+                disabled={resetPassword.isPending}
+              >
+                {auth.localization.auth.resetPassword}
+              </form.AuthFormSubmitButton>
 
-            <Show when={email()}>
-              <OpenEmailButton email={email()} variant="secondary" />
-            </Show>
-          </FieldGroup>
-        </form>
+              <Show when={email()}>
+                <OpenEmailButton email={email()} variant="secondary" />
+              </Show>
+              <form.AuthFormServerError />
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
 
       <CardFooter class="justify-center">

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/verify-email-otp.tsx
@@ -6,7 +6,7 @@ import {
 } from "@better-auth-ui/core/plugins/email-otp"
 import { AuthLink, useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import { createMutation } from "@tanstack/solid-query"
-import { Show } from "solid-js"
+import { createSignal, Show } from "solid-js"
 import { toast } from "solid-sonner"
 
 import { OpenEmailButton } from "@/components/auth/open-email-button"
@@ -55,6 +55,7 @@ export function VerifyEmailOtp(props: VerifyEmailOtpProps) {
     typeof sessionStorage === "undefined"
       ? ""
       : (sessionStorage.getItem(VERIFY_EMAIL_STORAGE_KEY) ?? "")
+  const [codeSent, setCodeSent] = createSignal(Boolean(storedEmail))
 
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown(
     storedEmail ? RESEND_COOLDOWN_SECONDS : 0
@@ -68,6 +69,7 @@ export function VerifyEmailOtp(props: VerifyEmailOtpProps) {
       const sentTo = (variables as { email: string }).email
       sessionStorage.setItem(VERIFY_EMAIL_STORAGE_KEY, sentTo)
       form.setFieldValue("email", sentTo)
+      setCodeSent(true)
       startCooldown()
       toast.success(emailOtpLocalization.codeSent)
     }
@@ -128,7 +130,7 @@ export function VerifyEmailOtp(props: VerifyEmailOtpProps) {
           <form.AuthFormRoot aria-label={auth.localization.auth.verifyEmail}>
             <FieldGroup>
               <Show
-                when={email()}
+                when={codeSent()}
                 fallback={
                   <form.AppField
                     name="email"
@@ -170,8 +172,7 @@ export function VerifyEmailOtp(props: VerifyEmailOtpProps) {
                 <Button
                   class="w-full"
                   disabled={
-                    isPending() ||
-                    (Boolean(email()) && code().length !== otpLength)
+                    isPending() || (codeSent() && code().length !== otpLength)
                   }
                   type="submit"
                 >
@@ -179,12 +180,12 @@ export function VerifyEmailOtp(props: VerifyEmailOtpProps) {
                     <Spinner />
                   </Show>
 
-                  {email()
+                  {codeSent()
                     ? emailOtpLocalization.verifyCode
                     : emailOtpLocalization.sendCode}
                 </Button>
 
-                <Show when={email()}>
+                <Show when={codeSent()}>
                   <OpenEmailButton email={email()} variant="secondary" />
 
                   <Button

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/verify-email-otp.tsx
@@ -1,4 +1,4 @@
-import { getAuthLinkURL } from "@better-auth-ui/core"
+import { getAuthLinkURL, validateEmailAddress } from "@better-auth-ui/core"
 import {
   type EmailOtpAuthClient,
   sendVerificationOtpOptions,
@@ -6,7 +6,7 @@ import {
 } from "@better-auth-ui/core/plugins/email-otp"
 import { AuthLink, useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import { createMutation } from "@tanstack/solid-query"
-import { createSignal, Show } from "solid-js"
+import { Show } from "solid-js"
 import { toast } from "solid-sonner"
 
 import { OpenEmailButton } from "@/components/auth/open-email-button"
@@ -20,13 +20,7 @@ import {
   CardHeader,
   CardTitle
 } from "@/components/ui/card"
-import {
-  Field,
-  FieldError,
-  FieldGroup,
-  FieldLabel
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
+import { FieldGroup } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
 import { emailOtpPlugin } from "@/lib/auth/email-otp-plugin"
 import {
@@ -34,6 +28,7 @@ import {
   useResendCooldown
 } from "@/lib/auth/use-resend-cooldown"
 import { cn } from "@/lib/utils"
+import { createAuthForm, submitAuthForm } from "../auth-form"
 
 /** `sessionStorage` key the sign-up and sign-in flows store the pending address under. */
 export const VERIFY_EMAIL_STORAGE_KEY = "better-auth-ui.verify-email"
@@ -61,9 +56,6 @@ export function VerifyEmailOtp(props: VerifyEmailOtpProps) {
       ? ""
       : (sessionStorage.getItem(VERIFY_EMAIL_STORAGE_KEY) ?? "")
 
-  const [email, setEmail] = createSignal(storedEmail)
-  const [emailError, setEmailError] = createSignal<string>()
-  const [code, setCode] = createSignal("")
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown(
     storedEmail ? RESEND_COOLDOWN_SECONDS : 0
   )
@@ -75,7 +67,7 @@ export function VerifyEmailOtp(props: VerifyEmailOtpProps) {
     onSuccess: (_data, variables) => {
       const sentTo = (variables as { email: string }).email
       sessionStorage.setItem(VERIFY_EMAIL_STORAGE_KEY, sentTo)
-      setEmail(sentTo)
+      form.setFieldValue("email", sentTo)
       startCooldown()
       toast.success(emailOtpLocalization.codeSent)
     }
@@ -83,7 +75,7 @@ export function VerifyEmailOtp(props: VerifyEmailOtpProps) {
 
   const verifyEmail = createMutation(() => ({
     ...verifyEmailOtpOptions(otpClient()),
-    onError: () => setCode(""),
+    onError: () => form.setFieldValue("code", ""),
     onSuccess: () => {
       sessionStorage.removeItem(VERIFY_EMAIL_STORAGE_KEY)
       toast.success(emailOtpLocalization.emailVerified)
@@ -93,27 +85,28 @@ export function VerifyEmailOtp(props: VerifyEmailOtpProps) {
 
   const isPending = () => sendCode.isPending || verifyEmail.isPending
 
-  const verifyCode = (completedCode: string) => {
-    if (isPending() || !email()) return
-
-    verifyEmail.mutate({ email: email(), otp: completedCode } as Parameters<
-      typeof verifyEmail.mutate
-    >[0])
-  }
-
-  const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
-    event.preventDefault()
-
-    if (!email()) {
-      const formData = new FormData(event.currentTarget)
-      sendCode.mutate({
-        email: formData.get("email") as string,
-        type: "email-verification"
-      } as Parameters<typeof sendCode.mutate>[0])
-      return
+  const form = createAuthForm(() => ({
+    defaultValues: { code: "", email: storedEmail },
+    onSubmit: async ({ value }) => {
+      if (!storedEmail && !sessionStorage.getItem(VERIFY_EMAIL_STORAGE_KEY)) {
+        await sendCode.mutateAsync({
+          email: value.email,
+          type: "email-verification"
+        } as Parameters<typeof sendCode.mutateAsync>[0])
+        return
+      }
+      await verifyEmail.mutateAsync({
+        email: value.email,
+        otp: value.code
+      } as Parameters<typeof verifyEmail.mutateAsync>[0])
     }
-
-    verifyCode(code())
+  }))
+  const email = () => form.state.values.email
+  const code = () => form.state.values.code
+  const verifyCode = async (completedCode: string) => {
+    if (isPending() || !email()) return
+    form.setFieldValue("code", completedCode)
+    await submitAuthForm(form)
   }
 
   return (
@@ -131,95 +124,94 @@ export function VerifyEmailOtp(props: VerifyEmailOtpProps) {
       </CardHeader>
 
       <CardContent>
-        <form aria-label={auth.localization.auth.verifyEmail} onSubmit={submit}>
-          <FieldGroup>
-            <Show
-              when={email()}
-              fallback={
-                <Field data-invalid={Boolean(emailError())}>
-                  <FieldLabel for="verify-email-address">
-                    {auth.localization.auth.email}
-                  </FieldLabel>
-
-                  <Input
-                    aria-invalid={Boolean(emailError())}
-                    autocomplete="email"
-                    disabled={isPending()}
-                    id="verify-email-address"
+        <form.AppForm>
+          <form.AuthFormRoot aria-label={auth.localization.auth.verifyEmail}>
+            <FieldGroup>
+              <Show
+                when={email()}
+                fallback={
+                  <form.AppField
                     name="email"
-                    onInput={() => setEmailError(undefined)}
-                    onInvalid={(event) => {
-                      event.preventDefault()
-                      setEmailError(event.currentTarget.validationMessage)
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateEmailAddress(value, {
+                          invalidMessage: auth.localization.auth.invalidEmail,
+                          requiredMessage: auth.localization.auth.fieldRequired
+                        })
                     }}
-                    placeholder={auth.localization.auth.emailPlaceholder}
-                    required
-                    type="email"
-                  />
-
-                  <Show when={emailError()}>
-                    {(message) => <FieldError>{message()}</FieldError>}
-                  </Show>
-                </Field>
-              }
-            >
-              <OtpField
-                autofocus
-                disabled={isPending()}
-                id="verify-email-code"
-                label={emailOtpLocalization.code}
-                length={otpLength}
-                name="otp"
-                onInput={setCode}
-                onComplete={verifyCode}
-                value={code()}
-              />
-            </Show>
-
-            <div class="flex flex-col gap-3">
-              <Button
-                class="w-full"
-                disabled={
-                  isPending() ||
-                  (Boolean(email()) && code().length !== otpLength)
+                  >
+                    {(field) => (
+                      <field.AuthFormTextField
+                        autocomplete="email"
+                        disabled={isPending()}
+                        id="verify-email-address"
+                        label={auth.localization.auth.email}
+                        placeholder={auth.localization.auth.emailPlaceholder}
+                        type="email"
+                      />
+                    )}
+                  </form.AppField>
                 }
-                type="submit"
               >
-                <Show when={isPending()}>
-                  <Spinner />
-                </Show>
+                <OtpField
+                  autofocus
+                  disabled={isPending()}
+                  id="verify-email-code"
+                  label={emailOtpLocalization.code}
+                  length={otpLength}
+                  name="otp"
+                  onInput={(value) => form.setFieldValue("code", value)}
+                  onComplete={verifyCode}
+                  value={code()}
+                />
+              </Show>
 
-                {email()
-                  ? emailOtpLocalization.verifyCode
-                  : emailOtpLocalization.sendCode}
-              </Button>
-
-              <Show when={email()}>
-                <OpenEmailButton email={email()} variant="secondary" />
-
+              <div class="flex flex-col gap-3">
                 <Button
                   class="w-full"
-                  disabled={isPending() || isCoolingDown()}
-                  onClick={() =>
-                    sendCode.mutate({
-                      email: email(),
-                      type: "email-verification"
-                    } as Parameters<typeof sendCode.mutate>[0])
+                  disabled={
+                    isPending() ||
+                    (Boolean(email()) && code().length !== otpLength)
                   }
-                  type="button"
-                  variant="outline"
+                  type="submit"
                 >
-                  {isCoolingDown()
-                    ? auth.localization.auth.resendIn.replace(
-                        "{{seconds}}",
-                        String(cooldown())
-                      )
-                    : auth.localization.auth.resend}
+                  <Show when={isPending()}>
+                    <Spinner />
+                  </Show>
+
+                  {email()
+                    ? emailOtpLocalization.verifyCode
+                    : emailOtpLocalization.sendCode}
                 </Button>
-              </Show>
-            </div>
-          </FieldGroup>
-        </form>
+
+                <Show when={email()}>
+                  <OpenEmailButton email={email()} variant="secondary" />
+
+                  <Button
+                    class="w-full"
+                    disabled={isPending() || isCoolingDown()}
+                    onClick={() =>
+                      void sendCode.mutateAsync({
+                        email: email(),
+                        type: "email-verification"
+                      } as Parameters<typeof sendCode.mutateAsync>[0])
+                    }
+                    type="button"
+                    variant="outline"
+                  >
+                    {isCoolingDown()
+                      ? auth.localization.auth.resendIn.replace(
+                          "{{seconds}}",
+                          String(cooldown())
+                        )
+                      : auth.localization.auth.resend}
+                  </Button>
+                </Show>
+              </div>
+              <form.AuthFormServerError />
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
 
       <CardFooter class="justify-center">

--- a/examples/start-solid-zaidan-example/src/components/auth/forgot-password.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/forgot-password.tsx
@@ -1,4 +1,4 @@
-import { getViewURL } from "@better-auth-ui/core"
+import { getViewURL, validateEmailAddress } from "@better-auth-ui/core"
 import {
   AuthLink,
   type AuthPlugin,
@@ -6,14 +6,13 @@ import {
   useFetchOptions,
   useRequestPasswordReset
 } from "@better-auth-ui/solid"
-import { createSignal, Show } from "solid-js"
+import { Show } from "solid-js"
 import { RESET_LINK_SENT_STORAGE_KEY } from "@/components/auth/reset-link-sent"
-import { Alert, AlertDescription } from "@/components/ui/alert"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
+import { createAuthForm, isAuthFormFieldInvalid } from "./auth-form"
 
 export type ForgotPasswordProps = {
   class?: string
@@ -23,8 +22,6 @@ export type ForgotPasswordProps = {
 export function ForgotPassword(props: ForgotPasswordProps) {
   const auth = useAuth()
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
-  const [email, setEmail] = createSignal("")
-  const [emailError, setEmailError] = createSignal<string>()
   const requestReset = useRequestPasswordReset(auth.authClient, () => ({
     onError: () => {
       resetFetchOptions()
@@ -41,21 +38,22 @@ export function ForgotPassword(props: ForgotPasswordProps) {
     (auth.plugins as AuthPlugin[]).find((plugin) => plugin.captchaComponent)
       ?.captchaComponent
 
-  const submitPasswordReset = (event: SubmitEvent) => {
-    event.preventDefault()
-
-    requestReset.mutate({
-      email: email(),
-      fetchOptions: fetchOptions(),
-      redirectTo:
-        props.redirectTo ??
-        getViewURL(
-          auth.baseURL,
-          auth.basePaths.auth,
-          auth.viewPaths.auth.resetPassword
-        )
-    } as Parameters<typeof requestReset.mutate>[0])
-  }
+  const form = createAuthForm(() => ({
+    defaultValues: { email: "" },
+    onSubmit: async ({ value }) => {
+      await requestReset.mutateAsync({
+        email: value.email,
+        fetchOptions: fetchOptions(),
+        redirectTo:
+          props.redirectTo ??
+          getViewURL(
+            auth.baseURL,
+            auth.basePaths.auth,
+            auth.viewPaths.auth.resetPassword
+          )
+      } as Parameters<typeof requestReset.mutateAsync>[0])
+    }
+  }))
 
   return (
     <Card class={cn("w-full max-w-sm", props.class)}>
@@ -66,51 +64,54 @@ export function ForgotPassword(props: ForgotPasswordProps) {
       </CardHeader>
 
       <CardContent>
-        <form aria-label="Forgot password" onSubmit={submitPasswordReset}>
-          <div class="flex flex-col gap-6">
-            <Field data-invalid={Boolean(emailError())}>
-              <FieldLabel for="forgot-password-email">
-                {auth.localization.auth.email}
-              </FieldLabel>
-              <Input
-                aria-invalid={Boolean(emailError())}
-                id="forgot-password-email"
+        <form.AppForm>
+          <form.AuthFormRoot aria-label="Forgot password">
+            <div class="flex flex-col gap-6">
+              <form.AppField
                 name="email"
-                onInput={(event) => {
-                  setEmail(event.currentTarget.value)
-                  setEmailError(undefined)
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: auth.localization.auth.invalidEmail,
+                      requiredMessage: auth.localization.auth.fieldRequired
+                    })
                 }}
-                onInvalid={(event) => {
-                  event.preventDefault()
-                  setEmailError(event.currentTarget.validationMessage)
-                }}
-                placeholder={auth.localization.auth.emailPlaceholder}
-                required
-                type="email"
-                value={email()}
-              />
-
-              <Show when={emailError()}>
-                {(message) => <FieldError>{message()}</FieldError>}
+              >
+                {(field) => (
+                  <Field
+                    data-invalid={isAuthFormFieldInvalid(field().state.meta)}
+                  >
+                    <FieldLabel for="forgot-password-email">
+                      {auth.localization.auth.email}
+                    </FieldLabel>
+                    <Input
+                      aria-invalid={isAuthFormFieldInvalid(field().state.meta)}
+                      id="forgot-password-email"
+                      name={field().name}
+                      onBlur={field().handleBlur}
+                      onInput={(event) =>
+                        field().handleChange(event.currentTarget.value)
+                      }
+                      placeholder={auth.localization.auth.emailPlaceholder}
+                      type="email"
+                      value={field().state.value}
+                    />
+                    <field.AuthFormFieldError />
+                  </Field>
+                )}
+              </form.AppField>
+              <Show when={captchaComponent()} keyed>
+                {(Captcha) => <Captcha />}
               </Show>
-            </Field>
-            <Show when={captchaComponent()} keyed>
-              {(Captcha) => <Captcha />}
-            </Show>
-            <Button disabled={requestReset.isPending} type="submit">
-              {requestReset.isPending
-                ? `${auth.localization.auth.sendResetLink}…`
-                : auth.localization.auth.sendResetLink}
-            </Button>
-            <Show when={requestReset.isError}>
-              <Alert variant="destructive">
-                <AlertDescription>
-                  Unable to send a reset link. Try again.
-                </AlertDescription>
-              </Alert>
-            </Show>
-          </div>
-        </form>
+              <form.AuthFormSubmitButton disabled={requestReset.isPending}>
+                {requestReset.isPending
+                  ? `${auth.localization.auth.sendResetLink}…`
+                  : auth.localization.auth.sendResetLink}
+              </form.AuthFormSubmitButton>
+              <form.AuthFormServerError />
+            </div>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <div class="mt-4 flex w-full flex-col items-center gap-3">
           <p class="text-center text-sm text-muted-foreground">

--- a/examples/start-solid-zaidan-example/src/components/auth/magic-link.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/magic-link.tsx
@@ -1,3 +1,4 @@
+import { validateEmailAddress } from "@better-auth-ui/core"
 import type { MagicLinkAuthClient } from "@better-auth-ui/core/plugins/magic-link"
 import {
   magicLinkPlugin as coreMagicLinkPlugin,
@@ -6,22 +7,17 @@ import {
 } from "@better-auth-ui/core/plugins/magic-link"
 import { AuthLink, type AuthPlugin, useAuth } from "@better-auth-ui/solid"
 import { useSignInMagicLink } from "@better-auth-ui/solid/plugins/magic-link"
-import { type Component, createSignal, For, Show } from "solid-js"
+import { type Component, For, Show } from "solid-js"
 import { MAGIC_LINK_SENT_STORAGE_KEY } from "@/components/auth/magic-link-sent"
 import {
   ProviderButtons,
   type SocialLayout
 } from "@/components/auth/provider-buttons"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import {
-  Field,
-  FieldError,
-  FieldGroup,
-  FieldLabel
-} from "@/components/ui/field"
+import { Field, FieldGroup, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
+import { createAuthForm, isAuthFormFieldInvalid } from "./auth-form"
 
 export type MagicLinkProps = {
   class?: string
@@ -37,8 +33,6 @@ type AuthPluginWithButtons = AuthPlugin & {
 
 export function MagicLink(props: MagicLinkProps) {
   const auth = useAuth<MagicLinkAuthClient>()
-  const [email, setEmail] = createSignal("")
-  const [emailError, setEmailError] = createSignal<string>()
   const magicLinkPluginConfig = () =>
     auth.plugins.find((plugin) => plugin.id === coreMagicLinkPlugin.id)
   const magicLinkLabels = (): MagicLinkLocalization => ({
@@ -60,15 +54,15 @@ export function MagicLink(props: MagicLinkProps) {
   const showSeparator = () => Boolean(auth.socialProviders?.length)
   const socialPosition = () => props.socialPosition ?? "bottom"
 
-  const submitMagicLink = (
-    event: SubmitEvent & { currentTarget: HTMLFormElement }
-  ) => {
-    event.preventDefault()
-    signInMagicLink.mutate({
-      callbackURL: `${auth.baseURL}${auth.redirectTo}`,
-      email: email()
-    } as Parameters<typeof signInMagicLink.mutate>[0])
-  }
+  const form = createAuthForm(() => ({
+    defaultValues: { email: "" },
+    onSubmit: async ({ value }) => {
+      await signInMagicLink.mutateAsync({
+        callbackURL: `${auth.baseURL}${auth.redirectTo}`,
+        email: value.email
+      } as Parameters<typeof signInMagicLink.mutateAsync>[0])
+    }
+  }))
 
   return (
     <Card class={cn("w-full max-w-sm", props.class)}>
@@ -89,53 +83,68 @@ export function MagicLink(props: MagicLinkProps) {
               </div>
             </Show>
           </Show>
-          <form aria-label="Magic link" onSubmit={submitMagicLink}>
-            <FieldGroup>
-              <Field data-invalid={Boolean(emailError())}>
-                <FieldLabel for="magic-link-email">
-                  {auth.localization.auth.email}
-                </FieldLabel>
-                <Input
-                  aria-invalid={Boolean(emailError())}
-                  autocomplete="email"
-                  disabled={signInMagicLink.isPending}
-                  id="magic-link-email"
+          <form.AppForm>
+            <form.AuthFormRoot aria-label="Magic link">
+              <FieldGroup>
+                <form.AppField
                   name="email"
-                  onInput={(event) => {
-                    setEmail(event.currentTarget.value)
-                    setEmailError(undefined)
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateEmailAddress(value, {
+                        invalidMessage: auth.localization.auth.invalidEmail,
+                        requiredMessage: auth.localization.auth.fieldRequired
+                      })
                   }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    setEmailError(event.currentTarget.validationMessage)
-                  }}
-                  placeholder={auth.localization.auth.emailPlaceholder}
-                  required
-                  type="email"
-                  value={email()}
-                />
-                <Show when={emailError()}>
-                  {(message) => <FieldError>{message()}</FieldError>}
-                </Show>
-              </Field>
-              <div class="flex flex-col gap-3">
-                <Button disabled={signInMagicLink.isPending} type="submit">
-                  {magicLinkLabels().sendMagicLink}
-                </Button>
-
-                <For
-                  each={(auth.plugins as AuthPluginWithButtons[]).flatMap(
-                    (plugin) =>
-                      (plugin.authButtons ?? []).map((AuthButton) => ({
-                        AuthButton
-                      }))
-                  )}
                 >
-                  {({ AuthButton }) => <AuthButton view="magicLink" />}
-                </For>
-              </div>
-            </FieldGroup>
-          </form>
+                  {(field) => (
+                    <Field
+                      data-invalid={isAuthFormFieldInvalid(field().state.meta)}
+                    >
+                      <FieldLabel for="magic-link-email">
+                        {auth.localization.auth.email}
+                      </FieldLabel>
+                      <Input
+                        aria-invalid={isAuthFormFieldInvalid(
+                          field().state.meta
+                        )}
+                        autocomplete="email"
+                        disabled={signInMagicLink.isPending}
+                        id="magic-link-email"
+                        name={field().name}
+                        onBlur={field().handleBlur}
+                        onInput={(event) =>
+                          field().handleChange(event.currentTarget.value)
+                        }
+                        placeholder={auth.localization.auth.emailPlaceholder}
+                        type="email"
+                        value={field().state.value}
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+                <div class="flex flex-col gap-3">
+                  <form.AuthFormSubmitButton
+                    disabled={signInMagicLink.isPending}
+                  >
+                    {magicLinkLabels().sendMagicLink}
+                  </form.AuthFormSubmitButton>
+
+                  <For
+                    each={(auth.plugins as AuthPluginWithButtons[]).flatMap(
+                      (plugin) =>
+                        (plugin.authButtons ?? []).map((AuthButton) => ({
+                          AuthButton
+                        }))
+                    )}
+                  >
+                    {({ AuthButton }) => <AuthButton view="magicLink" />}
+                  </For>
+                </div>
+              </FieldGroup>
+              <form.AuthFormServerError />
+            </form.AuthFormRoot>
+          </form.AppForm>
           <Show
             when={socialPosition() === "bottom" && auth.socialProviders?.length}
           >

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/delete-organization-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/delete-organization-dialog.tsx
@@ -18,9 +18,9 @@ import {
   AlertDialogMedia,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
+import { createAuthForm } from "../auth-form"
 import { OrganizationLogo } from "./organization-logo"
 
 export type DeleteOrganizationDialogProps = {
@@ -50,62 +50,68 @@ export function DeleteOrganizationDialog(props: DeleteOrganizationDialogProps) {
     }
   }))
 
-  const handleSubmit = (event: SubmitEvent) => {
-    event.preventDefault()
-
-    deleteOrganization.mutate({
-      organizationId: props.organization.id
-    } satisfies DeleteOrganizationParams)
-  }
+  const form = createAuthForm(() => ({
+    defaultValues: {},
+    onSubmit: async () => {
+      await deleteOrganization.mutateAsync({
+        organizationId: props.organization.id
+      } satisfies DeleteOrganizationParams)
+    }
+  }))
 
   return (
     <AlertDialog open={props.open} onOpenChange={props.onOpenChange}>
       <AlertDialogContent>
-        <form class="flex flex-col gap-6" onSubmit={handleSubmit}>
-          <AlertDialogHeader>
-            <AlertDialogMedia>
-              <TriangleAlert />
-            </AlertDialogMedia>
-            <AlertDialogTitle>
-              {props.localization.deleteOrganization}
-            </AlertDialogTitle>
-            <AlertDialogDescription>
-              {props.localization.deleteOrganizationDescription}
-            </AlertDialogDescription>
-          </AlertDialogHeader>
+        <form.AppForm>
+          <form.AuthFormRoot class="flex flex-col gap-6">
+            <AlertDialogHeader>
+              <AlertDialogMedia>
+                <TriangleAlert />
+              </AlertDialogMedia>
+              <AlertDialogTitle>
+                {props.localization.deleteOrganization}
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                {props.localization.deleteOrganizationDescription}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
 
-          <Card>
-            <CardContent>
-              <div class="flex items-center gap-3">
-                <OrganizationLogo organization={props.organization} size="sm" />
-                <div class="grid min-w-0 gap-1">
-                  <span class="truncate text-sm font-medium">
-                    {props.organization.name}
-                  </span>
-                  <span class="truncate text-muted-foreground text-xs">
-                    {props.organization.slug}
-                  </span>
+            <Card>
+              <CardContent>
+                <div class="flex items-center gap-3">
+                  <OrganizationLogo
+                    organization={props.organization}
+                    size="sm"
+                  />
+                  <div class="grid min-w-0 gap-1">
+                    <span class="truncate text-sm font-medium">
+                      {props.organization.name}
+                    </span>
+                    <span class="truncate text-muted-foreground text-xs">
+                      {props.organization.slug}
+                    </span>
+                  </div>
                 </div>
-              </div>
-            </CardContent>
-          </Card>
+              </CardContent>
+            </Card>
 
-          <AlertDialogFooter>
-            <AlertDialogCancel
-              disabled={deleteOrganization.isPending}
-              type="button"
-            >
-              {auth.localization.settings.cancel}
-            </AlertDialogCancel>
-            <Button
-              disabled={deleteOrganization.isPending}
-              type="submit"
-              variant="destructive"
-            >
-              {props.localization.deleteOrganization}
-            </Button>
-          </AlertDialogFooter>
-        </form>
+            <AlertDialogFooter>
+              <AlertDialogCancel
+                disabled={deleteOrganization.isPending}
+                type="button"
+              >
+                {auth.localization.settings.cancel}
+              </AlertDialogCancel>
+              <form.AuthFormSubmitButton
+                disabled={deleteOrganization.isPending}
+                variant="destructive"
+              >
+                {props.localization.deleteOrganization}
+              </form.AuthFormSubmitButton>
+            </AlertDialogFooter>
+            <form.AuthFormServerError />
+          </form.AuthFormRoot>
+        </form.AppForm>
       </AlertDialogContent>
     </AlertDialog>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-table-renderer.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-table-renderer.tsx
@@ -1,0 +1,74 @@
+import type { AppSolidTable, RowData } from "@tanstack/solid-table"
+import { For, type JSX, Show } from "solid-js"
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow
+} from "@/components/ui/table"
+import type { organizationTableFeatures } from "./organization-table"
+
+type OrganizationTableInstance<TData extends RowData> = AppSolidTable<
+  typeof organizationTableFeatures,
+  TData,
+  Record<string, never>,
+  Record<string, never>,
+  Record<string, never>
+>
+
+export function OrganizationTableRenderer<TData extends RowData>(props: {
+  empty: JSX.Element
+  table: OrganizationTableInstance<TData>
+}) {
+  return (
+    <Table>
+      <TableHeader>
+        <For each={props.table.getHeaderGroups()}>
+          {(headerGroup) => (
+            <TableRow>
+              <For each={headerGroup.headers}>
+                {(header) => (
+                  <TableHead colspan={header.colSpan}>
+                    <Show when={!header.isPlaceholder}>
+                      <props.table.FlexRender header={header} />
+                    </Show>
+                  </TableHead>
+                )}
+              </For>
+            </TableRow>
+          )}
+        </For>
+      </TableHeader>
+      <TableBody>
+        <Show
+          fallback={
+            <TableRow>
+              <TableCell colspan={props.table.getVisibleLeafColumns().length}>
+                {props.empty}
+              </TableCell>
+            </TableRow>
+          }
+          when={props.table.getRowModel().rows.length}
+        >
+          <For each={props.table.getRowModel().rows}>
+            {(row) => (
+              <TableRow
+                data-state={row.getIsSelected() ? "selected" : undefined}
+              >
+                <For each={row.getVisibleCells()}>
+                  {(cell) => (
+                    <TableCell>
+                      <props.table.FlexRender cell={cell} />
+                    </TableCell>
+                  )}
+                </For>
+              </TableRow>
+            )}
+          </For>
+        </Show>
+      </TableBody>
+    </Table>
+  )
+}

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-table-state.ts
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-table-state.ts
@@ -1,8 +1,10 @@
 import {
+  createBrowserTablePersistenceAdapters,
   parseTableColumnVisibility,
   parseTableUrlState,
   serializeTableColumnVisibility,
-  serializeTableUrlState
+  serializeTableUrlState,
+  type TablePersistenceAdapters
 } from "@better-auth-ui/core"
 import { createAtom, useSelector } from "@tanstack/solid-store"
 import {
@@ -20,12 +22,13 @@ import { ORGANIZATION_TABLE_PAGE_SIZE } from "./organization-table"
 const STORAGE_PREFIX = "better-auth-ui:organization-table"
 
 function readUrl(
+  adapters: TablePersistenceAdapters,
   stateKey: string,
   defaultPageSize: number,
   allowedColumnIds?: readonly string[]
 ) {
   return parseTableUrlState(
-    new URLSearchParams(window.location.search),
+    adapters.search.read(),
     stateKey,
     defaultPageSize,
     ORGANIZATION_TABLE_PAGE_SIZE_OPTIONS,
@@ -36,8 +39,11 @@ function readUrl(
 export function createOrganizationTableState(
   stateKey: string,
   defaultPageSize = ORGANIZATION_TABLE_PAGE_SIZE,
-  allowedColumnIds?: readonly string[]
+  allowedColumnIds?: readonly string[],
+  persistenceAdapters?: TablePersistenceAdapters
 ) {
+  const adapters =
+    persistenceAdapters ?? createBrowserTablePersistenceAdapters()
   const columnFiltersAtom = createAtom<ColumnFiltersState>([])
   const columnVisibilityAtom = createAtom<ColumnVisibilityState>({})
   const globalFilterAtom = createAtom("")
@@ -54,6 +60,7 @@ export function createOrganizationTableState(
   const rowSelection = useSelector(rowSelectionAtom)
   const sorting = useSelector(sortingAtom)
   const [ready, setReady] = createSignal(false)
+  let restoringUrlState = false
   const atoms = {
     columnFilters: columnFiltersAtom,
     globalFilter: globalFilterAtom,
@@ -80,6 +87,7 @@ export function createOrganizationTableState(
 
   onMount(() => {
     const resetPage = () => {
+      if (restoringUrlState) return
       const current = paginationAtom.get()
       if (current.pageIndex === 0) rowSelectionAtom.set({})
       else paginationAtom.set({ ...current, pageIndex: 0 })
@@ -92,9 +100,8 @@ export function createOrganizationTableState(
     ]
 
     try {
-      const saved = window.localStorage.getItem(
-        `${STORAGE_PREFIX}:${stateKey}:columns`
-      )
+      const saved =
+        adapters.storage?.read(`${STORAGE_PREFIX}:${stateKey}:columns`) ?? null
       columnVisibilityAtom.set(
         parseTableColumnVisibility(saved, allowedColumnIds)
       )
@@ -102,17 +109,24 @@ export function createOrganizationTableState(
       // Storage is optional.
     }
     const restore = () => {
-      const next = readUrl(stateKey, defaultPageSize, allowedColumnIds)
+      restoringUrlState = true
+      const next = readUrl(
+        adapters,
+        stateKey,
+        defaultPageSize,
+        allowedColumnIds
+      )
       columnFiltersAtom.set(next.columnFilters)
       globalFilterAtom.set(next.globalFilter)
       sortingAtom.set(next.sorting)
       paginationAtom.set(next.pagination)
+      restoringUrlState = false
       setReady(true)
     }
     restore()
-    window.addEventListener("popstate", restore)
+    const unsubscribe = adapters.search.subscribe(restore)
     onCleanup(() => {
-      window.removeEventListener("popstate", restore)
+      unsubscribe()
       for (const subscription of subscriptions) subscription.unsubscribe()
     })
   })
@@ -121,7 +135,7 @@ export function createOrganizationTableState(
     const visibility = columnVisibility()
     if (!ready()) return
     try {
-      window.localStorage.setItem(
+      adapters.storage?.write(
         `${STORAGE_PREFIX}:${stateKey}:columns`,
         serializeTableColumnVisibility(visibility)
       )
@@ -138,14 +152,14 @@ export function createOrganizationTableState(
       sorting: sorting()
     }
     if (!ready()) return
-    const url = new URL(window.location.href)
-    url.search = serializeTableUrlState(
-      url.searchParams,
-      stateKey,
-      defaultPageSize,
-      state
-    ).toString()
-    window.history.replaceState(window.history.state, "", url)
+    adapters.search.replace(
+      serializeTableUrlState(
+        adapters.search.read(),
+        stateKey,
+        defaultPageSize,
+        state
+      )
+    )
   })
 
   return {

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-table-state.ts
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-table-state.ts
@@ -22,13 +22,13 @@ import { ORGANIZATION_TABLE_PAGE_SIZE } from "./organization-table"
 const STORAGE_PREFIX = "better-auth-ui:organization-table"
 
 function readUrl(
-  adapters: TablePersistenceAdapters,
+  search: URLSearchParams,
   stateKey: string,
   defaultPageSize: number,
   allowedColumnIds?: readonly string[]
 ) {
   return parseTableUrlState(
-    adapters.search.read(),
+    search,
     stateKey,
     defaultPageSize,
     ORGANIZATION_TABLE_PAGE_SIZE_OPTIONS,
@@ -61,6 +61,7 @@ export function createOrganizationTableState(
   const sorting = useSelector(sortingAtom)
   const [ready, setReady] = createSignal(false)
   let restoringUrlState = false
+  let syncedSearch = ""
   const atoms = {
     columnFilters: columnFiltersAtom,
     globalFilter: globalFilterAtom,
@@ -110,12 +111,9 @@ export function createOrganizationTableState(
     }
     const restore = () => {
       restoringUrlState = true
-      const next = readUrl(
-        adapters,
-        stateKey,
-        defaultPageSize,
-        allowedColumnIds
-      )
+      const search = adapters.search.read()
+      syncedSearch = search.toString()
+      const next = readUrl(search, stateKey, defaultPageSize, allowedColumnIds)
       columnFiltersAtom.set(next.columnFilters)
       globalFilterAtom.set(next.globalFilter)
       sortingAtom.set(next.sorting)
@@ -152,14 +150,17 @@ export function createOrganizationTableState(
       sorting: sorting()
     }
     if (!ready()) return
-    adapters.search.replace(
-      serializeTableUrlState(
-        adapters.search.read(),
-        stateKey,
-        defaultPageSize,
-        state
-      )
+    const next = serializeTableUrlState(
+      adapters.search.read(),
+      stateKey,
+      defaultPageSize,
+      state
     )
+    const nextSearch = next.toString()
+    if (nextSearch === syncedSearch) return
+
+    syncedSearch = nextSearch
+    adapters.search.replace(next)
   })
 
   return {

--- a/examples/start-solid-zaidan-example/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -17,10 +17,11 @@ import {
   DialogHeader,
   DialogTitle
 } from "@/components/ui/dialog"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { passkeyPlugin } from "@/lib/auth/passkey-plugin"
+import { createAuthForm } from "../auth-form"
 import { FreshSessionPrompt } from "../settings/security/fresh-session-prompt"
 
 export function AddPasskeyDialog(props: {
@@ -42,7 +43,9 @@ export function AddPasskeyDialog(props: {
     props.onOpenChange(open)
   }
 
-  const submitRequest = (request: AddPasskeyParams<PasskeyAuthClient>) => {
+  const submitRequest = async (
+    request: AddPasskeyParams<PasskeyAuthClient>
+  ) => {
     const requestWithCallbacks = {
       ...request,
       fetchOptions: {
@@ -54,20 +57,19 @@ export function AddPasskeyDialog(props: {
       }
     }
     setPendingRequest(requestWithCallbacks)
-    addPasskey.mutate(requestWithCallbacks)
+    await addPasskey.mutateAsync(requestWithCallbacks)
   }
 
-  const submitAddPasskey = (event: SubmitEvent) => {
-    event.preventDefault()
-
-    const formData = new FormData(event.currentTarget as HTMLFormElement)
-    const name = String(formData.get("name") ?? "").trim()
-
-    submitRequest({
-      ...(name ? { name } : {}),
-      ...(authenticatorAttachment ? { authenticatorAttachment } : {})
-    } as Parameters<typeof addPasskey.mutate>[0])
-  }
+  const form = createAuthForm(() => ({
+    defaultValues: { name: "" },
+    onSubmit: async ({ value }) => {
+      const name = value.name.trim()
+      await submitRequest({
+        ...(name ? { name } : {}),
+        ...(authenticatorAttachment ? { authenticatorAttachment } : {})
+      } as Parameters<typeof addPasskey.mutateAsync>[0])
+    }
+  }))
 
   return (
     <DialogContent>
@@ -83,57 +85,62 @@ export function AddPasskeyDialog(props: {
             <FreshSessionPrompt
               onFresh={() => {
                 const request = pendingRequest()
-                if (request) submitRequest(request)
+                if (request) return submitRequest(request)
               }}
             />
           </>
         }
       >
-        <form class="flex flex-col gap-6" onSubmit={submitAddPasskey}>
-          <DialogHeader>
-            <div class="flex size-10 items-center justify-center rounded-md bg-muted">
-              <Fingerprint class="size-4.5" />
-            </div>
-            <DialogTitle>{labels().addPasskey}</DialogTitle>
-            <DialogDescription>
-              {labels().passkeysDescription}
-            </DialogDescription>
-          </DialogHeader>
+        <form.AppForm>
+          <form.AuthFormRoot class="flex flex-col gap-6">
+            <DialogHeader>
+              <div class="flex size-10 items-center justify-center rounded-md bg-muted">
+                <Fingerprint class="size-4.5" />
+              </div>
+              <DialogTitle>{labels().addPasskey}</DialogTitle>
+              <DialogDescription>
+                {labels().passkeysDescription}
+              </DialogDescription>
+            </DialogHeader>
 
-          <Field data-invalid={addPasskey.isError}>
-            <FieldLabel for="passkey-name">{labels().name}</FieldLabel>
-            <Input
-              autofocus
-              disabled={addPasskey.isPending}
-              id="passkey-name"
-              name="name"
-              placeholder={auth.localization.settings.optional}
-            />
-            <Show when={addPasskey.error}>
-              {(error) => (
-                <FieldError>
-                  {error().error?.message ?? error().message}
-                </FieldError>
+            <form.AppField name="name">
+              {(field) => (
+                <Field>
+                  <FieldLabel for="passkey-name">{labels().name}</FieldLabel>
+                  <Input
+                    autofocus
+                    disabled={addPasskey.isPending}
+                    id="passkey-name"
+                    name={field().name}
+                    placeholder={auth.localization.settings.optional}
+                    value={field().state.value}
+                    onBlur={field().handleBlur}
+                    onInput={(event) =>
+                      field().handleChange(event.currentTarget.value)
+                    }
+                  />
+                </Field>
               )}
-            </Show>
-          </Field>
+            </form.AppField>
+            <form.AuthFormServerError />
 
-          <DialogFooter>
-            <DialogClose
-              as={Button}
-              disabled={addPasskey.isPending}
-              onClick={() => handleOpenChange(false)}
-              type="button"
-              variant="outline"
-            >
-              {auth.localization.settings.cancel}
-            </DialogClose>
-            <Button disabled={addPasskey.isPending} type="submit">
-              {addPasskey.isPending ? <Spinner /> : null}
-              {labels().addPasskey}
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter>
+              <DialogClose
+                as={Button}
+                disabled={addPasskey.isPending}
+                onClick={() => handleOpenChange(false)}
+                type="button"
+                variant="outline"
+              >
+                {auth.localization.settings.cancel}
+              </DialogClose>
+              <form.AuthFormSubmitButton disabled={addPasskey.isPending}>
+                {addPasskey.isPending ? <Spinner /> : null}
+                {labels().addPasskey}
+              </form.AuthFormSubmitButton>
+            </DialogFooter>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </Show>
     </DialogContent>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/passkey/rename-passkey-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/passkey/rename-passkey-dialog.tsx
@@ -1,7 +1,8 @@
+import { validateStringLength } from "@better-auth-ui/core"
 import type { PasskeyAuthClient } from "@better-auth-ui/core/plugins/passkey"
 import { useAuth } from "@better-auth-ui/solid"
 import { useUpdatePasskey } from "@better-auth-ui/solid/plugins/passkey"
-import { createEffect, createSignal } from "solid-js"
+import { createEffect } from "solid-js"
 import { passkeyLabels } from "@/components/auth/passkey/passkey-localization"
 import type { ListedPasskey } from "@/components/auth/settings/shared/types"
 import { Button } from "@/components/ui/button"
@@ -15,6 +16,7 @@ import {
 import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
+import { createAuthForm } from "../auth-form"
 
 export function RenamePasskeyDialog(props: {
   open: boolean
@@ -23,51 +25,70 @@ export function RenamePasskeyDialog(props: {
 }) {
   const auth = useAuth<PasskeyAuthClient>()
   const labels = () => passkeyLabels(auth)
-  const [name, setName] = createSignal(props.passkey.name ?? "")
-  createEffect(() => {
-    if (props.open) setName(props.passkey.name ?? "")
-  })
-
   const updatePasskey = useUpdatePasskey(auth.authClient, () => ({
     onSuccess: () => props.onOpenChange(false)
   }))
-  const submit = (event: SubmitEvent) => {
-    event.preventDefault()
-    const nextName = name().trim()
-    if (nextName) updatePasskey.mutate({ id: props.passkey.id, name: nextName })
-  }
+  const form = createAuthForm(() => ({
+    defaultValues: { name: props.passkey.name ?? "" },
+    onSubmit: async ({ value }) => {
+      await updatePasskey.mutateAsync({
+        id: props.passkey.id,
+        name: value.name.trim()
+      })
+    }
+  }))
+  createEffect(() => {
+    if (props.open) form.setFieldValue("name", props.passkey.name ?? "")
+  })
 
   return (
     <DialogContent>
-      <form class="flex flex-col gap-6" onSubmit={submit}>
-        <DialogHeader>
-          <DialogTitle>{labels().renamePasskey}</DialogTitle>
-        </DialogHeader>
-        <Field>
-          <FieldLabel for={`passkey-name-${props.passkey.id}`}>
-            {labels().name}
-          </FieldLabel>
-          <Input
-            id={`passkey-name-${props.passkey.id}`}
-            autofocus
-            value={name()}
-            onInput={(event) => setName(event.currentTarget.value)}
-            required
-          />
-        </Field>
-        <DialogFooter>
-          <DialogClose as={Button} type="button" variant="outline">
-            {auth.localization.settings.cancel}
-          </DialogClose>
-          <Button
-            disabled={!name().trim() || updatePasskey.isPending}
-            type="submit"
+      <form.AppForm>
+        <form.AuthFormRoot class="flex flex-col gap-6">
+          <DialogHeader>
+            <DialogTitle>{labels().renamePasskey}</DialogTitle>
+          </DialogHeader>
+          <form.AppField
+            name="name"
+            validators={{
+              onChange: ({ value }) =>
+                validateStringLength(value, {
+                  requiredMessage: auth.localization.auth.fieldRequired,
+                  trim: true
+                })
+            }}
           >
-            {updatePasskey.isPending ? <Spinner /> : null}
-            {auth.localization.settings.saveChanges}
-          </Button>
-        </DialogFooter>
-      </form>
+            {(field) => (
+              <Field>
+                <FieldLabel for={`passkey-name-${props.passkey.id}`}>
+                  {labels().name}
+                </FieldLabel>
+                <Input
+                  id={`passkey-name-${props.passkey.id}`}
+                  autofocus
+                  name={field().name}
+                  value={field().state.value}
+                  onBlur={field().handleBlur}
+                  onInput={(event) =>
+                    field().handleChange(event.currentTarget.value)
+                  }
+                />
+                <field.AuthFormFieldError />
+              </Field>
+            )}
+          </form.AppField>
+          <DialogFooter>
+            <DialogClose as={Button} type="button" variant="outline">
+              {auth.localization.settings.cancel}
+            </DialogClose>
+            <form.AuthFormSubmitButton disabled={updatePasskey.isPending}>
+              {updatePasskey.isPending ? <Spinner /> : null}
+              {auth.localization.settings.saveChanges}
+            </form.AuthFormSubmitButton>
+          </DialogFooter>
+          <form.AuthFormServerError />
+        </form.AuthFormRoot>
+      </form.AppForm>
     </DialogContent>
   )
 }

--- a/examples/start-solid-zaidan-example/src/components/auth/phone-number/change-phone-number.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/phone-number/change-phone-number.tsx
@@ -20,9 +20,9 @@ import { InternationalPhoneField } from "@/components/auth/phone-number/internat
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
-import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { createAuthForm, isAuthFormFieldInvalid } from "../auth-form"
 import { RemovePhoneNumberDialog } from "./remove-phone-number-dialog"
 
 type PhoneNumberUser = {
@@ -48,18 +48,14 @@ export function ChangePhoneNumber(props: ChangePhoneNumberProps = {}) {
   const session = useSession(phoneClient())
   const currentPhoneNumber = () =>
     (session.data?.user as PhoneNumberUser | undefined)?.phoneNumber ?? ""
-  const [phoneNumber, setPhoneNumber] = createSignal(
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [fieldError, setFieldError] = createSignal<string>()
-  const [code, setCode] = createSignal("")
   const [codeSent, setCodeSent] = createSignal(false)
 
   let initialized = false
   createEffect(() => {
     if (!session.data || initialized) return
     initialized = true
-    setPhoneNumber(
+    form.setFieldValue(
+      "phoneNumber",
       createPhoneNumberValue(currentPhoneNumber(), defaultCountry, adapter)
     )
   })
@@ -68,39 +64,45 @@ export function ChangePhoneNumber(props: ChangePhoneNumberProps = {}) {
     onSuccess: () => setCodeSent(true)
   }))
   const verify = useVerifyPhoneNumber(phoneClient(), () => ({
-    onError: () => setCode(""),
+    onError: () => form.setFieldValue("code", ""),
     onSuccess: () => {
-      setCode("")
+      form.setFieldValue("code", "")
       setCodeSent(false)
       toast.success(localization.phoneNumberUpdated)
     }
   }))
   const remove = useUpdateUser(phoneClient(), () => ({
     onSuccess: () => {
-      setPhoneNumber(createPhoneNumberValue("", defaultCountry, adapter))
+      form.setFieldValue(
+        "phoneNumber",
+        createPhoneNumberValue("", defaultCountry, adapter)
+      )
       toast.success(localization.phoneNumberRemoved)
     }
   }))
   const isPending = () =>
     sendOtp.isPending || verify.isPending || remove.isPending
-  const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
-    event.preventDefault()
-    if (!phoneNumber().e164) {
-      setFieldError(localization.invalidPhoneNumber)
-      return
+  const form = createAuthForm(() => ({
+    defaultValues: {
+      code: "",
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter)
+    },
+    onSubmit: async ({ value }) => {
+      if (!codeSent()) {
+        await sendOtp.mutateAsync({
+          phoneNumber: value.phoneNumber.e164
+        } as Parameters<typeof sendOtp.mutateAsync>[0])
+        return
+      }
+      await verify.mutateAsync({
+        phoneNumber: value.phoneNumber.e164,
+        code: value.code,
+        updatePhoneNumber: true
+      } as Parameters<typeof verify.mutateAsync>[0])
     }
-    if (!codeSent()) {
-      sendOtp.mutate({ phoneNumber: phoneNumber().e164 } as Parameters<
-        typeof sendOtp.mutate
-      >[0])
-      return
-    }
-    verify.mutate({
-      phoneNumber: phoneNumber().e164,
-      code: code(),
-      updatePhoneNumber: true
-    } as Parameters<typeof verify.mutate>[0])
-  }
+  }))
+  const phoneNumber = () => form.state.values.phoneNumber
+  const code = () => form.state.values.code
   const removePhoneNumber = () =>
     remove.mutate({
       phoneNumber: null
@@ -111,105 +113,133 @@ export function ChangePhoneNumber(props: ChangePhoneNumberProps = {}) {
       <h2 class="mb-3 text-sm font-semibold">
         {localization.changePhoneNumber}
       </h2>
-      <form onSubmit={submit}>
-        <Card>
-          <CardContent class="flex flex-col gap-6">
-            <Show
-              when={codeSent()}
-              fallback={
-                <Show
-                  when={session.data}
-                  fallback={<Skeleton class="h-14 w-full" />}
-                >
-                  <InternationalPhoneField
-                    adapter={adapter}
-                    countryCodes={countries}
-                    countryLabel={localization.country}
-                    disabled={isPending()}
-                    error={fieldError()}
-                    locale={locale}
-                    phoneLabel={localization.phoneNumber}
-                    placeholder={localization.phoneNumberPlaceholder}
-                    value={phoneNumber()}
-                    onChange={(value) => {
-                      setPhoneNumber(value)
-                      setFieldError(undefined)
-                    }}
-                  />
-                </Show>
-              }
-            >
-              <div class="flex flex-col gap-3">
-                <p class="text-sm text-muted-foreground">
-                  {localization.codeSentTo.replace(
-                    "{{phoneNumber}}",
-                    phoneNumber().display
-                  )}
-                </p>
-                <OtpField
-                  autofocus
-                  disabled={isPending()}
-                  id="settings-phone-code"
-                  label={localization.phoneCode}
-                  length={otpLength}
-                  name="otp"
-                  onInput={setCode}
-                  value={code()}
-                />
-              </div>
-            </Show>
-          </CardContent>
-          <CardFooter class="gap-3">
-            <Show when={codeSent()}>
-              <Button
-                disabled={isPending()}
-                onClick={() => {
-                  setCode("")
-                  setCodeSent(false)
-                  setPhoneNumber(
-                    createPhoneNumberValue(
-                      currentPhoneNumber(),
-                      defaultCountry,
-                      adapter
-                    )
-                  )
-                }}
-                size="sm"
-                type="button"
-                variant="outline"
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card>
+            <CardContent class="flex flex-col gap-6">
+              <Show
+                when={codeSent()}
+                fallback={
+                  <Show
+                    when={session.data}
+                    fallback={<Skeleton class="h-14 w-full" />}
+                  >
+                    <form.AppField
+                      name="phoneNumber"
+                      validators={{
+                        onChange: ({ value }) =>
+                          value.e164
+                            ? undefined
+                            : localization.invalidPhoneNumber
+                      }}
+                    >
+                      {(field) => (
+                        <InternationalPhoneField
+                          adapter={adapter}
+                          countryCodes={countries}
+                          countryLabel={localization.country}
+                          disabled={isPending()}
+                          error={
+                            isAuthFormFieldInvalid(field().state.meta)
+                              ? field().state.meta.errors[0]?.toString()
+                              : undefined
+                          }
+                          locale={locale}
+                          onChange={field().handleChange}
+                          phoneLabel={localization.phoneNumber}
+                          placeholder={localization.phoneNumberPlaceholder}
+                          value={field().state.value}
+                        />
+                      )}
+                    </form.AppField>
+                  </Show>
+                }
               >
-                {localization.cancel}
-              </Button>
-            </Show>
-            <Button
-              disabled={
-                isPending() ||
-                !session.data ||
-                (codeSent() && code().length !== otpLength)
-              }
-              size="sm"
-              type="submit"
-            >
-              <Show when={sendOtp.isPending || verify.isPending}>
-                <Spinner />
+                <div class="flex flex-col gap-3">
+                  <p class="text-sm text-muted-foreground">
+                    {localization.codeSentTo.replace(
+                      "{{phoneNumber}}",
+                      phoneNumber().display
+                    )}
+                  </p>
+                  <form.AppField
+                    name="code"
+                    validators={{
+                      onChange: ({ value }) =>
+                        value.length === otpLength
+                          ? undefined
+                          : localization.codeLengthMismatch.replace(
+                              "{{length}}",
+                              String(otpLength)
+                            )
+                    }}
+                  >
+                    {(field) => (
+                      <OtpField
+                        autofocus
+                        disabled={isPending()}
+                        id="settings-phone-code"
+                        label={localization.phoneCode}
+                        length={otpLength}
+                        name={field().name}
+                        onInput={field().handleChange}
+                        value={field().state.value}
+                      />
+                    )}
+                  </form.AppField>
+                </div>
               </Show>
-              {codeSent()
-                ? localization.verifyCode
-                : localization.updatePhoneNumber}
-            </Button>
-            <Show when={!codeSent() && currentPhoneNumber()}>
-              <RemovePhoneNumberDialog
-                cancelLabel={localization.cancel}
-                description={localization.removePhoneNumberDescription}
-                isPending={remove.isPending}
-                label={localization.removePhoneNumber}
-                title={localization.removePhoneNumberTitle}
-                onConfirm={removePhoneNumber}
-              />
-            </Show>
-          </CardFooter>
-        </Card>
-      </form>
+            </CardContent>
+            <CardFooter class="gap-3">
+              <Show when={codeSent()}>
+                <Button
+                  disabled={isPending()}
+                  onClick={() => {
+                    form.setFieldValue("code", "")
+                    setCodeSent(false)
+                    form.setFieldValue(
+                      "phoneNumber",
+                      createPhoneNumberValue(
+                        currentPhoneNumber(),
+                        defaultCountry,
+                        adapter
+                      )
+                    )
+                  }}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  {localization.cancel}
+                </Button>
+              </Show>
+              <form.AuthFormSubmitButton
+                disabled={
+                  isPending() ||
+                  !session.data ||
+                  (codeSent() && code().length !== otpLength)
+                }
+                size="sm"
+              >
+                {codeSent()
+                  ? localization.verifyCode
+                  : localization.updatePhoneNumber}
+              </form.AuthFormSubmitButton>
+              <Show when={!codeSent() && currentPhoneNumber()}>
+                <RemovePhoneNumberDialog
+                  cancelLabel={localization.cancel}
+                  description={localization.removePhoneNumberDescription}
+                  isPending={remove.isPending}
+                  label={localization.removePhoneNumber}
+                  title={localization.removePhoneNumberTitle}
+                  onConfirm={removePhoneNumber}
+                />
+              </Show>
+              <form.AuthFormServerError />
+            </CardFooter>
+          </Card>
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/examples/start-solid-zaidan-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -9,9 +9,8 @@ import {
   useFetchOptions
 } from "@better-auth-ui/solid"
 import { useRequestPhoneNumberPasswordReset } from "@better-auth-ui/solid/plugins/phone-number"
-import { createSignal, Show } from "solid-js"
+import { Show } from "solid-js"
 
-import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -23,6 +22,7 @@ import { FieldGroup } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { createAuthForm } from "../auth-form"
 import { InternationalPhoneField } from "./international-phone-field"
 
 export const PHONE_NUMBER_RESET_STORAGE_KEY =
@@ -46,10 +46,6 @@ export function ForgotPhoneNumberPassword(
     viewPaths: phoneNumberViewPaths
   } = useAuthPlugin(phoneNumberPlugin)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
-  const [phoneNumber, setPhoneNumber] = createSignal(
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [fieldError, setFieldError] = createSignal<string>()
   const requestReset = useRequestPhoneNumberPasswordReset(
     auth.authClient as PhoneNumberAuthClient,
     () => ({
@@ -63,17 +59,18 @@ export function ForgotPhoneNumberPassword(
       }
     })
   )
-  const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
-    event.preventDefault()
-    if (!phoneNumber().e164) {
-      setFieldError(localization.invalidPhoneNumber)
-      return
+  const form = createAuthForm(() => ({
+    defaultValues: {
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter)
+    },
+    onSubmit: async ({ value }) => {
+      if (!value.phoneNumber.e164) return
+      await requestReset.mutateAsync({
+        phoneNumber: value.phoneNumber.e164,
+        fetchOptions: fetchOptions()
+      } as Parameters<typeof requestReset.mutateAsync>[0])
     }
-    requestReset.mutate({
-      phoneNumber: phoneNumber().e164,
-      fetchOptions: fetchOptions()
-    } as Parameters<typeof requestReset.mutate>[0])
-  }
+  }))
 
   return (
     <Card class={cn("w-full max-w-sm", props.class)}>
@@ -83,35 +80,44 @@ export function ForgotPhoneNumberPassword(
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <form aria-label={localization.forgotPassword} onSubmit={submit}>
-          <FieldGroup>
-            <InternationalPhoneField
-              adapter={adapter}
-              countryCodes={countries}
-              countryLabel={localization.country}
-              disabled={requestReset.isPending}
-              error={fieldError()}
-              locale={locale}
-              phoneLabel={localization.phoneNumber}
-              placeholder={localization.phoneNumberPlaceholder}
-              value={phoneNumber()}
-              onChange={(value) => {
-                setPhoneNumber(value)
-                setFieldError(undefined)
-              }}
-            />
-            <Button
-              class="w-full"
-              disabled={requestReset.isPending}
-              type="submit"
-            >
-              <Show when={requestReset.isPending}>
-                <Spinner />
-              </Show>
-              {localization.sendCode}
-            </Button>
-          </FieldGroup>
-        </form>
+        <form.AppForm>
+          <form.AuthFormRoot aria-label={localization.forgotPassword}>
+            <FieldGroup>
+              <form.AppField
+                name="phoneNumber"
+                validators={{
+                  onChange: ({ value }) =>
+                    value.e164 ? undefined : localization.invalidPhoneNumber
+                }}
+              >
+                {(field) => (
+                  <InternationalPhoneField
+                    adapter={adapter}
+                    countryCodes={countries}
+                    countryLabel={localization.country}
+                    disabled={requestReset.isPending}
+                    error={field().state.meta.errors[0]?.toString()}
+                    locale={locale}
+                    phoneLabel={localization.phoneNumber}
+                    placeholder={localization.phoneNumberPlaceholder}
+                    value={field().state.value}
+                    onChange={field().handleChange}
+                  />
+                )}
+              </form.AppField>
+              <form.AuthFormSubmitButton
+                class="w-full"
+                disabled={requestReset.isPending}
+              >
+                <Show when={requestReset.isPending}>
+                  <Spinner />
+                </Show>
+                {localization.sendCode}
+              </form.AuthFormSubmitButton>
+              <form.AuthFormServerError />
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
       <CardFooter class="justify-center">
         <p class="text-sm text-muted-foreground">

--- a/examples/start-solid-zaidan-example/src/components/auth/phone-number/phone-number.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/phone-number/phone-number.tsx
@@ -1,3 +1,4 @@
+import { validateStringLength } from "@better-auth-ui/core"
 import {
   createPhoneNumberValue,
   type PhoneNumberAuthClient
@@ -33,18 +34,18 @@ import {
   CardTitle
 } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
-import {
-  Field,
-  FieldError,
-  FieldGroup,
-  FieldLabel
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
+import { FieldGroup } from "@/components/ui/field"
 import { Spinner } from "@/components/ui/spinner"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { useResendCooldown } from "@/lib/auth/use-resend-cooldown"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import {
+  createAuthForm,
+  isAuthFormFieldInvalid,
+  setAuthFormServerError,
+  submitAuthForm
+} from "../auth-form"
 
 type PhoneNumberMode = "code" | "password"
 
@@ -80,13 +81,6 @@ export function PhoneNumber(props: PhoneNumberProps) {
   const [mode, setMode] = createSignal<PhoneNumberMode>(
     signIn ? "code" : "password"
   )
-  const [phoneNumber, setPhoneNumber] = createSignal(
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [phoneError, setPhoneError] = createSignal<string>()
-  const [password, setPassword] = createSignal("")
-  const [passwordError, setPasswordError] = createSignal<string>()
-  const [code, setCode] = createSignal("")
   const [codeSent, setCodeSent] = createSignal(false)
   const sendOtp = useSendPhoneNumberOtp(phoneClient(), () => ({
     onError: () => resetFetchOptions(),
@@ -96,12 +90,12 @@ export function PhoneNumber(props: PhoneNumberProps) {
     }
   }))
   const verify = useVerifyPhoneNumber(phoneClient(), () => ({
-    onError: () => setCode(""),
+    onError: () => form.setFieldValue("code", ""),
     onSuccess: (data) => continueSignIn(data)
   }))
   const signInWithPassword = useSignInPhoneNumber(phoneClient(), () => ({
     onError: (error) => {
-      setPassword("")
+      form.setFieldValue("password", "")
       resetFetchOptions()
       if (
         signIn &&
@@ -116,54 +110,61 @@ export function PhoneNumber(props: PhoneNumberProps) {
   }))
   const isPending = () =>
     sendOtp.isPending || verify.isPending || signInWithPassword.isPending
-  const normalizedPhoneNumber = () => {
-    const value = phoneNumber().e164
-    if (value) return value
-    setPhoneError(localization.invalidPhoneNumber)
+  const form = createAuthForm(() => ({
+    defaultValues: {
+      code: "",
+      password: "",
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter),
+      rememberMe: false
+    },
+    onSubmit: async ({ value }) => {
+      if (mode() === "password") {
+        await signInWithPassword.mutateAsync({
+          phoneNumber: value.phoneNumber.e164,
+          password: value.password,
+          ...(auth.emailAndPassword?.rememberMe
+            ? { rememberMe: value.rememberMe }
+            : {}),
+          fetchOptions: fetchOptions()
+        } as Parameters<typeof signInWithPassword.mutateAsync>[0])
+        return
+      }
+      if (!codeSent()) {
+        await sendOtp.mutateAsync({
+          phoneNumber: value.phoneNumber.e164,
+          fetchOptions: fetchOptions()
+        } as Parameters<typeof sendOtp.mutateAsync>[0])
+        return
+      }
+      await verify.mutateAsync({
+        phoneNumber: value.phoneNumber.e164,
+        code: value.code
+      } as Parameters<typeof verify.mutateAsync>[0])
+    }
+  }))
+  const phoneNumber = () => form.state.values.phoneNumber
+  const code = () => form.state.values.code
+  const requestCode = async () => {
+    try {
+      await sendOtp.mutateAsync({
+        phoneNumber: phoneNumber().e164,
+        fetchOptions: fetchOptions()
+      } as Parameters<typeof sendOtp.mutateAsync>[0])
+    } catch (error) {
+      setAuthFormServerError(form, error, "Unable to send a code. Try again.")
+    }
   }
-  const requestCode = () => {
-    const value = normalizedPhoneNumber()
-    if (!value) return
-    sendOtp.mutate({
-      phoneNumber: value,
-      fetchOptions: fetchOptions()
-    } as Parameters<typeof sendOtp.mutate>[0])
-  }
-  const verifyCode = (completedCode: string) => {
+  const verifyCode = async (completedCode: string) => {
     if (isPending() || completedCode.length !== otpLength) return
     if (!phoneNumber().e164) return
-    verify.mutate({
-      phoneNumber: phoneNumber().e164,
-      code: completedCode
-    } as Parameters<typeof verify.mutate>[0])
-  }
-  const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
-    event.preventDefault()
-    if (mode() === "password") {
-      const value = normalizedPhoneNumber()
-      if (!value) return
-      const formData = new FormData(event.currentTarget)
-      signInWithPassword.mutate({
-        phoneNumber: value,
-        password: password(),
-        ...(auth.emailAndPassword?.rememberMe
-          ? { rememberMe: formData.get("rememberMe") === "on" }
-          : {}),
-        fetchOptions: fetchOptions()
-      } as Parameters<typeof signInWithPassword.mutate>[0])
-      return
-    }
-    if (!codeSent()) {
-      requestCode()
-      return
-    }
-    verifyCode(code())
+    form.setFieldValue("code", completedCode)
+    await submitAuthForm(form)
   }
   const switchMode = () => {
     setMode((current) => (current === "code" ? "password" : "code"))
-    setCode("")
+    form.setFieldValue("code", "")
     setCodeSent(false)
-    setPassword("")
+    form.setFieldValue("password", "")
   }
   const socialPosition = () => props.socialPosition ?? "bottom"
   const authButtons = () =>
@@ -204,147 +205,179 @@ export function PhoneNumber(props: PhoneNumberProps) {
               {auth.localization.auth.or}
             </div>
           </Show>
-          <form aria-label={auth.localization.auth.signIn} onSubmit={submit}>
-            <FieldGroup>
-              <Show
-                when={codeSent()}
-                fallback={
-                  <>
-                    <InternationalPhoneField
-                      adapter={adapter}
-                      countryCodes={countries}
-                      countryLabel={localization.country}
-                      disabled={isPending()}
-                      error={phoneError()}
-                      locale={locale}
-                      phoneLabel={localization.phoneNumber}
-                      placeholder={localization.phoneNumberPlaceholder}
-                      value={phoneNumber()}
-                      onChange={(value) => {
-                        setPhoneNumber(value)
-                        setPhoneError(undefined)
-                      }}
-                    />
-                    <Show when={mode() === "password"}>
-                      <Field data-invalid={Boolean(passwordError())}>
-                        <FieldLabel for="phone-password">
-                          {auth.localization.auth.password}
-                        </FieldLabel>
-                        <Input
-                          aria-invalid={Boolean(passwordError())}
-                          autocomplete="current-password"
-                          disabled={isPending()}
-                          id="phone-password"
+          <form.AppForm>
+            <form.AuthFormRoot aria-label={auth.localization.auth.signIn}>
+              <FieldGroup>
+                <Show
+                  when={codeSent()}
+                  fallback={
+                    <>
+                      <form.AppField
+                        name="phoneNumber"
+                        validators={{
+                          onChange: ({ value }) =>
+                            value.e164
+                              ? undefined
+                              : localization.invalidPhoneNumber
+                        }}
+                      >
+                        {(field) => (
+                          <InternationalPhoneField
+                            adapter={adapter}
+                            countryCodes={countries}
+                            countryLabel={localization.country}
+                            disabled={isPending()}
+                            error={
+                              isAuthFormFieldInvalid(field().state.meta)
+                                ? field().state.meta.errors[0]?.toString()
+                                : undefined
+                            }
+                            locale={locale}
+                            onChange={field().handleChange}
+                            phoneLabel={localization.phoneNumber}
+                            placeholder={localization.phoneNumberPlaceholder}
+                            value={field().state.value}
+                          />
+                        )}
+                      </form.AppField>
+                      <Show when={mode() === "password"}>
+                        <form.AppField
                           name="password"
-                          onInput={(event) => {
-                            setPassword(event.currentTarget.value)
-                            setPasswordError(undefined)
+                          validators={{
+                            onChange: ({ value }) =>
+                              validateStringLength(value, {
+                                requiredMessage:
+                                  auth.localization.auth.fieldRequired
+                              })
                           }}
-                          onInvalid={(event) => {
-                            event.preventDefault()
-                            setPasswordError(
-                              event.currentTarget.validationMessage
-                            )
-                          }}
-                          placeholder={
-                            auth.localization.auth.passwordPlaceholder
-                          }
-                          required
-                          type="password"
-                          value={password()}
-                        />
-                        <Show when={passwordError()}>
-                          {(message) => <FieldError>{message()}</FieldError>}
+                        >
+                          {(field) => (
+                            <field.AuthFormTextField
+                              autocomplete="current-password"
+                              disabled={isPending()}
+                              id="phone-password"
+                              label={auth.localization.auth.password}
+                              placeholder={
+                                auth.localization.auth.passwordPlaceholder
+                              }
+                              type="password"
+                            />
+                          )}
+                        </form.AppField>
+                        <Show when={auth.emailAndPassword?.rememberMe}>
+                          <form.AppField name="rememberMe">
+                            {(field) => (
+                              <Checkbox
+                                checked={field().state.value}
+                                disabled={isPending()}
+                                name={field().name}
+                                onChange={field().handleChange}
+                              >
+                                {auth.localization.auth.rememberMe}
+                              </Checkbox>
+                            )}
+                          </form.AppField>
                         </Show>
-                      </Field>
-                      <Show when={auth.emailAndPassword?.rememberMe}>
-                        <Checkbox disabled={isPending()} name="rememberMe">
-                          {auth.localization.auth.rememberMe}
-                        </Checkbox>
                       </Show>
-                    </Show>
-                  </>
-                }
-              >
-                <OtpField
-                  autofocus
-                  disabled={isPending()}
-                  id="phone-code"
-                  label={localization.phoneCode}
-                  length={otpLength}
-                  name="otp"
-                  onInput={setCode}
-                  onComplete={verifyCode}
-                  value={code()}
-                />
-              </Show>
-              <Show when={captchaComponent()} keyed>
-                {(Captcha) => <Captcha />}
-              </Show>
-              <Button
-                class="w-full"
-                disabled={
-                  isPending() || (codeSent() && code().length !== otpLength)
-                }
-                type="submit"
-              >
-                <Show when={isPending()}>
-                  <Spinner />
+                    </>
+                  }
+                >
+                  <form.AppField
+                    name="code"
+                    validators={{
+                      onChange: ({ value }) =>
+                        value.length === otpLength
+                          ? undefined
+                          : localization.codeLengthMismatch.replace(
+                              "{{length}}",
+                              String(otpLength)
+                            )
+                    }}
+                  >
+                    {(field) => (
+                      <OtpField
+                        autofocus
+                        disabled={isPending()}
+                        id="phone-code"
+                        label={localization.phoneCode}
+                        length={otpLength}
+                        name={field().name}
+                        onInput={field().handleChange}
+                        onComplete={(value) => void verifyCode(value)}
+                        value={field().state.value}
+                      />
+                    )}
+                  </form.AppField>
                 </Show>
-                {mode() === "password"
-                  ? auth.localization.auth.signIn
-                  : codeSent()
-                    ? localization.verifyCode
-                    : localization.sendCode}
-              </Button>
-              <Show when={codeSent()}>
+                <Show when={captchaComponent()} keyed>
+                  {(Captcha) => <Captcha />}
+                </Show>
                 <Button
                   class="w-full"
-                  disabled={isPending() || isCoolingDown()}
-                  onClick={requestCode}
-                  type="button"
-                  variant="outline"
+                  disabled={
+                    isPending() || (codeSent() && code().length !== otpLength)
+                  }
+                  type="submit"
                 >
-                  {isCoolingDown()
-                    ? auth.localization.auth.resendIn.replace(
-                        "{{seconds}}",
-                        String(cooldown())
-                      )
-                    : auth.localization.auth.resend}
+                  <Show when={isPending()}>
+                    <Spinner />
+                  </Show>
+                  {mode() === "password"
+                    ? auth.localization.auth.signIn
+                    : codeSent()
+                      ? localization.verifyCode
+                      : localization.sendCode}
                 </Button>
-                <Button
-                  class="w-full"
-                  disabled={isPending()}
-                  onClick={() => {
-                    setCode("")
-                    setCodeSent(false)
-                  }}
-                  type="button"
-                  variant="ghost"
-                >
-                  {localization.useDifferentPhoneNumber}
-                </Button>
-              </Show>
-              <Show when={!codeSent() && signIn && passwordSignIn}>
-                <Button
-                  class="w-full"
-                  disabled={isPending()}
-                  onClick={switchMode}
-                  type="button"
-                  variant="outline"
-                >
-                  {mode() === "code"
-                    ? localization.usePassword
-                    : localization.useVerificationCode}
-                </Button>
-              </Show>
-              <Show when={!codeSent()}>
-                <For each={authButtons()}>
-                  {(AuthButton) => <AuthButton view="phoneNumber" />}
-                </For>
-              </Show>
-            </FieldGroup>
-          </form>
+                <Show when={codeSent()}>
+                  <Button
+                    class="w-full"
+                    disabled={isPending() || isCoolingDown()}
+                    onClick={() => void requestCode()}
+                    type="button"
+                    variant="outline"
+                  >
+                    {isCoolingDown()
+                      ? auth.localization.auth.resendIn.replace(
+                          "{{seconds}}",
+                          String(cooldown())
+                        )
+                      : auth.localization.auth.resend}
+                  </Button>
+                  <Button
+                    class="w-full"
+                    disabled={isPending()}
+                    onClick={() => {
+                      form.setFieldValue("code", "")
+                      setCodeSent(false)
+                    }}
+                    type="button"
+                    variant="ghost"
+                  >
+                    {localization.useDifferentPhoneNumber}
+                  </Button>
+                </Show>
+                <Show when={!codeSent() && signIn && passwordSignIn}>
+                  <Button
+                    class="w-full"
+                    disabled={isPending()}
+                    onClick={switchMode}
+                    type="button"
+                    variant="outline"
+                  >
+                    {mode() === "code"
+                      ? localization.usePassword
+                      : localization.useVerificationCode}
+                  </Button>
+                </Show>
+                <Show when={!codeSent()}>
+                  <For each={authButtons()}>
+                    {(AuthButton) => <AuthButton view="phoneNumber" />}
+                  </For>
+                </Show>
+                <form.AuthFormServerError />
+              </FieldGroup>
+            </form.AuthFormRoot>
+          </form.AppForm>
           <Show
             when={
               socialPosition() === "bottom" &&

--- a/examples/start-solid-zaidan-example/src/components/auth/phone-number/reset-phone-number-password.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/phone-number/reset-phone-number-password.tsx
@@ -1,12 +1,14 @@
-import { isPasswordCompromisedError } from "@better-auth-ui/core"
+import {
+  isPasswordCompromisedError,
+  validateStringLength
+} from "@better-auth-ui/core"
 import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import { useResetPhoneNumberPassword } from "@better-auth-ui/solid/plugins/phone-number"
-import { createSignal, Show } from "solid-js"
+import { Show } from "solid-js"
 import { toast } from "solid-sonner"
 
 import { OtpField } from "@/components/auth/otp-field"
-import { Button } from "@/components/ui/button"
 import {
   Card,
   CardContent,
@@ -14,16 +16,10 @@ import {
   CardHeader,
   CardTitle
 } from "@/components/ui/card"
-import {
-  Field,
-  FieldError,
-  FieldGroup,
-  FieldLabel
-} from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
-import { Spinner } from "@/components/ui/spinner"
+import { FieldGroup } from "@/components/ui/field"
 import { phoneNumberPlugin } from "@/lib/auth/phone-number-plugin"
 import { cn } from "@/lib/utils"
+import { createAuthForm, setAuthFormServerError } from "../auth-form"
 import { PasswordStrengthMeter } from "../password-strength-meter"
 import { PHONE_NUMBER_RESET_STORAGE_KEY } from "./forgot-phone-number-password"
 
@@ -43,10 +39,6 @@ export function ResetPhoneNumberPassword(props: ResetPhoneNumberPasswordProps) {
     typeof sessionStorage === "undefined"
       ? ""
       : (sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY) ?? "")
-  const [phoneNumber, setPhoneNumber] = createSignal(storedPhoneNumber)
-  const [code, setCode] = createSignal("")
-  const [password, setPassword] = createSignal("")
-  const [passwordError, setPasswordError] = createSignal<string>()
   const resetPassword = useResetPhoneNumberPassword(
     auth.authClient as PhoneNumberAuthClient,
     () => ({
@@ -54,10 +46,16 @@ export function ResetPhoneNumberPassword(props: ResetPhoneNumberPasswordProps) {
         // The haveIBeenPwned plugin rejects on the password itself, so it
         // belongs against the field rather than in a toast.
         if (isPasswordCompromisedError(error)) {
-          setPasswordError(auth.localization.auth.passwordCompromised)
+          setAuthFormServerError(
+            form,
+            {
+              fields: { password: auth.localization.auth.passwordCompromised }
+            },
+            auth.localization.auth.passwordCompromised
+          )
         }
 
-        setCode("")
+        form.setFieldValue("code", "")
       },
       onSuccess: () => {
         sessionStorage.removeItem(PHONE_NUMBER_RESET_STORAGE_KEY)
@@ -68,32 +66,37 @@ export function ResetPhoneNumberPassword(props: ResetPhoneNumberPasswordProps) {
       }
     })
   )
-  const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    const password = String(formData.get("password") ?? "")
-    const confirmPassword = String(formData.get("confirmPassword") ?? "")
-
-    if (
-      auth.emailAndPassword?.confirmPassword &&
-      password !== confirmPassword
-    ) {
-      toast.error(auth.localization.auth.passwordsDoNotMatch)
-      return
+  const validatePassword = (value: string) =>
+    validateStringLength(value, {
+      maxLength: auth.emailAndPassword?.maxPasswordLength,
+      maxLengthMessage: auth.localization.auth.tooLong.replace(
+        "{{max}}",
+        String(auth.emailAndPassword?.maxPasswordLength)
+      ),
+      minLength: auth.emailAndPassword?.minPasswordLength,
+      minLengthMessage: auth.localization.auth.tooShort.replace(
+        "{{min}}",
+        String(auth.emailAndPassword?.minPasswordLength)
+      ),
+      requiredMessage: auth.localization.auth.fieldRequired
+    })
+  const form = createAuthForm(() => ({
+    defaultValues: {
+      code: "",
+      confirmPassword: "",
+      password: "",
+      phoneNumber: storedPhoneNumber
+    },
+    onSubmit: async ({ value }) => {
+      await resetPassword.mutateAsync({
+        phoneNumber: value.phoneNumber,
+        otp: value.code,
+        newPassword: value.password
+      } as Parameters<typeof resetPassword.mutateAsync>[0])
     }
-    if (code().length !== otpLength) {
-      toast.error(
-        localization.codeLengthMismatch.replace("{{length}}", String(otpLength))
-      )
-      return
-    }
-    resetPassword.mutate({
-      phoneNumber: phoneNumber(),
-      otp: code(),
-      newPassword: password
-    } as Parameters<typeof resetPassword.mutate>[0])
-  }
-
+  }))
+  const phoneNumber = () => form.state.values.phoneNumber
+  const password = () => form.state.values.password
   return (
     <Card class={cn("w-full max-w-sm", props.class)}>
       <CardHeader>
@@ -107,98 +110,113 @@ export function ResetPhoneNumberPassword(props: ResetPhoneNumberPasswordProps) {
         </Show>
       </CardHeader>
       <CardContent>
-        <form aria-label={localization.resetPassword} onSubmit={submit}>
-          <FieldGroup>
-            <Show when={!storedPhoneNumber}>
-              <Field>
-                <FieldLabel for="reset-phone-number">
-                  {localization.phoneNumber}
-                </FieldLabel>
-                <Input
-                  autocomplete="tel"
-                  disabled={resetPassword.isPending}
-                  id="reset-phone-number"
-                  inputmode="tel"
+        <form.AppForm>
+          <form.AuthFormRoot aria-label={localization.resetPassword}>
+            <FieldGroup>
+              <Show when={!storedPhoneNumber}>
+                <form.AppField
                   name="phoneNumber"
-                  onInput={(event) => setPhoneNumber(event.currentTarget.value)}
-                  placeholder={localization.phoneNumberPlaceholder}
-                  required
-                  type="tel"
-                  value={phoneNumber()}
-                />
-              </Field>
-            </Show>
-            <OtpField
-              autofocus={Boolean(storedPhoneNumber)}
-              disabled={resetPassword.isPending}
-              id="reset-phone-code"
-              label={localization.phoneCode}
-              length={otpLength}
-              name="otp"
-              onInput={setCode}
-              value={code()}
-            />
-            <Field data-invalid={Boolean(passwordError())}>
-              <FieldLabel for="reset-phone-password">
-                {auth.localization.auth.newPassword}
-              </FieldLabel>
-              <Input
-                aria-invalid={Boolean(passwordError())}
-                autocomplete="new-password"
-                disabled={resetPassword.isPending}
-                id="reset-phone-password"
-                maxLength={auth.emailAndPassword?.maxPasswordLength}
-                minLength={auth.emailAndPassword?.minPasswordLength}
+                  validators={{
+                    onChange: ({ value }) =>
+                      value.trim()
+                        ? undefined
+                        : auth.localization.auth.fieldRequired
+                  }}
+                >
+                  {(field) => (
+                    <field.AuthFormTextField
+                      autocomplete="tel"
+                      disabled={resetPassword.isPending}
+                      id="reset-phone-number"
+                      inputmode="tel"
+                      label={localization.phoneNumber}
+                      placeholder={localization.phoneNumberPlaceholder}
+                      type="tel"
+                    />
+                  )}
+                </form.AppField>
+              </Show>
+              <form.AppField
+                name="code"
+                validators={{
+                  onChange: ({ value }) =>
+                    value.length === otpLength
+                      ? undefined
+                      : localization.codeLengthMismatch.replace(
+                          "{{length}}",
+                          String(otpLength)
+                        )
+                }}
+              >
+                {(field) => (
+                  <OtpField
+                    autofocus={Boolean(storedPhoneNumber)}
+                    disabled={resetPassword.isPending}
+                    id="reset-phone-code"
+                    label={localization.phoneCode}
+                    length={otpLength}
+                    name={field().name}
+                    onInput={field().handleChange}
+                    value={field().state.value}
+                  />
+                )}
+              </form.AppField>
+              <form.AppField
                 name="password"
-                onInput={(event) => {
-                  setPassword(event.currentTarget.value)
-                  setPasswordError(undefined)
+                validators={{
+                  onChange: ({ value }) => validatePassword(value)
                 }}
-                onInvalid={(event) => {
-                  event.preventDefault()
-                  setPasswordError(event.currentTarget.validationMessage)
-                }}
-                placeholder={auth.localization.auth.newPasswordPlaceholder}
-                required
-                type="password"
-              />
-
-              <Show when={passwordError()}>
-                {(message) => <FieldError>{message()}</FieldError>}
-              </Show>
-
-              <PasswordStrengthMeter password={password()} />
-            </Field>
-            <Show when={auth.emailAndPassword?.confirmPassword}>
-              <Field>
-                <FieldLabel for="reset-phone-confirm-password">
-                  {auth.localization.auth.confirmPassword}
-                </FieldLabel>
-                <Input
-                  autocomplete="new-password"
-                  disabled={resetPassword.isPending}
-                  id="reset-phone-confirm-password"
+              >
+                {(field) => (
+                  <>
+                    <field.AuthFormTextField
+                      autocomplete="new-password"
+                      disabled={resetPassword.isPending}
+                      id="reset-phone-password"
+                      label={auth.localization.auth.newPassword}
+                      placeholder={
+                        auth.localization.auth.newPasswordPlaceholder
+                      }
+                      type="password"
+                    />
+                    <PasswordStrengthMeter password={password()} />
+                  </>
+                )}
+              </form.AppField>
+              <Show when={auth.emailAndPassword?.confirmPassword}>
+                <form.AppField
                   name="confirmPassword"
-                  placeholder={
-                    auth.localization.auth.confirmPasswordPlaceholder
-                  }
-                  required
-                  type="password"
-                />
-              </Field>
-            </Show>
-            <Button
-              class="w-full"
-              disabled={resetPassword.isPending || code().length !== otpLength}
-              type="submit"
-            >
-              <Show when={resetPassword.isPending}>
-                <Spinner />
+                  validators={{
+                    onChange: ({ value }) =>
+                      value === password()
+                        ? undefined
+                        : auth.localization.auth.passwordsDoNotMatch
+                  }}
+                >
+                  {(field) => (
+                    <field.AuthFormTextField
+                      autocomplete="new-password"
+                      disabled={resetPassword.isPending}
+                      id="reset-phone-confirm-password"
+                      label={auth.localization.auth.confirmPassword}
+                      placeholder={
+                        auth.localization.auth.confirmPasswordPlaceholder
+                      }
+                      type="password"
+                    />
+                  )}
+                </form.AppField>
               </Show>
-              {localization.resetPassword}
-            </Button>
-          </FieldGroup>
-        </form>
+              <form.AuthFormSubmitButton
+                class="w-full"
+                disabled={resetPassword.isPending}
+              >
+                {localization.resetPassword}
+              </form.AuthFormSubmitButton>
+              <form.AuthFormServerError />
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
     </Card>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/settings/account/change-email.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/settings/account/change-email.tsx
@@ -1,12 +1,11 @@
-import { getViewURL } from "@better-auth-ui/core"
+import { getViewURL, validateEmailAddress } from "@better-auth-ui/core"
 import { useAuth, useChangeEmail, useSession } from "@better-auth-ui/solid"
-import { createSignal, Show } from "solid-js"
 import { toast } from "solid-sonner"
-import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardFooter } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
+import { createAuthForm, isAuthFormFieldInvalid } from "../../auth-form"
 
 export type ChangeEmailProps = {
   class?: string
@@ -15,71 +14,82 @@ export type ChangeEmailProps = {
 export function ChangeEmail(props: ChangeEmailProps = {}) {
   const auth = useAuth()
   const session = useSession(auth.authClient)
-  const [emailFieldError, setEmailFieldError] = createSignal<string>()
   const changeEmail = useChangeEmail(auth.authClient, () => ({
     onSuccess: () =>
       toast.success(auth.localization.settings.changeEmailSuccess)
   }))
 
-  const submitChangeEmail = (event: SubmitEvent) => {
-    event.preventDefault()
-
-    const formData = new FormData(event.currentTarget as HTMLFormElement)
-
-    changeEmail.mutate({
-      callbackURL: getViewURL(
-        auth.baseURL,
-        auth.basePaths.settings,
-        auth.viewPaths.settings.account
-      ),
-      newEmail: String(formData.get("email") ?? "")
-    } as Parameters<typeof changeEmail.mutate>[0])
-  }
+  const form = createAuthForm(() => ({
+    defaultValues: { email: session.data?.user.email ?? "" },
+    onSubmit: async ({ value }) => {
+      await changeEmail.mutateAsync({
+        callbackURL: getViewURL(
+          auth.baseURL,
+          auth.basePaths.settings,
+          auth.viewPaths.settings.account
+        ),
+        newEmail: value.email
+      } as Parameters<typeof changeEmail.mutateAsync>[0])
+    }
+  }))
 
   return (
     <div class={cn(props.class)}>
       <h2 class="mb-3 text-sm font-semibold">
         {auth.localization.settings.changeEmail}
       </h2>
-      <form onSubmit={submitChangeEmail}>
-        <Card>
-          <CardContent class="flex flex-col gap-6">
-            <Field data-invalid={Boolean(emailFieldError())}>
-              <FieldLabel for="settings-email">
-                {auth.localization.auth.email}
-              </FieldLabel>
-              <Input
-                aria-invalid={!!emailFieldError()}
-                autocomplete="email"
-                disabled={changeEmail.isPending || !session.data}
-                id="settings-email"
+      <form.AppForm>
+        <form.AuthFormRoot>
+          <Card>
+            <CardContent class="flex flex-col gap-6">
+              <form.AppField
                 name="email"
-                onInput={() => setEmailFieldError(undefined)}
-                onInvalid={(event) => {
-                  event.preventDefault()
-                  setEmailFieldError(event.currentTarget.validationMessage)
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: auth.localization.auth.invalidEmail,
+                      requiredMessage: auth.localization.auth.fieldRequired
+                    })
                 }}
-                placeholder={auth.localization.auth.emailPlaceholder}
-                required
-                type="email"
-                value={session.data?.user.email ?? ""}
-              />
-              <Show when={emailFieldError()}>
-                {(message) => <FieldError>{message()}</FieldError>}
-              </Show>
-            </Field>
-          </CardContent>
-          <CardFooter>
-            <Button
-              disabled={changeEmail.isPending || !session.data}
-              size="sm"
-              type="submit"
-            >
-              {auth.localization.settings.updateEmail}
-            </Button>
-          </CardFooter>
-        </Card>
-      </form>
+              >
+                {(field) => (
+                  <Field
+                    data-invalid={isAuthFormFieldInvalid(field().state.meta)}
+                  >
+                    <FieldLabel for="settings-email">
+                      {auth.localization.auth.email}
+                    </FieldLabel>
+                    <Input
+                      aria-invalid={isAuthFormFieldInvalid(field().state.meta)}
+                      autocomplete="email"
+                      disabled={changeEmail.isPending || !session.data}
+                      id="settings-email"
+                      name={field().name}
+                      onBlur={field().handleBlur}
+                      onInput={(event) =>
+                        field().handleChange(event.currentTarget.value)
+                      }
+                      placeholder={auth.localization.auth.emailPlaceholder}
+                      type="email"
+                      value={field().state.value}
+                    />
+                    <field.AuthFormFieldError />
+                  </Field>
+                )}
+              </form.AppField>
+            </CardContent>
+            <CardFooter>
+              <form.AuthFormSubmitButton
+                disabled={changeEmail.isPending || !session.data}
+                size="sm"
+              >
+                {auth.localization.settings.updateEmail}
+              </form.AuthFormSubmitButton>
+            </CardFooter>
+          </Card>
+          <form.AuthFormServerError />
+        </form.AuthFormRoot>
+      </form.AppForm>
     </div>
   )
 }

--- a/examples/start-solid-zaidan-example/src/components/auth/settings/security/fresh-session-prompt.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/settings/security/fresh-session-prompt.tsx
@@ -1,17 +1,17 @@
+import { validateStringLength } from "@better-auth-ui/core"
 import { isTwoFactorRedirect } from "@better-auth-ui/core/plugins/two-factor"
 import { useAuth, useSession, useSignInEmail } from "@better-auth-ui/solid"
-import { createSignal, Show } from "solid-js"
+import { Show } from "solid-js"
 import { Button } from "@/components/ui/button"
 import {
   Field,
   FieldDescription,
-  FieldError,
   FieldGroup,
   FieldLabel
 } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
-import { Spinner } from "@/components/ui/spinner"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
+import { createAuthForm, isAuthFormFieldInvalid } from "../../auth-form"
 
 export interface FreshSessionPromptProps {
   onFresh: () => unknown | Promise<unknown>
@@ -21,26 +21,27 @@ export function FreshSessionPrompt(props: FreshSessionPromptProps) {
   const auth = useAuth()
   const session = useSession(auth.authClient)
   const continueSignIn = useSignInContinuation()
-  const [password, setPassword] = createSignal("")
   const signIn = useSignInEmail(auth.authClient, () => ({
     meta: { errorPresentation: "inline" },
-    onError: () => setPassword(""),
+    onError: () => form.setFieldValue("password", ""),
     onSuccess: async (data) => {
       if (isTwoFactorRedirect(data)) {
         continueSignIn(data)
         return
       }
-      setPassword("")
+      form.setFieldValue("password", "")
       await props.onFresh()
     }
   }))
 
-  const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
-    event.preventDefault()
-    const email = session.data?.user.email
-    if (!email) return
-    signIn.mutate({ email, password: password() })
-  }
+  const form = createAuthForm(() => ({
+    defaultValues: { password: "" },
+    onSubmit: async ({ value }) => {
+      const email = session.data?.user.email
+      if (!email) return
+      await signIn.mutateAsync({ email, password: value.password })
+    }
+  }))
 
   return (
     <div class="p-4">
@@ -67,35 +68,46 @@ export function FreshSessionPrompt(props: FreshSessionPromptProps) {
           }
           when={auth.emailAndPassword?.enabled}
         >
-          <form class="flex flex-col gap-3" onSubmit={submit}>
-            <Field data-invalid={signIn.isError}>
-              <FieldLabel for="fresh-session-password">
-                {auth.localization.auth.password}
-              </FieldLabel>
-              <Input
-                id="fresh-session-password"
-                autocomplete="current-password"
-                disabled={signIn.isPending}
-                value={password()}
-                onInput={(event) => setPassword(event.currentTarget.value)}
-                type="password"
-                required
-              />
-              <Show when={signIn.error}>
-                {(error) => (
-                  <FieldError>
-                    {error().error?.message ?? error().message}
-                  </FieldError>
+          <form.AppForm>
+            <form.AuthFormRoot class="flex flex-col gap-3">
+              <form.AppField
+                name="password"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: auth.localization.auth.fieldRequired
+                    })
+                }}
+              >
+                {(field) => (
+                  <Field
+                    data-invalid={isAuthFormFieldInvalid(field().state.meta)}
+                  >
+                    <FieldLabel for="fresh-session-password">
+                      {auth.localization.auth.password}
+                    </FieldLabel>
+                    <Input
+                      id="fresh-session-password"
+                      autocomplete="current-password"
+                      disabled={signIn.isPending}
+                      name={field().name}
+                      value={field().state.value}
+                      onBlur={field().handleBlur}
+                      onInput={(event) =>
+                        field().handleChange(event.currentTarget.value)
+                      }
+                      type="password"
+                    />
+                    <field.AuthFormFieldError />
+                  </Field>
                 )}
-              </Show>
-            </Field>
-            <Button disabled={!password() || signIn.isPending} type="submit">
-              <Show when={signIn.isPending}>
-                <Spinner />
-              </Show>
-              {auth.localization.settings.freshSessionSubmit}
-            </Button>
-          </form>
+              </form.AppField>
+              <form.AuthFormServerError />
+              <form.AuthFormSubmitButton disabled={signIn.isPending}>
+                {auth.localization.settings.freshSessionSubmit}
+              </form.AuthFormSubmitButton>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </Show>
       </FieldGroup>
     </div>

--- a/examples/start-solid-zaidan-example/src/components/auth/siwe/sign-in-ethereum-button.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/siwe/sign-in-ethereum-button.tsx
@@ -1,4 +1,8 @@
-import { type AuthView, authMutationKeys } from "@better-auth-ui/core"
+import {
+  type AuthView,
+  authMutationKeys,
+  validateEmailAddress
+} from "@better-auth-ui/core"
 import {
   type SiweAuthClient,
   siweMutationKeys
@@ -23,6 +27,7 @@ import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { siwePlugin } from "@/lib/auth/siwe-plugin"
 import { cn } from "@/lib/utils"
+import { createAuthForm, isAuthFormFieldInvalid } from "../auth-form"
 
 export type SignInEthereumButtonProps = {
   /** @remarks `AuthView` */
@@ -60,8 +65,8 @@ export function SignInEthereumButton(props: SignInEthereumButtonProps) {
   const isPending = () =>
     signInMutating() + signUpMutating() + siweMutating() > 0
 
-  const complete = (email?: string) => {
-    signIn.mutate(email ? { email } : undefined, {
+  const complete = async (email?: string) => {
+    await signIn.mutateAsync(email ? { email } : undefined, {
       onSuccess: () => {
         setOpen(false)
         auth.navigate({ to: auth.redirectTo })
@@ -69,21 +74,19 @@ export function SignInEthereumButton(props: SignInEthereumButtonProps) {
     })
   }
 
-  const submit = (event: SubmitEvent) => {
-    event.preventDefault()
-    const email = String(
-      new FormData(event.currentTarget as HTMLFormElement).get("email") ?? ""
-    ).trim()
-
-    complete(email || undefined)
-  }
+  const form = createAuthForm(() => ({
+    defaultValues: { email: "" },
+    onSubmit: async ({ value }) => complete(value.email.trim() || undefined)
+  }))
 
   return (
     <Show when={props.view !== "signUp"}>
       <Button
         class={cn("w-full", isPending() && "pointer-events-none")}
         disabled={isPending()}
-        onClick={() => (plugin.email === "none" ? complete() : setOpen(true))}
+        onClick={() =>
+          plugin.email === "none" ? void complete() : setOpen(true)
+        }
         type="button"
         variant="outline"
       >
@@ -98,52 +101,77 @@ export function SignInEthereumButton(props: SignInEthereumButtonProps) {
 
       <Dialog onOpenChange={setOpen} open={open()}>
         <DialogContent>
-          <form class="flex flex-col gap-6" onSubmit={submit}>
-            <DialogHeader>
-              <DialogTitle>
-                {plugin.localization.continueWithEthereum}
-              </DialogTitle>
-              <DialogDescription>
-                {plugin.localization.emailDescription}
-              </DialogDescription>
-            </DialogHeader>
+          <form.AppForm>
+            <form.AuthFormRoot class="flex flex-col gap-6">
+              <DialogHeader>
+                <DialogTitle>
+                  {plugin.localization.continueWithEthereum}
+                </DialogTitle>
+                <DialogDescription>
+                  {plugin.localization.emailDescription}
+                </DialogDescription>
+              </DialogHeader>
 
-            <Field>
-              <FieldLabel for="siwe-email">
-                {plugin.email === "required"
-                  ? plugin.localization.email
-                  : plugin.localization.emailOptional}
-              </FieldLabel>
-              <Input
-                autocomplete="email"
-                disabled={signIn.isPending}
-                id="siwe-email"
+              <form.AppField
                 name="email"
-                required={plugin.email === "required"}
-                type="email"
-              />
-              <FieldDescription>
-                {plugin.localization.emailDescription}
-              </FieldDescription>
-            </Field>
-
-            <DialogFooter>
-              <Button
-                disabled={signIn.isPending}
-                onClick={() => setOpen(false)}
-                type="button"
-                variant="outline"
+                validators={{
+                  onChange: ({ value }) =>
+                    !value && plugin.email !== "required"
+                      ? undefined
+                      : validateEmailAddress(value, {
+                          invalidMessage: auth.localization.auth.invalidEmail,
+                          requiredMessage: auth.localization.auth.fieldRequired
+                        })
+                }}
               >
-                {auth.localization.settings.cancel}
-              </Button>
-              <Button disabled={signIn.isPending} type="submit">
-                <Show when={signIn.isPending}>
-                  <Spinner data-icon="inline-start" />
-                </Show>
-                {plugin.localization.signMessage}
-              </Button>
-            </DialogFooter>
-          </form>
+                {(field) => (
+                  <Field
+                    data-invalid={isAuthFormFieldInvalid(field().state.meta)}
+                  >
+                    <FieldLabel for="siwe-email">
+                      {plugin.email === "required"
+                        ? plugin.localization.email
+                        : plugin.localization.emailOptional}
+                    </FieldLabel>
+                    <Input
+                      autocomplete="email"
+                      disabled={signIn.isPending}
+                      id="siwe-email"
+                      name={field().name}
+                      type="email"
+                      value={field().state.value}
+                      onBlur={field().handleBlur}
+                      onInput={(event) =>
+                        field().handleChange(event.currentTarget.value)
+                      }
+                    />
+                    <FieldDescription>
+                      {plugin.localization.emailDescription}
+                    </FieldDescription>
+                    <field.AuthFormFieldError />
+                  </Field>
+                )}
+              </form.AppField>
+
+              <DialogFooter>
+                <Button
+                  disabled={signIn.isPending}
+                  onClick={() => setOpen(false)}
+                  type="button"
+                  variant="outline"
+                >
+                  {auth.localization.settings.cancel}
+                </Button>
+                <form.AuthFormSubmitButton disabled={signIn.isPending}>
+                  <Show when={signIn.isPending}>
+                    <Spinner data-icon="inline-start" />
+                  </Show>
+                  {plugin.localization.signMessage}
+                </form.AuthFormSubmitButton>
+              </DialogFooter>
+              <form.AuthFormServerError />
+            </form.AuthFormRoot>
+          </form.AppForm>
         </DialogContent>
       </Dialog>
     </Show>

--- a/examples/start-solid-zaidan-example/src/components/auth/siwe/sign-in-ethereum-button.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/siwe/sign-in-ethereum-button.tsx
@@ -85,7 +85,9 @@ export function SignInEthereumButton(props: SignInEthereumButtonProps) {
         class={cn("w-full", isPending() && "pointer-events-none")}
         disabled={isPending()}
         onClick={() =>
-          plugin.email === "none" ? void complete() : setOpen(true)
+          plugin.email === "none"
+            ? void complete().catch(() => undefined)
+            : setOpen(true)
         }
         type="button"
         variant="outline"

--- a/examples/start-solid-zaidan-example/src/components/auth/sso/email-first-sign-in.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/sso/email-first-sign-in.tsx
@@ -1,3 +1,4 @@
+import { validateEmailAddress } from "@better-auth-ui/core"
 import {
   isPasskeyAutoFillEnabled,
   withPasskeyAutoFill
@@ -28,18 +29,17 @@ import {
   CardTitle
 } from "@/components/ui/card"
 import { Checkbox } from "@/components/ui/checkbox"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
+import { Field, FieldLabel } from "@/components/ui/field"
 import {
   InputGroup,
   InputGroupAddon,
   InputGroupButton,
   InputGroupInput
 } from "@/components/ui/input-group"
-import { Spinner } from "@/components/ui/spinner"
 import { ssoPlugin } from "@/lib/auth/sso-plugin"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { createAuthForm, isAuthFormFieldInvalid } from "../auth-form"
 import type { SocialLayout } from "../provider-buttons"
 import { ProviderButtons } from "../provider-buttons"
 
@@ -66,12 +66,8 @@ export function EmailFirstSignIn(props: EmailFirstSignInProps) {
   const socialPosition = () => props.socialPosition ?? "bottom"
 
   const [step, setStep] = createSignal<"email" | "fallback">("email")
-  const [email, setEmail] = createSignal("")
-  const [password, setPassword] = createSignal("")
   const [isPasswordVisible, setIsPasswordVisible] = createSignal(false)
   const [discoveryError, setDiscoveryError] = createSignal("")
-  const [emailError, setEmailError] = createSignal<string>()
-  const [passwordError, setPasswordError] = createSignal<string>()
 
   const signInSso = useSignInSso(auth.authClient as SsoAuthClient, () => ({
     onError: (error) => {
@@ -90,7 +86,7 @@ export function EmailFirstSignIn(props: EmailFirstSignInProps) {
 
   const signInEmail = useSignInEmail(auth.authClient, () => ({
     onError: (error) => {
-      setPassword("")
+      passwordForm.setFieldValue("password", "")
 
       if (error.error?.code === "EMAIL_NOT_VERIFIED") {
         sessionStorage.setItem("better-auth-ui.verify-email", email())
@@ -114,35 +110,40 @@ export function EmailFirstSignIn(props: EmailFirstSignInProps) {
   const showSocialSeparator = () =>
     auth.emailAndPassword.enabled && Boolean(auth.socialProviders?.length)
 
-  const submitEmail = (event: SubmitEvent) => {
-    event.preventDefault()
-    setDiscoveryError("")
-    setSsoFallbackEmail(email())
-
-    signInSso.mutate({
-      email: email(),
-      callbackURL: `${auth.baseURL}${auth.redirectTo}`,
-      loginHint: email()
-    })
-  }
-
-  const submitPassword = (event: SubmitEvent) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget as HTMLFormElement)
-
-    signInEmail.mutate({
-      email: email(),
-      password: password(),
-      ...(auth.emailAndPassword.rememberMe
-        ? { rememberMe: formData.get("rememberMe") === "on" }
-        : {}),
-      fetchOptions: fetchOptions()
-    })
-  }
+  const emailForm = createAuthForm(() => ({
+    defaultValues: { email: "" },
+    onSubmit: async ({ value }) => {
+      setDiscoveryError("")
+      setSsoFallbackEmail(value.email)
+      try {
+        await signInSso.mutateAsync({
+          email: value.email,
+          callbackURL: `${auth.baseURL}${auth.redirectTo}`,
+          loginHint: value.email
+        })
+      } catch (error) {
+        if ((error as { status?: number }).status !== 404) throw error
+      }
+    }
+  }))
+  const passwordForm = createAuthForm(() => ({
+    defaultValues: { password: "", rememberMe: true },
+    onSubmit: async ({ value }) => {
+      await signInEmail.mutateAsync({
+        email: email(),
+        password: value.password,
+        ...(auth.emailAndPassword.rememberMe
+          ? { rememberMe: value.rememberMe }
+          : {}),
+        fetchOptions: fetchOptions()
+      })
+    }
+  }))
+  const email = () => emailForm.state.values.email
 
   const startOver = () => {
     setStep("email")
-    setPassword("")
+    passwordForm.reset()
     setDiscoveryError("")
   }
 
@@ -188,91 +189,114 @@ export function EmailFirstSignIn(props: EmailFirstSignInProps) {
               </Show>
 
               <Show when={auth.emailAndPassword.enabled}>
-                <form class="flex flex-col gap-4" onSubmit={submitPassword}>
-                  <Field data-invalid={Boolean(passwordError())}>
-                    <FieldLabel for="sso-password">
-                      {auth.localization.auth.password}
-                    </FieldLabel>
+                <passwordForm.AppForm>
+                  <passwordForm.AuthFormRoot class="flex flex-col gap-4">
+                    <passwordForm.AppField
+                      name="password"
+                      validators={{
+                        onChange: ({ value }) =>
+                          value
+                            ? undefined
+                            : auth.localization.auth.fieldRequired
+                      }}
+                    >
+                      {(field) => (
+                        <Field
+                          data-invalid={isAuthFormFieldInvalid(
+                            field().state.meta
+                          )}
+                        >
+                          <FieldLabel for="sso-password">
+                            {auth.localization.auth.password}
+                          </FieldLabel>
 
-                    <InputGroup>
-                      <InputGroupInput
-                        aria-invalid={Boolean(passwordError())}
-                        autocomplete={withPasskeyAutoFill(
-                          "current-password",
-                          passkeyAutoFill()
+                          <InputGroup>
+                            <InputGroupInput
+                              aria-invalid={isAuthFormFieldInvalid(
+                                field().state.meta
+                              )}
+                              autocomplete={withPasskeyAutoFill(
+                                "current-password",
+                                passkeyAutoFill()
+                              )}
+                              disabled={isPending()}
+                              id="sso-password"
+                              maxLength={
+                                auth.emailAndPassword.maxPasswordLength
+                              }
+                              minLength={
+                                auth.emailAndPassword.minPasswordLength
+                              }
+                              name={field().name}
+                              onBlur={field().handleBlur}
+                              onInput={(event) =>
+                                field().handleChange(event.currentTarget.value)
+                              }
+                              placeholder={
+                                auth.localization.auth.passwordPlaceholder
+                              }
+                              type={isPasswordVisible() ? "text" : "password"}
+                              value={field().state.value}
+                            />
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                aria-label={
+                                  isPasswordVisible()
+                                    ? auth.localization.auth.hidePassword
+                                    : auth.localization.auth.showPassword
+                                }
+                                onClick={() =>
+                                  setIsPasswordVisible((visible) => !visible)
+                                }
+                                size="icon-xs"
+                                type="button"
+                              >
+                                {isPasswordVisible() ? <EyeOff /> : <Eye />}
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
+
+                          <field.AuthFormFieldError />
+                        </Field>
+                      )}
+                    </passwordForm.AppField>
+
+                    <Show when={auth.emailAndPassword.rememberMe}>
+                      <passwordForm.AppField name="rememberMe">
+                        {(field) => (
+                          <Field>
+                            <div class="flex items-center gap-3">
+                              <Checkbox
+                                disabled={isPending()}
+                                id="sso-remember-me"
+                                name={field().name}
+                                checked={field().state.value}
+                                onChange={(checked) =>
+                                  field().handleChange(checked)
+                                }
+                              />
+                              <FieldLabel
+                                class="cursor-pointer text-sm font-normal"
+                                for="sso-remember-me"
+                              >
+                                {auth.localization.auth.rememberMe}
+                              </FieldLabel>
+                            </div>
+                          </Field>
                         )}
-                        disabled={isPending()}
-                        id="sso-password"
-                        maxLength={auth.emailAndPassword.maxPasswordLength}
-                        minLength={auth.emailAndPassword.minPasswordLength}
-                        name="password"
-                        onInput={(event) => {
-                          setPassword(event.currentTarget.value)
-                          setPasswordError(undefined)
-                        }}
-                        onInvalid={(event) => {
-                          event.preventDefault()
-                          setPasswordError(
-                            event.currentTarget.validationMessage
-                          )
-                        }}
-                        placeholder={auth.localization.auth.passwordPlaceholder}
-                        required
-                        type={isPasswordVisible() ? "text" : "password"}
-                        value={password()}
-                      />
-                      <InputGroupAddon align="inline-end">
-                        <InputGroupButton
-                          aria-label={
-                            isPasswordVisible()
-                              ? auth.localization.auth.hidePassword
-                              : auth.localization.auth.showPassword
-                          }
-                          onClick={() =>
-                            setIsPasswordVisible((visible) => !visible)
-                          }
-                          size="icon-xs"
-                          type="button"
-                        >
-                          {isPasswordVisible() ? <EyeOff /> : <Eye />}
-                        </InputGroupButton>
-                      </InputGroupAddon>
-                    </InputGroup>
-
-                    <Show when={passwordError()}>
-                      {(message) => <FieldError>{message()}</FieldError>}
+                      </passwordForm.AppField>
                     </Show>
-                  </Field>
 
-                  <Show when={auth.emailAndPassword.rememberMe}>
-                    <Field>
-                      <div class="flex items-center gap-3">
-                        <Checkbox
-                          disabled={isPending()}
-                          id="sso-remember-me"
-                          name="rememberMe"
-                        />
-                        <FieldLabel
-                          class="cursor-pointer text-sm font-normal"
-                          for="sso-remember-me"
-                        >
-                          {auth.localization.auth.rememberMe}
-                        </FieldLabel>
-                      </div>
-                    </Field>
-                  </Show>
-
-                  <Show keyed when={captchaComponent()}>
-                    {(Captcha) => <Captcha />}
-                  </Show>
-
-                  <Button disabled={isPending()} type="submit">
-                    <Show when={signInEmail.isPending}>
-                      <Spinner data-icon="inline-start" />
+                    <Show keyed when={captchaComponent()}>
+                      {(Captcha) => <Captcha />}
                     </Show>
-                    {auth.localization.auth.signIn}
-                  </Button>
-                </form>
+
+                    <passwordForm.AuthFormSubmitButton disabled={isPending()}>
+                      {auth.localization.auth.signIn}
+                    </passwordForm.AuthFormSubmitButton>
+                    <passwordForm.AuthFormServerError />
+                  </passwordForm.AuthFormRoot>
+                </passwordForm.AppForm>
               </Show>
 
               <For
@@ -310,50 +334,47 @@ export function EmailFirstSignIn(props: EmailFirstSignInProps) {
           }
           when={step() === "email"}
         >
-          <form class="flex flex-col gap-4" onSubmit={submitEmail}>
-            <Field data-invalid={Boolean(emailError())}>
-              <FieldLabel for="sso-email">
-                {auth.localization.auth.email}
-              </FieldLabel>
-              <Input
-                aria-invalid={Boolean(emailError())}
-                autocomplete={withPasskeyAutoFill("email", passkeyAutoFill())}
-                disabled={isPending()}
-                id="sso-email"
+          <emailForm.AppForm>
+            <emailForm.AuthFormRoot class="flex flex-col gap-4">
+              <emailForm.AppField
                 name="email"
-                onInput={(event) => {
-                  setEmail(event.currentTarget.value)
-                  setEmailError(undefined)
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: auth.localization.auth.invalidEmail,
+                      requiredMessage: auth.localization.auth.fieldRequired
+                    })
                 }}
-                onInvalid={(event) => {
-                  event.preventDefault()
-                  setEmailError(event.currentTarget.validationMessage)
-                }}
-                placeholder={auth.localization.auth.emailPlaceholder}
-                required
-                type="email"
-                value={email()}
-              />
-              <Show when={emailError()}>
-                {(message) => <FieldError>{message()}</FieldError>}
-              </Show>
-            </Field>
+              >
+                {(field) => (
+                  <field.AuthFormTextField
+                    autocomplete={withPasskeyAutoFill(
+                      "email",
+                      passkeyAutoFill()
+                    )}
+                    disabled={isPending()}
+                    id="sso-email"
+                    label={auth.localization.auth.email}
+                    placeholder={auth.localization.auth.emailPlaceholder}
+                    type="email"
+                  />
+                )}
+              </emailForm.AppField>
 
-            <Show when={discoveryError()}>
-              {(message) => (
-                <p class="text-sm text-destructive" role="alert">
-                  {message()}
-                </p>
-              )}
-            </Show>
-
-            <Button disabled={isPending()} type="submit">
-              <Show when={signInSso.isPending}>
-                <Spinner data-icon="inline-start" />
+              <Show when={discoveryError()}>
+                {(message) => (
+                  <p class="text-sm text-destructive" role="alert">
+                    {message()}
+                  </p>
+                )}
               </Show>
-              {ssoLocalization.continueWithEmail}
-            </Button>
-          </form>
+
+              <emailForm.AuthFormSubmitButton disabled={isPending()}>
+                {ssoLocalization.continueWithEmail}
+              </emailForm.AuthFormSubmitButton>
+              <emailForm.AuthFormServerError />
+            </emailForm.AuthFormRoot>
+          </emailForm.AppForm>
         </Show>
 
         <Show when={auth.emailAndPassword.enabled}>

--- a/examples/start-solid-zaidan-example/src/components/auth/sso/sso-domain-verification.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/sso/sso-domain-verification.tsx
@@ -8,7 +8,6 @@ import {
   useRequestSsoDomainVerification,
   useVerifySsoDomain
 } from "@better-auth-ui/solid/plugins/sso"
-import type { BetterFetchError } from "better-auth/client"
 import { Check, Copy } from "lucide-solid"
 import { createSignal, Show } from "solid-js"
 
@@ -27,7 +26,6 @@ import {
   FieldGroup,
   FieldLabel
 } from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
 import {
   InputGroup,
   InputGroupButton,
@@ -36,6 +34,7 @@ import {
 import { Spinner } from "@/components/ui/spinner"
 import { ssoPlugin } from "@/lib/auth/sso-plugin"
 import { cn } from "@/lib/utils"
+import { createAuthForm, setAuthFormServerError } from "../auth-form"
 
 export type SsoDomainVerificationProps = {
   class?: string
@@ -44,17 +43,9 @@ export type SsoDomainVerificationProps = {
   tokenPrefix?: string
 }
 
-const getErrorMessage = (error: Error | null | undefined) => {
-  const authError = error as BetterFetchError | null | undefined
-  return authError?.error?.message ?? authError?.message
-}
-
 export function SsoDomainVerification(props: SsoDomainVerificationProps) {
   const auth = useAuth()
   const { localization } = useAuthPlugin(ssoPlugin)
-  const [providerId, setProviderId] = createSignal(
-    props.defaultProviderId ?? ""
-  )
   const [token, setToken] = createSignal(props.defaultToken ?? "")
   const [verified, setVerified] = createSignal(false)
   const [copyError, setCopyError] = createSignal("")
@@ -68,8 +59,8 @@ export function SsoDomainVerification(props: SsoDomainVerificationProps) {
     onSuccess: () => setVerified(true)
   }))
   const host = () =>
-    providerId()
-      ? `_${props.tokenPrefix ?? "better-auth-token"}-${providerId()}`
+    form.state.values.providerId
+      ? `_${props.tokenPrefix ?? "better-auth-token"}-${form.state.values.providerId}`
       : ""
   const hostCopy = createCopyToClipboard({
     onError: (error) =>
@@ -79,16 +70,29 @@ export function SsoDomainVerification(props: SsoDomainVerificationProps) {
     onError: (error) =>
       setCopyError(error instanceof Error ? error.message : String(error))
   })
-  const error = () =>
-    requestToken.submittedAt > verify.submittedAt
-      ? requestToken.error
-      : verify.error
+  const form = createAuthForm(() => ({
+    defaultValues: { providerId: props.defaultProviderId ?? "" },
+    onSubmit: async ({ value }) => {
+      setCopyError("")
+      setVerified(false)
+      await verify.mutateAsync({ providerId: value.providerId.trim() })
+    }
+  }))
 
-  const submit = (event: SubmitEvent) => {
-    event.preventDefault()
+  const requestNewToken = async () => {
     setCopyError("")
     setVerified(false)
-    verify.mutate({ providerId: providerId() })
+    try {
+      await requestToken.mutateAsync({
+        providerId: form.state.values.providerId.trim()
+      })
+    } catch (error) {
+      setAuthFormServerError(
+        form,
+        error,
+        "Unable to request a domain verification token. Try again."
+      )
+    }
   }
 
   return (
@@ -100,115 +104,118 @@ export function SsoDomainVerification(props: SsoDomainVerificationProps) {
         </CardDescription>
       </CardHeader>
       <CardContent>
-        <form onSubmit={submit}>
-          <FieldGroup>
-            <Field>
-              <FieldLabel for="solid-sso-verification-provider-id">
-                {localization.providerId}
-              </FieldLabel>
-              <Input
-                id="solid-sso-verification-provider-id"
+        <form.AppForm>
+          <form.AuthFormRoot>
+            <FieldGroup>
+              <form.AppField
+                listeners={{
+                  onChange: () => {
+                    setToken("")
+                    setVerified(false)
+                  }
+                }}
                 name="providerId"
-                onInput={(event) => {
-                  setProviderId(event.currentTarget.value.trim())
-                  setToken("")
-                  setVerified(false)
+                validators={{
+                  onChange: ({ value }) =>
+                    value.trim()
+                      ? undefined
+                      : auth.localization.auth.fieldRequired
                 }}
-                required
-                value={providerId()}
-              />
-            </Field>
-            <Show when={token()}>
-              <div class="grid gap-3 rounded-lg border p-3">
-                <Field>
-                  <FieldLabel for="solid-sso-dns-host">
-                    {localization.txtRecordHost}
-                  </FieldLabel>
-                  <InputGroup>
-                    <InputGroupInput
-                      id="solid-sso-dns-host"
-                      readonly
-                      value={host()}
-                    />
-                    <InputGroupButton
-                      aria-label={localization.copyDnsHost}
-                      onClick={() => {
-                        setCopyError("")
-                        void hostCopy.copy(host())
-                      }}
-                      type="button"
-                    >
-                      <Show fallback={<Copy />} when={hostCopy.copied()}>
-                        <Check />
-                      </Show>
-                    </InputGroupButton>
-                  </InputGroup>
-                </Field>
-                <Field>
-                  <FieldLabel for="solid-sso-dns-value">
-                    {localization.txtRecordValue}
-                  </FieldLabel>
-                  <InputGroup>
-                    <InputGroupInput
-                      id="solid-sso-dns-value"
-                      readonly
-                      value={token()}
-                    />
-                    <InputGroupButton
-                      aria-label={localization.copyDnsValue}
-                      onClick={() => {
-                        setCopyError("")
-                        void tokenCopy.copy(token())
-                      }}
-                      type="button"
-                    >
-                      <Show fallback={<Copy />} when={tokenCopy.copied()}>
-                        <Check />
-                      </Show>
-                    </InputGroupButton>
-                  </InputGroup>
-                </Field>
+              >
+                {(field) => (
+                  <field.AuthFormTextField
+                    id="solid-sso-verification-provider-id"
+                    label={localization.providerId}
+                  />
+                )}
+              </form.AppField>
+              <Show when={token()}>
+                <div class="grid gap-3 rounded-lg border p-3">
+                  <Field>
+                    <FieldLabel for="solid-sso-dns-host">
+                      {localization.txtRecordHost}
+                    </FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        id="solid-sso-dns-host"
+                        readonly
+                        value={host()}
+                      />
+                      <InputGroupButton
+                        aria-label={localization.copyDnsHost}
+                        onClick={() => {
+                          setCopyError("")
+                          void hostCopy.copy(host())
+                        }}
+                        type="button"
+                      >
+                        <Show fallback={<Copy />} when={hostCopy.copied()}>
+                          <Check />
+                        </Show>
+                      </InputGroupButton>
+                    </InputGroup>
+                  </Field>
+                  <Field>
+                    <FieldLabel for="solid-sso-dns-value">
+                      {localization.txtRecordValue}
+                    </FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        id="solid-sso-dns-value"
+                        readonly
+                        value={token()}
+                      />
+                      <InputGroupButton
+                        aria-label={localization.copyDnsValue}
+                        onClick={() => {
+                          setCopyError("")
+                          void tokenCopy.copy(token())
+                        }}
+                        type="button"
+                      >
+                        <Show fallback={<Copy />} when={tokenCopy.copied()}>
+                          <Check />
+                        </Show>
+                      </InputGroupButton>
+                    </InputGroup>
+                  </Field>
+                </div>
+              </Show>
+              <div class="flex flex-wrap gap-2">
+                <Button
+                  disabled={
+                    !form.state.values.providerId || requestToken.isPending
+                  }
+                  onClick={() => void requestNewToken()}
+                  type="button"
+                  variant="outline"
+                >
+                  <Show when={requestToken.isPending}>
+                    <Spinner />
+                  </Show>
+                  {localization.requestNewToken}
+                </Button>
+                <form.AuthFormSubmitButton
+                  disabled={!form.state.values.providerId || verify.isPending}
+                >
+                  {localization.verifyDomain}
+                </form.AuthFormSubmitButton>
               </div>
-            </Show>
-            <div class="flex flex-wrap gap-2">
-              <Button
-                disabled={!providerId() || requestToken.isPending}
-                onClick={() => {
-                  setCopyError("")
-                  setVerified(false)
-                  requestToken.mutate({ providerId: providerId() })
-                }}
-                type="button"
-                variant="outline"
-              >
-                <Show when={requestToken.isPending}>
-                  <Spinner />
-                </Show>
-                {localization.requestNewToken}
-              </Button>
-              <Button
-                disabled={!providerId() || verify.isPending}
-                type="submit"
-              >
-                <Show when={verify.isPending}>
-                  <Spinner />
-                </Show>
-                {localization.verifyDomain}
-              </Button>
-            </div>
-            <Show when={verified()}>
-              <FieldDescription role="status">
-                {localization.domainVerified}
-              </FieldDescription>
-            </Show>
-            <FieldError>{copyError() || getErrorMessage(error())}</FieldError>
-            <span aria-live="polite" class="sr-only">
-              {token() && !verified()
-                ? localization.domainVerificationRequested
-                : ""}
-            </span>
-          </FieldGroup>
-        </form>
+              <Show when={verified()}>
+                <FieldDescription role="status">
+                  {localization.domainVerified}
+                </FieldDescription>
+              </Show>
+              <FieldError>{copyError()}</FieldError>
+              <form.AuthFormServerError />
+              <span aria-live="polite" class="sr-only">
+                {token() && !verified()
+                  ? localization.domainVerificationRequested
+                  : ""}
+              </span>
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
     </Card>
   )

--- a/examples/start-solid-zaidan-example/src/components/auth/two-factor/disable-two-factor-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/two-factor/disable-two-factor-dialog.tsx
@@ -17,12 +17,12 @@ import {
   AlertDialogMedia,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
-import { Button } from "@/components/ui/button"
 import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
+import { createAuthForm } from "../auth-form"
 
 /** Confirm turning two-factor off. */
 export function DisableTwoFactorDialog(props: {
@@ -44,71 +44,84 @@ export function DisableTwoFactorDialog(props: {
   const isPending = () =>
     disableTwoFactor.isPending || isResolvingPasswordRequirement()
 
-  const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
-    event.preventDefault()
-
-    const formData = new FormData(event.currentTarget)
-    const password = String(formData.get("password") ?? "")
-
-    disableTwoFactor.mutate(
-      (requiresPassword() ? { password } : {}) as Parameters<
-        typeof disableTwoFactor.mutate
-      >[0]
-    )
-  }
+  const form = createAuthForm(() => ({
+    defaultValues: { password: "" },
+    onSubmit: async ({ value }) => {
+      await disableTwoFactor.mutateAsync(
+        (requiresPassword() ? { password: value.password } : {}) as Parameters<
+          typeof disableTwoFactor.mutateAsync
+        >[0]
+      )
+    }
+  }))
 
   return (
     <AlertDialogContent>
-      <form class="flex flex-col gap-6" onSubmit={submit}>
-        <AlertDialogHeader>
-          <AlertDialogMedia>
-            <ShieldAlert />
-          </AlertDialogMedia>
+      <form.AppForm>
+        <form.AuthFormRoot class="flex flex-col gap-6">
+          <AlertDialogHeader>
+            <AlertDialogMedia>
+              <ShieldAlert />
+            </AlertDialogMedia>
 
-          <AlertDialogTitle>
-            {twoFactorLocalization.disableTwoFactor}
-          </AlertDialogTitle>
+            <AlertDialogTitle>
+              {twoFactorLocalization.disableTwoFactor}
+            </AlertDialogTitle>
 
-          <AlertDialogDescription>
-            {requiresPassword()
-              ? twoFactorLocalization.passwordConfirmation
-              : twoFactorLocalization.twoFactorDescription}
-          </AlertDialogDescription>
-        </AlertDialogHeader>
+            <AlertDialogDescription>
+              {requiresPassword()
+                ? twoFactorLocalization.passwordConfirmation
+                : twoFactorLocalization.twoFactorDescription}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
 
-        <Show when={requiresPassword()}>
-          <Field>
-            <FieldLabel for="disable-two-factor-password">
-              {auth.localization.auth.password}
-            </FieldLabel>
+          <Show when={requiresPassword()}>
+            <form.AppField name="password">
+              {(field) => (
+                <Field>
+                  <FieldLabel for="disable-two-factor-password">
+                    {auth.localization.auth.password}
+                  </FieldLabel>
 
-            <Input
-              autocomplete="current-password"
-              autofocus
+                  <Input
+                    autocomplete="current-password"
+                    autofocus
+                    disabled={isPending()}
+                    id="disable-two-factor-password"
+                    name={field().name}
+                    placeholder={auth.localization.auth.passwordPlaceholder}
+                    value={field().state.value}
+                    onBlur={field().handleBlur}
+                    onInput={(event) =>
+                      field().handleChange(event.currentTarget.value)
+                    }
+                    type="password"
+                  />
+                  <field.AuthFormFieldError />
+                </Field>
+              )}
+            </form.AppField>
+          </Show>
+
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending()} type="button">
+              {auth.localization.settings.cancel}
+            </AlertDialogCancel>
+
+            <form.AuthFormSubmitButton
               disabled={isPending()}
-              id="disable-two-factor-password"
-              name="password"
-              placeholder={auth.localization.auth.passwordPlaceholder}
-              required
-              type="password"
-            />
-          </Field>
-        </Show>
+              variant="destructive"
+            >
+              <Show when={isPending()}>
+                <Spinner />
+              </Show>
 
-        <AlertDialogFooter>
-          <AlertDialogCancel disabled={isPending()} type="button">
-            {auth.localization.settings.cancel}
-          </AlertDialogCancel>
-
-          <Button disabled={isPending()} type="submit" variant="destructive">
-            <Show when={isPending()}>
-              <Spinner />
-            </Show>
-
-            {twoFactorLocalization.disableTwoFactor}
-          </Button>
-        </AlertDialogFooter>
-      </form>
+              {twoFactorLocalization.disableTwoFactor}
+            </form.AuthFormSubmitButton>
+          </AlertDialogFooter>
+          <form.AuthFormServerError />
+        </form.AuthFormRoot>
+      </form.AppForm>
     </AlertDialogContent>
   )
 }

--- a/examples/start-solid-zaidan-example/src/components/auth/two-factor/disable-two-factor-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/two-factor/disable-two-factor-dialog.tsx
@@ -1,3 +1,4 @@
+import { validateStringLength } from "@better-auth-ui/core"
 import {
   disableTwoFactorOptions,
   type TwoFactorAuthClient
@@ -76,7 +77,15 @@ export function DisableTwoFactorDialog(props: {
           </AlertDialogHeader>
 
           <Show when={requiresPassword()}>
-            <form.AppField name="password">
+            <form.AppField
+              name="password"
+              validators={{
+                onChange: ({ value }) =>
+                  validateStringLength(value, {
+                    requiredMessage: auth.localization.auth.fieldRequired
+                  })
+              }}
+            >
               {(field) => (
                 <Field>
                   <FieldLabel for="disable-two-factor-password">

--- a/examples/start-solid-zaidan-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -26,17 +26,16 @@ import {
   DialogTitle
 } from "@/components/ui/dialog"
 import { Field, FieldLabel } from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
 import {
   InputGroup,
   InputGroupAddon,
   InputGroupButton,
   InputGroupInput
 } from "@/components/ui/input-group"
-import { Spinner } from "@/components/ui/spinner"
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
+import { createAuthForm, submitAuthForm } from "../auth-form"
 
 type EnrollmentStep = "password" | "verify" | "backupCodes"
 
@@ -64,7 +63,6 @@ export function EnableTwoFactorDialog(props: {
   )
   const [totpUri, setTotpUri] = createSignal("")
   const [backupCodes, setBackupCodes] = createSignal<string[]>([])
-  const [code, setCode] = createSignal("")
   const { copied: setupKeyCopied, copy: copySetupKey } = createCopyToClipboard({
     onError: () => toast.error(twoFactorLocalization.setupKeyCopyFailed)
   })
@@ -102,7 +100,7 @@ export function EnableTwoFactorDialog(props: {
 
   const verifyTotp = createMutation(() => ({
     ...verifyTotpOptions(twoFactorClient()),
-    onError: () => setCode(""),
+    onError: () => form.setFieldValue("code", ""),
     onSuccess: () => {
       toast.success(twoFactorLocalization.twoFactorEnabled)
       setStep("backupCodes")
@@ -114,7 +112,7 @@ export function EnableTwoFactorDialog(props: {
     verifyTotp.isPending ||
     isResolvingPasswordRequirement()
 
-  const verifyCode = (completedCode: string) => {
+  const verifyCode = async (completedCode: string) => {
     if (
       isPending() ||
       step() !== "verify" ||
@@ -123,33 +121,33 @@ export function EnableTwoFactorDialog(props: {
       return
     }
 
-    verifyTotp.mutate({ code: completedCode } as Parameters<
-      typeof verifyTotp.mutate
-    >[0])
+    form.setFieldValue("code", completedCode)
+    await submitAuthForm(form)
   }
 
-  const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
-    event.preventDefault()
-
-    if (step() === "backupCodes") {
-      props.onOpenChange(false)
-      return
+  const form = createAuthForm(() => ({
+    defaultValues: { code: "", password: "" },
+    onSubmit: async ({ value }) => {
+      if (step() === "backupCodes") {
+        props.onOpenChange(false)
+        return
+      }
+      if (step() === "verify") {
+        await verifyTotp.mutateAsync({ code: value.code } as Parameters<
+          typeof verifyTotp.mutateAsync
+        >[0])
+        return
+      }
+      await enableTwoFactor.mutateAsync(
+        (requiresPassword()
+          ? { method: method(), password: value.password }
+          : { method: method() }) as Parameters<
+          typeof enableTwoFactor.mutateAsync
+        >[0]
+      )
     }
-
-    if (step() === "verify") {
-      verifyCode(code())
-      return
-    }
-
-    const formData = new FormData(event.currentTarget)
-    const password = String(formData.get("password") ?? "")
-
-    enableTwoFactor.mutate(
-      (requiresPassword()
-        ? { method: method(), password }
-        : { method: method() }) as Parameters<typeof enableTwoFactor.mutate>[0]
-    )
-  }
+  }))
+  const code = () => form.state.values.code
 
   const submitLabel = () => {
     if (step() === "backupCodes") return twoFactorLocalization.done
@@ -168,172 +166,173 @@ export function EnableTwoFactorDialog(props: {
 
   return (
     <DialogContent>
-      <form class="flex flex-col gap-6" onSubmit={submit}>
-        <DialogHeader>
-          <div class="flex size-10 items-center justify-center rounded-md bg-muted">
-            <ShieldCheck class="size-4.5" />
-          </div>
+      <form.AppForm>
+        <form.AuthFormRoot class="flex flex-col gap-6">
+          <DialogHeader>
+            <div class="flex size-10 items-center justify-center rounded-md bg-muted">
+              <ShieldCheck class="size-4.5" />
+            </div>
 
-          <DialogTitle>{twoFactorLocalization.twoFactor}</DialogTitle>
-          <DialogDescription>{description()}</DialogDescription>
-        </DialogHeader>
+            <DialogTitle>{twoFactorLocalization.twoFactor}</DialogTitle>
+            <DialogDescription>{description()}</DialogDescription>
+          </DialogHeader>
 
-        <Show when={step() === "password"}>
-          <div class="flex flex-col gap-4">
-            <Show when={enrollmentMethods.length > 1}>
-              <Tabs value={method()} onChange={setMethod}>
-                <TabsList
-                  aria-label={twoFactorLocalization.chooseEnrollmentMethod}
-                  class="w-full"
-                >
-                  <Show when={enrollmentMethods.includes("totp")}>
-                    <TabsTrigger value="totp">
-                      {twoFactorLocalization.authenticatorApp}
-                    </TabsTrigger>
-                  </Show>
-                  <Show when={enrollmentMethods.includes("otp")}>
-                    <TabsTrigger value="otp">
-                      {twoFactorLocalization.deliveredCode}
-                    </TabsTrigger>
-                  </Show>
-                </TabsList>
-              </Tabs>
-            </Show>
-
-            <p class="text-muted-foreground text-sm">
-              {method() === "totp"
-                ? twoFactorLocalization.authenticatorAppDescription
-                : twoFactorLocalization.deliveredCodeDescription}
-            </p>
-
-            <Show when={requiresPassword()}>
-              <Field>
-                <FieldLabel for="enable-two-factor-password">
-                  {auth.localization.auth.password}
-                </FieldLabel>
-
-                <Input
-                  autocomplete="current-password"
-                  autofocus
-                  disabled={isPending()}
-                  id="enable-two-factor-password"
-                  name="password"
-                  placeholder={auth.localization.auth.passwordPlaceholder}
-                  required
-                  type="password"
-                />
-              </Field>
-            </Show>
-          </div>
-        </Show>
-
-        <Show when={step() === "verify"}>
-          <div class="flex flex-col items-center gap-4">
-            <Show when={qrCode()}>
-              {(data) => (
-                <svg
-                  aria-hidden="true"
-                  class="size-44 rounded-md border"
-                  viewBox={`0 0 ${data().size} ${data().size}`}
-                >
-                  <path
-                    d={`M0 0h${data().size}v${data().size}H0z`}
-                    fill="white"
-                  />
-                  <path
-                    d={data().path}
-                    fill="black"
-                    shape-rendering="crispEdges"
-                  />
-                </svg>
-              )}
-            </Show>
-
-            <Show when={setupKey()}>
-              {(key) => (
-                <Field class="w-full gap-1">
-                  <FieldLabel
-                    class="text-muted-foreground text-xs"
-                    for="two-factor-setup-key"
+          <Show when={step() === "password"}>
+            <div class="flex flex-col gap-4">
+              <Show when={enrollmentMethods.length > 1}>
+                <Tabs value={method()} onChange={setMethod}>
+                  <TabsList
+                    aria-label={twoFactorLocalization.chooseEnrollmentMethod}
+                    class="w-full"
                   >
-                    {twoFactorLocalization.setupKey}
-                  </FieldLabel>
+                    <Show when={enrollmentMethods.includes("totp")}>
+                      <TabsTrigger value="totp">
+                        {twoFactorLocalization.authenticatorApp}
+                      </TabsTrigger>
+                    </Show>
+                    <Show when={enrollmentMethods.includes("otp")}>
+                      <TabsTrigger value="otp">
+                        {twoFactorLocalization.deliveredCode}
+                      </TabsTrigger>
+                    </Show>
+                  </TabsList>
+                </Tabs>
+              </Show>
 
-                  <InputGroup>
-                    <InputGroupInput
-                      class="font-mono text-xs"
-                      id="two-factor-setup-key"
-                      readonly
-                      value={key()}
+              <p class="text-muted-foreground text-sm">
+                {method() === "totp"
+                  ? twoFactorLocalization.authenticatorAppDescription
+                  : twoFactorLocalization.deliveredCodeDescription}
+              </p>
+
+              <Show when={requiresPassword()}>
+                <form.AppField
+                  name="password"
+                  validators={{
+                    onChange: ({ value }) =>
+                      value ? undefined : auth.localization.auth.fieldRequired
+                  }}
+                >
+                  {(field) => (
+                    <field.AuthFormTextField
+                      autocomplete="current-password"
+                      autofocus
+                      disabled={isPending()}
+                      id="enable-two-factor-password"
+                      label={auth.localization.auth.password}
+                      placeholder={auth.localization.auth.passwordPlaceholder}
+                      type="password"
                     />
-
-                    <InputGroupAddon align="inline-end">
-                      <InputGroupButton
-                        aria-label={
-                          setupKeyCopied()
-                            ? twoFactorLocalization.setupKeyCopied
-                            : auth.localization.settings.copyToClipboard
-                        }
-                        onClick={() => copySetupKey(key())}
-                        size="icon-xs"
-                        type="button"
-                      >
-                        <Show fallback={<Copy />} when={setupKeyCopied()}>
-                          <Check />
-                        </Show>
-                      </InputGroupButton>
-                    </InputGroupAddon>
-                  </InputGroup>
-                </Field>
-              )}
-            </Show>
-
-            <OtpField
-              autofocus
-              class="w-full"
-              disabled={isPending()}
-              id="enable-two-factor-code"
-              label={twoFactorLocalization.authenticatorCode}
-              length={codeLength}
-              name="code"
-              onInput={setCode}
-              onComplete={verifyCode}
-              value={code()}
-            />
-          </div>
-        </Show>
-
-        <Show when={step() === "backupCodes"}>
-          <BackupCodes codes={backupCodes()} />
-        </Show>
-
-        <DialogFooter>
-          <Show when={step() !== "backupCodes"}>
-            <DialogClose
-              as={Button}
-              disabled={isPending()}
-              type="button"
-              variant="outline"
-            >
-              {auth.localization.settings.cancel}
-            </DialogClose>
+                  )}
+                </form.AppField>
+              </Show>
+            </div>
           </Show>
 
-          <Button
-            disabled={
-              isPending() ||
-              (step() === "verify" && code().length !== codeLength)
-            }
-            type="submit"
-          >
-            <Show when={isPending()}>
-              <Spinner />
+          <Show when={step() === "verify"}>
+            <div class="flex flex-col items-center gap-4">
+              <Show when={qrCode()}>
+                {(data) => (
+                  <svg
+                    aria-hidden="true"
+                    class="size-44 rounded-md border"
+                    viewBox={`0 0 ${data().size} ${data().size}`}
+                  >
+                    <path
+                      d={`M0 0h${data().size}v${data().size}H0z`}
+                      fill="white"
+                    />
+                    <path
+                      d={data().path}
+                      fill="black"
+                      shape-rendering="crispEdges"
+                    />
+                  </svg>
+                )}
+              </Show>
+
+              <Show when={setupKey()}>
+                {(key) => (
+                  <Field class="w-full gap-1">
+                    <FieldLabel
+                      class="text-muted-foreground text-xs"
+                      for="two-factor-setup-key"
+                    >
+                      {twoFactorLocalization.setupKey}
+                    </FieldLabel>
+
+                    <InputGroup>
+                      <InputGroupInput
+                        class="font-mono text-xs"
+                        id="two-factor-setup-key"
+                        readonly
+                        value={key()}
+                      />
+
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupButton
+                          aria-label={
+                            setupKeyCopied()
+                              ? twoFactorLocalization.setupKeyCopied
+                              : auth.localization.settings.copyToClipboard
+                          }
+                          onClick={() => copySetupKey(key())}
+                          size="icon-xs"
+                          type="button"
+                        >
+                          <Show fallback={<Copy />} when={setupKeyCopied()}>
+                            <Check />
+                          </Show>
+                        </InputGroupButton>
+                      </InputGroupAddon>
+                    </InputGroup>
+                  </Field>
+                )}
+              </Show>
+
+              <OtpField
+                autofocus
+                class="w-full"
+                disabled={isPending()}
+                id="enable-two-factor-code"
+                label={twoFactorLocalization.authenticatorCode}
+                length={codeLength}
+                name="code"
+                onInput={(value) => form.setFieldValue("code", value)}
+                onComplete={(value) => void verifyCode(value)}
+                value={code()}
+              />
+            </div>
+          </Show>
+
+          <Show when={step() === "backupCodes"}>
+            <BackupCodes codes={backupCodes()} />
+          </Show>
+
+          <DialogFooter>
+            <Show when={step() !== "backupCodes"}>
+              <DialogClose
+                as={Button}
+                disabled={isPending()}
+                type="button"
+                variant="outline"
+              >
+                {auth.localization.settings.cancel}
+              </DialogClose>
             </Show>
 
-            {submitLabel()}
-          </Button>
-        </DialogFooter>
-      </form>
+            <form.AuthFormSubmitButton
+              disabled={
+                isPending() ||
+                (step() === "verify" && code().length !== codeLength)
+              }
+            >
+              {submitLabel()}
+            </form.AuthFormSubmitButton>
+          </DialogFooter>
+          <form.AuthFormServerError />
+        </form.AuthFormRoot>
+      </form.AppForm>
     </DialogContent>
   )
 }

--- a/examples/start-solid-zaidan-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -122,7 +122,7 @@ export function EnableTwoFactorDialog(props: {
     }
 
     form.setFieldValue("code", completedCode)
-    await submitAuthForm(form)
+    await submitAuthForm(form, auth.localization.auth.callbackFailedTitle)
   }
 
   const form = createAuthForm(() => ({
@@ -167,7 +167,10 @@ export function EnableTwoFactorDialog(props: {
   return (
     <DialogContent>
       <form.AppForm>
-        <form.AuthFormRoot class="flex flex-col gap-6">
+        <form.AuthFormRoot
+          class="flex flex-col gap-6"
+          serverErrorMessage={auth.localization.auth.callbackFailedTitle}
+        >
           <DialogHeader>
             <div class="flex size-10 items-center justify-center rounded-md bg-muted">
               <ShieldCheck class="size-4.5" />

--- a/examples/start-solid-zaidan-example/src/components/auth/two-factor/regenerate-backup-codes-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/two-factor/regenerate-backup-codes-dialog.tsx
@@ -18,12 +18,12 @@ import {
   AlertDialogMedia,
   AlertDialogTitle
 } from "@/components/ui/alert-dialog"
-import { Button } from "@/components/ui/button"
 import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import { twoFactorPlugin } from "@/lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "@/lib/auth/use-two-factor-password"
+import { createAuthForm } from "../auth-form"
 
 /**
  * Replace the existing backup codes with a fresh set.
@@ -52,87 +52,96 @@ export function RegenerateBackupCodesDialog(props: {
   const isPending = () =>
     generateBackupCodes.isPending || isResolvingPasswordRequirement()
 
-  const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
-    event.preventDefault()
-
-    if (codes().length) {
-      props.onOpenChange(false)
-      return
+  const form = createAuthForm(() => ({
+    defaultValues: { password: "" },
+    onSubmit: async ({ value }) => {
+      if (codes().length) {
+        props.onOpenChange(false)
+        return
+      }
+      await generateBackupCodes.mutateAsync(
+        (requiresPassword() ? { password: value.password } : {}) as Parameters<
+          typeof generateBackupCodes.mutateAsync
+        >[0]
+      )
     }
-
-    const formData = new FormData(event.currentTarget)
-    const password = String(formData.get("password") ?? "")
-
-    generateBackupCodes.mutate(
-      (requiresPassword() ? { password } : {}) as Parameters<
-        typeof generateBackupCodes.mutate
-      >[0]
-    )
-  }
+  }))
 
   return (
     <AlertDialogContent>
-      <form class="flex flex-col gap-6" onSubmit={submit}>
-        <AlertDialogHeader>
-          <AlertDialogMedia>
-            <KeyRound />
-          </AlertDialogMedia>
+      <form.AppForm>
+        <form.AuthFormRoot class="flex flex-col gap-6">
+          <AlertDialogHeader>
+            <AlertDialogMedia>
+              <KeyRound />
+            </AlertDialogMedia>
 
-          <AlertDialogTitle>
-            {twoFactorLocalization.backupCodes}
-          </AlertDialogTitle>
+            <AlertDialogTitle>
+              {twoFactorLocalization.backupCodes}
+            </AlertDialogTitle>
 
-          <AlertDialogDescription>
-            {codes().length || !requiresPassword()
-              ? twoFactorLocalization.backupCodesDescription
-              : twoFactorLocalization.passwordConfirmation}
-          </AlertDialogDescription>
-        </AlertDialogHeader>
+            <AlertDialogDescription>
+              {codes().length || !requiresPassword()
+                ? twoFactorLocalization.backupCodesDescription
+                : twoFactorLocalization.passwordConfirmation}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
 
-        <Show
-          when={codes().length}
-          fallback={
-            <Show when={requiresPassword()}>
-              <Field>
-                <FieldLabel for="regenerate-backup-codes-password">
-                  {auth.localization.auth.password}
-                </FieldLabel>
+          <Show
+            when={codes().length}
+            fallback={
+              <Show when={requiresPassword()}>
+                <form.AppField name="password">
+                  {(field) => (
+                    <Field>
+                      <FieldLabel for="regenerate-backup-codes-password">
+                        {auth.localization.auth.password}
+                      </FieldLabel>
 
-                <Input
-                  autocomplete="current-password"
-                  autofocus
-                  disabled={isPending()}
-                  id="regenerate-backup-codes-password"
-                  name="password"
-                  placeholder={auth.localization.auth.passwordPlaceholder}
-                  required
-                  type="password"
-                />
-              </Field>
-            </Show>
-          }
-        >
-          <BackupCodes codes={codes()} />
-        </Show>
-
-        <AlertDialogFooter>
-          <Show when={!codes().length}>
-            <AlertDialogCancel disabled={isPending()} type="button">
-              {auth.localization.settings.cancel}
-            </AlertDialogCancel>
+                      <Input
+                        autocomplete="current-password"
+                        autofocus
+                        disabled={isPending()}
+                        id="regenerate-backup-codes-password"
+                        name={field().name}
+                        placeholder={auth.localization.auth.passwordPlaceholder}
+                        value={field().state.value}
+                        onBlur={field().handleBlur}
+                        onInput={(event) =>
+                          field().handleChange(event.currentTarget.value)
+                        }
+                        type="password"
+                      />
+                      <field.AuthFormFieldError />
+                    </Field>
+                  )}
+                </form.AppField>
+              </Show>
+            }
+          >
+            <BackupCodes codes={codes()} />
           </Show>
 
-          <Button disabled={isPending()} type="submit">
-            <Show when={isPending()}>
-              <Spinner />
+          <AlertDialogFooter>
+            <Show when={!codes().length}>
+              <AlertDialogCancel disabled={isPending()} type="button">
+                {auth.localization.settings.cancel}
+              </AlertDialogCancel>
             </Show>
 
-            {codes().length
-              ? twoFactorLocalization.done
-              : twoFactorLocalization.regenerateBackupCodes}
-          </Button>
-        </AlertDialogFooter>
-      </form>
+            <form.AuthFormSubmitButton disabled={isPending()}>
+              <Show when={isPending()}>
+                <Spinner />
+              </Show>
+
+              {codes().length
+                ? twoFactorLocalization.done
+                : twoFactorLocalization.regenerateBackupCodes}
+            </form.AuthFormSubmitButton>
+          </AlertDialogFooter>
+          <form.AuthFormServerError />
+        </form.AuthFormRoot>
+      </form.AppForm>
     </AlertDialogContent>
   )
 }

--- a/examples/start-solid-zaidan-example/src/components/auth/two-factor/regenerate-backup-codes-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/two-factor/regenerate-backup-codes-dialog.tsx
@@ -1,3 +1,4 @@
+import { validateStringLength } from "@better-auth-ui/core"
 import {
   generateBackupCodesOptions,
   type TwoFactorAuthClient
@@ -91,7 +92,15 @@ export function RegenerateBackupCodesDialog(props: {
             when={codes().length}
             fallback={
               <Show when={requiresPassword()}>
-                <form.AppField name="password">
+                <form.AppField
+                  name="password"
+                  validators={{
+                    onChange: ({ value }) =>
+                      validateStringLength(value, {
+                        requiredMessage: auth.localization.auth.fieldRequired
+                      })
+                  }}
+                >
                   {(field) => (
                     <Field>
                       <FieldLabel for="regenerate-backup-codes-password">

--- a/examples/start-solid-zaidan-example/src/components/auth/two-factor/two-factor-challenge.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/two-factor/two-factor-challenge.tsx
@@ -32,7 +32,6 @@ import {
   FieldGroup,
   FieldLabel
 } from "@/components/ui/field"
-import { Input } from "@/components/ui/input"
 import { Spinner } from "@/components/ui/spinner"
 import {
   clearTwoFactorMethods,
@@ -45,6 +44,11 @@ import {
   useResendCooldown
 } from "@/lib/auth/use-resend-cooldown"
 import { cn } from "@/lib/utils"
+import {
+  createAuthForm,
+  setAuthFormServerError,
+  submitAuthForm
+} from "../auth-form"
 
 /** Challenge surfaces the view can render, in the order they are offered. */
 type ChallengeMethod = TwoFactorMethod | "backup"
@@ -78,7 +82,6 @@ export function TwoFactorChallenge(props: TwoFactorChallengeProps) {
   const [method, setMethod] = createSignal<ChallengeMethod>(
     storedMethods[0] ?? "totp"
   )
-  const [code, setCode] = createSignal("")
   const [trustDevice, setTrustDevice] = createSignal(false)
   const [otpRequested, setOtpRequested] = createSignal(false)
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
@@ -103,13 +106,13 @@ export function TwoFactorChallenge(props: TwoFactorChallengeProps) {
 
   const verifyTotp = createMutation(() => ({
     ...verifyTotpOptions(twoFactorClient()),
-    onError: () => setCode(""),
+    onError: () => form.setFieldValue("code", ""),
     onSuccess: onVerified
   }))
 
   const verifyOtp = createMutation(() => ({
     ...verifyTwoFactorOtpOptions(twoFactorClient()),
-    onError: () => setCode(""),
+    onError: () => form.setFieldValue("code", ""),
     onSuccess: onVerified
   }))
 
@@ -126,7 +129,33 @@ export function TwoFactorChallenge(props: TwoFactorChallengeProps) {
 
   const needsOtpRequest = () => method() === "otp" && !otpRequested()
 
-  const verifyCode = (completedCode: string) => {
+  const form = createAuthForm(() => ({
+    defaultValues: { backupCode: "", code: "" },
+    onSubmit: async ({ value }) => {
+      const trust = trustDeviceEnabled ? { trustDevice: trustDevice() } : {}
+      if (method() === "backup") {
+        await verifyBackupCode.mutateAsync({
+          code: value.backupCode.trim(),
+          ...trust
+        } as Parameters<typeof verifyBackupCode.mutateAsync>[0])
+        return
+      }
+      if (method() === "otp") {
+        await verifyOtp.mutateAsync({
+          code: value.code,
+          ...trust
+        } as Parameters<typeof verifyOtp.mutateAsync>[0])
+        return
+      }
+      await verifyTotp.mutateAsync({
+        code: value.code,
+        ...trust
+      } as Parameters<typeof verifyTotp.mutateAsync>[0])
+    }
+  }))
+  const code = () => form.state.values.code
+
+  const verifyCode = async (completedCode: string) => {
     if (
       isPending() ||
       needsOtpRequest() ||
@@ -136,18 +165,8 @@ export function TwoFactorChallenge(props: TwoFactorChallengeProps) {
       return
     }
 
-    const trust = trustDeviceEnabled ? { trustDevice: trustDevice() } : {}
-
-    if (method() === "otp") {
-      verifyOtp.mutate({ code: completedCode, ...trust } as Parameters<
-        typeof verifyOtp.mutate
-      >[0])
-      return
-    }
-
-    verifyTotp.mutate({ code: completedCode, ...trust } as Parameters<
-      typeof verifyTotp.mutate
-    >[0])
+    form.setFieldValue("code", completedCode)
+    await submitAuthForm(form)
   }
 
   const description = () => {
@@ -175,21 +194,12 @@ export function TwoFactorChallenge(props: TwoFactorChallengeProps) {
       : [])
   ]
 
-  const submit = (event: SubmitEvent & { currentTarget: HTMLFormElement }) => {
-    event.preventDefault()
-
-    const trust = trustDeviceEnabled ? { trustDevice: trustDevice() } : {}
-
-    if (method() === "backup") {
-      const formData = new FormData(event.currentTarget)
-      verifyBackupCode.mutate({
-        code: String(formData.get("backupCode") ?? "").trim(),
-        ...trust
-      } as Parameters<typeof verifyBackupCode.mutate>[0])
-      return
+  const requestOtp = async () => {
+    try {
+      await sendOtp.mutateAsync({} as Parameters<typeof sendOtp.mutateAsync>[0])
+    } catch (error) {
+      setAuthFormServerError(form, error, "Unable to send a code. Try again.")
     }
-
-    verifyCode(code())
   }
 
   return (
@@ -203,134 +213,151 @@ export function TwoFactorChallenge(props: TwoFactorChallengeProps) {
       </CardHeader>
 
       <CardContent>
-        <form aria-label={twoFactorLocalization.twoFactor} onSubmit={submit}>
-          <FieldGroup>
-            <Show
-              when={method() === "backup"}
-              fallback={
-                <OtpField
-                  autofocus
-                  disabled={isPending() || needsOtpRequest()}
-                  id="two-factor-code"
-                  label={
-                    method() === "otp"
-                      ? twoFactorLocalization.emailedCode
-                      : twoFactorLocalization.authenticatorCode
-                  }
-                  length={codeLength}
-                  name="code"
-                  onInput={setCode}
-                  onComplete={verifyCode}
-                  value={code()}
-                />
-              }
-            >
-              <Field>
-                <FieldLabel for="two-factor-backup-code">
-                  {twoFactorLocalization.backupCode}
-                </FieldLabel>
-                <Input
-                  autocomplete="one-time-code"
-                  autofocus
-                  disabled={isPending()}
-                  id="two-factor-backup-code"
-                  name="backupCode"
-                  required
-                />
-              </Field>
-            </Show>
-
-            <Show when={trustDeviceEnabled}>
-              <Field orientation="horizontal">
-                <Checkbox
-                  checked={trustDevice()}
-                  disabled={isPending()}
-                  id="two-factor-trust-device"
-                  name="trustDevice"
-                  onChange={(event) => setTrustDevice(event)}
-                />
-                <FieldContent>
-                  <FieldLabel for="two-factor-trust-device">
-                    {twoFactorLocalization.trustDevice}
-                  </FieldLabel>
-                </FieldContent>
-              </Field>
-            </Show>
-
-            <div class="flex flex-col gap-3">
+        <form.AppForm>
+          <form.AuthFormRoot aria-label={twoFactorLocalization.twoFactor}>
+            <FieldGroup>
               <Show
-                when={needsOtpRequest()}
+                when={method() === "backup"}
                 fallback={
+                  <form.AppField
+                    name="code"
+                    validators={{
+                      onChange: ({ value }) =>
+                        value.length === codeLength
+                          ? undefined
+                          : `Enter the ${codeLength}-digit code.`
+                    }}
+                  >
+                    {(field) => (
+                      <OtpField
+                        autofocus
+                        disabled={isPending() || needsOtpRequest()}
+                        id="two-factor-code"
+                        label={
+                          method() === "otp"
+                            ? twoFactorLocalization.emailedCode
+                            : twoFactorLocalization.authenticatorCode
+                        }
+                        length={codeLength}
+                        name={field().name}
+                        onInput={field().handleChange}
+                        onComplete={(value) => void verifyCode(value)}
+                        value={field().state.value}
+                      />
+                    )}
+                  </form.AppField>
+                }
+              >
+                <form.AppField
+                  name="backupCode"
+                  validators={{
+                    onChange: ({ value }) =>
+                      value.trim()
+                        ? undefined
+                        : auth.localization.auth.fieldRequired
+                  }}
+                >
+                  {(field) => (
+                    <field.AuthFormTextField
+                      autocomplete="one-time-code"
+                      autofocus
+                      disabled={isPending()}
+                      id="two-factor-backup-code"
+                      label={twoFactorLocalization.backupCode}
+                    />
+                  )}
+                </form.AppField>
+              </Show>
+
+              <Show when={trustDeviceEnabled}>
+                <Field orientation="horizontal">
+                  <Checkbox
+                    checked={trustDevice()}
+                    disabled={isPending()}
+                    id="two-factor-trust-device"
+                    name="trustDevice"
+                    onChange={(event) => setTrustDevice(event)}
+                  />
+                  <FieldContent>
+                    <FieldLabel for="two-factor-trust-device">
+                      {twoFactorLocalization.trustDevice}
+                    </FieldLabel>
+                  </FieldContent>
+                </Field>
+              </Show>
+
+              <div class="flex flex-col gap-3">
+                <Show
+                  when={needsOtpRequest()}
+                  fallback={
+                    <Button
+                      class="w-full"
+                      disabled={
+                        isPending() ||
+                        (method() !== "backup" && code().length !== codeLength)
+                      }
+                      type="submit"
+                    >
+                      <Show when={isPending()}>
+                        <Spinner />
+                      </Show>
+
+                      {twoFactorLocalization.verify}
+                    </Button>
+                  }
+                >
                   <Button
                     class="w-full"
-                    disabled={
-                      isPending() ||
-                      (method() !== "backup" && code().length !== codeLength)
-                    }
-                    type="submit"
+                    disabled={sendOtp.isPending}
+                    onClick={() => void requestOtp()}
+                    type="button"
                   >
-                    <Show when={isPending()}>
+                    <Show when={sendOtp.isPending}>
                       <Spinner />
                     </Show>
 
-                    {twoFactorLocalization.verify}
+                    {twoFactorLocalization.sendEmailCode}
                   </Button>
-                }
-              >
-                <Button
-                  class="w-full"
-                  disabled={sendOtp.isPending}
-                  onClick={() =>
-                    sendOtp.mutate({} as Parameters<typeof sendOtp.mutate>[0])
-                  }
-                  type="button"
-                >
-                  <Show when={sendOtp.isPending}>
-                    <Spinner />
-                  </Show>
+                </Show>
 
-                  {twoFactorLocalization.sendEmailCode}
-                </Button>
-              </Show>
-
-              <Show when={method() === "otp" && otpRequested()}>
-                <Button
-                  class="w-full"
-                  disabled={isPending() || isCoolingDown()}
-                  onClick={() =>
-                    sendOtp.mutate({} as Parameters<typeof sendOtp.mutate>[0])
-                  }
-                  type="button"
-                  variant="outline"
-                >
-                  {isCoolingDown()
-                    ? auth.localization.auth.resendIn.replace(
-                        "{{seconds}}",
-                        String(cooldown())
-                      )
-                    : auth.localization.auth.resend}
-                </Button>
-              </Show>
-
-              <For each={alternatives()}>
-                {(alternative) => (
+                <Show when={method() === "otp" && otpRequested()}>
                   <Button
                     class="w-full"
-                    disabled={isPending()}
-                    onClick={() => {
-                      setCode("")
-                      setMethod(alternative.key)
-                    }}
+                    disabled={isPending() || isCoolingDown()}
+                    onClick={() => void requestOtp()}
                     type="button"
-                    variant="ghost"
+                    variant="outline"
                   >
-                    {alternative.label}
+                    {isCoolingDown()
+                      ? auth.localization.auth.resendIn.replace(
+                          "{{seconds}}",
+                          String(cooldown())
+                        )
+                      : auth.localization.auth.resend}
                   </Button>
-                )}
-              </For>
-            </div>
-          </FieldGroup>
-        </form>
+                </Show>
+
+                <For each={alternatives()}>
+                  {(alternative) => (
+                    <Button
+                      class="w-full"
+                      disabled={isPending()}
+                      onClick={() => {
+                        form.setFieldValue("code", "")
+                        setMethod(alternative.key)
+                      }}
+                      type="button"
+                      variant="ghost"
+                    >
+                      {alternative.label}
+                    </Button>
+                  )}
+                </For>
+              </div>
+              <form.AuthFormServerError />
+            </FieldGroup>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </CardContent>
 
       <CardFooter class="justify-center">

--- a/examples/start-solid-zaidan-example/src/components/auth/two-factor/two-factor-challenge.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/two-factor/two-factor-challenge.tsx
@@ -202,6 +202,14 @@ export function TwoFactorChallenge(props: TwoFactorChallengeProps) {
     }
   }
 
+  const switchMethod = (nextMethod: ChallengeMethod) => {
+    setMethod(nextMethod)
+    form.setFieldValue("code", "")
+    form.setFieldValue("backupCode", "")
+    form.validateField("code", "change")
+    form.validateField("backupCode", "change")
+  }
+
   return (
     <Card class={cn("w-full max-w-sm", props.class)}>
       <CardHeader>
@@ -223,9 +231,12 @@ export function TwoFactorChallenge(props: TwoFactorChallengeProps) {
                     name="code"
                     validators={{
                       onChange: ({ value }) =>
-                        value.length === codeLength
+                        method() === "backup" || value.length === codeLength
                           ? undefined
-                          : `Enter the ${codeLength}-digit code.`
+                          : twoFactorLocalization.codeLengthMismatch.replace(
+                              "{{length}}",
+                              String(codeLength)
+                            )
                     }}
                   >
                     {(field) => (
@@ -252,7 +263,7 @@ export function TwoFactorChallenge(props: TwoFactorChallengeProps) {
                   name="backupCode"
                   validators={{
                     onChange: ({ value }) =>
-                      value.trim()
+                      method() !== "backup" || value.trim()
                         ? undefined
                         : auth.localization.auth.fieldRequired
                   }}
@@ -342,10 +353,7 @@ export function TwoFactorChallenge(props: TwoFactorChallengeProps) {
                     <Button
                       class="w-full"
                       disabled={isPending()}
-                      onClick={() => {
-                        form.setFieldValue("code", "")
-                        setMethod(alternative.key)
-                      }}
+                      onClick={() => switchMethod(alternative.key)}
                       type="button"
                       variant="ghost"
                     >

--- a/examples/start-solid-zaidan-example/src/components/auth/username/sign-in-username.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/username/sign-in-username.tsx
@@ -31,7 +31,7 @@ import { createAuthForm, isAuthFormFieldInvalid } from "../auth-form"
 import { LastUsedBadge } from "../last-login-method/last-used-badge"
 import type { SocialLayout } from "../provider-buttons"
 import { ProviderButtons } from "../provider-buttons"
-import { resolveSubmittedSignIn } from "../sign-in-path"
+import { resolveSignInPath } from "../sign-in-path"
 
 export type SignInUsernameProps = {
   class?: string
@@ -94,18 +94,14 @@ export function SignInUsername(props: SignInUsernameProps) {
   const form = createAuthForm(() => ({
     defaultValues: { identifier: "", password: "" },
     onSubmit: async ({ value }) => {
-      const formData = new FormData()
-      formData.set(usernameAuth ? "username" : "email", value.identifier)
-      formData.set("password", value.password)
-      const { password: submittedPassword, signInPath } =
-        resolveSubmittedSignIn({
-          formData,
-          usernameAuth
-        })
+      const signInPath = resolveSignInPath({
+        identifier: value.identifier,
+        usernameAuth
+      })
       if (signInPath.kind === "username") {
         await signInUsername.mutateAsync({
           fetchOptions: fetchOptions(),
-          password: submittedPassword,
+          password: value.password,
           username: signInPath.username
         })
         return
@@ -113,7 +109,7 @@ export function SignInUsername(props: SignInUsernameProps) {
       await signIn.mutateAsync({
         email: signInPath.email,
         fetchOptions: fetchOptions(),
-        password: submittedPassword
+        password: value.password
       })
     }
   }))

--- a/examples/start-solid-zaidan-example/src/components/auth/username/sign-in-username.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/username/sign-in-username.tsx
@@ -21,13 +21,13 @@ import { useQueryClient } from "@tanstack/solid-query"
 import type { BetterFetchError } from "better-auth/client"
 import { Eye, EyeOff } from "lucide-solid"
 import { type Component, createSignal, For, Show } from "solid-js"
-import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { Field, FieldError, FieldLabel } from "@/components/ui/field"
+import { Field, FieldLabel } from "@/components/ui/field"
 import { Input } from "@/components/ui/input"
 import { useSignInContinuation } from "@/lib/auth/use-sign-in-continuation"
 import { cn } from "@/lib/utils"
+import { createAuthForm, isAuthFormFieldInvalid } from "../auth-form"
 import { LastUsedBadge } from "../last-login-method/last-used-badge"
 import type { SocialLayout } from "../provider-buttons"
 import { ProviderButtons } from "../provider-buttons"
@@ -50,10 +50,6 @@ export function SignInUsername(props: SignInUsernameProps) {
   const auth = useAuth<UsernameAuthClient>()
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
   const queryClient = useQueryClient()
-  const [identifier, setIdentifier] = createSignal("")
-  const [identifierError, setIdentifierError] = createSignal<string>()
-  const [password, setPassword] = createSignal("")
-  const [passwordError, setPasswordError] = createSignal<string>()
   const [isPasswordVisible, setIsPasswordVisible] = createSignal(false)
   const continueSignIn = useSignInContinuation()
   const onSignInSuccess = (data: unknown) => {
@@ -95,36 +91,32 @@ export function SignInUsername(props: SignInUsernameProps) {
   const showSeparator = () =>
     Boolean(auth.emailAndPassword?.enabled && auth.socialProviders?.length)
 
-  const submitSignIn = (
-    event: SubmitEvent & { currentTarget: HTMLFormElement }
-  ) => {
-    event.preventDefault()
-
-    const { password: submittedPassword, signInPath } = resolveSubmittedSignIn({
-      formData: new FormData(event.currentTarget),
-      usernameAuth
-    })
-
-    setIdentifier(
-      signInPath.kind === "username" ? signInPath.username : signInPath.email
-    )
-    setPassword(submittedPassword)
-
-    if (signInPath.kind === "username") {
-      signInUsername.mutate({
+  const form = createAuthForm(() => ({
+    defaultValues: { identifier: "", password: "" },
+    onSubmit: async ({ value }) => {
+      const formData = new FormData()
+      formData.set(usernameAuth ? "username" : "email", value.identifier)
+      formData.set("password", value.password)
+      const { password: submittedPassword, signInPath } =
+        resolveSubmittedSignIn({
+          formData,
+          usernameAuth
+        })
+      if (signInPath.kind === "username") {
+        await signInUsername.mutateAsync({
+          fetchOptions: fetchOptions(),
+          password: submittedPassword,
+          username: signInPath.username
+        })
+        return
+      }
+      await signIn.mutateAsync({
+        email: signInPath.email,
         fetchOptions: fetchOptions(),
-        password: submittedPassword,
-        username: signInPath.username
+        password: submittedPassword
       })
-      return
     }
-
-    signIn.mutate({
-      email: signInPath.email,
-      fetchOptions: fetchOptions(),
-      password: submittedPassword
-    })
-  }
+  }))
 
   return (
     <Card class={cn("w-full max-w-sm", props.class)}>
@@ -147,142 +139,150 @@ export function SignInUsername(props: SignInUsernameProps) {
           </Show>
         </Show>
 
-        <form aria-label="Sign in" onSubmit={submitSignIn}>
-          <div class="flex flex-col gap-6">
-            <Field>
-              <FieldLabel for="sign-in-email">
-                {usernameAuth
-                  ? usernameLabels.username
-                  : auth.localization.auth.email}
-              </FieldLabel>
-              <Input
-                aria-invalid={Boolean(identifierError())}
-                autocomplete={withPasskeyAutoFill(
-                  usernameAuth ? "username" : "email",
-                  passkeyAutoFill
+        <form.AppForm>
+          <form.AuthFormRoot aria-label="Sign in">
+            <div class="flex flex-col gap-6">
+              <form.AppField
+                name="identifier"
+                validators={{
+                  onChange: ({ value }) =>
+                    value.trim()
+                      ? undefined
+                      : auth.localization.auth.fieldRequired
+                }}
+              >
+                {(field) => (
+                  <Field
+                    data-invalid={isAuthFormFieldInvalid(field().state.meta)}
+                  >
+                    <FieldLabel for="sign-in-email">
+                      {usernameAuth
+                        ? usernameLabels.username
+                        : auth.localization.auth.email}
+                    </FieldLabel>
+                    <Input
+                      aria-invalid={isAuthFormFieldInvalid(field().state.meta)}
+                      autocomplete={withPasskeyAutoFill(
+                        usernameAuth ? "username" : "email",
+                        passkeyAutoFill
+                      )}
+                      id="sign-in-email"
+                      name={field().name}
+                      onBlur={field().handleBlur}
+                      onInput={(event) =>
+                        field().handleChange(event.currentTarget.value)
+                      }
+                      placeholder={
+                        usernameAuth
+                          ? usernameLabels.usernameOrEmailPlaceholder
+                          : auth.localization.auth.emailPlaceholder
+                      }
+                      type={usernameAuth ? "text" : "email"}
+                      value={field().state.value}
+                    />
+                    <field.AuthFormFieldError />
+                  </Field>
                 )}
-                id="sign-in-email"
-                name={usernameAuth ? "username" : "email"}
-                onInput={(event) => {
-                  setIdentifier(event.currentTarget.value)
-                  setIdentifierError(undefined)
+              </form.AppField>
+
+              <form.AppField
+                name="password"
+                validators={{
+                  onChange: ({ value }) =>
+                    value ? undefined : auth.localization.auth.fieldRequired
                 }}
-                onInvalid={(event) => {
-                  event.preventDefault()
-                  setIdentifierError(event.currentTarget.validationMessage)
-                }}
-                placeholder={
-                  usernameAuth
-                    ? usernameLabels.usernameOrEmailPlaceholder
-                    : auth.localization.auth.emailPlaceholder
-                }
-                required
-                type={usernameAuth ? "text" : "email"}
-                value={identifier()}
-              />
+              >
+                {(field) => (
+                  <Field
+                    data-invalid={isAuthFormFieldInvalid(field().state.meta)}
+                  >
+                    <FieldLabel for="sign-in-password">
+                      {auth.localization.auth.password}
+                    </FieldLabel>
+                    <div class="relative">
+                      <Input
+                        aria-invalid={isAuthFormFieldInvalid(
+                          field().state.meta
+                        )}
+                        autocomplete={withPasskeyAutoFill(
+                          "current-password",
+                          passkeyAutoFill
+                        )}
+                        class="pr-12"
+                        id="sign-in-password"
+                        maxLength={auth.emailAndPassword.maxPasswordLength}
+                        minLength={auth.emailAndPassword.minPasswordLength}
+                        name={field().name}
+                        onBlur={field().handleBlur}
+                        onInput={(event) =>
+                          field().handleChange(event.currentTarget.value)
+                        }
+                        placeholder={auth.localization.auth.passwordPlaceholder}
+                        type={isPasswordVisible() ? "text" : "password"}
+                        value={field().state.value}
+                      />
 
-              <Show when={identifierError()}>
-                {(message) => <FieldError>{message()}</FieldError>}
+                      <Button
+                        aria-label={
+                          isPasswordVisible()
+                            ? auth.localization.auth.hidePassword
+                            : auth.localization.auth.showPassword
+                        }
+                        class="absolute right-1 top-1/2 -translate-y-1/2"
+                        onClick={() =>
+                          setIsPasswordVisible((visible) => !visible)
+                        }
+                        size="icon-sm"
+                        title={
+                          isPasswordVisible()
+                            ? auth.localization.auth.hidePassword
+                            : auth.localization.auth.showPassword
+                        }
+                        type="button"
+                        variant="ghost"
+                      >
+                        {isPasswordVisible() ? (
+                          <EyeOff aria-hidden class="size-4" />
+                        ) : (
+                          <Eye aria-hidden class="size-4" />
+                        )}
+                      </Button>
+                    </div>
+
+                    <field.AuthFormFieldError />
+                  </Field>
+                )}
+              </form.AppField>
+
+              <Show when={captchaComponent()} keyed>
+                {(Captcha) => <Captcha />}
               </Show>
-            </Field>
 
-            <Field>
-              <FieldLabel for="sign-in-password">
-                {auth.localization.auth.password}
-              </FieldLabel>
-              <div class="relative">
-                <Input
-                  aria-invalid={Boolean(passwordError())}
-                  autocomplete={withPasskeyAutoFill(
-                    "current-password",
-                    passkeyAutoFill
-                  )}
-                  class="pr-12"
-                  id="sign-in-password"
-                  maxLength={auth.emailAndPassword.maxPasswordLength}
-                  minLength={auth.emailAndPassword.minPasswordLength}
-                  name="password"
-                  onInput={(event) => {
-                    setPassword(event.currentTarget.value)
-                    setPasswordError(undefined)
-                  }}
-                  onInvalid={(event) => {
-                    event.preventDefault()
-                    setPasswordError(event.currentTarget.validationMessage)
-                  }}
-                  placeholder={auth.localization.auth.passwordPlaceholder}
-                  required
-                  type={isPasswordVisible() ? "text" : "password"}
-                  value={password()}
-                />
+              <form.AuthFormSubmitButton
+                class="relative overflow-visible"
+                disabled={signIn.isPending || signInUsername.isPending}
+              >
+                {auth.localization.auth.signIn}
 
-                <Button
-                  aria-label={
-                    isPasswordVisible()
-                      ? auth.localization.auth.hidePassword
-                      : auth.localization.auth.showPassword
-                  }
-                  class="absolute right-1 top-1/2 -translate-y-1/2"
-                  onClick={() => setIsPasswordVisible((visible) => !visible)}
-                  size="icon-sm"
-                  title={
-                    isPasswordVisible()
-                      ? auth.localization.auth.hidePassword
-                      : auth.localization.auth.showPassword
-                  }
-                  type="button"
-                  variant="ghost"
-                >
-                  {isPasswordVisible() ? (
-                    <EyeOff aria-hidden class="size-4" />
-                  ) : (
-                    <Eye aria-hidden class="size-4" />
-                  )}
-                </Button>
-              </div>
+                <LastUsedBadge floating method={["email", "username"]} />
+              </form.AuthFormSubmitButton>
 
-              <Show when={passwordError()}>
-                {(message) => <FieldError>{message()}</FieldError>}
-              </Show>
-            </Field>
+              <For
+                each={(auth.plugins as AuthPluginWithButtons[]).flatMap(
+                  (plugin) =>
+                    (plugin.authButtons ?? []).map((AuthButton, index) => ({
+                      AuthButton,
+                      key: `${plugin.id}-${index.toString()}`
+                    }))
+                )}
+              >
+                {({ AuthButton }) => <AuthButton view="signIn" />}
+              </For>
 
-            <Show when={captchaComponent()} keyed>
-              {(Captcha) => <Captcha />}
-            </Show>
-
-            <Button
-              class="relative overflow-visible"
-              disabled={signIn.isPending || signInUsername.isPending}
-              type="submit"
-            >
-              {signIn.isPending || signInUsername.isPending
-                ? `${auth.localization.auth.signIn}…`
-                : auth.localization.auth.signIn}
-
-              <LastUsedBadge floating method={["email", "username"]} />
-            </Button>
-
-            <For
-              each={(auth.plugins as AuthPluginWithButtons[]).flatMap(
-                (plugin) =>
-                  (plugin.authButtons ?? []).map((AuthButton, index) => ({
-                    AuthButton,
-                    key: `${plugin.id}-${index.toString()}`
-                  }))
-              )}
-            >
-              {({ AuthButton }) => <AuthButton view="signIn" />}
-            </For>
-
-            <Show when={signIn.isError || signInUsername.isError}>
-              <Alert variant="destructive">
-                <AlertDescription>
-                  Unable to sign in. Try again.
-                </AlertDescription>
-              </Alert>
-            </Show>
-          </div>
-        </form>
+              <form.AuthFormServerError />
+            </div>
+          </form.AuthFormRoot>
+        </form.AppForm>
 
         <Show
           when={socialPosition() === "bottom" && auth.socialProviders?.length}

--- a/examples/start-solid-zaidan-example/tests/auth-form.browser.test.tsx
+++ b/examples/start-solid-zaidan-example/tests/auth-form.browser.test.tsx
@@ -1,10 +1,42 @@
+import type { TablePersistenceAdapters } from "@better-auth-ui/core"
 import { cleanup, fireEvent, render } from "@solidjs/testing-library"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { createAuthForm } from "../src/components/auth/auth-form"
+import {
+  createOrganizationColumnHelper,
+  createOrganizationTable
+} from "../src/components/auth/organization/organization-table"
+import { OrganizationTableRenderer } from "../src/components/auth/organization/organization-table-renderer"
 import { OrganizationTableSelectRow } from "../src/components/auth/organization/organization-table-selection"
+import { createOrganizationTableState } from "../src/components/auth/organization/organization-table-state"
 
 afterEach(cleanup)
+
+type TestRow = {
+  group: string
+  id: string
+  name: string
+}
+
+const tableColumnHelper = createOrganizationColumnHelper<TestRow>()
+const tableColumns = tableColumnHelper.columns([
+  tableColumnHelper.accessor("group", {
+    cell: ({ getValue }) => getValue(),
+    filterFn: "includesString",
+    header: "Group"
+  }),
+  tableColumnHelper.accessor("name", {
+    cell: ({ getValue }) => getValue(),
+    filterFn: "includesString",
+    header: "Name"
+  })
+])
+const tableRows: TestRow[] = [
+  { group: "b", id: "1", name: "Ada" },
+  { group: "a", id: "2", name: "Charlie" },
+  { group: "a", id: "3", name: "Bea" }
+]
 
 function NativeValidationForm() {
   const form = createAuthForm(() => ({
@@ -35,6 +67,98 @@ function PendingAuthForm(props: { onSubmit: () => Promise<void> }) {
         <form.AuthFormSubmitButton>Submit</form.AuthFormSubmitButton>
       </form.AuthFormRoot>
     </form.AppForm>
+  )
+}
+
+function ValidatedAuthForm() {
+  const form = createAuthForm(() => ({
+    defaultValues: { email: "" },
+    onSubmit: async () => {
+      throw {
+        body: {
+          fieldErrors: { email: "This email is already registered" },
+          message: "Account creation failed"
+        }
+      }
+    }
+  }))
+
+  return (
+    <form.AppForm>
+      <form.AuthFormRoot>
+        <form.AppField
+          name="email"
+          validators={{
+            onChange: ({ value }) => (value ? undefined : "Email is required")
+          }}
+        >
+          {(field) => <field.AuthFormTextField label="Email" type="email" />}
+        </form.AppField>
+        <form.AuthFormSubmitButton>Submit</form.AuthFormSubmitButton>
+        <form.AuthFormServerError />
+      </form.AuthFormRoot>
+    </form.AppForm>
+  )
+}
+
+function OrganizationTableFixture() {
+  const table = createOrganizationTable({
+    columns: tableColumns,
+    data: tableRows,
+    getRowId: (row) => row.id,
+    initialState: { pagination: { pageIndex: 0, pageSize: 2 } }
+  })
+
+  return (
+    <>
+      <button
+        onClick={() => table.getColumn("group")?.setFilterValue("a")}
+        type="button"
+      >
+        Filter group
+      </button>
+      <button
+        onClick={() => table.getColumn("name")?.toggleSorting(true)}
+        type="button"
+      >
+        Sort names
+      </button>
+      <button onClick={() => table.nextPage()} type="button">
+        Next page
+      </button>
+      <button
+        onClick={() => table.getRow("1").toggleSelected(true)}
+        type="button"
+      >
+        Select Ada
+      </button>
+      <output aria-label="Selected rows">
+        {table
+          .getSelectedRowModel()
+          .rows.map((row) => row.id)
+          .join(",")}
+      </output>
+      <OrganizationTableRenderer empty="No people" table={table} />
+    </>
+  )
+}
+
+function RouterTableStateFixture(props: {
+  adapters: TablePersistenceAdapters
+}) {
+  const state = createOrganizationTableState(
+    "router",
+    10,
+    ["group", "name"],
+    props.adapters
+  )
+
+  return (
+    <output aria-label="Restored table state">
+      {state.ready()
+        ? `${state.globalFilter()}|${state.sorting()[0]?.id ?? ""}|${state.pagination().pageIndex}`
+        : "loading"}
+    </output>
   )
 }
 
@@ -73,6 +197,26 @@ describe("Solid auth form", () => {
     finishSubmission()
     await vi.waitFor(() => expect(submitButton).toBeEnabled())
   })
+
+  it("owns field validation and maps rejected server errors", async () => {
+    const view = render(() => <ValidatedAuthForm />)
+    const email = view.getByRole("textbox", { name: "Email" })
+    const submit = view.getByRole("button", { name: "Submit" })
+
+    fireEvent.input(email, { target: { value: "" } })
+    fireEvent.blur(email)
+    await vi.waitFor(() =>
+      expect(view.getByText("Email is required")).toBeVisible()
+    )
+
+    fireEvent.input(email, { target: { value: "ada@example.com" } })
+    fireEvent.click(submit)
+
+    await vi.waitFor(() =>
+      expect(view.getByText("This email is already registered")).toBeVisible()
+    )
+    expect(view.getByText("Account creation failed")).toBeVisible()
+  })
 })
 
 describe("Solid organization table selection", () => {
@@ -101,5 +245,78 @@ describe("Solid organization table selection", () => {
       shiftKey: true,
       target: { checked: true }
     })
+  })
+
+  it("renders columns and composes filtering, sorting, pagination, and selection", async () => {
+    const view = render(() => <OrganizationTableFixture />)
+
+    expect(view.getByRole("columnheader", { name: "Group" })).toBeVisible()
+    expect(view.getByRole("columnheader", { name: "Name" })).toBeVisible()
+    expect(view.getByRole("cell", { name: "Ada" })).toBeVisible()
+    expect(view.getByRole("cell", { name: "Charlie" })).toBeVisible()
+    expect(view.queryByRole("cell", { name: "Bea" })).not.toBeInTheDocument()
+
+    fireEvent.click(view.getByRole("button", { name: "Select Ada" }))
+    expect(
+      view.getByRole("status", { name: "Selected rows" })
+    ).toHaveTextContent("1")
+
+    fireEvent.click(view.getByRole("button", { name: "Next page" }))
+    await vi.waitFor(() =>
+      expect(view.getByRole("cell", { name: "Bea" })).toBeVisible()
+    )
+
+    fireEvent.click(view.getByRole("button", { name: "Filter group" }))
+    await vi.waitFor(() => {
+      expect(view.queryByRole("cell", { name: "Ada" })).not.toBeInTheDocument()
+      expect(view.getByRole("cell", { name: "Charlie" })).toBeVisible()
+      expect(view.getByRole("cell", { name: "Bea" })).toBeVisible()
+    })
+
+    fireEvent.click(view.getByRole("button", { name: "Sort names" }))
+    await vi.waitFor(() => {
+      const names = view
+        .getAllByRole("cell")
+        .map((cell) => cell.textContent)
+        .filter((value) => value === "Bea" || value === "Charlie")
+      expect(names).toEqual(["Charlie", "Bea"])
+    })
+  })
+
+  it("restores URL state when a router adapter reports navigation", async () => {
+    let params = new URLSearchParams("router.search=first")
+    let notifyNavigation = () => undefined
+    const adapters: TablePersistenceAdapters = {
+      search: {
+        read: () => new URLSearchParams(params),
+        replace: (next) => {
+          params = new URLSearchParams(next)
+        },
+        subscribe: (listener) => {
+          notifyNavigation = listener
+          return () => {
+            notifyNavigation = () => undefined
+          }
+        }
+      }
+    }
+    const view = render(() => <RouterTableStateFixture adapters={adapters} />)
+
+    await vi.waitFor(() =>
+      expect(
+        view.getByRole("status", { name: "Restored table state" })
+      ).toHaveTextContent("first||0")
+    )
+
+    params = new URLSearchParams(
+      "router.search=restored&router.sort=name.desc&router.page=2"
+    )
+    notifyNavigation()
+
+    await vi.waitFor(() =>
+      expect(
+        view.getByRole("status", { name: "Restored table state" })
+      ).toHaveTextContent("restored|name|1")
+    )
   })
 })

--- a/examples/start-solid-zaidan-example/tests/auth-form.browser.test.tsx
+++ b/examples/start-solid-zaidan-example/tests/auth-form.browser.test.tsx
@@ -2,7 +2,10 @@ import type { TablePersistenceAdapters } from "@better-auth-ui/core"
 import { cleanup, fireEvent, render } from "@solidjs/testing-library"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { createAuthForm } from "../src/components/auth/auth-form"
+import {
+  createAuthForm,
+  setAuthFormServerError
+} from "../src/components/auth/auth-form"
 import {
   createOrganizationColumnHelper,
   createOrganizationTable
@@ -74,12 +77,15 @@ function ValidatedAuthForm() {
   const form = createAuthForm(() => ({
     defaultValues: { email: "" },
     onSubmit: async () => {
-      throw {
-        body: {
-          fieldErrors: { email: "This email is already registered" },
+      setAuthFormServerError(
+        form,
+        {
+          fields: { email: "This email is already registered" },
           message: "Account creation failed"
-        }
-      }
+        },
+        "Fallback submission error"
+      )
+      throw new Error("Mutation rejected")
     }
   }))
 
@@ -154,11 +160,16 @@ function RouterTableStateFixture(props: {
   )
 
   return (
-    <output aria-label="Restored table state">
-      {state.ready()
-        ? `${state.globalFilter()}|${state.sorting()[0]?.id ?? ""}|${state.pagination().pageIndex}`
-        : "loading"}
-    </output>
+    <>
+      <button onClick={() => state.setGlobalFilter("local")} type="button">
+        Set table search
+      </button>
+      <output aria-label="Restored table state">
+        {state.ready()
+          ? `${state.globalFilter()}|${state.sorting()[0]?.id ?? ""}|${state.pagination().pageIndex}`
+          : "loading"}
+      </output>
+    </>
   )
 }
 
@@ -318,5 +329,41 @@ describe("Solid organization table selection", () => {
         view.getByRole("status", { name: "Restored table state" })
       ).toHaveTextContent("restored|name|1")
     )
+  })
+
+  it("bounds URL replacements when the adapter notifies synchronously", async () => {
+    let params = new URLSearchParams("router.search=first")
+    let replacements = 0
+    const listeners = new Set<() => void>()
+    const adapters: TablePersistenceAdapters = {
+      search: {
+        read: () => new URLSearchParams(params),
+        replace: (next) => {
+          replacements += 1
+          params = new URLSearchParams(next)
+          for (const listener of listeners) listener()
+        },
+        subscribe: (listener) => {
+          listeners.add(listener)
+          return () => listeners.delete(listener)
+        }
+      }
+    }
+    const view = render(() => <RouterTableStateFixture adapters={adapters} />)
+
+    await vi.waitFor(() =>
+      expect(
+        view.getByRole("status", { name: "Restored table state" })
+      ).toHaveTextContent("first||0")
+    )
+    fireEvent.click(view.getByRole("button", { name: "Set table search" }))
+
+    await vi.waitFor(() =>
+      expect(
+        view.getByRole("status", { name: "Restored table state" })
+      ).toHaveTextContent("local||0")
+    )
+    expect(replacements).toBe(1)
+    expect(params.get("router.search")).toBe("local")
   })
 })

--- a/examples/start-solid-zaidan-example/tests/auth-route.test.ts
+++ b/examples/start-solid-zaidan-example/tests/auth-route.test.ts
@@ -1363,7 +1363,7 @@ describe("Solid auth route component selection", () => {
 
     expect(signIn).toContain('from "./username/sign-in-username"')
     expect(signIn).not.toContain("function resolveSubmittedSignIn")
-    expect(signInUsername).toContain("resolveSubmittedSignIn")
+    expect(signInUsername).toContain("resolveSignInPath")
     expect(signInUsername).toContain("useSignInUsername")
     expect(signInUsername).toContain("authQueryKeys.session")
     expect(userProfile).toContain(

--- a/examples/start-solid-zaidan-example/tests/auth-route.test.ts
+++ b/examples/start-solid-zaidan-example/tests/auth-route.test.ts
@@ -1992,9 +1992,9 @@ describe("Solid auth route component selection", () => {
 
     expect(changeEmail).toContain("useChangeEmail")
     expect(changeEmail).toContain("const changeEmail = useChangeEmail")
-    expect(changeEmail).toContain("onSubmit={submitChangeEmail}")
-    expect(changeEmail).toContain("const formData = new FormData")
-    expect(changeEmail).toContain('formData.get("email")')
+    expect(changeEmail).toContain("createAuthForm")
+    expect(changeEmail).toContain("changeEmail.mutateAsync")
+    expect(changeEmail).toContain("value.email")
     expect(changeEmail).toContain("newEmail:")
     expect(changeEmail).toContain("callbackURL:")
     expect(changeEmail).toContain("auth.baseURL")
@@ -2699,7 +2699,7 @@ describe("Solid auth route component selection", () => {
     expect(createApiKeyDialog).not.toMatch(
       /auth\.authClient\s+as\s+ApiKeyAuthClient/
     )
-    expect(createApiKeyDialog).toContain("createApiKey.mutate(")
+    expect(createApiKeyDialog).toContain("createApiKey.mutateAsync(")
     expect(createApiKeyDialog).toContain("setNewApiKeySecret(apiKey.key)")
     expect(createApiKeyDialog).toContain("setIsNewKeyDialogOpen(true)")
     expect(newApiKeyDialog).toContain("createCopyToClipboard")
@@ -2893,7 +2893,7 @@ describe("Solid auth route component selection", () => {
     )
     expect(passkeys).toContain("onPasskeyAdded={() => passkeys.refetch()}")
     expect(addPasskeyDialog).toContain("props.onPasskeyAdded()")
-    expect(addPasskeyDialog).toContain("addPasskey.mutate(")
+    expect(addPasskeyDialog).toContain("addPasskey.mutateAsync(")
     expect(addPasskeyDialog).toContain("useAuthPlugin(passkeyPlugin)")
     expect(addPasskeyDialog).toContain("authenticatorAttachment")
     expect(addPasskeyDialog).toContain("props.onOpenChange(false)")
@@ -3001,7 +3001,7 @@ describe("Solid auth route component selection", () => {
       "queryClient.removeQueries({ queryKey: authQueryKeys.all })"
     )
     expect(deleteAccount).toContain("auth.viewPaths.auth.signIn")
-    expect(deleteAccount).toContain('setPassword("")')
+    expect(deleteAccount).toContain("form.reset()")
     expect(deleteAccount).toContain('name="password"')
     expect(deleteAccount).toContain('autocomplete="current-password"')
     expect(deleteAccount).toContain(

--- a/examples/start-solid-zaidan-example/tests/registry.test.ts
+++ b/examples/start-solid-zaidan-example/tests/registry.test.ts
@@ -789,62 +789,8 @@ describe("Solid registry isolation", () => {
       "@zaidan/input",
       "@zaidan/label"
     ]
-    const formAuthFiles = [
-      {
-        path: "src/components/auth/username/sign-in-username.tsx",
-        imports: [
-          'from "@/components/ui/alert"',
-          'from "@/components/ui/button"',
-          'from "@/components/ui/card"',
-          'from "@/components/ui/field"',
-          'from "@/components/ui/input"'
-        ]
-      },
-      {
-        path: "src/components/auth/sign-up.tsx",
-        imports: [
-          'from "@/components/ui/alert"',
-          'from "@/components/ui/button"',
-          'from "@/components/ui/card"',
-          'from "@/components/ui/field"',
-          'from "@/components/ui/input"'
-        ]
-      },
-      {
-        path: "src/components/auth/forgot-password.tsx",
-        imports: [
-          'from "@/components/ui/alert"',
-          'from "@/components/ui/button"',
-          'from "@/components/ui/card"',
-          'from "@/components/ui/field"',
-          'from "@/components/ui/input"'
-        ]
-      },
-      {
-        path: "src/components/auth/reset-password.tsx",
-        imports: [
-          'from "@/components/ui/alert"',
-          'from "@/components/ui/button"',
-          'from "@/components/ui/card"',
-          'from "@/components/ui/field"',
-          'from "@/components/ui/input"'
-        ]
-      }
-    ]
-
     for (const file of uiFiles) {
       expect(existsSync(resolve(__dirname, "..", file))).toBe(true)
-    }
-
-    for (const file of formAuthFiles) {
-      const content = readFileSync(resolve(__dirname, "..", file.path), "utf8")
-
-      for (const expectedImport of file.imports) {
-        expect(content).toContain(expectedImport)
-      }
-      expect(content).not.toContain("<button")
-      expect(content).not.toContain("<input")
-      expect(content).not.toContain("<label")
     }
 
     const outputRoot = makeTempRoot()
@@ -889,6 +835,8 @@ describe("Solid registry isolation", () => {
       "src/components/auth/provider-button.tsx",
       "src/components/auth/provider-buttons.tsx",
       "src/components/auth/last-login-method/last-used-badge.tsx",
+      "src/components/auth/auth-form.tsx",
+      "src/components/auth/additional-field.tsx",
       "src/lib/utils.ts"
     ])
     expect(signUp.files.map((file) => file.path)).not.toEqual(
@@ -1580,16 +1528,14 @@ describe("Solid registry isolation", () => {
       "utf8"
     )
 
-    expect(signIn).toContain("validationMessage")
+    expect(signIn).toContain("field.AuthFormFieldError")
     expect(signIn).toContain("aria-invalid")
     expect(signIn).toContain("auth.localization.auth.showPassword")
     expect(signIn).toContain("auth.localization.auth.hidePassword")
     expect(signIn).toContain('import { Eye, EyeOff } from "lucide-solid"')
     expect(signIn).toContain('type={isPasswordVisible() ? "text" : "password"}')
     expect(signIn).toContain('type="button"')
-    expect(signIn).toContain(
-      "onClick={() => setIsPasswordVisible((visible) => !visible)}"
-    )
+    expect(signIn).toContain("setIsPasswordVisible((visible) => !visible)")
     expect(signIn).toContain("<EyeOff aria-hidden")
     expect(signIn).toContain("<Eye aria-hidden")
     expect(signIn).not.toContain('isPasswordVisible() ? "Hide" : "Show"')
@@ -1611,7 +1557,7 @@ describe("Solid registry isolation", () => {
     expect(signUp).not.toContain('isPasswordVisible() ? "Hide" : "Show"')
     expect(signUp).not.toContain('isConfirmPasswordVisible() ? "Hide" : "Show"')
 
-    expect(forgotPassword).toContain("validationMessage")
+    expect(forgotPassword).toContain("field.AuthFormFieldError")
     expect(forgotPassword).toContain("aria-invalid")
 
     expect(resetPassword).toContain("auth.localization.auth.showPassword")
@@ -1685,7 +1631,8 @@ describe("Solid registry isolation", () => {
     expect(signIn).toContain("useSignInUsername")
     expect(signIn).toContain("usernameOrEmailPlaceholder")
     expect(signIn).toContain("resolveSubmittedSignIn")
-    expect(signIn).toContain("new FormData(event.currentTarget)")
+    expect(signIn).toContain("createAuthForm")
+    expect(signIn).toContain("signInUsername.mutateAsync")
     expect(signIn).toContain("username: signInPath.username")
     expect(signIn).toContain("email: signInPath.email")
     expect(signIn).toMatch(
@@ -2325,9 +2272,7 @@ describe("Solid registry isolation", () => {
     expect(forgotPassword.files[0]?.content).toContain(
       "RESET_LINK_SENT_STORAGE_KEY"
     )
-    expect(forgotPassword.files[0]?.content).toContain(
-      "Unable to send a reset link. Try again."
-    )
+    expect(forgotPassword.files[0]?.content).toContain("AuthFormServerError")
     expect(forgotPassword.files[1]?.path).toBe(
       "src/components/auth/reset-link-sent.tsx"
     )

--- a/examples/start-solid-zaidan-example/tests/registry.test.ts
+++ b/examples/start-solid-zaidan-example/tests/registry.test.ts
@@ -789,8 +789,58 @@ describe("Solid registry isolation", () => {
       "@zaidan/input",
       "@zaidan/label"
     ]
+    const formAuthFiles = [
+      {
+        imports: [
+          'from "@/components/ui/button"',
+          'from "@/components/ui/card"',
+          'from "@/components/ui/field"',
+          'from "@/components/ui/input"'
+        ],
+        path: "src/components/auth/username/sign-in-username.tsx"
+      },
+      {
+        imports: [
+          'from "@/components/ui/alert"',
+          'from "@/components/ui/button"',
+          'from "@/components/ui/card"',
+          'from "@/components/ui/field"',
+          'from "@/components/ui/input"'
+        ],
+        path: "src/components/auth/sign-up.tsx"
+      },
+      {
+        imports: [
+          'from "@/components/ui/card"',
+          'from "@/components/ui/field"',
+          'from "@/components/ui/input"'
+        ],
+        path: "src/components/auth/forgot-password.tsx"
+      },
+      {
+        imports: [
+          'from "@/components/ui/alert"',
+          'from "@/components/ui/button"',
+          'from "@/components/ui/card"',
+          'from "@/components/ui/field"',
+          'from "@/components/ui/input"'
+        ],
+        path: "src/components/auth/reset-password.tsx"
+      }
+    ]
     for (const file of uiFiles) {
       expect(existsSync(resolve(__dirname, "..", file))).toBe(true)
+    }
+
+    for (const file of formAuthFiles) {
+      const content = readFileSync(resolve(__dirname, "..", file.path), "utf8")
+
+      for (const expectedImport of file.imports) {
+        expect(content).toContain(expectedImport)
+      }
+      expect(content).not.toContain("<button")
+      expect(content).not.toContain("<input")
+      expect(content).not.toContain("<label")
     }
 
     const outputRoot = makeTempRoot()
@@ -1630,7 +1680,7 @@ describe("Solid registry isolation", () => {
 
     expect(signIn).toContain("useSignInUsername")
     expect(signIn).toContain("usernameOrEmailPlaceholder")
-    expect(signIn).toContain("resolveSubmittedSignIn")
+    expect(signIn).toContain("resolveSignInPath")
     expect(signIn).toContain("createAuthForm")
     expect(signIn).toContain("signInUsername.mutateAsync")
     expect(signIn).toContain("username: signInPath.username")

--- a/examples/start-solid-zaidan-example/vitest.config.ts
+++ b/examples/start-solid-zaidan-example/vitest.config.ts
@@ -4,6 +4,9 @@ import solid from "vite-plugin-solid"
 import { defineConfig } from "vitest/config"
 
 export default defineConfig({
+  optimizeDeps: {
+    include: ["@tanstack/solid-store"]
+  },
   plugins: [solid({ ssr: true })],
   resolve: {
     alias: {

--- a/packages/core/src/lib/form-validation.ts
+++ b/packages/core/src/lib/form-validation.ts
@@ -1,5 +1,10 @@
 export type FormFieldError = Readonly<{ message: string }>
 
+export type AuthFormServerError = Readonly<{
+  fields?: Readonly<Record<string, FormFieldError>>
+  form?: FormFieldError
+}>
+
 export type StringLengthValidation = {
   maxLength?: number
   maxLengthMessage?: string
@@ -45,6 +50,67 @@ export function getFormFieldErrors(
 
     return []
   })
+}
+
+function getErrorMessage(error: unknown): string | undefined {
+  if (typeof error === "string") return error || undefined
+  if (!error || typeof error !== "object") return undefined
+
+  if ("message" in error && typeof error.message === "string" && error.message)
+    return error.message
+
+  if (
+    "statusText" in error &&
+    typeof error.statusText === "string" &&
+    error.statusText
+  )
+    return error.statusText
+}
+
+function getServerFieldErrors(value: unknown) {
+  if (!value || typeof value !== "object") return undefined
+
+  const candidate =
+    "fieldErrors" in value
+      ? value.fieldErrors
+      : "fields" in value
+        ? value.fields
+        : undefined
+
+  if (!candidate || typeof candidate !== "object") return undefined
+
+  return Object.fromEntries(
+    Object.entries(candidate).flatMap(([field, error]) => {
+      const message = Array.isArray(error)
+        ? getFormFieldErrorMessage(error)
+        : getErrorMessage(error)
+      return message ? [[field, { message }]] : []
+    })
+  )
+}
+
+/** Normalizes thrown mutation errors for TanStack Form's global error map. */
+export function normalizeAuthFormServerError(
+  error: unknown,
+  fallbackMessage: string
+): AuthFormServerError {
+  const nestedBody =
+    error &&
+    typeof error === "object" &&
+    "body" in error &&
+    error.body &&
+    typeof error.body === "object"
+      ? error.body
+      : undefined
+  const fields =
+    getServerFieldErrors(error) ?? getServerFieldErrors(nestedBody) ?? undefined
+  const message =
+    getErrorMessage(error) ?? getErrorMessage(nestedBody) ?? fallbackMessage
+
+  return {
+    fields,
+    form: createFormFieldError(message)
+  }
 }
 
 export function validateStringLength(

--- a/packages/core/src/lib/table-state.ts
+++ b/packages/core/src/lib/table-state.ts
@@ -18,6 +18,66 @@ export type TableUrlState = {
   sorting: TableSortingEntry[]
 }
 
+export type TableSearchParamsAdapter = {
+  read: () => URLSearchParams
+  replace: (params: URLSearchParams) => void
+  subscribe: (listener: () => void) => () => void
+}
+
+export type TableStorageAdapter = {
+  read: (key: string) => string | null
+  write: (key: string, value: string) => void
+}
+
+export type TablePersistenceAdapters = {
+  search: TableSearchParamsAdapter
+  storage?: TableStorageAdapter
+}
+
+/**
+ * Create a search adapter from a router's search and navigation primitives.
+ *
+ * TanStack Router consumers can pass `router.state.location.searchStr` from
+ * `read`, use `router.navigate({ replace: true, search })` from `replace`, and
+ * subscribe to router state changes from `subscribe`. Other routers can expose
+ * the same three operations without coupling the table package to that router.
+ */
+export function createTableSearchParamsAdapter(
+  adapter: TableSearchParamsAdapter
+): TableSearchParamsAdapter {
+  return adapter
+}
+
+/** Create browser-backed persistence for tables outside a router context. */
+export function createBrowserTablePersistenceAdapters(): TablePersistenceAdapters {
+  return {
+    search: {
+      read: () =>
+        typeof window === "undefined"
+          ? new URLSearchParams()
+          : new URLSearchParams(window.location.search),
+      replace: (params) => {
+        if (typeof window === "undefined") return
+        const url = new URL(window.location.href)
+        url.search = params.toString()
+        window.history.replaceState(window.history.state, "", url)
+      },
+      subscribe: (listener) => {
+        if (typeof window === "undefined") return () => undefined
+        window.addEventListener("popstate", listener)
+        return () => window.removeEventListener("popstate", listener)
+      }
+    },
+    storage:
+      typeof window === "undefined"
+        ? undefined
+        : {
+            read: (key) => window.localStorage.getItem(key),
+            write: (key, value) => window.localStorage.setItem(key, value)
+          }
+  }
+}
+
 const TABLE_STATE_VERSION = 1
 const TABLE_FILTER_VALUE_PREFIX = "~"
 

--- a/packages/core/tests/form-validation.test.ts
+++ b/packages/core/tests/form-validation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import {
   getFormFieldErrorMessage,
   getFormFieldErrors,
+  normalizeAuthFormServerError,
   validateAbsoluteUrl,
   validateAbsoluteUrlList,
   validateEmailAddress,
@@ -93,5 +94,29 @@ describe("form validation", () => {
         { other: true }
       ])
     ).toEqual([{ message: "Invalid" }, { message: "Required" }])
+  })
+
+  it("normalizes form and field errors from mutation responses", () => {
+    expect(
+      normalizeAuthFormServerError(
+        {
+          body: {
+            fieldErrors: {
+              email: ["Email is already in use"]
+            }
+          },
+          message: "Could not create the account"
+        },
+        "Request failed"
+      )
+    ).toEqual({
+      fields: { email: { message: "Email is already in use" } },
+      form: { message: "Could not create the account" }
+    })
+
+    expect(normalizeAuthFormServerError(null, "Request failed")).toEqual({
+      fields: undefined,
+      form: { message: "Request failed" }
+    })
   })
 })

--- a/packages/core/tests/table-state.test.ts
+++ b/packages/core/tests/table-state.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import {
+  createTableSearchParamsAdapter,
   getClampedTablePageIndex,
   getLookaheadPage,
   parseTableColumnVisibility,
@@ -126,5 +127,38 @@ describe("table state", () => {
         { desc: true, id: "createdAt" }
       ]
     })
+  })
+
+  it("supports router-owned search state through the persistence contract", () => {
+    let current = new URLSearchParams("tab=members")
+    const listeners = new Set<() => void>()
+    const adapter = createTableSearchParamsAdapter({
+      read: () => new URLSearchParams(current),
+      replace: (params) => {
+        current = new URLSearchParams(params)
+        for (const listener of listeners) listener()
+      },
+      subscribe: (listener) => {
+        listeners.add(listener)
+        return () => listeners.delete(listener)
+      }
+    })
+    let notifications = 0
+    const unsubscribe = adapter.subscribe(() => notifications++)
+
+    adapter.replace(
+      serializeTableUrlState(adapter.read(), "members", 10, {
+        columnFilters: [],
+        globalFilter: "Ada",
+        pagination: { pageIndex: 1, pageSize: 20 },
+        sorting: [{ desc: false, id: "name" }]
+      })
+    )
+
+    expect(notifications).toBe(1)
+    expect(current.get("tab")).toBe("members")
+    expect(current.get("members.search")).toBe("Ada")
+    expect(current.get("members.page")).toBe("2")
+    unsubscribe()
   })
 })

--- a/packages/heroui/src/components/auth/admin/admin-users.tsx
+++ b/packages/heroui/src/components/auth/admin/admin-users.tsx
@@ -1685,8 +1685,7 @@ function PasswordDialog({
     onSubmit: async ({ value }) => {
       if (!userId) return
       await mutation.mutateAsync({ userId, newPassword: value.password })
-      mutation.reset()
-      onOpenChange(false)
+      close()
     }
   })
   const close = () => {

--- a/packages/heroui/src/components/auth/admin/admin-users.tsx
+++ b/packages/heroui/src/components/auth/admin/admin-users.tsx
@@ -45,7 +45,6 @@ import {
   cn,
   Dropdown,
   FieldError,
-  Form,
   Input,
   Label,
   ListBox,
@@ -68,15 +67,10 @@ import {
   type Updater
 } from "@tanstack/react-table"
 import type { BetterFetchError } from "better-auth/client"
-import {
-  type FormEvent,
-  useDeferredValue,
-  useEffect,
-  useMemo,
-  useState
-} from "react"
+import { useDeferredValue, useEffect, useMemo, useState } from "react"
 import { adminPlugin } from "../../../lib/auth/admin-plugin"
 import { getAuthAdditionalFieldValidators, useAuthForm } from "../auth-form"
+import { getHeroUISortDescriptor, getTanStackSorting } from "../table-bridge"
 import { UserAvatar } from "../user/user-avatar"
 import { createAdminColumnHelper, useAdminTable } from "./admin-table"
 
@@ -429,14 +423,44 @@ export function AdminUsers({
       ) : (
         <Table>
           <Table.ScrollContainer>
-            <Table.Content aria-label={config.localization.users}>
+            <Table.Content
+              aria-label={config.localization.users}
+              selectedKeys={
+                selectedUserId ? new Set([selectedUserId]) : new Set()
+              }
+              selectionBehavior="replace"
+              selectionMode={getPermission.data?.success ? "single" : undefined}
+              sortDescriptor={getHeroUISortDescriptor(sorting)}
+              onSelectionChange={(selection) => {
+                if (selection === "all") return
+                const [userId] = selection
+                selectUser(userId == null ? undefined : String(userId))
+              }}
+              onSortChange={(descriptor) =>
+                setSorting(getTanStackSorting(descriptor))
+              }
+            >
               <Table.Header>
-                <Table.Column isRowHeader>
-                  {config.localization.name}
+                <Table.Column id="name" isRowHeader allowsSorting>
+                  {({ sortDirection }) => (
+                    <Table.SortableColumnHeader sortDirection={sortDirection}>
+                      {config.localization.name}
+                    </Table.SortableColumnHeader>
+                  )}
                 </Table.Column>
-                <Table.Column>{config.localization.role}</Table.Column>
-                <Table.Column>{config.localization.status}</Table.Column>
-                <Table.Column>{config.localization.created}</Table.Column>
+                <Table.Column id="role">
+                  {config.localization.role}
+                </Table.Column>
+                <Table.Column id="status">
+                  {config.localization.status}
+                </Table.Column>
+                <Table.Column id="createdAt" allowsSorting>
+                  {({ sortDirection }) => (
+                    <Table.SortableColumnHeader sortDirection={sortDirection}>
+                      {config.localization.created}
+                    </Table.SortableColumnHeader>
+                  )}
+                </Table.Column>
               </Table.Header>
               <Table.Body>
                 {users.isPending
@@ -1656,25 +1680,19 @@ function PasswordDialog({
   userId?: string
 }) {
   const config = useAuthPlugin(adminPlugin)
-  const [password, setPassword] = useState("")
-  const [errorMessage, setErrorMessage] = useState<string>()
+  const form = useAuthForm({
+    defaultValues: { password: "" },
+    onSubmit: async ({ value }) => {
+      if (!userId) return
+      await mutation.mutateAsync({ userId, newPassword: value.password })
+      mutation.reset()
+      onOpenChange(false)
+    }
+  })
   const close = () => {
-    setPassword("")
-    setErrorMessage(undefined)
+    form.reset()
     mutation.reset()
     onOpenChange(false)
-  }
-  const submit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setErrorMessage(undefined)
-    if (userId)
-      mutation.mutate(
-        { userId, newPassword: password },
-        {
-          onError: (error) => setErrorMessage(getAdminErrorMessage(error)),
-          onSuccess: close
-        }
-      )
   }
 
   return (
@@ -1684,46 +1702,54 @@ function PasswordDialog({
     >
       <AlertDialog.Container>
         <AlertDialog.Dialog>
-          <Form onSubmit={submit}>
-            <AlertDialog.CloseTrigger />
-            <AlertDialog.Header>
-              <AlertDialog.Icon status="default">
-                <Key />
-              </AlertDialog.Icon>
-              <AlertDialog.Heading>
-                {config.localization.setPassword}
-              </AlertDialog.Heading>
-            </AlertDialog.Header>
-            <AlertDialog.Body className="overflow-visible">
-              <TextField
-                isInvalid={Boolean(errorMessage)}
-                isRequired
-                type="password"
-                value={password}
-                onChange={setPassword}
-              >
-                <Label>{config.localization.password}</Label>
-                <Input autoComplete="new-password" variant="secondary" />
-                <FieldError>{errorMessage}</FieldError>
-              </TextField>
-            </AlertDialog.Body>
-            <AlertDialog.Footer>
-              <Button
-                isDisabled={mutation.isPending}
-                slot="close"
-                variant="tertiary"
-              >
-                {config.localization.cancel}
-              </Button>
-              <Button
-                isDisabled={!password}
-                isPending={mutation.isPending}
-                type="submit"
-              >
-                {config.localization.setPassword}
-              </Button>
-            </AlertDialog.Footer>
-          </Form>
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <AlertDialog.CloseTrigger />
+              <AlertDialog.Header>
+                <AlertDialog.Icon status="default">
+                  <Key />
+                </AlertDialog.Icon>
+                <AlertDialog.Heading>
+                  {config.localization.setPassword}
+                </AlertDialog.Heading>
+              </AlertDialog.Header>
+              <AlertDialog.Body className="overflow-visible">
+                <form.AppField
+                  name="password"
+                  validators={{
+                    onChange: ({ value }) =>
+                      value ? undefined : config.localization.password
+                  }}
+                >
+                  {(field) => (
+                    <field.AuthFormTextField
+                      inputProps={{
+                        autoComplete: "new-password",
+                        variant: "secondary"
+                      }}
+                      label={config.localization.password}
+                      type="password"
+                    />
+                  )}
+                </form.AppField>
+                <form.AuthFormServerError />
+              </AlertDialog.Body>
+              <AlertDialog.Footer>
+                <Button
+                  isDisabled={mutation.isPending}
+                  slot="close"
+                  variant="tertiary"
+                >
+                  {config.localization.cancel}
+                </Button>
+                <form.AuthFormSubmitButton
+                  isDisabled={mutation.isPending || !userId}
+                >
+                  {config.localization.setPassword}
+                </form.AuthFormSubmitButton>
+              </AlertDialog.Footer>
+            </form.AuthFormRoot>
+          </form.AppForm>
         </AlertDialog.Dialog>
       </AlertDialog.Container>
     </AlertDialog.Backdrop>

--- a/packages/heroui/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/packages/heroui/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -75,9 +75,9 @@ export function CreateApiKeyDialog({
     defaultValues: {
       configId: availableConfigurations[0]?.id ?? "",
       expiration:
-        keyExpiration && keyExpiration.defaultInterval === null
+        !keyExpiration || keyExpiration.defaultInterval === null
           ? "never"
-          : String(keyExpiration?.defaultInterval ?? "never"),
+          : String(keyExpiration.defaultInterval),
       name: ""
     },
     onSubmit: async ({ value }) => {
@@ -259,6 +259,7 @@ export function CreateApiKeyDialog({
                       </form.AppField>
                     ) : null}
                   </div>
+                  <form.AuthFormServerError />
                 </AlertDialog.Body>
 
                 <AlertDialog.Footer>

--- a/packages/heroui/src/components/auth/api-key/create-api-key-dialog.tsx
+++ b/packages/heroui/src/components/auth/api-key/create-api-key-dialog.tsx
@@ -42,7 +42,7 @@ export function CreateApiKeyDialog({
     localization: apiKeyLocalization
   } = useAuthPlugin(apiKeyPlugin)
 
-  const { mutate: createApiKey, isPending: isCreating } =
+  const { mutateAsync: createApiKey, isPending: isCreating } =
     useCreateApiKey(authClient)
 
   const [isNewKeyDialogOpen, setIsNewKeyDialogOpen] = useState(false)
@@ -77,10 +77,10 @@ export function CreateApiKeyDialog({
       expiration:
         keyExpiration && keyExpiration.defaultInterval === null
           ? "never"
-          : String((keyExpiration && keyExpiration.defaultInterval) ?? "never"),
+          : String(keyExpiration?.defaultInterval ?? "never"),
       name: ""
     },
-    onSubmit: ({ value }) => {
+    onSubmit: async ({ value }) => {
       const name = value.name.trim()
       const expirationDays =
         value.expiration !== "never" ? Number(value.expiration) : undefined
@@ -98,14 +98,17 @@ export function CreateApiKeyDialog({
         ...(organizationId ? { organizationId } : {})
       }
 
-      createApiKey(Object.keys(payload).length > 0 ? payload : undefined, {
-        onSuccess: (result) => {
-          handleOpenChange(false)
-          setKeyName(name)
-          setSecretKey(result.key)
-          setIsNewKeyDialogOpen(true)
+      await createApiKey(
+        Object.keys(payload).length > 0 ? payload : undefined,
+        {
+          onSuccess: (result) => {
+            handleOpenChange(false)
+            setKeyName(name)
+            setSecretKey(result.key)
+            setIsNewKeyDialogOpen(true)
+          }
         }
-      })
+      )
     }
   })
 

--- a/packages/heroui/src/components/auth/api-key/edit-api-key-dialog.tsx
+++ b/packages/heroui/src/components/auth/api-key/edit-api-key-dialog.tsx
@@ -34,8 +34,8 @@ export function EditApiKeyDialog({
 
   const form = useAuthForm({
     defaultValues: { name: apiKey.name ?? "" },
-    onSubmit: ({ value }) => {
-      updateApiKey.mutate({
+    onSubmit: async ({ value }) => {
+      await updateApiKey.mutateAsync({
         keyId: apiKey.id,
         configId: apiKey.configId,
         name: value.name.trim()

--- a/packages/heroui/src/components/auth/auth-form.tsx
+++ b/packages/heroui/src/components/auth/auth-form.tsx
@@ -35,6 +35,8 @@ import { AdditionalField, type AdditionalFieldProps } from "./additional-field"
 const { fieldContext, formContext, useFieldContext, useFormContext } =
   createFormHookContexts()
 
+const DEFAULT_AUTH_FORM_SERVER_ERROR = "Unable to submit this form. Try again."
+
 export function focusFirstInvalidAuthFormControl(form: HTMLFormElement) {
   requestAnimationFrame(() => {
     form
@@ -92,14 +94,16 @@ export function clearAuthFormServerError(form: AnyFormApi) {
 
 export async function submitAuthForm(
   form: AnyFormApi,
-  serverErrorMessage = "Unable to submit this form. Try again."
+  serverErrorMessage = DEFAULT_AUTH_FORM_SERVER_ERROR
 ) {
   clearAuthFormServerError(form)
   try {
     await form.handleSubmit()
     return form.state.isValid
   } catch (error) {
-    setAuthFormServerError(form, error, serverErrorMessage)
+    if (!form.state.errorMap.onServer) {
+      setAuthFormServerError(form, error, serverErrorMessage)
+    }
     return false
   }
 }
@@ -112,7 +116,7 @@ type AuthFormRootProps = Omit<ComponentProps<typeof Form>, "onSubmit"> & {
 function AuthFormRoot({
   children,
   onBeforeSubmit,
-  serverErrorMessage = "Unable to submit this form. Try again.",
+  serverErrorMessage = DEFAULT_AUTH_FORM_SERVER_ERROR,
   ...props
 }: AuthFormRootProps) {
   const form = useFormContext()

--- a/packages/heroui/src/components/auth/auth-form.tsx
+++ b/packages/heroui/src/components/auth/auth-form.tsx
@@ -4,11 +4,26 @@ import {
   DEFAULT_ADDITIONAL_FIELD_VALIDATION_DEBOUNCE_MS,
   getFormFieldErrorMessage,
   getFormFieldErrors,
+  normalizeAuthFormServerError,
   validateAdditionalFieldRequired,
   validateAdditionalFieldValue
 } from "@better-auth-ui/core"
-import { Button, FieldError, Form, Spinner } from "@heroui/react"
-import { createFormHook, createFormHookContexts } from "@tanstack/react-form"
+import {
+  Button,
+  Description,
+  ErrorMessage,
+  FieldError,
+  Form,
+  Input,
+  Label,
+  Spinner,
+  TextField
+} from "@heroui/react"
+import {
+  type AnyFormApi,
+  createFormHook,
+  createFormHookContexts
+} from "@tanstack/react-form"
 import {
   type ComponentProps,
   type FormEvent,
@@ -40,13 +55,64 @@ function AuthFormFieldError() {
   return message ? <FieldError>{message}</FieldError> : null
 }
 
+function AuthFormServerError() {
+  const form = useFormContext()
+
+  return (
+    <form.Subscribe selector={(state) => state.errorMap.onServer}>
+      {(error) => {
+        const formError =
+          error && typeof error === "object" && "form" in error
+            ? error.form
+            : error
+        const message = getFormFieldErrorMessage(formError ? [formError] : [])
+        return message ? <ErrorMessage>{message}</ErrorMessage> : null
+      }}
+    </form.Subscribe>
+  )
+}
+
+export function setAuthFormServerError(
+  form: AnyFormApi,
+  error: unknown,
+  fallbackMessage: string
+) {
+  const normalized = normalizeAuthFormServerError(error, fallbackMessage)
+  form.setErrorMap({
+    onServer: {
+      fields: normalized.fields ?? {},
+      form: normalized.form
+    }
+  })
+}
+
+export function clearAuthFormServerError(form: AnyFormApi) {
+  form.setErrorMap({ onServer: undefined })
+}
+
+export async function submitAuthForm(
+  form: AnyFormApi,
+  serverErrorMessage = "Unable to submit this form. Try again."
+) {
+  clearAuthFormServerError(form)
+  try {
+    await form.handleSubmit()
+    return form.state.isValid
+  } catch (error) {
+    setAuthFormServerError(form, error, serverErrorMessage)
+    return false
+  }
+}
+
 type AuthFormRootProps = Omit<ComponentProps<typeof Form>, "onSubmit"> & {
   onBeforeSubmit?: () => void
+  serverErrorMessage?: string
 }
 
 function AuthFormRoot({
   children,
   onBeforeSubmit,
+  serverErrorMessage = "Unable to submit this form. Try again.",
   ...props
 }: AuthFormRootProps) {
   const form = useFormContext()
@@ -60,8 +126,8 @@ function AuthFormRoot({
     onBeforeSubmit?.()
     submittingRef.current = true
     try {
-      await form.handleSubmit()
-      if (!form.state.isValid) focusFirstInvalidAuthFormControl(formElement)
+      const isValid = await submitAuthForm(form, serverErrorMessage)
+      if (!isValid) focusFirstInvalidAuthFormControl(formElement)
     } finally {
       submittingRef.current = false
     }
@@ -70,6 +136,7 @@ function AuthFormRoot({
   return (
     <Form
       {...props}
+      validationBehavior="aria"
       onInvalid={(event) =>
         focusFirstInvalidAuthFormControl(event.currentTarget)
       }
@@ -77,6 +144,42 @@ function AuthFormRoot({
     >
       {children}
     </Form>
+  )
+}
+
+type AuthFormTextFieldProps = Omit<
+  ComponentProps<typeof TextField>,
+  "children" | "name" | "onBlur" | "onChange" | "value"
+> & {
+  description?: ReactNode
+  inputProps?: Omit<ComponentProps<typeof Input>, "name">
+  label: ReactNode
+}
+
+function AuthFormTextField({
+  description,
+  inputProps,
+  label,
+  ...props
+}: AuthFormTextFieldProps) {
+  const field = useFieldContext<string>()
+  const isInvalid = isAuthFormFieldInvalid(field.state.meta)
+
+  return (
+    <TextField
+      {...props}
+      isInvalid={isInvalid || undefined}
+      name={field.name}
+      onBlur={field.handleBlur}
+      onChange={field.handleChange}
+      validationBehavior="aria"
+      value={field.state.value}
+    >
+      <Label>{label}</Label>
+      <Input {...inputProps} />
+      {description ? <Description>{description}</Description> : null}
+      <AuthFormFieldError />
+    </TextField>
   )
 }
 
@@ -135,9 +238,17 @@ export const {
   withFieldGroup: withAuthFieldGroup,
   withForm: withAuthForm
 } = createFormHook({
-  fieldComponents: { AuthFormAdditionalField, AuthFormFieldError },
+  fieldComponents: {
+    AuthFormAdditionalField,
+    AuthFormFieldError,
+    AuthFormTextField
+  },
   fieldContext,
-  formComponents: { AuthFormRoot, AuthFormSubmitButton },
+  formComponents: {
+    AuthFormRoot,
+    AuthFormServerError,
+    AuthFormSubmitButton
+  },
   formContext
 })
 

--- a/packages/heroui/src/components/auth/delete-user/delete-account.tsx
+++ b/packages/heroui/src/components/auth/delete-user/delete-account.tsx
@@ -188,6 +188,7 @@ export function DeleteAccount({
                           )}
                         </form.AppField>
                       )}
+                      <form.AuthFormServerError />
                     </AlertDialog.Body>
 
                     <AlertDialog.Footer>

--- a/packages/heroui/src/components/auth/delete-user/delete-account.tsx
+++ b/packages/heroui/src/components/auth/delete-user/delete-account.tsx
@@ -56,7 +56,7 @@ export function DeleteAccount({
   )
   const needsPassword = !sendDeleteAccountVerification && hasCredentialAccount
 
-  const { mutate: deleteUser, isPending } = useDeleteUser(authClient)
+  const { mutateAsync: deleteUser, isPending } = useDeleteUser(authClient)
 
   const handleDialogOpenChange = (open: boolean) => {
     setConfirmOpen(open)
@@ -66,12 +66,12 @@ export function DeleteAccount({
 
   const form = useAuthForm({
     defaultValues: { password: "" },
-    onSubmit: ({ value }) => {
+    onSubmit: async ({ value }) => {
       const params = {
         ...(needsPassword ? { password: value.password } : {})
       }
 
-      deleteUser(params, {
+      await deleteUser(params, {
         onSuccess: () => {
           setConfirmOpen(false)
           form.setFieldValue("password", "")

--- a/packages/heroui/src/components/auth/delete-user/delete-account.tsx
+++ b/packages/heroui/src/components/auth/delete-user/delete-account.tsx
@@ -1,4 +1,4 @@
-import { authQueryKeys } from "@better-auth-ui/core"
+import { authQueryKeys, validateStringLength } from "@better-auth-ui/core"
 import {
   useAuth,
   useAuthPlugin,
@@ -11,7 +11,6 @@ import {
   Button,
   Card,
   type CardProps,
-  FieldError,
   InputGroup,
   Label,
   Spinner,
@@ -22,7 +21,11 @@ import { useQueryClient } from "@tanstack/react-query"
 import { useState } from "react"
 
 import { deleteUserPlugin } from "../../../lib/auth/delete-user-plugin"
-import { useAuthForm } from "../auth-form"
+import {
+  clearAuthFormServerError,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 
 export type DeleteAccountProps = {
   className?: string
@@ -61,6 +64,7 @@ export function DeleteAccount({
   const handleDialogOpenChange = (open: boolean) => {
     setConfirmOpen(open)
     form.setFieldValue("password", "")
+    clearAuthFormServerError(form)
     setIsPasswordVisible(false)
   }
 
@@ -141,10 +145,21 @@ export function DeleteAccount({
                       </p>
 
                       {needsPassword && (
-                        <form.AppField name="password">
+                        <form.AppField
+                          name="password"
+                          validators={{
+                            onChange: ({ value }) =>
+                              validateStringLength(value, {
+                                requiredMessage: localization.auth.fieldRequired
+                              })
+                          }}
+                        >
                           {(field) => (
                             <TextField
                               className="mt-4"
+                              isInvalid={isAuthFormFieldInvalid(
+                                field.state.meta
+                              )}
                               name={field.name}
                               isDisabled={isPending}
                               value={field.state.value}
@@ -183,7 +198,7 @@ export function DeleteAccount({
                                 </InputGroup.Suffix>
                               </InputGroup>
 
-                              <FieldError />
+                              <field.AuthFormFieldError />
                             </TextField>
                           )}
                         </form.AppField>

--- a/packages/heroui/src/components/auth/device-authorization/device-authorization.tsx
+++ b/packages/heroui/src/components/auth/device-authorization/device-authorization.tsx
@@ -14,14 +14,12 @@ import {
   Card,
   type CardProps,
   cn,
-  Form,
   InputOTP,
   Label,
   REGEXP_ONLY_DIGITS_AND_CHARS,
   Spinner
 } from "@heroui/react"
 import {
-  type FormEvent,
   type ReactNode,
   useCallback,
   useEffect,
@@ -31,6 +29,7 @@ import {
 } from "react"
 
 import { deviceAuthorizationPlugin } from "../../../lib/auth/device-authorization-plugin"
+import { submitAuthForm, useAuthForm } from "../auth-form"
 
 type DeviceAuthorizationStep = "code" | "approval" | "approved" | "denied"
 
@@ -121,7 +120,6 @@ export function DeviceAuthorization({
     initialDeviceAuthorizationState
   )
   const submittedCodeRef = useRef<string | null>(null)
-  const normalizedUserCode = normalizeDeviceCode(userCode)
 
   const handleAuthorizationError = () => {
     dispatch({
@@ -141,7 +139,7 @@ export function DeviceAuthorization({
     )
   }, [userCodeLength])
 
-  const { mutate: verifyDeviceCode, isPending: isVerifying } =
+  const { mutateAsync: verifyDeviceCode, isPending: isVerifying } =
     useVerifyDeviceCode(deviceAuthClient, {
       onError: handleAuthorizationError,
       onSuccess: ({ status }) => {
@@ -179,7 +177,7 @@ export function DeviceAuthorization({
   }
 
   const submitCode = useCallback(
-    (completedCode: string) => {
+    async (completedCode: string) => {
       const normalizedCode = normalizeDeviceCode(completedCode)
 
       if (
@@ -200,7 +198,7 @@ export function DeviceAuthorization({
         return
       }
 
-      verifyDeviceCode({
+      await verifyDeviceCode({
         query: { user_code: normalizedCode }
       })
     },
@@ -217,25 +215,31 @@ export function DeviceAuthorization({
     ]
   )
 
+  const handleSubmit = useCallback(
+    async (code: string) => {
+      const normalizedCode = normalizeDeviceCode(code)
+      if (normalizedCode.length !== userCodeLength) {
+        dispatch({
+          type: "verificationFailed",
+          message: localization.invalidDeviceCode
+        })
+        return
+      }
+      await submitCode(normalizedCode)
+    },
+    [localization.invalidDeviceCode, submitCode, userCodeLength]
+  )
+
   useEffect(() => {
-    if (normalizedUserCode.length === userCodeLength) {
-      submitCode(normalizedUserCode)
+    if (
+      !isSessionPending &&
+      normalizeDeviceCode(userCode).length === userCodeLength
+    ) {
+      void submitCode(userCode).catch(() => undefined)
     }
-  }, [normalizedUserCode, submitCode, userCodeLength])
+  }, [isSessionPending, submitCode, userCode, userCodeLength])
 
-  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault()
-
-    if (normalizedUserCode.length !== userCodeLength) {
-      dispatch({
-        type: "verificationFailed",
-        message: localization.invalidDeviceCode
-      })
-      return
-    }
-
-    submitCode(normalizedUserCode)
-  }
+  const authorizedCode = submittedCodeRef.current ?? ""
 
   const cardClassName = cn("w-full max-w-sm gap-4 md:p-6", className) ?? ""
 
@@ -244,13 +248,13 @@ export function DeviceAuthorization({
       <DeviceApproval
         className={cardClassName}
         localization={localization}
-        userCode={normalizedUserCode}
+        userCode={authorizedCode}
         user={session.user}
         variant={variant}
         isApproving={isApproving}
         isDenying={isDenying}
-        onApprove={() => approveDevice({ userCode: normalizedUserCode })}
-        onDeny={() => denyDevice({ userCode: normalizedUserCode })}
+        onApprove={() => approveDevice({ userCode: authorizedCode })}
+        onDeny={() => denyDevice({ userCode: authorizedCode })}
       />
     )
   }
@@ -281,11 +285,11 @@ export function DeviceAuthorization({
       isSessionPending={isSessionPending}
       isVerifying={isVerifying}
       localization={localization}
-      userCode={userCode}
+      initialUserCode={userCode}
       userCodeLength={userCodeLength}
       variant={variant}
       onCodeChange={handleCodeChange}
-      onSubmit={handleSubmit}
+      onSubmitCode={handleSubmit}
     />
   )
 }
@@ -296,11 +300,11 @@ type DeviceCodeFormProps = {
   isSessionPending: boolean
   isVerifying: boolean
   localization: DeviceAuthorizationLocalization
-  userCode: string
+  initialUserCode: string
   userCodeLength: number
   variant?: CardProps["variant"]
   onCodeChange: (value: string) => void
-  onSubmit: (event: FormEvent<HTMLFormElement>) => void
+  onSubmitCode: (code: string) => Promise<void>
 }
 
 function DeviceCodeForm({
@@ -309,17 +313,28 @@ function DeviceCodeForm({
   isSessionPending,
   isVerifying,
   localization,
-  userCode,
+  initialUserCode,
   userCodeLength,
   variant,
   onCodeChange,
-  onSubmit
+  onSubmitCode
 }: DeviceCodeFormProps) {
   const slots = createDeviceCodeSlots(userCodeLength)
   const groupBreak = Math.ceil(userCodeLength / 2)
   const firstGroup = slots.slice(0, groupBreak)
   const secondGroup = slots.slice(groupBreak)
   const errorId = "device-code-error"
+  const form = useAuthForm({
+    defaultValues: { userCode: initialUserCode },
+    onSubmit: async ({ value }) => onSubmitCode(value.userCode)
+  })
+
+  useEffect(() => {
+    form.setFieldValue("userCode", initialUserCode)
+    if (initialUserCode.length === userCodeLength) {
+      void submitAuthForm(form, localization.invalidDeviceCode)
+    }
+  }, [form, initialUserCode, localization.invalidDeviceCode, userCodeLength])
 
   return (
     <Card className={className} variant={variant}>
@@ -333,71 +348,98 @@ function DeviceCodeForm({
       </Card.Header>
 
       <Card.Content>
-        <Form className="flex flex-col gap-4" onSubmit={onSubmit}>
-          <div className="flex flex-col gap-2">
-            <Label htmlFor="device-code">{localization.deviceCode}</Label>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-4">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="device-code">{localization.deviceCode}</Label>
 
-            <InputOTP
-              id="device-code"
-              aria-describedby={codeError ? errorId : undefined}
-              aria-label={localization.deviceCode}
-              className="w-full flex-col items-center justify-center gap-2 sm:flex-row"
-              inputMode="text"
-              isDisabled={isVerifying}
-              isInvalid={Boolean(codeError)}
-              maxLength={userCodeLength}
-              name="userCode"
-              pasteTransformer={normalizeDeviceCode}
-              pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
-              value={userCode}
-              variant={variant === "transparent" ? "primary" : "secondary"}
-              onChange={onCodeChange}
+              <form.AppField name="userCode">
+                {(field) => (
+                  <InputOTP
+                    id="device-code"
+                    aria-describedby={codeError ? errorId : undefined}
+                    aria-label={localization.deviceCode}
+                    className="w-full flex-col items-center justify-center gap-2 sm:flex-row"
+                    inputMode="text"
+                    isDisabled={isVerifying}
+                    isInvalid={Boolean(codeError)}
+                    maxLength={userCodeLength}
+                    name={field.name}
+                    pasteTransformer={normalizeDeviceCode}
+                    pattern={REGEXP_ONLY_DIGITS_AND_CHARS}
+                    value={field.state.value}
+                    variant={
+                      variant === "transparent" ? "primary" : "secondary"
+                    }
+                    onChange={(value) => {
+                      const nextCode = normalizeDeviceCode(value)
+                        .replace(/[^A-Z0-9]/g, "")
+                        .slice(0, userCodeLength)
+                      field.handleChange(nextCode)
+                      onCodeChange(nextCode)
+                      if (nextCode.length === userCodeLength) {
+                        void submitAuthForm(
+                          form,
+                          localization.invalidDeviceCode
+                        )
+                      }
+                    }}
+                  >
+                    <InputOTP.Group className="gap-1">
+                      {firstGroup.map((slot) => (
+                        <InputOTP.Slot
+                          className="size-8 text-sm sm:size-9"
+                          key={slot.id}
+                          index={slot.index}
+                        />
+                      ))}
+                    </InputOTP.Group>
+
+                    {secondGroup.length > 0 ? (
+                      <>
+                        <InputOTP.Separator className="hidden sm:block" />
+                        <InputOTP.Group className="gap-1">
+                          {secondGroup.map((slot) => (
+                            <InputOTP.Slot
+                              className="size-8 text-sm sm:size-9"
+                              key={slot.id}
+                              index={slot.index}
+                            />
+                          ))}
+                        </InputOTP.Group>
+                      </>
+                    ) : null}
+                  </InputOTP>
+                )}
+              </form.AppField>
+
+              <span
+                className="field-error"
+                data-visible={Boolean(codeError)}
+                id={errorId}
+              >
+                {codeError}
+              </span>
+            </div>
+
+            <form.Subscribe
+              selector={(state) =>
+                state.values.userCode.length === userCodeLength
+              }
             >
-              <InputOTP.Group className="gap-1">
-                {firstGroup.map((slot) => (
-                  <InputOTP.Slot
-                    className="size-8 text-sm sm:size-9"
-                    key={slot.id}
-                    index={slot.index}
-                  />
-                ))}
-              </InputOTP.Group>
-
-              {secondGroup.length > 0 ? (
-                <>
-                  <InputOTP.Separator className="hidden sm:block" />
-                  <InputOTP.Group className="gap-1">
-                    {secondGroup.map((slot) => (
-                      <InputOTP.Slot
-                        className="size-8 text-sm sm:size-9"
-                        key={slot.id}
-                        index={slot.index}
-                      />
-                    ))}
-                  </InputOTP.Group>
-                </>
-              ) : null}
-            </InputOTP>
-
-            <span
-              className="field-error"
-              data-visible={Boolean(codeError)}
-              id={errorId}
-            >
-              {codeError}
-            </span>
-          </div>
-
-          <Button
-            className="w-full"
-            isDisabled={userCode.length !== userCodeLength || isSessionPending}
-            isPending={isVerifying}
-            type="submit"
-          >
-            {isVerifying ? <Spinner color="current" size="sm" /> : null}
-            {localization.continue}
-          </Button>
-        </Form>
+              {(complete) => (
+                <form.AuthFormSubmitButton
+                  className="w-full"
+                  isDisabled={!complete || isSessionPending || isVerifying}
+                >
+                  {isVerifying ? <Spinner color="current" size="sm" /> : null}
+                  {localization.continue}
+                </form.AuthFormSubmitButton>
+              )}
+            </form.Subscribe>
+            <form.AuthFormServerError />
+          </form.AuthFormRoot>
+        </form.AppForm>
       </Card.Content>
     </Card>
   )

--- a/packages/heroui/src/components/auth/email-otp/change-email-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/change-email-otp.tsx
@@ -1,3 +1,4 @@
+import { validateEmailAddress } from "@better-auth-ui/core"
 import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin, useSession } from "@better-auth-ui/react"
 import {
@@ -10,9 +11,7 @@ import {
   Card,
   type CardProps,
   cn,
-  FieldError,
   Fieldset,
-  Form,
   Input,
   Label,
   Skeleton,
@@ -20,9 +19,15 @@ import {
   TextField,
   toast
 } from "@heroui/react"
-import { type SyntheticEvent, useReducer, useState } from "react"
+import { useSelector } from "@tanstack/react-form"
+import { useReducer } from "react"
 
 import { emailOtpPlugin } from "../../../lib/auth/email-otp-plugin"
+import {
+  isAuthFormFieldInvalid,
+  submitAuthForm,
+  useAuthForm
+} from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 
@@ -95,79 +100,80 @@ export function ChangeEmailOtp({
     changeEmailReducer,
     initialChangeEmailState
   )
-  const [code, setCode] = useState("")
-
   const resetFlow = () => {
-    setCode("")
+    form.reset()
+    if (currentEmail) form.setFieldValue("email", currentEmail)
     dispatch({ type: "restarted" })
   }
 
   // The step transition is attached per call: the code goes to the current
   // address while the pending change targets the new one, so the address to
   // remember isn't in this mutation's variables.
-  const { mutate: sendVerificationOtp, isPending: isSending } =
+  const { mutateAsync: sendVerificationOtp, isPending: isSending } =
     useSendVerificationOtp(otpClient)
 
-  const { mutate: requestEmailChangeOtp, isPending: isRequesting } =
+  const { mutateAsync: requestEmailChangeOtp, isPending: isRequesting } =
     useRequestEmailChangeOtp(otpClient, {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: (_data, { newEmail }) => {
-        setCode("")
+        form.setFieldValue("code", "")
         dispatch({ type: "changeRequested", newEmail })
       }
     })
 
-  const { mutate: changeEmailOtp, isPending: isChanging } = useChangeEmailOtp(
-    otpClient,
-    {
-      onError: () => setCode(""),
+  const { mutateAsync: changeEmailOtp, isPending: isChanging } =
+    useChangeEmailOtp(otpClient, {
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
         toast.success(localization.settings.changeEmailSuccess)
         resetFlow()
       }
-    }
-  )
+    })
 
   const isPending = isSending || isRequesting || isChanging
 
-  const submitCode = (completedCode: string) => {
+  const submitCode = async (completedCode: string) => {
     if (isPending || state.step === "email") return
 
     if (state.step === "currentCode") {
-      requestEmailChangeOtp({
+      await requestEmailChangeOtp({
         newEmail: state.newEmail,
         otp: completedCode
       })
       return
     }
 
-    changeEmailOtp({ newEmail: state.newEmail, otp: completedCode })
+    await changeEmailOtp({ newEmail: state.newEmail, otp: completedCode })
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
+  const form = useAuthForm({
+    defaultValues: { code: "", email: currentEmail ?? "" },
+    onSubmit: async ({ value }) => {
+      if (state.step === "email") {
+        const newEmail = value.email
 
-    if (state.step === "email") {
-      const formData = new FormData(e.currentTarget)
-      const newEmail = formData.get("email") as string
+        if (verifyCurrentEmail && currentEmail) {
+          await sendVerificationOtp(
+            { email: currentEmail, type: "change-email" },
+            {
+              onSuccess: () =>
+                dispatch({ type: "currentEmailChallenged", newEmail })
+            }
+          )
+          return
+        }
 
-      if (verifyCurrentEmail && currentEmail) {
-        sendVerificationOtp(
-          { email: currentEmail, type: "change-email" },
-          {
-            onSuccess: () =>
-              dispatch({ type: "currentEmailChallenged", newEmail })
-          }
-        )
+        await requestEmailChangeOtp({ newEmail })
         return
       }
 
-      requestEmailChangeOtp({ newEmail })
-      return
+      await submitCode(value.code)
     }
-
-    submitCode(code)
-  }
+  })
+  const codeComplete = useSelector(
+    form.store,
+    (formState) => formState.values.code.length === otpLength
+  )
 
   const codeTarget =
     state.step === "currentCode" ? currentEmail : state.newEmail
@@ -180,96 +186,122 @@ export function ChangeEmailOtp({
 
       <Card className={cn("p-4 gap-4", className)} variant={variant} {...props}>
         <Card.Content>
-          <Form onSubmit={handleSubmit}>
-            <Fieldset className="w-full gap-4">
-              <Fieldset.Group>
-                {state.step === "email" ? (
-                  <TextField
-                    key={`${session?.user.id}-${currentEmail}-email`}
-                    name="email"
-                    type="email"
-                    defaultValue={currentEmail}
-                    isDisabled={isPending || !session}
-                  >
-                    <Label>{localization.auth.email}</Label>
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <Fieldset className="w-full gap-4">
+                <Fieldset.Group>
+                  {state.step === "email" ? (
+                    <form.AppField
+                      key={`${session?.user.id}-${currentEmail}-email`}
+                      name="email"
+                      validators={{
+                        onChange: ({ value }) =>
+                          validateEmailAddress(value, {
+                            invalidMessage: localization.auth.invalidEmail,
+                            requiredMessage: localization.auth.fieldRequired
+                          })
+                      }}
+                    >
+                      {(field) => (
+                        <TextField
+                          type="email"
+                          isDisabled={isPending || !session}
+                          isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                          name={field.name}
+                          validationBehavior="aria"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={field.handleChange}
+                        >
+                          <Label>{localization.auth.email}</Label>
 
-                    {session ? (
-                      <Input
-                        required
-                        variant={
-                          variant === "transparent" ? "primary" : "secondary"
-                        }
-                        autoComplete="email"
-                        placeholder={localization.auth.emailPlaceholder}
-                      />
-                    ) : (
-                      <Skeleton className="h-10 md:h-9 w-full rounded-xl" />
-                    )}
+                          {session ? (
+                            <Input
+                              variant={
+                                variant === "transparent"
+                                  ? "primary"
+                                  : "secondary"
+                              }
+                              autoComplete="email"
+                              placeholder={localization.auth.emailPlaceholder}
+                            />
+                          ) : (
+                            <Skeleton className="h-10 md:h-9 w-full rounded-xl" />
+                          )}
 
-                    <FieldError />
-                  </TextField>
-                ) : (
-                  <div className="flex flex-col gap-2">
-                    <p className="text-muted text-sm">
-                      {emailOtpLocalization.confirmEmailDescription.replace(
-                        "{{email}}",
-                        codeTarget ?? ""
+                          <field.AuthFormFieldError />
+                        </TextField>
                       )}
-                    </p>
+                    </form.AppField>
+                  ) : (
+                    <div className="flex flex-col gap-2">
+                      <p className="text-muted text-sm">
+                        {emailOtpLocalization.confirmEmailDescription.replace(
+                          "{{email}}",
+                          codeTarget ?? ""
+                        )}
+                      </p>
 
-                    <OtpField
-                      autoFocus
+                      <form.AppField name="code">
+                        {(field) => (
+                          <OtpField
+                            autoFocus
+                            isDisabled={isPending}
+                            label={
+                              state.step === "currentCode"
+                                ? emailOtpLocalization.confirmCurrentEmail
+                                : emailOtpLocalization.confirmNewEmail
+                            }
+                            length={otpLength}
+                            name="otp"
+                            value={field.state.value}
+                            variant={variant}
+                            onChange={field.handleChange}
+                            onComplete={() => void submitAuthForm(form)}
+                          />
+                        )}
+                      </form.AppField>
+
+                      {codeTarget && (
+                        <OpenEmailButton
+                          email={codeTarget}
+                          variant="secondary"
+                        />
+                      )}
+                    </div>
+                  )}
+                </Fieldset.Group>
+
+                <Fieldset.Actions>
+                  {state.step !== "email" && (
+                    <Button
+                      variant="tertiary"
+                      size="sm"
                       isDisabled={isPending}
-                      label={
-                        state.step === "currentCode"
-                          ? emailOtpLocalization.confirmCurrentEmail
-                          : emailOtpLocalization.confirmNewEmail
-                      }
-                      length={otpLength}
-                      name="otp"
-                      value={code}
-                      variant={variant}
-                      onChange={setCode}
-                      onComplete={submitCode}
-                    />
+                      onPress={resetFlow}
+                    >
+                      {localization.settings.cancel}
+                    </Button>
+                  )}
 
-                    {codeTarget && (
-                      <OpenEmailButton email={codeTarget} variant="secondary" />
-                    )}
-                  </div>
-                )}
-              </Fieldset.Group>
-
-              <Fieldset.Actions>
-                {state.step !== "email" && (
-                  <Button
-                    variant="tertiary"
+                  <form.AuthFormSubmitButton
+                    isPending={isPending}
+                    isDisabled={
+                      !session || (state.step !== "email" && !codeComplete)
+                    }
                     size="sm"
-                    isDisabled={isPending}
-                    onPress={resetFlow}
                   >
-                    {localization.settings.cancel}
-                  </Button>
-                )}
+                    {isPending && <Spinner color="current" size="sm" />}
 
-                <Button
-                  type="submit"
-                  isPending={isPending}
-                  isDisabled={
-                    !session ||
-                    (state.step !== "email" && code.length !== otpLength)
-                  }
-                  size="sm"
-                >
-                  {isPending && <Spinner color="current" size="sm" />}
-
-                  {state.step === "email"
-                    ? localization.settings.updateEmail
-                    : emailOtpLocalization.verifyCode}
-                </Button>
-              </Fieldset.Actions>
-            </Fieldset>
-          </Form>
+                    {state.step === "email"
+                      ? localization.settings.updateEmail
+                      : emailOtpLocalization.verifyCode}
+                  </form.AuthFormSubmitButton>
+                </Fieldset.Actions>
+              </Fieldset>
+              <form.AuthFormServerError />
+            </form.AuthFormRoot>
+          </form.AppForm>
         </Card.Content>
       </Card>
     </div>

--- a/packages/heroui/src/components/auth/email-otp/email-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/email-otp.tsx
@@ -1,4 +1,4 @@
-import { authMutationKeys } from "@better-auth-ui/core"
+import { authMutationKeys, validateEmailAddress } from "@better-auth-ui/core"
 import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { getSsoFallbackEmail } from "@better-auth-ui/core/plugins/sso"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
@@ -12,7 +12,6 @@ import {
   type CardProps,
   cn,
   Description,
-  FieldError,
   Input,
   Label,
   Link,
@@ -74,7 +73,7 @@ export function EmailOtp({
 
   const [codeSent, setCodeSent] = useState(false)
 
-  const { mutate: sendVerificationOtp, isPending: isSending } =
+  const { mutateAsync: sendVerificationOtp, isPending: isSending } =
     useSendVerificationOtp(otpClient, {
       onSuccess: () => {
         setCodeSent(true)
@@ -82,13 +81,11 @@ export function EmailOtp({
       }
     })
 
-  const { mutate: signInEmailOtp, isPending: isSigningIn } = useSignInEmailOtp(
-    otpClient,
-    {
+  const { mutateAsync: signInEmailOtp, isPending: isSigningIn } =
+    useSignInEmailOtp(otpClient, {
       onError: () => form.setFieldValue("code", ""),
       onSuccess: (data) => continueSignIn(data)
-    }
-  )
+    })
 
   const signInMutating = useIsMutating({
     mutationKey: authMutationKeys.signIn.all
@@ -108,12 +105,12 @@ export function EmailOtp({
 
   const form = useAuthForm({
     defaultValues: { code: "", email: getSsoFallbackEmail() },
-    onSubmit: ({ value }) => {
+    onSubmit: async ({ value }) => {
       if (!codeSent) {
-        sendVerificationOtp({ email: value.email, type: "sign-in" })
+        await sendVerificationOtp({ email: value.email, type: "sign-in" })
         return
       }
-      verifyCode(value.code)
+      await verifyCode(value.code)
     }
   })
   const codeComplete = useSelector(
@@ -178,7 +175,16 @@ export function EmailOtp({
                 )}
               </form.AppField>
             ) : (
-              <form.AppField name="email">
+              <form.AppField
+                name="email"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
+                }}
+              >
                 {(field) => (
                   <TextField
                     name={field.name}
@@ -188,11 +194,7 @@ export function EmailOtp({
                     value={field.state.value}
                     onBlur={field.handleBlur}
                     onChange={field.handleChange}
-                    validate={(value) => {
-                      if (!value) return localization.auth.fieldRequired
-                      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
-                        return localization.auth.invalidEmail
-                    }}
+                    validationBehavior="aria"
                   >
                     <Label>{localization.auth.email}</Label>
 
@@ -204,11 +206,13 @@ export function EmailOtp({
                       }
                     />
 
-                    <FieldError />
+                    <field.AuthFormFieldError />
                   </TextField>
                 )}
               </form.AppField>
             )}
+
+            <form.AuthFormServerError />
 
             <div className="flex flex-col gap-3">
               <form.AuthFormSubmitButton

--- a/packages/heroui/src/components/auth/email-otp/email-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/email-otp.tsx
@@ -25,7 +25,7 @@ import { useState } from "react"
 import { emailOtpPlugin } from "../../../lib/auth/email-otp-plugin"
 import { useResendCooldown } from "../../../lib/auth/use-resend-cooldown"
 import { useSignInContinuation } from "../../../lib/auth/use-sign-in-continuation"
-import { useAuthForm } from "../auth-form"
+import { setAuthFormServerError, useAuthForm } from "../auth-form"
 import { FieldSeparator } from "../field-separator"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
@@ -97,10 +97,13 @@ export function EmailOtp({
 
   const sendCode = () =>
     sendVerificationOtp({ email: form.state.values.email, type: "sign-in" })
-  const verifyCode = (completedCode: string) => {
+  const verifyCode = async (completedCode: string) => {
     if (isPending || isSigningIn) return
 
-    signInEmailOtp({ email: form.state.values.email, otp: completedCode })
+    return signInEmailOtp({
+      email: form.state.values.email,
+      otp: completedCode
+    })
   }
 
   const form = useAuthForm({
@@ -170,7 +173,15 @@ export function EmailOtp({
                     value={field.state.value}
                     variant={variant}
                     onChange={field.handleChange}
-                    onComplete={verifyCode}
+                    onComplete={(completedCode) =>
+                      void verifyCode(completedCode).catch((error) =>
+                        setAuthFormServerError(
+                          form,
+                          error,
+                          localization.auth.callbackFailedTitle
+                        )
+                      )
+                    }
                   />
                 )}
               </form.AppField>

--- a/packages/heroui/src/components/auth/email-otp/email-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/email-otp.tsx
@@ -25,7 +25,11 @@ import { useState } from "react"
 import { emailOtpPlugin } from "../../../lib/auth/email-otp-plugin"
 import { useResendCooldown } from "../../../lib/auth/use-resend-cooldown"
 import { useSignInContinuation } from "../../../lib/auth/use-sign-in-continuation"
-import { setAuthFormServerError, useAuthForm } from "../auth-form"
+import {
+  clearAuthFormServerError,
+  setAuthFormServerError,
+  useAuthForm
+} from "../auth-form"
 import { FieldSeparator } from "../field-separator"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
@@ -95,8 +99,13 @@ export function EmailOtp({
   })
   const isPending = signInMutating + signUpMutating > 0 || isSending
 
-  const sendCode = () =>
-    sendVerificationOtp({ email: form.state.values.email, type: "sign-in" })
+  const sendCode = () => {
+    clearAuthFormServerError(form)
+    return sendVerificationOtp({
+      email: form.state.values.email,
+      type: "sign-in"
+    })
+  }
   const verifyCode = async (completedCode: string) => {
     if (isPending || isSigningIn) return
 
@@ -125,6 +134,7 @@ export function EmailOtp({
   const startOver = () => {
     setCodeSent(false)
     form.setFieldValue("code", "")
+    clearAuthFormServerError(form)
   }
 
   const showSeparator = !!socialProviders?.length

--- a/packages/heroui/src/components/auth/email-otp/email-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/email-otp.tsx
@@ -249,7 +249,15 @@ export function EmailOtp({
                     className="w-full"
                     variant="tertiary"
                     isDisabled={isPending || isSigningIn || isCoolingDown}
-                    onPress={sendCode}
+                    onPress={() =>
+                      void sendCode().catch((error) =>
+                        setAuthFormServerError(
+                          form,
+                          error,
+                          localization.auth.callbackFailedTitle
+                        )
+                      )
+                    }
                   >
                     {isCoolingDown
                       ? localization.auth.resendIn.replace(

--- a/packages/heroui/src/components/auth/email-otp/forgot-password-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/forgot-password-otp.tsx
@@ -1,4 +1,4 @@
-import { getAuthLinkURL } from "@better-auth-ui/core"
+import { getAuthLinkURL, validateEmailAddress } from "@better-auth-ui/core"
 import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin, useFetchOptions } from "@better-auth-ui/react"
 import { useRequestPasswordResetOtp } from "@better-auth-ui/react/plugins/email-otp"
@@ -7,7 +7,6 @@ import {
   type CardProps,
   cn,
   Description,
-  FieldError,
   Input,
   Label,
   Link,
@@ -55,7 +54,7 @@ export function ForgotPasswordOtp({
 
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
 
-  const { mutate: requestPasswordResetOtp, isPending } =
+  const { mutateAsync: requestPasswordResetOtp, isPending } =
     useRequestPasswordResetOtp(authClient as EmailOtpAuthClient, {
       onError: () => resetFetchOptions(),
       onSuccess: (_data, { email }) => {
@@ -66,8 +65,8 @@ export function ForgotPasswordOtp({
 
   const form = useAuthForm({
     defaultValues: { email: "" },
-    onSubmit: ({ value }) =>
-      requestPasswordResetOtp({
+    onSubmit: async ({ value }) =>
+      await requestPasswordResetOtp({
         email: value.email,
         fetchOptions
       })
@@ -91,7 +90,16 @@ export function ForgotPasswordOtp({
       <Card.Content className="gap-4">
         <form.AppForm>
           <form.AuthFormRoot className="flex flex-col gap-4">
-            <form.AppField name="email">
+            <form.AppField
+              name="email"
+              validators={{
+                onChange: ({ value }) =>
+                  validateEmailAddress(value, {
+                    invalidMessage: localization.auth.invalidEmail,
+                    requiredMessage: localization.auth.fieldRequired
+                  })
+              }}
+            >
               {(field) => (
                 <TextField
                   name={field.name}
@@ -101,11 +109,7 @@ export function ForgotPasswordOtp({
                   value={field.state.value}
                   onBlur={field.handleBlur}
                   onChange={field.handleChange}
-                  validate={(value) => {
-                    if (!value) return localization.auth.fieldRequired
-                    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
-                      return localization.auth.invalidEmail
-                  }}
+                  validationBehavior="aria"
                 >
                   <Label>{localization.auth.email}</Label>
 
@@ -117,10 +121,12 @@ export function ForgotPasswordOtp({
                     }
                   />
 
-                  <FieldError />
+                  <field.AuthFormFieldError />
                 </TextField>
               )}
             </form.AppField>
+
+            <form.AuthFormServerError />
 
             {Captcha && <div className="flex justify-center">{Captcha}</div>}
 

--- a/packages/heroui/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/reset-password-otp.tsx
@@ -1,6 +1,8 @@
 import {
   getAuthLinkURL,
-  isPasswordCompromisedError
+  isPasswordCompromisedError,
+  validateEmailAddress,
+  validateStringLength
 } from "@better-auth-ui/core"
 import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
@@ -12,8 +14,6 @@ import {
   type CardProps,
   cn,
   Description,
-  FieldError,
-  Form,
   Input,
   InputGroup,
   Label,
@@ -23,9 +23,16 @@ import {
   toast,
   useIsHydrated
 } from "@heroui/react"
-import { type SyntheticEvent, useEffect, useRef, useState } from "react"
+import { useSelector } from "@tanstack/react-form"
+import { useEffect, useState } from "react"
 
 import { emailOtpPlugin } from "../../../lib/auth/email-otp-plugin"
+import {
+  isAuthFormFieldInvalid,
+  setAuthFormServerError,
+  submitAuthForm,
+  useAuthForm
+} from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 import { PasswordStrengthMeter } from "../password-strength-meter"
@@ -67,34 +74,24 @@ export function ResetPasswordOtp({
   const isHydrated = useIsHydrated()
   const initialEmail =
     (isHydrated && sessionStorage.getItem(RESET_PASSWORD_OTP_STORAGE_KEY)) || ""
-  const [email, setEmail] = useState(initialEmail)
   const [hasStoredEmail, setHasStoredEmail] = useState(Boolean(initialEmail))
-  const [code, setCode] = useState("")
-  const [password, setPassword] = useState("")
-  const [isCompromised, setIsCompromised] = useState(false)
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
   const [isConfirmPasswordVisible, setIsConfirmPasswordVisible] =
     useState(false)
-  const formRef = useRef<HTMLFormElement>(null)
-  const submissionLockedRef = useRef(false)
-
-  useEffect(() => {
-    const storedEmail =
-      sessionStorage.getItem(RESET_PASSWORD_OTP_STORAGE_KEY) ?? ""
-    setEmail(storedEmail)
-    setHasStoredEmail(Boolean(storedEmail))
-  }, [])
-
-  const { mutate: resetPasswordOtp, isPending } = useResetPasswordOtp(
+  const { mutateAsync: resetPasswordOtp, isPending } = useResetPasswordOtp(
     authClient as EmailOtpAuthClient,
     {
       onError: (error) => {
         // The haveIBeenPwned plugin rejects on the password itself, so
         // it belongs against the field rather than in a toast.
-        setIsCompromised(isPasswordCompromisedError(error))
-
-        submissionLockedRef.current = false
-        setCode("")
+        if (isPasswordCompromisedError(error)) {
+          setAuthFormServerError(
+            form,
+            { fields: { password: localization.auth.passwordCompromised } },
+            localization.auth.passwordCompromised
+          )
+        }
+        form.setFieldValue("code", "")
       },
       onSuccess: () => {
         sessionStorage.removeItem(RESET_PASSWORD_OTP_STORAGE_KEY)
@@ -104,68 +101,44 @@ export function ResetPasswordOtp({
     }
   )
 
-  const validatePassword = (value: string) => {
-    if (!value) return localization.auth.fieldRequired
-    const min = emailAndPassword?.minPasswordLength
-    const max = emailAndPassword?.maxPasswordLength
-    if (min && value.length < min)
-      return localization.auth.tooShort.replace("{{min}}", String(min))
-    if (max && value.length > max)
-      return localization.auth.tooLong.replace("{{max}}", String(max))
-  }
+  const validatePassword = (value: string) =>
+    validateStringLength(value, {
+      maxLength: emailAndPassword?.maxPasswordLength,
+      maxLengthMessage: localization.auth.tooLong.replace(
+        "{{max}}",
+        String(emailAndPassword?.maxPasswordLength)
+      ),
+      minLength: emailAndPassword?.minPasswordLength,
+      minLengthMessage: localization.auth.tooShort.replace(
+        "{{min}}",
+        String(emailAndPassword?.minPasswordLength)
+      ),
+      requiredMessage: localization.auth.fieldRequired
+    })
 
-  const submitReset = (
-    form: HTMLFormElement,
-    submittedCode: string,
-    reportErrors: boolean
-  ) => {
-    if (isPending || submissionLockedRef.current) return
-
-    const formData = new FormData(form)
-    const password = formData.get("password") as string
-    const confirmPassword = formData.get("confirmPassword") as string
-    const submittedEmail = hasStoredEmail
-      ? email
-      : (formData.get("email") as string)
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      if (reportErrors) {
-        toast.danger(localization.auth.passwordsDoNotMatch)
-      }
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      confirmPassword: "",
+      email: initialEmail,
+      password: ""
+    },
+    onSubmit: async ({ value }) => {
+      await resetPasswordOtp({
+        email: value.email,
+        otp: value.code,
+        password: value.password
+      })
     }
+  })
+  const email = useSelector(form.store, (state) => state.values.email)
 
-    if (submittedCode.length !== otpLength) {
-      if (reportErrors) {
-        toast.danger(
-          emailOtpLocalization.codeLengthMismatch.replace(
-            "{{length}}",
-            String(otpLength)
-          )
-        )
-      }
-      return
-    }
-
-    submissionLockedRef.current = true
-    resetPasswordOtp({ email: submittedEmail, otp: submittedCode, password })
-  }
-
-  const tryAutoSubmit = (completedCode?: string) => {
-    const form = formRef.current
-
-    if (!form?.matches(":valid")) return
-
-    const formData = new FormData(form)
-    const submittedCode = completedCode ?? String(formData.get("otp") ?? "")
-
-    submitReset(form, submittedCode, false)
-  }
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-    submitReset(e.currentTarget, code, true)
-  }
+  useEffect(() => {
+    const storedEmail =
+      sessionStorage.getItem(RESET_PASSWORD_OTP_STORAGE_KEY) ?? ""
+    form.setFieldValue("email", storedEmail)
+    setHasStoredEmail(Boolean(storedEmail))
+  }, [form.setFieldValue])
 
   return (
     <Card
@@ -185,157 +158,205 @@ export function ResetPasswordOtp({
       </Card.Header>
 
       <Card.Content className="gap-4">
-        <Form
-          ref={formRef}
-          className="flex flex-col gap-4"
-          onSubmit={handleSubmit}
-        >
-          {!hasStoredEmail && (
-            <TextField
-              name="email"
-              type="email"
-              autoComplete="email"
-              isDisabled={isPending}
-              value={email}
-              onChange={setEmail}
-              validate={(value) => {
-                if (!value) return localization.auth.fieldRequired
-                if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
-                  return localization.auth.invalidEmail
-              }}
-            >
-              <Label>{localization.auth.email}</Label>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-4">
+            {!hasStoredEmail && (
+              <form.AppField
+                name="email"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
+                }}
+              >
+                {(field) => (
+                  <TextField
+                    name={field.name}
+                    type="email"
+                    autoComplete="email"
+                    isDisabled={isPending}
+                    isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                    validationBehavior="aria"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={field.handleChange}
+                  >
+                    <Label>{localization.auth.email}</Label>
 
-              <Input
-                placeholder={localization.auth.emailPlaceholder}
-                required
-                variant={variant === "transparent" ? "primary" : "secondary"}
-              />
+                    <Input
+                      placeholder={localization.auth.emailPlaceholder}
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
+                      }
+                    />
 
-              <FieldError />
-            </TextField>
-          )}
-
-          <OtpField
-            autoFocus={hasStoredEmail}
-            isDisabled={isPending}
-            label={emailOtpLocalization.code}
-            length={otpLength}
-            name="otp"
-            value={code}
-            variant={variant}
-            onChange={setCode}
-            onComplete={tryAutoSubmit}
-          />
-
-          <TextField
-            minLength={emailAndPassword?.minPasswordLength}
-            maxLength={emailAndPassword?.maxPasswordLength}
-            name="password"
-            autoComplete="new-password"
-            value={password}
-            onChange={(value) => {
-              setPassword(value)
-              setIsCompromised(false)
-            }}
-            isInvalid={isCompromised || undefined}
-            isDisabled={isPending}
-            validate={validatePassword}
-          >
-            <Label>{localization.auth.newPassword}</Label>
-
-            <InputGroup
-              variant={variant === "transparent" ? "primary" : "secondary"}
-            >
-              <InputGroup.Input
-                name="password"
-                placeholder={localization.auth.newPasswordPlaceholder}
-                type={isPasswordVisible ? "text" : "password"}
-                required
-              />
-
-              <InputGroup.Suffix className="px-0">
-                <Button
-                  isIconOnly
-                  aria-label={
-                    isPasswordVisible
-                      ? localization.auth.hidePassword
-                      : localization.auth.showPassword
-                  }
-                  size="sm"
-                  variant="ghost"
-                  onPress={() => setIsPasswordVisible(!isPasswordVisible)}
-                  isDisabled={isPending}
-                >
-                  {isPasswordVisible ? <EyeSlash /> : <Eye />}
-                </Button>
-              </InputGroup.Suffix>
-            </InputGroup>
-
-            {isCompromised ? (
-              <FieldError>{localization.auth.passwordCompromised}</FieldError>
-            ) : (
-              <FieldError />
+                    <field.AuthFormFieldError />
+                  </TextField>
+                )}
+              </form.AppField>
             )}
 
-            <PasswordStrengthMeter password={password} />
-          </TextField>
-
-          {emailAndPassword?.confirmPassword && (
-            <TextField
-              minLength={emailAndPassword?.minPasswordLength}
-              maxLength={emailAndPassword?.maxPasswordLength}
-              name="confirmPassword"
-              autoComplete="new-password"
-              isDisabled={isPending}
-              validate={validatePassword}
+            <form.AppField
+              name="code"
+              validators={{
+                onChange: ({ value }) =>
+                  value.length === otpLength
+                    ? undefined
+                    : emailOtpLocalization.codeLengthMismatch.replace(
+                        "{{length}}",
+                        String(otpLength)
+                      )
+              }}
             >
-              <Label>{localization.auth.confirmPassword}</Label>
-
-              <InputGroup
-                variant={variant === "transparent" ? "primary" : "secondary"}
-              >
-                <InputGroup.Input
-                  name="confirmPassword"
-                  placeholder={localization.auth.confirmPasswordPlaceholder}
-                  type={isConfirmPasswordVisible ? "text" : "password"}
-                  required
+              {(field) => (
+                <OtpField
+                  autoFocus={hasStoredEmail}
+                  isDisabled={isPending}
+                  label={emailOtpLocalization.code}
+                  length={otpLength}
+                  name="otp"
+                  value={field.state.value}
+                  variant={variant}
+                  onChange={field.handleChange}
+                  onComplete={() => void submitAuthForm(form)}
                 />
+              )}
+            </form.AppField>
 
-                <InputGroup.Suffix className="px-0">
-                  <Button
-                    isIconOnly
-                    aria-label={
-                      isConfirmPasswordVisible
-                        ? localization.auth.hidePassword
-                        : localization.auth.showPassword
+            <form.AppField
+              name="password"
+              validators={{ onChange: ({ value }) => validatePassword(value) }}
+            >
+              {(field) => (
+                <TextField
+                  name={field.name}
+                  autoComplete="new-password"
+                  value={field.state.value}
+                  onBlur={field.handleBlur}
+                  onChange={field.handleChange}
+                  isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                  isDisabled={isPending}
+                  validationBehavior="aria"
+                >
+                  <Label>{localization.auth.newPassword}</Label>
+
+                  <InputGroup
+                    variant={
+                      variant === "transparent" ? "primary" : "secondary"
                     }
-                    size="sm"
-                    variant="ghost"
-                    onPress={() =>
-                      setIsConfirmPasswordVisible(!isConfirmPasswordVisible)
-                    }
-                    isDisabled={isPending}
                   >
-                    {isConfirmPasswordVisible ? <EyeSlash /> : <Eye />}
-                  </Button>
-                </InputGroup.Suffix>
-              </InputGroup>
+                    <InputGroup.Input
+                      placeholder={localization.auth.newPasswordPlaceholder}
+                      type={isPasswordVisible ? "text" : "password"}
+                    />
 
-              <FieldError />
-            </TextField>
-          )}
+                    <InputGroup.Suffix className="px-0">
+                      <Button
+                        isIconOnly
+                        aria-label={
+                          isPasswordVisible
+                            ? localization.auth.hidePassword
+                            : localization.auth.showPassword
+                        }
+                        size="sm"
+                        variant="ghost"
+                        onPress={() => setIsPasswordVisible(!isPasswordVisible)}
+                        isDisabled={isPending}
+                      >
+                        {isPasswordVisible ? <EyeSlash /> : <Eye />}
+                      </Button>
+                    </InputGroup.Suffix>
+                  </InputGroup>
 
-          <div className="flex flex-col gap-3">
-            <Button type="submit" className="w-full" isPending={isPending}>
-              {isPending && <Spinner color="current" size="sm" />}
+                  <field.AuthFormFieldError />
 
-              {localization.auth.resetPassword}
-            </Button>
+                  <PasswordStrengthMeter password={field.state.value} />
+                </TextField>
+              )}
+            </form.AppField>
 
-            {email && <OpenEmailButton email={email} variant="secondary" />}
-          </div>
-        </Form>
+            {emailAndPassword?.confirmPassword && (
+              <form.AppField
+                name="confirmPassword"
+                validators={{
+                  onChangeListenTo: ["password"],
+                  onChange: ({ value, fieldApi }) =>
+                    validatePassword(value) ??
+                    (value === fieldApi.form.getFieldValue("password")
+                      ? undefined
+                      : localization.auth.passwordsDoNotMatch)
+                }}
+              >
+                {(field) => (
+                  <TextField
+                    name={field.name}
+                    autoComplete="new-password"
+                    isDisabled={isPending}
+                    isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                    validationBehavior="aria"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={field.handleChange}
+                  >
+                    <Label>{localization.auth.confirmPassword}</Label>
+
+                    <InputGroup
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
+                      }
+                    >
+                      <InputGroup.Input
+                        placeholder={
+                          localization.auth.confirmPasswordPlaceholder
+                        }
+                        type={isConfirmPasswordVisible ? "text" : "password"}
+                      />
+
+                      <InputGroup.Suffix className="px-0">
+                        <Button
+                          isIconOnly
+                          aria-label={
+                            isConfirmPasswordVisible
+                              ? localization.auth.hidePassword
+                              : localization.auth.showPassword
+                          }
+                          size="sm"
+                          variant="ghost"
+                          onPress={() =>
+                            setIsConfirmPasswordVisible(
+                              !isConfirmPasswordVisible
+                            )
+                          }
+                          isDisabled={isPending}
+                        >
+                          {isConfirmPasswordVisible ? <EyeSlash /> : <Eye />}
+                        </Button>
+                      </InputGroup.Suffix>
+                    </InputGroup>
+
+                    <field.AuthFormFieldError />
+                  </TextField>
+                )}
+              </form.AppField>
+            )}
+
+            <div className="flex flex-col gap-3">
+              <form.AuthFormSubmitButton
+                className="w-full"
+                isDisabled={isPending}
+              >
+                {isPending && <Spinner color="current" size="sm" />}
+
+                {localization.auth.resetPassword}
+              </form.AuthFormSubmitButton>
+
+              {email && <OpenEmailButton email={email} variant="secondary" />}
+            </div>
+            <form.AuthFormServerError />
+          </form.AuthFormRoot>
+        </form.AppForm>
       </Card.Content>
 
       <Card.Footer className="flex-col gap-3">

--- a/packages/heroui/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/verify-email-otp.tsx
@@ -1,4 +1,4 @@
-import { getAuthLinkURL } from "@better-auth-ui/core"
+import { getAuthLinkURL, validateEmailAddress } from "@better-auth-ui/core"
 import type { EmailOtpAuthClient } from "@better-auth-ui/core/plugins/email-otp"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import {
@@ -11,7 +11,6 @@ import {
   type CardProps,
   cn,
   Description,
-  FieldError,
   Input,
   Label,
   Link,
@@ -83,7 +82,7 @@ export function VerifyEmailOtp({ className, variant }: VerifyEmailOtpProps) {
     if (pendingEmail) startCooldown(RESEND_COOLDOWN_SECONDS)
   }, [startCooldown])
 
-  const { mutate: sendVerificationOtp, isPending: isSending } =
+  const { mutateAsync: sendVerificationOtp, isPending: isSending } =
     useSendVerificationOtp(otpClient, {
       onSuccess: (_data, { email: sentTo }) => {
         sessionStorage.setItem(VERIFY_EMAIL_STORAGE_KEY, sentTo)
@@ -93,17 +92,15 @@ export function VerifyEmailOtp({ className, variant }: VerifyEmailOtpProps) {
       }
     })
 
-  const { mutate: verifyEmailOtp, isPending: isVerifying } = useVerifyEmailOtp(
-    otpClient,
-    {
+  const { mutateAsync: verifyEmailOtp, isPending: isVerifying } =
+    useVerifyEmailOtp(otpClient, {
       onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
         sessionStorage.removeItem(VERIFY_EMAIL_STORAGE_KEY)
         toast.success(emailOtpLocalization.emailVerified)
         navigate({ to: redirectTo })
       }
-    }
-  )
+    })
 
   const isPending = isSending || isVerifying
 
@@ -115,16 +112,16 @@ export function VerifyEmailOtp({ className, variant }: VerifyEmailOtpProps) {
 
   const form = useAuthForm({
     defaultValues: { code: "", email: "" },
-    onSubmit: ({ value }) => {
+    onSubmit: async ({ value }) => {
       if (!email) {
-        sendVerificationOtp({
+        await sendVerificationOtp({
           email: value.email,
           type: "email-verification"
         })
         return
       }
 
-      verifyCode(value.code)
+      await verifyCode(value.code)
     }
   })
   const codeComplete = useSelector(
@@ -169,7 +166,16 @@ export function VerifyEmailOtp({ className, variant }: VerifyEmailOtpProps) {
                 )}
               </form.AppField>
             ) : (
-              <form.AppField name="email">
+              <form.AppField
+                name="email"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
+                }}
+              >
                 {(field) => (
                   <TextField
                     name={field.name}
@@ -179,11 +185,7 @@ export function VerifyEmailOtp({ className, variant }: VerifyEmailOtpProps) {
                     value={field.state.value}
                     onBlur={field.handleBlur}
                     onChange={field.handleChange}
-                    validate={(value) => {
-                      if (!value) return localization.auth.fieldRequired
-                      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
-                        return localization.auth.invalidEmail
-                    }}
+                    validationBehavior="aria"
                   >
                     <Label>{localization.auth.email}</Label>
 
@@ -195,11 +197,13 @@ export function VerifyEmailOtp({ className, variant }: VerifyEmailOtpProps) {
                       }
                     />
 
-                    <FieldError />
+                    <field.AuthFormFieldError />
                   </TextField>
                 )}
               </form.AppField>
             )}
+
+            <form.AuthFormServerError />
 
             <div className="flex flex-col gap-3">
               <form.AuthFormSubmitButton

--- a/packages/heroui/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/packages/heroui/src/components/auth/email-otp/verify-email-otp.tsx
@@ -27,7 +27,7 @@ import {
   RESEND_COOLDOWN_SECONDS,
   useResendCooldown
 } from "../../../lib/auth/use-resend-cooldown"
-import { useAuthForm } from "../auth-form"
+import { setAuthFormServerError, useAuthForm } from "../auth-form"
 import { OpenEmailButton } from "../open-email-button"
 import { OtpField } from "../otp-field"
 
@@ -104,10 +104,10 @@ export function VerifyEmailOtp({ className, variant }: VerifyEmailOtpProps) {
 
   const isPending = isSending || isVerifying
 
-  const verifyCode = (completedCode: string) => {
+  const verifyCode = async (completedCode: string) => {
     if (isPending || !email) return
 
-    verifyEmailOtp({ email, otp: completedCode })
+    return verifyEmailOtp({ email, otp: completedCode })
   }
 
   const form = useAuthForm({
@@ -161,7 +161,15 @@ export function VerifyEmailOtp({ className, variant }: VerifyEmailOtpProps) {
                     value={field.state.value}
                     variant={variant}
                     onChange={field.handleChange}
-                    onComplete={verifyCode}
+                    onComplete={(completedCode) =>
+                      void verifyCode(completedCode).catch((error) =>
+                        setAuthFormServerError(
+                          form,
+                          error,
+                          localization.auth.callbackFailedTitle
+                        )
+                      )
+                    }
                   />
                 )}
               </form.AppField>
@@ -225,7 +233,16 @@ export function VerifyEmailOtp({ className, variant }: VerifyEmailOtpProps) {
                   variant="tertiary"
                   isDisabled={isPending || isCoolingDown}
                   onPress={() =>
-                    sendVerificationOtp({ email, type: "email-verification" })
+                    void sendVerificationOtp({
+                      email,
+                      type: "email-verification"
+                    }).catch((error) =>
+                      setAuthFormServerError(
+                        form,
+                        error,
+                        localization.auth.callbackFailedTitle
+                      )
+                    )
                   }
                 >
                   {isCoolingDown

--- a/packages/heroui/src/components/auth/forgot-password.tsx
+++ b/packages/heroui/src/components/auth/forgot-password.tsx
@@ -138,6 +138,7 @@ export function ForgotPassword({ className, variant }: ForgotPasswordProps) {
                 {localization.auth.sendResetLink}
               </form.AuthFormSubmitButton>
             </div>
+            <form.AuthFormServerError />
           </form.AuthFormRoot>
         </form.AppForm>
       </Card.Content>

--- a/packages/heroui/src/components/auth/forgot-password.tsx
+++ b/packages/heroui/src/components/auth/forgot-password.tsx
@@ -47,9 +47,8 @@ export function ForgotPassword({ className, variant }: ForgotPasswordProps) {
 
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
 
-  const { mutate: requestPasswordReset, isPending } = useRequestPasswordReset(
-    authClient,
-    {
+  const { mutateAsync: requestPasswordReset, isPending } =
+    useRequestPasswordReset(authClient, {
       onError: () => {
         resetFetchOptions()
       },
@@ -57,13 +56,12 @@ export function ForgotPassword({ className, variant }: ForgotPasswordProps) {
         sessionStorage.setItem(RESET_LINK_SENT_STORAGE_KEY, email)
         navigate({ to: `${basePaths.auth}/${viewPaths.auth.resetLinkSent}` })
       }
-    }
-  )
+    })
 
   const form = useAuthForm({
     defaultValues: { email: "" },
-    onSubmit: ({ value }) =>
-      requestPasswordReset({
+    onSubmit: async ({ value }) =>
+      await requestPasswordReset({
         email: value.email,
         redirectTo: getViewURL(
           baseURL,

--- a/packages/heroui/src/components/auth/magic-link/magic-link.tsx
+++ b/packages/heroui/src/components/auth/magic-link/magic-link.tsx
@@ -147,6 +147,8 @@ export function MagicLink({
               )}
             </form.AppField>
 
+            <form.AuthFormServerError />
+
             <div className="flex flex-col gap-3">
               <form.AuthFormSubmitButton
                 className="w-full"

--- a/packages/heroui/src/components/auth/magic-link/magic-link.tsx
+++ b/packages/heroui/src/components/auth/magic-link/magic-link.tsx
@@ -57,7 +57,7 @@ export function MagicLink({
   const { localization: magicLinkLocalization, viewPaths: magicLinkViewPaths } =
     useAuthPlugin(magicLinkPlugin)
 
-  const { mutate: signInMagicLink, isPending: signInMagicLinkPending } =
+  const { mutateAsync: signInMagicLink, isPending: signInMagicLinkPending } =
     useSignInMagicLink(authClient as MagicLinkAuthClient, {
       onSuccess: (_data, variables) => {
         sessionStorage.setItem(MAGIC_LINK_SENT_STORAGE_KEY, variables.email)
@@ -77,8 +77,8 @@ export function MagicLink({
 
   const form = useAuthForm({
     defaultValues: { email: getSsoFallbackEmail() },
-    onSubmit: ({ value }) =>
-      signInMagicLink({
+    onSubmit: async ({ value }) =>
+      await signInMagicLink({
         email: value.email,
         callbackURL: `${baseURL}${redirectTo}`
       })

--- a/packages/heroui/src/components/auth/magic-link/magic-link.tsx
+++ b/packages/heroui/src/components/auth/magic-link/magic-link.tsx
@@ -1,4 +1,4 @@
-import { authMutationKeys } from "@better-auth-ui/core"
+import { authMutationKeys, validateEmailAddress } from "@better-auth-ui/core"
 import type { MagicLinkAuthClient } from "@better-auth-ui/core/plugins/magic-link"
 import { getSsoFallbackEmail } from "@better-auth-ui/core/plugins/sso"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
@@ -112,7 +112,16 @@ export function MagicLink({
 
         <form.AppForm>
           <form.AuthFormRoot className="flex flex-col gap-4">
-            <form.AppField name="email">
+            <form.AppField
+              name="email"
+              validators={{
+                onChange: ({ value }) =>
+                  validateEmailAddress(value, {
+                    invalidMessage: localization.auth.invalidEmail,
+                    requiredMessage: localization.auth.fieldRequired
+                  })
+              }}
+            >
               {(field) => (
                 <TextField
                   name={field.name}

--- a/packages/heroui/src/components/auth/organization/delete-organization-dialog.tsx
+++ b/packages/heroui/src/components/auth/organization/delete-organization-dialog.tsx
@@ -75,6 +75,7 @@ export function DeleteOrganizationDialog({
                     <OrganizationView organization={organization} hideRole />
                   </Card.Content>
                 </Card>
+                <form.AuthFormServerError />
               </AlertDialog.Body>
 
               <AlertDialog.Footer>

--- a/packages/heroui/src/components/auth/organization/delete-organization-dialog.tsx
+++ b/packages/heroui/src/components/auth/organization/delete-organization-dialog.tsx
@@ -26,7 +26,7 @@ export function DeleteOrganizationDialog({
     viewPaths: organizationPluginViewPaths
   } = useAuthPlugin(organizationPlugin)
 
-  const { mutate: deleteOrganization, isPending } = useDeleteOrganization(
+  const { mutateAsync: deleteOrganization, isPending } = useDeleteOrganization(
     authClient as OrganizationAuthClient,
     {
       onSuccess: () => {
@@ -43,7 +43,8 @@ export function DeleteOrganizationDialog({
 
   const form = useAuthForm({
     defaultValues: {},
-    onSubmit: () => deleteOrganization({ organizationId: organization.id })
+    onSubmit: async () =>
+      await deleteOrganization({ organizationId: organization.id })
   })
 
   return (

--- a/packages/heroui/src/components/auth/organization/organization-table-renderer.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-table-renderer.tsx
@@ -1,0 +1,73 @@
+import { Table } from "@heroui/react"
+import type { ReactNode } from "react"
+import {
+  getHeroUISelection,
+  getHeroUISortDescriptor,
+  getTanStackRowSelection,
+  getTanStackSorting
+} from "../table-bridge"
+import { useOrganizationTableContext } from "./organization-table"
+
+export function OrganizationTableRenderer({
+  ariaLabel,
+  empty,
+  selectable = false
+}: {
+  ariaLabel: string
+  empty: ReactNode
+  selectable?: boolean
+}) {
+  const table = useOrganizationTableContext()
+  const rows = table.getRowModel().rows
+  const rowIds = rows.map((row) => row.id)
+
+  return (
+    <Table>
+      <Table.ScrollContainer>
+        <Table.Content
+          aria-label={ariaLabel}
+          onSelectionChange={(selection) =>
+            table.setRowSelection(getTanStackRowSelection(selection, rowIds))
+          }
+          onSortChange={(descriptor) =>
+            table.setSorting(getTanStackSorting(descriptor))
+          }
+          selectedKeys={getHeroUISelection(table.state.rowSelection)}
+          selectionMode={selectable ? "multiple" : "none"}
+          sortDescriptor={getHeroUISortDescriptor(table.state.sorting)}
+        >
+          <Table.Header>
+            {table.getHeaderGroups().flatMap((headerGroup) =>
+              headerGroup.headers.map((header) => (
+                <Table.Column
+                  allowsSorting={header.column.getCanSort()}
+                  id={header.column.id}
+                  key={header.id}
+                >
+                  {header.isPlaceholder ? null : header.column.getCanSort() ? (
+                    <Table.SortableColumnHeader>
+                      <table.FlexRender header={header} />
+                    </Table.SortableColumnHeader>
+                  ) : (
+                    <table.FlexRender header={header} />
+                  )}
+                </Table.Column>
+              ))
+            )}
+          </Table.Header>
+          <Table.Body renderEmptyState={() => empty}>
+            {rows.map((row) => (
+              <Table.Row id={row.id} key={row.id}>
+                {row.getVisibleCells().map((cell) => (
+                  <Table.Cell key={cell.id}>
+                    <table.FlexRender cell={cell} />
+                  </Table.Cell>
+                ))}
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table.Content>
+      </Table.ScrollContainer>
+    </Table>
+  )
+}

--- a/packages/heroui/src/components/auth/organization/organization-table-state.ts
+++ b/packages/heroui/src/components/auth/organization/organization-table-state.ts
@@ -1,8 +1,10 @@
 import {
+  createBrowserTablePersistenceAdapters,
   parseTableColumnVisibility,
   parseTableUrlState,
   serializeTableColumnVisibility,
   serializeTableUrlState,
+  type TablePersistenceAdapters,
   type TableUrlState
 } from "@better-auth-ui/core"
 import { useCreateAtom, useSelector } from "@tanstack/react-store"
@@ -15,7 +17,7 @@ import {
   type SortingState,
   type Updater
 } from "@tanstack/react-table"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { ORGANIZATION_TABLE_PAGE_SIZE } from "./organization-table"
 
 const TABLE_STATE_STORAGE_PREFIX = "better-auth-ui:organization-table"
@@ -28,16 +30,13 @@ type OrganizationTableUrlState = {
 }
 
 function readUrlState(
+  adapters: TablePersistenceAdapters,
   stateKey: string,
   defaultPageSize: number,
   allowedColumnIds?: readonly string[]
 ): TableUrlState {
-  const params =
-    typeof window === "undefined"
-      ? new URLSearchParams()
-      : new URLSearchParams(window.location.search)
   return parseTableUrlState(
-    params,
+    adapters.search.read(),
     stateKey,
     defaultPageSize,
     ORGANIZATION_TABLE_PAGE_SIZE_OPTIONS,
@@ -46,14 +45,15 @@ function readUrlState(
 }
 
 function readColumnVisibility(
+  adapters: TablePersistenceAdapters,
   stateKey: string,
   allowedColumnIds?: readonly string[]
 ): ColumnVisibilityState {
-  if (typeof window === "undefined") return {}
   try {
-    const value = window.localStorage.getItem(
-      `${TABLE_STATE_STORAGE_PREFIX}:${stateKey}:columns`
-    )
+    const value =
+      adapters.storage?.read(
+        `${TABLE_STATE_STORAGE_PREFIX}:${stateKey}:columns`
+      ) ?? null
     return parseTableColumnVisibility(value, allowedColumnIds)
   } catch {
     return {}
@@ -61,26 +61,31 @@ function readColumnVisibility(
 }
 
 function writeUrlState(
+  adapters: TablePersistenceAdapters,
   stateKey: string,
   defaultPageSize: number,
   state: OrganizationTableUrlState
 ) {
-  if (typeof window === "undefined") return
-  const url = new URL(window.location.href)
-  url.search = serializeTableUrlState(
-    url.searchParams,
-    stateKey,
-    defaultPageSize,
-    state
-  ).toString()
-  window.history.replaceState(window.history.state, "", url)
+  adapters.search.replace(
+    serializeTableUrlState(
+      adapters.search.read(),
+      stateKey,
+      defaultPageSize,
+      state
+    )
+  )
 }
 
 export function useOrganizationTableState(
   stateKey: string,
   defaultPageSize = ORGANIZATION_TABLE_PAGE_SIZE,
-  allowedColumnIds?: readonly string[]
+  allowedColumnIds?: readonly string[],
+  persistenceAdapters?: TablePersistenceAdapters
 ) {
+  const adapters = useMemo(
+    () => persistenceAdapters ?? createBrowserTablePersistenceAdapters(),
+    [persistenceAdapters]
+  )
   const columnFiltersAtom = useCreateAtom<ColumnFiltersState>([])
   const columnVisibilityAtom = useCreateAtom<ColumnVisibilityState>({})
   const globalFilterAtom = useCreateAtom("")
@@ -98,6 +103,7 @@ export function useOrganizationTableState(
   const sorting = useSelector(sortingAtom)
   const [urlReady, setUrlReady] = useState(false)
   const [visibilityReady, setVisibilityReady] = useState(false)
+  const restoringUrlState = useRef(false)
   const atoms = useMemo(
     () => ({
       columnFilters: columnFiltersAtom,
@@ -148,6 +154,7 @@ export function useOrganizationTableState(
 
   useEffect(() => {
     const resetPage = () => {
+      if (restoringUrlState.current) return
       const current = paginationAtom.get()
       if (current.pageIndex === 0) rowSelectionAtom.set({})
       else paginationAtom.set({ ...current, pageIndex: 0 })
@@ -172,13 +179,14 @@ export function useOrganizationTableState(
 
   useEffect(() => {
     if (!urlReady) return
-    writeUrlState(stateKey, defaultPageSize, {
+    writeUrlState(adapters, stateKey, defaultPageSize, {
       columnFilters,
       globalFilter,
       pagination,
       sorting
     })
   }, [
+    adapters,
     columnFilters,
     defaultPageSize,
     globalFilter,
@@ -191,30 +199,39 @@ export function useOrganizationTableState(
   useEffect(() => {
     if (!visibilityReady) return
     try {
-      window.localStorage.setItem(
+      adapters.storage?.write(
         `${TABLE_STATE_STORAGE_PREFIX}:${stateKey}:columns`,
         serializeTableColumnVisibility(columnVisibility)
       )
     } catch {
       // Browsers can disable storage while still allowing the table to work.
     }
-  }, [columnVisibility, stateKey, visibilityReady])
+  }, [adapters, columnVisibility, stateKey, visibilityReady])
 
   useEffect(() => {
-    columnVisibilityAtom.set(readColumnVisibility(stateKey, allowedColumnIds))
+    columnVisibilityAtom.set(
+      readColumnVisibility(adapters, stateKey, allowedColumnIds)
+    )
     setVisibilityReady(true)
     const restoreUrlState = () => {
-      const next = readUrlState(stateKey, defaultPageSize, allowedColumnIds)
+      restoringUrlState.current = true
+      const next = readUrlState(
+        adapters,
+        stateKey,
+        defaultPageSize,
+        allowedColumnIds
+      )
       columnFiltersAtom.set(next.columnFilters)
       globalFilterAtom.set(next.globalFilter)
       sortingAtom.set(next.sorting)
       paginationAtom.set(next.pagination)
+      restoringUrlState.current = false
       setUrlReady(true)
     }
     restoreUrlState()
-    window.addEventListener("popstate", restoreUrlState)
-    return () => window.removeEventListener("popstate", restoreUrlState)
+    return adapters.search.subscribe(restoreUrlState)
   }, [
+    adapters,
     allowedColumnIds,
     columnFiltersAtom,
     columnVisibilityAtom,

--- a/packages/heroui/src/components/auth/organization/organization-table.ts
+++ b/packages/heroui/src/components/auth/organization/organization-table.ts
@@ -36,7 +36,8 @@ export const organizationTableFeatures = tableFeatures({
 
 export const {
   createAppColumnHelper: createOrganizationColumnHelper,
-  useAppTable: useOrganizationTable
+  useAppTable: useOrganizationTable,
+  useTableContext: useOrganizationTableContext
 } = createTableHook({
   enableMultiSort: true,
   sortDescFirst: false,

--- a/packages/heroui/src/components/auth/passkey/add-passkey-dialog.tsx
+++ b/packages/heroui/src/components/auth/passkey/add-passkey-dialog.tsx
@@ -45,7 +45,9 @@ export function AddPasskeyDialog({
     onOpenChange(open)
   }
 
-  const submitRequest = (request: AddPasskeyParams<PasskeyAuthClient>) => {
+  const submitRequest = async (
+    request: AddPasskeyParams<PasskeyAuthClient>
+  ) => {
     const requestWithCallbacks = {
       ...request,
       fetchOptions: {
@@ -54,14 +56,14 @@ export function AddPasskeyDialog({
       }
     }
     pendingRequest.current = requestWithCallbacks
-    addPasskey.mutate(requestWithCallbacks)
+    await addPasskey.mutateAsync(requestWithCallbacks)
   }
 
   const form = useAuthForm({
     defaultValues: { name: "" },
-    onSubmit: ({ value }) => {
+    onSubmit: async ({ value }) => {
       const name = value.name.trim()
-      submitRequest({
+      await submitRequest({
         ...(name ? { name } : {}),
         ...(authenticatorAttachment ? { authenticatorAttachment } : {})
       } as AddPasskeyParams<PasskeyAuthClient>)
@@ -84,9 +86,9 @@ export function AddPasskeyDialog({
               </AlertDialog.Header>
               <AlertDialog.Body>
                 <FreshSessionPrompt
-                  onFresh={() => {
+                  onFresh={async () => {
                     const request = pendingRequest.current
-                    if (request) submitRequest(request)
+                    if (request) await submitRequest(request)
                   }}
                 />
               </AlertDialog.Body>

--- a/packages/heroui/src/components/auth/passkey/rename-passkey-dialog.tsx
+++ b/packages/heroui/src/components/auth/passkey/rename-passkey-dialog.tsx
@@ -72,6 +72,7 @@ export function RenamePasskeyDialog({
                     </TextField>
                   )}
                 </form.AppField>
+                <form.AuthFormServerError />
               </AlertDialog.Body>
               <AlertDialog.Footer>
                 <Button slot="close" variant="tertiary">

--- a/packages/heroui/src/components/auth/passkey/rename-passkey-dialog.tsx
+++ b/packages/heroui/src/components/auth/passkey/rename-passkey-dialog.tsx
@@ -31,9 +31,11 @@ export function RenamePasskeyDialog({
   })
   const form = useAuthForm({
     defaultValues: { name: passkey.name ?? "" },
-    onSubmit: ({ value }) => {
+    onSubmit: async ({ value }) => {
       const nextName = value.name.trim()
-      if (nextName) updatePasskey.mutate({ id: passkey.id, name: nextName })
+      if (nextName) {
+        await updatePasskey.mutateAsync({ id: passkey.id, name: nextName })
+      }
     }
   })
   const nameIsEmpty = useSelector(

--- a/packages/heroui/src/components/auth/phone-number/change-phone-number.tsx
+++ b/packages/heroui/src/components/auth/phone-number/change-phone-number.tsx
@@ -62,11 +62,11 @@ export function ChangePhoneNumber({
     (session?.user as PhoneNumberUser | undefined)?.phoneNumber ?? ""
   const [codeSent, setCodeSent] = useState(false)
 
-  const { mutate: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
+  const { mutateAsync: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
     phoneClient,
     { onSuccess: () => setCodeSent(true) }
   )
-  const { mutate: verify, isPending: isVerifying } = useVerifyPhoneNumber(
+  const { mutateAsync: verify, isPending: isVerifying } = useVerifyPhoneNumber(
     phoneClient,
     {
       onError: () => form.setFieldValue("code", ""),
@@ -96,13 +96,13 @@ export function ChangePhoneNumber({
       code: "",
       phoneNumber: createPhoneNumberValue("", defaultCountry, adapter)
     },
-    onSubmit: ({ value }) => {
+    onSubmit: async ({ value }) => {
       if (!value.phoneNumber.e164) return
       if (!codeSent) {
-        sendOtp({ phoneNumber: value.phoneNumber.e164 })
+        await sendOtp({ phoneNumber: value.phoneNumber.e164 })
         return
       }
-      verify({
+      await verify({
         phoneNumber: value.phoneNumber.e164,
         code: value.code,
         updatePhoneNumber: true

--- a/packages/heroui/src/components/auth/phone-number/forgot-phone-number-password.tsx
+++ b/packages/heroui/src/components/auth/phone-number/forgot-phone-number-password.tsx
@@ -41,7 +41,7 @@ export function ForgotPhoneNumberPassword({
     viewPaths: phoneNumberViewPaths
   } = useAuthPlugin(phoneNumberPlugin)
   const { fetchOptions, resetFetchOptions } = useFetchOptions()
-  const { mutate: requestReset, isPending } =
+  const { mutateAsync: requestReset, isPending } =
     useRequestPhoneNumberPasswordReset(authClient as PhoneNumberAuthClient, {
       onError: () => resetFetchOptions(),
       onSuccess: (_data, { phoneNumber }) => {
@@ -59,9 +59,9 @@ export function ForgotPhoneNumberPassword({
     defaultValues: {
       phoneNumber: createPhoneNumberValue("", defaultCountry, adapter)
     },
-    onSubmit: ({ value }) => {
+    onSubmit: async ({ value }) => {
       if (!value.phoneNumber.e164) return
-      requestReset({
+      await requestReset({
         phoneNumber: value.phoneNumber.e164,
         fetchOptions
       })

--- a/packages/heroui/src/components/auth/phone-number/phone-number.tsx
+++ b/packages/heroui/src/components/auth/phone-number/phone-number.tsx
@@ -1,4 +1,8 @@
-import { authMutationKeys } from "@better-auth-ui/core"
+import {
+  authMutationKeys,
+  getFormFieldErrorMessage,
+  validateStringLength
+} from "@better-auth-ui/core"
 import {
   createPhoneNumberValue,
   type PhoneNumberAuthClient
@@ -22,20 +26,25 @@ import {
   Checkbox,
   cn,
   Description,
-  FieldError,
-  Form,
   InputGroup,
   Label,
   Link,
   Spinner,
   TextField
 } from "@heroui/react"
+import { useSelector } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { phoneNumberPlugin } from "../../../lib/auth/phone-number-plugin"
 import { useResendCooldown } from "../../../lib/auth/use-resend-cooldown"
 import { useSignInContinuation } from "../../../lib/auth/use-sign-in-continuation"
+import {
+  isAuthFormFieldInvalid,
+  setAuthFormServerError,
+  submitAuthForm,
+  useAuthForm
+} from "../auth-form"
 import { FieldSeparator } from "../field-separator"
 import { OtpField } from "../otp-field"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
@@ -85,16 +94,10 @@ export function PhoneNumber({
   const [mode, setMode] = useState<PhoneNumberMode>(
     signIn ? "code" : "password"
   )
-  const [phoneNumber, setPhoneNumber] = useState(() =>
-    createPhoneNumberValue("", defaultCountry, adapter)
-  )
-  const [phoneError, setPhoneError] = useState<string>()
-  const [password, setPassword] = useState("")
-  const [code, setCode] = useState("")
   const [codeSent, setCodeSent] = useState(false)
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
 
-  const { mutate: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
+  const { mutateAsync: sendOtp, isPending: isSending } = useSendPhoneNumberOtp(
     phoneClient,
     {
       onError: () => resetFetchOptions(),
@@ -104,17 +107,17 @@ export function PhoneNumber({
       }
     }
   )
-  const { mutate: verify, isPending: isVerifying } = useVerifyPhoneNumber(
+  const { mutateAsync: verify, isPending: isVerifying } = useVerifyPhoneNumber(
     phoneClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: (data) => continueSignIn(data)
     }
   )
-  const { mutate: signInWithPassword, isPending: isPasswordPending } =
+  const { mutateAsync: signInWithPassword, isPending: isPasswordPending } =
     useSignInPhoneNumber(phoneClient, {
       onError: (error) => {
-        setPassword("")
+        form.setFieldValue("password", "")
         resetFetchOptions()
 
         if (signIn && error.error?.code === "PHONE_NUMBER_NOT_VERIFIED") {
@@ -145,48 +148,67 @@ export function PhoneNumber({
     (plugin) => plugin.captchaComponent
   )?.captchaComponent
 
-  const getPhoneNumber = () => {
-    if (phoneNumber.e164) return phoneNumber.e164
-    setPhoneError(phoneLocalization.invalidPhoneNumber)
-  }
-  const sendCode = () => {
-    const normalizedPhoneNumber = getPhoneNumber()
+  const sendCode = async () => {
+    const normalizedPhoneNumber = form.state.values.phoneNumber.e164
     if (!normalizedPhoneNumber) return
-    sendOtp({ phoneNumber: normalizedPhoneNumber, fetchOptions })
+    await sendOtp({ phoneNumber: normalizedPhoneNumber, fetchOptions })
   }
-  const verifyCode = (completedCode: string) => {
+  const verifyCode = async (completedCode: string) => {
     if (isPending || completedCode.length !== otpLength) return
-    if (!phoneNumber.e164) return
-    verify({ phoneNumber: phoneNumber.e164, code: completedCode })
+    const normalizedPhoneNumber = form.state.values.phoneNumber.e164
+    if (!normalizedPhoneNumber) return
+    await verify({ phoneNumber: normalizedPhoneNumber, code: completedCode })
   }
   const switchMode = () => {
     setMode((current) => (current === "code" ? "password" : "code"))
-    setCode("")
+    form.setFieldValue("code", "")
     setCodeSent(false)
-    setPassword("")
+    form.setFieldValue("password", "")
   }
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
 
-    if (mode === "password") {
-      const normalizedPhoneNumber = getPhoneNumber()
-      if (!normalizedPhoneNumber) return
-      const formData = new FormData(event.currentTarget)
-      signInWithPassword({
-        phoneNumber: normalizedPhoneNumber,
-        password,
-        ...(emailAndPassword?.rememberMe
-          ? { rememberMe: formData.get("rememberMe") === "on" }
-          : {}),
-        fetchOptions
-      })
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      password: "",
+      phoneNumber: createPhoneNumberValue("", defaultCountry, adapter),
+      rememberMe: false
+    },
+    onSubmit: async ({ value }) => {
+      if (mode === "password") {
+        const normalizedPhoneNumber = value.phoneNumber.e164
+        if (!normalizedPhoneNumber) return
+        await signInWithPassword({
+          phoneNumber: normalizedPhoneNumber,
+          password: value.password,
+          ...(emailAndPassword?.rememberMe
+            ? { rememberMe: value.rememberMe }
+            : {}),
+          fetchOptions
+        })
+        return
+      }
+      if (!codeSent) {
+        await sendCode()
+        return
+      }
+      await verifyCode(value.code)
     }
-    if (!codeSent) {
-      sendCode()
-      return
+  })
+  const codeComplete = useSelector(
+    form.store,
+    (state) => state.values.code.length === otpLength
+  )
+  const phoneNumberDisplay = useSelector(
+    form.store,
+    (state) => state.values.phoneNumber.display
+  )
+
+  const resendCode = async () => {
+    try {
+      await sendCode()
+    } catch (error) {
+      setAuthFormServerError(form, error, phoneLocalization.sendCode)
     }
-    verifyCode(code)
   }
 
   return (
@@ -203,7 +225,7 @@ export function PhoneNumber({
           <Card.Description>
             {phoneLocalization.codeSentTo.replace(
               "{{phoneNumber}}",
-              phoneNumber.display
+              phoneNumberDisplay
             )}
           </Card.Description>
         )}
@@ -217,165 +239,205 @@ export function PhoneNumber({
             )}
           </>
         )}
-        <Form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-          {codeSent ? (
-            <OtpField
-              autoFocus
-              isDisabled={isPending}
-              label={phoneLocalization.phoneCode}
-              length={otpLength}
-              name="otp"
-              value={code}
-              variant={variant}
-              onChange={setCode}
-              onComplete={verifyCode}
-            />
-          ) : (
-            <>
-              <InternationalPhoneField
-                adapter={adapter}
-                countryCodes={countries}
-                countryLabel={phoneLocalization.country}
-                error={phoneError}
-                isDisabled={isPending}
-                locale={locale}
-                phoneLabel={phoneLocalization.phoneNumber}
-                placeholder={phoneLocalization.phoneNumberPlaceholder}
-                value={phoneNumber}
-                variant={variant === "transparent" ? "primary" : "secondary"}
-                onChange={(value) => {
-                  setPhoneNumber(value)
-                  setPhoneError(undefined)
-                }}
-              />
-              {mode === "password" && (
-                <TextField
-                  name="password"
-                  autoComplete="current-password"
-                  value={password}
-                  isDisabled={isPending}
-                  onChange={setPassword}
-                  validate={(value) =>
-                    value ? undefined : localization.auth.fieldRequired
-                  }
-                >
-                  <Label>{localization.auth.password}</Label>
-                  <InputGroup
-                    variant={
-                      variant === "transparent" ? "primary" : "secondary"
-                    }
-                  >
-                    <InputGroup.Input
-                      placeholder={localization.auth.passwordPlaceholder}
-                      type={isPasswordVisible ? "text" : "password"}
-                      required
-                    />
-                    <InputGroup.Suffix className="px-0">
-                      <Button
-                        isIconOnly
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        size="sm"
-                        variant="ghost"
-                        isDisabled={isPending || isPasswordPending}
-                        onPress={() => setIsPasswordVisible(!isPasswordVisible)}
-                      >
-                        {isPasswordVisible ? <EyeSlash /> : <Eye />}
-                      </Button>
-                    </InputGroup.Suffix>
-                  </InputGroup>
-                  <FieldError />
-                </TextField>
-              )}
-              {mode === "password" && emailAndPassword?.rememberMe && (
-                <Checkbox
-                  name="rememberMe"
-                  isDisabled={isPending || isPasswordPending}
-                  variant={variant === "transparent" ? "primary" : "secondary"}
-                >
-                  <Checkbox.Content>
-                    <Checkbox.Control>
-                      <Checkbox.Indicator />
-                    </Checkbox.Control>
-                    {localization.auth.rememberMe}
-                  </Checkbox.Content>
-                </Checkbox>
-              )}
-            </>
-          )}
-          {Captcha && <div className="flex justify-center">{Captcha}</div>}
-          <div className="flex flex-col gap-3">
-            <Button
-              className="w-full"
-              type="submit"
-              isDisabled={codeSent && code.length !== otpLength}
-              isPending={isPending || isPasswordPending}
-            >
-              {(isSending || isVerifying || isPasswordPending) && (
-                <Spinner color="current" size="sm" />
-              )}
-              {mode === "password"
-                ? localization.auth.signIn
-                : codeSent
-                  ? phoneLocalization.verifyCode
-                  : phoneLocalization.sendCode}
-            </Button>
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-4">
             {codeSent ? (
-              <>
-                <Button
-                  className="w-full"
-                  variant="tertiary"
-                  isDisabled={isPending || isCoolingDown}
-                  onPress={sendCode}
-                >
-                  {isCoolingDown
-                    ? localization.auth.resendIn.replace(
-                        "{{seconds}}",
-                        String(cooldown)
-                      )
-                    : localization.auth.resend}
-                </Button>
-                <Button
-                  className="w-full"
-                  variant="ghost"
-                  isDisabled={isPending}
-                  onPress={() => {
-                    setCode("")
-                    setCodeSent(false)
-                  }}
-                >
-                  {phoneLocalization.useDifferentPhoneNumber}
-                </Button>
-              </>
+              <form.AppField name="code">
+                {(field) => (
+                  <OtpField
+                    autoFocus
+                    isDisabled={isPending}
+                    label={phoneLocalization.phoneCode}
+                    length={otpLength}
+                    name="otp"
+                    value={field.state.value}
+                    variant={variant}
+                    onChange={field.handleChange}
+                    onComplete={() => void submitAuthForm(form)}
+                  />
+                )}
+              </form.AppField>
             ) : (
               <>
-                {canSwitchMode && (
-                  <Button
-                    className="w-full"
-                    variant="tertiary"
-                    isDisabled={isPending || isPasswordPending}
-                    onPress={switchMode}
-                  >
-                    {mode === "code"
-                      ? phoneLocalization.usePassword
-                      : phoneLocalization.useVerificationCode}
-                  </Button>
-                )}
-                {plugins.flatMap((plugin) =>
-                  (plugin.authButtons ?? []).map((AuthButton) => (
-                    <AuthButton
-                      key={`${plugin.id}-${AuthButton.displayName ?? AuthButton.name}`}
-                      view="phoneNumber"
+                <form.AppField
+                  name="phoneNumber"
+                  validators={{
+                    onChange: ({ value }) =>
+                      value.e164
+                        ? undefined
+                        : phoneLocalization.invalidPhoneNumber
+                  }}
+                >
+                  {(field) => (
+                    <InternationalPhoneField
+                      adapter={adapter}
+                      countryCodes={countries}
+                      countryLabel={phoneLocalization.country}
+                      error={getFormFieldErrorMessage(field.state.meta.errors)}
+                      isDisabled={isPending}
+                      locale={locale}
+                      phoneLabel={phoneLocalization.phoneNumber}
+                      placeholder={phoneLocalization.phoneNumberPlaceholder}
+                      value={field.state.value}
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
+                      }
+                      onChange={field.handleChange}
                     />
-                  ))
+                  )}
+                </form.AppField>
+                {mode === "password" && (
+                  <form.AppField
+                    name="password"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          requiredMessage: localization.auth.fieldRequired
+                        })
+                    }}
+                  >
+                    {(field) => (
+                      <TextField
+                        name={field.name}
+                        autoComplete="current-password"
+                        value={field.state.value}
+                        isDisabled={isPending}
+                        isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                        validationBehavior="aria"
+                        onBlur={field.handleBlur}
+                        onChange={field.handleChange}
+                      >
+                        <Label>{localization.auth.password}</Label>
+                        <InputGroup
+                          variant={
+                            variant === "transparent" ? "primary" : "secondary"
+                          }
+                        >
+                          <InputGroup.Input
+                            placeholder={localization.auth.passwordPlaceholder}
+                            type={isPasswordVisible ? "text" : "password"}
+                            required
+                          />
+                          <InputGroup.Suffix className="px-0">
+                            <Button
+                              isIconOnly
+                              aria-label={
+                                isPasswordVisible
+                                  ? localization.auth.hidePassword
+                                  : localization.auth.showPassword
+                              }
+                              size="sm"
+                              variant="ghost"
+                              isDisabled={isPending || isPasswordPending}
+                              onPress={() =>
+                                setIsPasswordVisible(!isPasswordVisible)
+                              }
+                            >
+                              {isPasswordVisible ? <EyeSlash /> : <Eye />}
+                            </Button>
+                          </InputGroup.Suffix>
+                        </InputGroup>
+                        <field.AuthFormFieldError />
+                      </TextField>
+                    )}
+                  </form.AppField>
+                )}
+                {mode === "password" && emailAndPassword?.rememberMe && (
+                  <form.AppField name="rememberMe">
+                    {(field) => (
+                      <Checkbox
+                        name={field.name}
+                        isDisabled={isPending || isPasswordPending}
+                        isSelected={field.state.value}
+                        variant={
+                          variant === "transparent" ? "primary" : "secondary"
+                        }
+                        onChange={field.handleChange}
+                      >
+                        <Checkbox.Content>
+                          <Checkbox.Control>
+                            <Checkbox.Indicator />
+                          </Checkbox.Control>
+                          {localization.auth.rememberMe}
+                        </Checkbox.Content>
+                      </Checkbox>
+                    )}
+                  </form.AppField>
                 )}
               </>
             )}
-          </div>
-        </Form>
+            {Captcha && <div className="flex justify-center">{Captcha}</div>}
+            <div className="flex flex-col gap-3">
+              <form.AuthFormSubmitButton
+                className="w-full"
+                isDisabled={
+                  isPending || isPasswordPending || (codeSent && !codeComplete)
+                }
+              >
+                {(isSending || isVerifying || isPasswordPending) && (
+                  <Spinner color="current" size="sm" />
+                )}
+                {mode === "password"
+                  ? localization.auth.signIn
+                  : codeSent
+                    ? phoneLocalization.verifyCode
+                    : phoneLocalization.sendCode}
+              </form.AuthFormSubmitButton>
+              {codeSent ? (
+                <>
+                  <Button
+                    className="w-full"
+                    variant="tertiary"
+                    isDisabled={isPending || isCoolingDown}
+                    onPress={() => void resendCode()}
+                  >
+                    {isCoolingDown
+                      ? localization.auth.resendIn.replace(
+                          "{{seconds}}",
+                          String(cooldown)
+                        )
+                      : localization.auth.resend}
+                  </Button>
+                  <Button
+                    className="w-full"
+                    variant="ghost"
+                    isDisabled={isPending}
+                    onPress={() => {
+                      form.setFieldValue("code", "")
+                      setCodeSent(false)
+                    }}
+                  >
+                    {phoneLocalization.useDifferentPhoneNumber}
+                  </Button>
+                </>
+              ) : (
+                <>
+                  {canSwitchMode && (
+                    <Button
+                      className="w-full"
+                      variant="tertiary"
+                      isDisabled={isPending || isPasswordPending}
+                      onPress={switchMode}
+                    >
+                      {mode === "code"
+                        ? phoneLocalization.usePassword
+                        : phoneLocalization.useVerificationCode}
+                    </Button>
+                  )}
+                  {plugins.flatMap((plugin) =>
+                    (plugin.authButtons ?? []).map((AuthButton) => (
+                      <AuthButton
+                        key={`${plugin.id}-${AuthButton.displayName ?? AuthButton.name}`}
+                        view="phoneNumber"
+                      />
+                    ))
+                  )}
+                </>
+              )}
+            </div>
+            <form.AuthFormServerError />
+          </form.AuthFormRoot>
+        </form.AppForm>
         {socialPosition === "bottom" && showProviders && (
           <>
             {showSeparator && (

--- a/packages/heroui/src/components/auth/phone-number/reset-phone-number-password.tsx
+++ b/packages/heroui/src/components/auth/phone-number/reset-phone-number-password.tsx
@@ -1,4 +1,7 @@
-import { isPasswordCompromisedError } from "@better-auth-ui/core"
+import {
+  isPasswordCompromisedError,
+  validateStringLength
+} from "@better-auth-ui/core"
 import type { PhoneNumberAuthClient } from "@better-auth-ui/core/plugins/phone-number"
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useResetPhoneNumberPassword } from "@better-auth-ui/react/plugins/phone-number"
@@ -8,8 +11,6 @@ import {
   Card,
   type CardProps,
   cn,
-  FieldError,
-  Form,
   Input,
   InputGroup,
   Label,
@@ -18,9 +19,15 @@ import {
   toast,
   useIsHydrated
 } from "@heroui/react"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useSelector } from "@tanstack/react-form"
+import { useEffect, useState } from "react"
 
 import { phoneNumberPlugin } from "../../../lib/auth/phone-number-plugin"
+import {
+  isAuthFormFieldInvalid,
+  setAuthFormServerError,
+  useAuthForm
+} from "../auth-form"
 import { OtpField } from "../otp-field"
 import { PasswordStrengthMeter } from "../password-strength-meter"
 import { PHONE_NUMBER_RESET_STORAGE_KEY } from "./forgot-phone-number-password"
@@ -45,30 +52,25 @@ export function ResetPhoneNumberPassword({
   const isHydrated = useIsHydrated()
   const initialPhoneNumber =
     (isHydrated && sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY)) || ""
-  const [phoneNumber, setPhoneNumber] = useState(initialPhoneNumber)
   const [hasStoredPhoneNumber, setHasStoredPhoneNumber] = useState(
     Boolean(initialPhoneNumber)
   )
-  const [code, setCode] = useState("")
-  const [password, setPassword] = useState("")
-  const [isCompromised, setIsCompromised] = useState(false)
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
 
-  useEffect(() => {
-    const stored = sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY) ?? ""
-    setPhoneNumber(stored)
-    setHasStoredPhoneNumber(Boolean(stored))
-  }, [])
-
-  const { mutate: resetPassword, isPending } = useResetPhoneNumberPassword(
+  const { mutateAsync: resetPassword, isPending } = useResetPhoneNumberPassword(
     authClient as PhoneNumberAuthClient,
     {
       onError: (error) => {
         // The haveIBeenPwned plugin rejects on the password itself, so
         // it belongs against the field rather than in a toast.
-        setIsCompromised(isPasswordCompromisedError(error))
-
-        setCode("")
+        if (isPasswordCompromisedError(error)) {
+          setAuthFormServerError(
+            form,
+            { fields: { password: localization.auth.passwordCompromised } },
+            localization.auth.passwordCompromised
+          )
+        }
+        form.setFieldValue("code", "")
       },
       onSuccess: () => {
         sessionStorage.removeItem(PHONE_NUMBER_RESET_STORAGE_KEY)
@@ -80,63 +82,50 @@ export function ResetPhoneNumberPassword({
     }
   )
 
-  const validatePassword = (value: string) => {
-    if (!value) return localization.auth.fieldRequired
-    const min = emailAndPassword?.minPasswordLength
-    const max = emailAndPassword?.maxPasswordLength
-    if (min && value.length < min)
-      return localization.auth.tooShort.replace("{{min}}", String(min))
-    if (max && value.length > max)
-      return localization.auth.tooLong.replace("{{max}}", String(max))
-  }
+  const validatePassword = (value: string) =>
+    validateStringLength(value, {
+      maxLength: emailAndPassword?.maxPasswordLength,
+      maxLengthMessage: localization.auth.tooLong.replace(
+        "{{max}}",
+        String(emailAndPassword?.maxPasswordLength)
+      ),
+      minLength: emailAndPassword?.minPasswordLength,
+      minLengthMessage: localization.auth.tooShort.replace(
+        "{{min}}",
+        String(emailAndPassword?.minPasswordLength)
+      ),
+      requiredMessage: localization.auth.fieldRequired
+    })
 
-  const handleSubmit = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    const confirmPassword = String(formData.get("confirmPassword") ?? "")
-
-    if (emailAndPassword?.confirmPassword && password !== confirmPassword) {
-      toast.danger(localization.auth.passwordsDoNotMatch)
-      return
+  const form = useAuthForm({
+    defaultValues: {
+      code: "",
+      confirmPassword: "",
+      password: "",
+      phoneNumber: initialPhoneNumber
+    },
+    onSubmit: async ({ value }) => {
+      await resetPassword({
+        phoneNumber: value.phoneNumber,
+        otp: value.code,
+        newPassword: value.password
+      })
     }
-    if (code.length !== otpLength) {
-      toast.danger(
-        phoneLocalization.codeLengthMismatch.replace(
-          "{{length}}",
-          String(otpLength)
-        )
-      )
-      return
-    }
-
-    resetPassword({ phoneNumber, otp: code, newPassword: password })
-  }
-
-  const passwordInput = (
-    <InputGroup variant={variant === "transparent" ? "primary" : "secondary"}>
-      <InputGroup.Input
-        placeholder={localization.auth.newPasswordPlaceholder}
-        type={isPasswordVisible ? "text" : "password"}
-        required
-      />
-      <InputGroup.Suffix className="px-0">
-        <Button
-          isIconOnly
-          aria-label={
-            isPasswordVisible
-              ? localization.auth.hidePassword
-              : localization.auth.showPassword
-          }
-          size="sm"
-          variant="ghost"
-          isDisabled={isPending}
-          onPress={() => setIsPasswordVisible(!isPasswordVisible)}
-        >
-          {isPasswordVisible ? <EyeSlash /> : <Eye />}
-        </Button>
-      </InputGroup.Suffix>
-    </InputGroup>
+  })
+  const codeComplete = useSelector(
+    form.store,
+    (state) => state.values.code.length === otpLength
   )
+  const phoneNumber = useSelector(
+    form.store,
+    (state) => state.values.phoneNumber
+  )
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem(PHONE_NUMBER_RESET_STORAGE_KEY) ?? ""
+    form.setFieldValue("phoneNumber", stored)
+    setHasStoredPhoneNumber(Boolean(stored))
+  }, [form.setFieldValue])
 
   return (
     <Card
@@ -157,90 +146,162 @@ export function ResetPhoneNumberPassword({
         )}
       </Card.Header>
       <Card.Content className="gap-4">
-        <Form className="flex flex-col gap-4" onSubmit={handleSubmit}>
-          {!hasStoredPhoneNumber && (
-            <TextField
-              name="phoneNumber"
-              type="tel"
-              autoComplete="tel"
-              value={phoneNumber}
-              isDisabled={isPending}
-              onChange={setPhoneNumber}
-              validate={(value) =>
-                value ? undefined : localization.auth.fieldRequired
-              }
-            >
-              <Label>{phoneLocalization.phoneNumber}</Label>
-              <Input
-                inputMode="tel"
-                placeholder={phoneLocalization.phoneNumberPlaceholder}
-                required
-                variant={variant === "transparent" ? "primary" : "secondary"}
-              />
-              <FieldError />
-            </TextField>
-          )}
-          <OtpField
-            autoFocus={hasStoredPhoneNumber}
-            isDisabled={isPending}
-            label={phoneLocalization.phoneCode}
-            length={otpLength}
-            name="otp"
-            value={code}
-            variant={variant}
-            onChange={setCode}
-          />
-          <TextField
-            name="password"
-            autoComplete="new-password"
-            minLength={emailAndPassword?.minPasswordLength}
-            maxLength={emailAndPassword?.maxPasswordLength}
-            value={password}
-            isDisabled={isPending}
-            onChange={(value) => {
-              setPassword(value)
-              setIsCompromised(false)
-            }}
-            isInvalid={isCompromised || undefined}
-            validate={validatePassword}
-          >
-            <Label>{localization.auth.newPassword}</Label>
-            {passwordInput}
-            {isCompromised ? (
-              <FieldError>{localization.auth.passwordCompromised}</FieldError>
-            ) : (
-              <FieldError />
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-4">
+            {!hasStoredPhoneNumber && (
+              <form.AppField
+                name="phoneNumber"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired
+                    })
+                }}
+              >
+                {(field) => (
+                  <TextField
+                    type="tel"
+                    autoComplete="tel"
+                    value={field.state.value}
+                    name={field.name}
+                    isDisabled={isPending}
+                    isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                    validationBehavior="aria"
+                    onBlur={field.handleBlur}
+                    onChange={field.handleChange}
+                  >
+                    <Label>{phoneLocalization.phoneNumber}</Label>
+                    <Input
+                      inputMode="tel"
+                      placeholder={phoneLocalization.phoneNumberPlaceholder}
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
+                      }
+                    />
+                    <field.AuthFormFieldError />
+                  </TextField>
+                )}
+              </form.AppField>
             )}
-
-            <PasswordStrengthMeter password={password} />
-          </TextField>
-          {emailAndPassword?.confirmPassword && (
-            <TextField
-              name="confirmPassword"
-              autoComplete="new-password"
-              isDisabled={isPending}
-              validate={validatePassword}
+            <form.AppField
+              name="code"
+              validators={{
+                onChange: ({ value }) =>
+                  value.length === otpLength
+                    ? undefined
+                    : phoneLocalization.codeLengthMismatch.replace(
+                        "{{length}}",
+                        String(otpLength)
+                      )
+              }}
             >
-              <Label>{localization.auth.confirmPassword}</Label>
-              <Input
-                type="password"
-                placeholder={localization.auth.confirmPasswordPlaceholder}
-                required
-                variant={variant === "transparent" ? "primary" : "secondary"}
-              />
-              <FieldError />
-            </TextField>
-          )}
-          <Button
-            className="w-full"
-            type="submit"
-            isDisabled={code.length !== otpLength}
-            isPending={isPending}
-          >
-            {isPending && <Spinner color="current" size="sm" />}
-            {phoneLocalization.resetPassword}
-          </Button>
-        </Form>
+              {(field) => (
+                <OtpField
+                  autoFocus={hasStoredPhoneNumber}
+                  isDisabled={isPending}
+                  label={phoneLocalization.phoneCode}
+                  length={otpLength}
+                  name="otp"
+                  value={field.state.value}
+                  variant={variant}
+                  onChange={field.handleChange}
+                />
+              )}
+            </form.AppField>
+            <form.AppField
+              name="password"
+              validators={{ onChange: ({ value }) => validatePassword(value) }}
+            >
+              {(field) => (
+                <TextField
+                  name={field.name}
+                  autoComplete="new-password"
+                  value={field.state.value}
+                  isDisabled={isPending}
+                  isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                  validationBehavior="aria"
+                  onBlur={field.handleBlur}
+                  onChange={field.handleChange}
+                >
+                  <Label>{localization.auth.newPassword}</Label>
+                  <InputGroup
+                    variant={
+                      variant === "transparent" ? "primary" : "secondary"
+                    }
+                  >
+                    <InputGroup.Input
+                      placeholder={localization.auth.newPasswordPlaceholder}
+                      type={isPasswordVisible ? "text" : "password"}
+                    />
+                    <InputGroup.Suffix className="px-0">
+                      <Button
+                        isIconOnly
+                        aria-label={
+                          isPasswordVisible
+                            ? localization.auth.hidePassword
+                            : localization.auth.showPassword
+                        }
+                        size="sm"
+                        variant="ghost"
+                        isDisabled={isPending}
+                        onPress={() => setIsPasswordVisible(!isPasswordVisible)}
+                      >
+                        {isPasswordVisible ? <EyeSlash /> : <Eye />}
+                      </Button>
+                    </InputGroup.Suffix>
+                  </InputGroup>
+                  <field.AuthFormFieldError />
+
+                  <PasswordStrengthMeter password={field.state.value} />
+                </TextField>
+              )}
+            </form.AppField>
+            {emailAndPassword?.confirmPassword && (
+              <form.AppField
+                name="confirmPassword"
+                validators={{
+                  onChangeListenTo: ["password"],
+                  onChange: ({ value, fieldApi }) =>
+                    validatePassword(value) ??
+                    (value === fieldApi.form.getFieldValue("password")
+                      ? undefined
+                      : localization.auth.passwordsDoNotMatch)
+                }}
+              >
+                {(field) => (
+                  <TextField
+                    name={field.name}
+                    autoComplete="new-password"
+                    isDisabled={isPending}
+                    isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                    validationBehavior="aria"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={field.handleChange}
+                  >
+                    <Label>{localization.auth.confirmPassword}</Label>
+                    <Input
+                      type="password"
+                      placeholder={localization.auth.confirmPasswordPlaceholder}
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
+                      }
+                    />
+                    <field.AuthFormFieldError />
+                  </TextField>
+                )}
+              </form.AppField>
+            )}
+            <form.AuthFormServerError />
+            <form.AuthFormSubmitButton
+              className="w-full"
+              isDisabled={!codeComplete || isPending}
+            >
+              {isPending && <Spinner color="current" size="sm" />}
+              {phoneLocalization.resetPassword}
+            </form.AuthFormSubmitButton>
+          </form.AuthFormRoot>
+        </form.AppForm>
       </Card.Content>
     </Card>
   )

--- a/packages/heroui/src/components/auth/settings/account/change-email.tsx
+++ b/packages/heroui/src/components/auth/settings/account/change-email.tsx
@@ -38,14 +38,14 @@ export function ChangeEmail({
   const { authClient, basePaths, baseURL, localization, viewPaths } = useAuth()
   const { data: session } = useSession(authClient)
 
-  const { mutate: changeEmail, isPending } = useChangeEmail(authClient, {
+  const { mutateAsync: changeEmail, isPending } = useChangeEmail(authClient, {
     onSuccess: () => toast.success(localization.settings.changeEmailSuccess)
   })
 
   const form = useAuthForm({
     defaultValues: { email: "" },
-    onSubmit: ({ value }) =>
-      changeEmail({
+    onSubmit: async ({ value }) =>
+      await changeEmail({
         newEmail: value.email,
         callbackURL: getViewURL(
           baseURL,

--- a/packages/heroui/src/components/auth/settings/security/fresh-session-prompt.tsx
+++ b/packages/heroui/src/components/auth/settings/security/fresh-session-prompt.tsx
@@ -37,10 +37,10 @@ export function FreshSessionPrompt({ onFresh }: FreshSessionPromptProps) {
 
   const form = useAuthForm({
     defaultValues: { password: "" },
-    onSubmit: ({ value }) => {
+    onSubmit: async ({ value }) => {
       const email = session.data?.user.email
       if (!email) return
-      signIn.mutate({ email, password: value.password })
+      await signIn.mutateAsync({ email, password: value.password })
     }
   })
   const passwordIsEmpty = useSelector(

--- a/packages/heroui/src/components/auth/sign-in.tsx
+++ b/packages/heroui/src/components/auth/sign-in.tsx
@@ -1,4 +1,8 @@
-import { authMutationKeys } from "@better-auth-ui/core"
+import {
+  authMutationKeys,
+  validateEmailAddress,
+  validateStringLength
+} from "@better-auth-ui/core"
 import {
   isPasskeyAutoFillEnabled,
   withPasskeyAutoFill
@@ -17,7 +21,6 @@ import {
   Checkbox,
   cn,
   Description,
-  FieldError,
   Input,
   InputGroup,
   Label,
@@ -68,9 +71,8 @@ export function SignIn({
 
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
 
-  const { mutate: signInEmail, isPending: signInEmailPending } = useSignInEmail(
-    authClient,
-    {
+  const { mutateAsync: signInEmail, isPending: signInEmailPending } =
+    useSignInEmail(authClient, {
       onError: (error, { email }) => {
         form.setFieldValue("password", "")
 
@@ -84,13 +86,12 @@ export function SignIn({
         resetFetchOptions()
       },
       onSuccess: (data) => continueSignIn(data)
-    }
-  )
+    })
 
   const form = useAuthForm({
     defaultValues: { email: "", password: "", rememberMe: false },
-    onSubmit: ({ value }) =>
-      signInEmail({
+    onSubmit: async ({ value }) =>
+      await signInEmail({
         email: value.email,
         password: value.password,
         ...(emailAndPassword?.rememberMe
@@ -144,7 +145,16 @@ export function SignIn({
         {emailAndPassword?.enabled && (
           <form.AppForm>
             <form.AuthFormRoot className="flex flex-col gap-4">
-              <form.AppField name="email">
+              <form.AppField
+                name="email"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
+                }}
+              >
                 {(field) => (
                   <TextField
                     name={field.name}
@@ -154,11 +164,7 @@ export function SignIn({
                     value={field.state.value}
                     onBlur={field.handleBlur}
                     onChange={field.handleChange}
-                    validate={(value) => {
-                      if (!value) return localization.auth.fieldRequired
-                      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
-                        return localization.auth.invalidEmail
-                    }}
+                    validationBehavior="aria"
                   >
                     <Label>{localization.auth.email}</Label>
 
@@ -170,12 +176,30 @@ export function SignIn({
                       required
                     />
 
-                    <FieldError />
+                    <field.AuthFormFieldError />
                   </TextField>
                 )}
               </form.AppField>
 
-              <form.AppField name="password">
+              <form.AppField
+                name="password"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      maxLength: emailAndPassword?.maxPasswordLength,
+                      maxLengthMessage: localization.auth.tooLong.replace(
+                        "{{max}}",
+                        String(emailAndPassword?.maxPasswordLength)
+                      ),
+                      minLength: emailAndPassword?.minPasswordLength,
+                      minLengthMessage: localization.auth.tooShort.replace(
+                        "{{min}}",
+                        String(emailAndPassword?.minPasswordLength)
+                      ),
+                      requiredMessage: localization.auth.fieldRequired
+                    })
+                }}
+              >
                 {(field) => (
                   <TextField
                     minLength={emailAndPassword?.minPasswordLength}
@@ -189,21 +213,7 @@ export function SignIn({
                     value={field.state.value}
                     onBlur={field.handleBlur}
                     onChange={field.handleChange}
-                    validate={(value) => {
-                      if (!value) return localization.auth.fieldRequired
-                      const min = emailAndPassword?.minPasswordLength
-                      const max = emailAndPassword?.maxPasswordLength
-                      if (min && value.length < min)
-                        return localization.auth.tooShort.replace(
-                          "{{min}}",
-                          String(min)
-                        )
-                      if (max && value.length > max)
-                        return localization.auth.tooLong.replace(
-                          "{{max}}",
-                          String(max)
-                        )
-                    }}
+                    validationBehavior="aria"
                   >
                     <Label>{localization.auth.password}</Label>
 
@@ -238,7 +248,7 @@ export function SignIn({
                       </InputGroup.Suffix>
                     </InputGroup>
 
-                    <FieldError />
+                    <field.AuthFormFieldError />
                   </TextField>
                 )}
               </form.AppField>
@@ -268,6 +278,8 @@ export function SignIn({
               )}
 
               {Captcha && <div className="flex justify-center">{Captcha}</div>}
+
+              <form.AuthFormServerError />
 
               <div className="flex flex-col gap-3">
                 <form.AuthFormSubmitButton

--- a/packages/heroui/src/components/auth/siwe/sign-in-ethereum-button.tsx
+++ b/packages/heroui/src/components/auth/siwe/sign-in-ethereum-button.tsx
@@ -53,8 +53,9 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
   }
 
   const handlePress = () => {
-    if (plugin.email === "none") completeSignIn()
-    else setIsOpen(true)
+    if (plugin.email === "none") {
+      void completeSignIn().catch(() => undefined)
+    } else setIsOpen(true)
   }
 
   const form = useAuthForm({

--- a/packages/heroui/src/components/auth/siwe/sign-in-ethereum-button.tsx
+++ b/packages/heroui/src/components/auth/siwe/sign-in-ethereum-button.tsx
@@ -43,8 +43,8 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
       useIsMutating({ mutationKey: siweMutationKeys.all }) >
     0
 
-  const completeSignIn = (email?: string) => {
-    signIn.mutate(email ? { email } : undefined, {
+  const completeSignIn = async (email?: string) => {
+    await signIn.mutateAsync(email ? { email } : undefined, {
       onSuccess: () => {
         setIsOpen(false)
         navigate({ to: redirectTo })
@@ -59,9 +59,9 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
 
   const form = useAuthForm({
     defaultValues: { email: "" },
-    onSubmit: ({ value }) => {
+    onSubmit: async ({ value }) => {
       const email = value.email.trim()
-      completeSignIn(email || undefined)
+      await completeSignIn(email || undefined)
     }
   })
 

--- a/packages/heroui/src/components/auth/siwe/sign-in-ethereum-button.tsx
+++ b/packages/heroui/src/components/auth/siwe/sign-in-ethereum-button.tsx
@@ -1,6 +1,10 @@
 "use client"
 
-import { type AuthView, authMutationKeys } from "@better-auth-ui/core"
+import {
+  type AuthView,
+  authMutationKeys,
+  validateEmailAddress
+} from "@better-auth-ui/core"
 import {
   type SiweAuthClient,
   siweMutationKeys
@@ -8,20 +12,12 @@ import {
 import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useSignInSiwe } from "@better-auth-ui/react/plugins/siwe"
 import { Wallet } from "@gravity-ui/icons"
-import {
-  Button,
-  FieldError,
-  Input,
-  Label,
-  Modal,
-  Spinner,
-  TextField
-} from "@heroui/react"
+import { Button, Input, Label, Modal, Spinner, TextField } from "@heroui/react"
 import { useIsMutating } from "@tanstack/react-query"
 import { useState } from "react"
 
 import { siwePlugin } from "../../../lib/auth/siwe-plugin"
-import { useAuthForm } from "../auth-form"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 
 export type SignInEthereumButtonProps = {
   view?: AuthView
@@ -99,10 +95,24 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
                   </p>
                 </Modal.Header>
                 <Modal.Body className="overflow-visible">
-                  <form.AppField name="email">
+                  <form.AppField
+                    name="email"
+                    validators={
+                      plugin.email === "required"
+                        ? {
+                            onChange: ({ value }) =>
+                              validateEmailAddress(value, {
+                                invalidMessage: localization.auth.invalidEmail,
+                                requiredMessage: localization.auth.fieldRequired
+                              })
+                          }
+                        : undefined
+                    }
+                  >
                     {(field) => (
                       <TextField
                         className="w-full"
+                        isInvalid={isAuthFormFieldInvalid(field.state.meta)}
                         name={field.name}
                         type="email"
                         isRequired={plugin.email === "required"}
@@ -118,10 +128,11 @@ export function SignInEthereumButton({ view }: SignInEthereumButtonProps) {
                             : plugin.localization.emailOptional}
                         </Label>
                         <Input autoFocus autoComplete="email" />
-                        <FieldError />
+                        <field.AuthFormFieldError />
                       </TextField>
                     )}
                   </form.AppField>
+                  <form.AuthFormServerError />
                 </Modal.Body>
                 <Modal.Footer>
                   <Button

--- a/packages/heroui/src/components/auth/sso/email-first-sign-in.tsx
+++ b/packages/heroui/src/components/auth/sso/email-first-sign-in.tsx
@@ -1,4 +1,8 @@
-import { authMutationKeys } from "@better-auth-ui/core"
+import {
+  authMutationKeys,
+  validateEmailAddress,
+  validateStringLength
+} from "@better-auth-ui/core"
 import {
   isPasskeyAutoFillEnabled,
   type PasskeyAuthClient,
@@ -26,8 +30,6 @@ import {
   Checkbox,
   cn,
   Description,
-  FieldError,
-  Form,
   Input,
   InputGroup,
   Label,
@@ -35,11 +37,13 @@ import {
   Spinner,
   TextField
 } from "@heroui/react"
+import { useSelector } from "@tanstack/react-form"
 import { useIsMutating } from "@tanstack/react-query"
-import { type SyntheticEvent, useState } from "react"
+import { useState } from "react"
 
 import { ssoPlugin } from "../../../lib/auth/sso-plugin"
 import { useSignInContinuation } from "../../../lib/auth/use-sign-in-continuation"
+import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
 import { FieldSeparator } from "../field-separator"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
 
@@ -80,17 +84,15 @@ export function EmailFirstSignIn({
   })
 
   const [step, setStep] = useState<Step>("email")
-  const [email, setEmail] = useState("")
-  const [password, setPassword] = useState("")
   const [isPasswordVisible, setIsPasswordVisible] = useState(false)
   const [discoveryError, setDiscoveryError] = useState("")
 
-  const { mutate: signInSso, isPending: isDiscovering } = useSignInSso(
+  const { mutateAsync: signInSso, isPending: isDiscovering } = useSignInSso(
     authClient as SsoAuthClient,
     {
       onError: (error) => {
         if (error.status === 404) {
-          setSsoFallbackEmail(email)
+          setSsoFallbackEmail(form.state.values.email)
           setDiscoveryError(ssoLocalization.noProvider)
           setStep("fallback")
           return
@@ -101,14 +103,17 @@ export function EmailFirstSignIn({
     }
   )
 
-  const { mutate: signInEmail, isPending: isSigningIn } = useSignInEmail(
+  const { mutateAsync: signInEmail, isPending: isSigningIn } = useSignInEmail(
     authClient,
     {
       onError: (error) => {
-        setPassword("")
+        form.setFieldValue("password", "")
 
         if (error.error?.code === "EMAIL_NOT_VERIFIED") {
-          sessionStorage.setItem("better-auth-ui.verify-email", email)
+          sessionStorage.setItem(
+            "better-auth-ui.verify-email",
+            form.state.values.email
+          )
           navigate({
             to: `${basePaths.auth}/${viewPaths.auth.verifyEmail}`
           })
@@ -132,33 +137,39 @@ export function EmailFirstSignIn({
   const showSocialSeparator =
     emailAndPassword.enabled && !!socialProviders?.length
 
-  const submitEmail = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    setDiscoveryError("")
-    setSsoFallbackEmail(email)
-    signInSso({
-      email,
-      callbackURL: `${baseURL}${redirectTo}`,
-      loginHint: email
-    })
-  }
+  const form = useAuthForm({
+    defaultValues: { email: "", password: "", rememberMe: false },
+    onSubmit: async ({ value }) => {
+      if (step === "email") {
+        setDiscoveryError("")
+        setSsoFallbackEmail(value.email)
+        try {
+          await signInSso({
+            callbackURL: `${baseURL}${redirectTo}`,
+            email: value.email,
+            loginHint: value.email
+          })
+        } catch (error) {
+          if ((error as { status?: number }).status !== 404) throw error
+        }
+        return
+      }
 
-  const submitPassword = (event: SyntheticEvent<HTMLFormElement>) => {
-    event.preventDefault()
-    const formData = new FormData(event.currentTarget)
-    signInEmail({
-      email,
-      password,
-      ...(emailAndPassword.rememberMe
-        ? { rememberMe: formData.get("rememberMe") === "on" }
-        : {}),
-      fetchOptions
-    })
-  }
+      await signInEmail({
+        email: value.email,
+        password: value.password,
+        ...(emailAndPassword.rememberMe
+          ? { rememberMe: value.rememberMe }
+          : {}),
+        fetchOptions
+      })
+    }
+  })
+  const email = useSelector(form.store, (state) => state.values.email)
 
   const startOver = () => {
     setStep("email")
-    setPassword("")
+    form.setFieldValue("password", "")
     setDiscoveryError("")
   }
 
@@ -178,171 +189,213 @@ export function EmailFirstSignIn({
       </Card.Header>
 
       <Card.Content className="gap-4">
-        {step === "email" ? (
-          <Form className="flex flex-col gap-4" onSubmit={submitEmail}>
-            <TextField
-              name="email"
-              type="email"
-              autoComplete={withPasskeyAutoFill("email", passkeyAutoFill)}
-              isDisabled={isPending}
-              value={email}
-              onChange={setEmail}
-              validate={(value) => {
-                if (!value) return localization.auth.fieldRequired
-                if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value))
-                  return localization.auth.invalidEmail
-              }}
-            >
-              <Label>{localization.auth.email}</Label>
-              <Input
-                autoFocus
-                placeholder={localization.auth.emailPlaceholder}
-                required
-                variant={variant === "transparent" ? "primary" : "secondary"}
-              />
-              <FieldError />
-            </TextField>
-
-            {discoveryError && (
-              <Description role="alert" className="text-danger">
-                {discoveryError}
-              </Description>
-            )}
-
-            <Button type="submit" className="w-full" isPending={isDiscovering}>
-              {isDiscovering && <Spinner color="current" size="sm" />}
-              {ssoLocalization.continueWithEmail}
-            </Button>
-          </Form>
-        ) : (
-          <div className="flex flex-col gap-4">
-            {socialPosition === "top" && (
-              <>
-                {!!socialProviders?.length && (
-                  <ProviderButtons socialLayout={socialLayout} view="signIn" />
-                )}
-                {showSocialSeparator && (
-                  <FieldSeparator>{localization.auth.or}</FieldSeparator>
-                )}
-              </>
-            )}
-
-            {discoveryError && (
-              <Description role="status">{discoveryError}</Description>
-            )}
-
-            {emailAndPassword.enabled && (
-              <Form className="flex flex-col gap-4" onSubmit={submitPassword}>
-                <TextField
-                  minLength={emailAndPassword.minPasswordLength}
-                  maxLength={emailAndPassword.maxPasswordLength}
-                  name="password"
-                  autoComplete={withPasskeyAutoFill(
-                    "current-password",
-                    passkeyAutoFill
-                  )}
-                  isDisabled={isPending}
-                  value={password}
-                  onChange={setPassword}
-                  validate={(value) => {
-                    if (!value) return localization.auth.fieldRequired
-                    if (value.length < emailAndPassword.minPasswordLength)
-                      return localization.auth.tooShort.replace(
-                        "{{min}}",
-                        String(emailAndPassword.minPasswordLength)
-                      )
-                    if (value.length > emailAndPassword.maxPasswordLength)
-                      return localization.auth.tooLong.replace(
-                        "{{max}}",
-                        String(emailAndPassword.maxPasswordLength)
-                      )
-                  }}
-                >
-                  <Label>{localization.auth.password}</Label>
-                  <InputGroup
-                    variant={
-                      variant === "transparent" ? "primary" : "secondary"
-                    }
+        <form.AppForm>
+          {step === "email" ? (
+            <form.AuthFormRoot className="flex flex-col gap-4">
+              <form.AppField
+                name="email"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateEmailAddress(value, {
+                      invalidMessage: localization.auth.invalidEmail,
+                      requiredMessage: localization.auth.fieldRequired
+                    })
+                }}
+              >
+                {(field) => (
+                  <TextField
+                    isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                    name={field.name}
+                    type="email"
+                    autoComplete={withPasskeyAutoFill("email", passkeyAutoFill)}
+                    isDisabled={isPending}
+                    validationBehavior="aria"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={field.handleChange}
                   >
-                    <InputGroup.Input
+                    <Label>{localization.auth.email}</Label>
+                    <Input
                       autoFocus
-                      placeholder={localization.auth.passwordPlaceholder}
-                      type={isPasswordVisible ? "text" : "password"}
-                      required
+                      placeholder={localization.auth.emailPlaceholder}
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
+                      }
                     />
-                    <InputGroup.Suffix className="px-0">
-                      <Button
-                        isIconOnly
-                        aria-label={
-                          isPasswordVisible
-                            ? localization.auth.hidePassword
-                            : localization.auth.showPassword
-                        }
-                        size="sm"
-                        variant="ghost"
-                        onPress={() =>
-                          setIsPasswordVisible((visible) => !visible)
-                        }
+                    <field.AuthFormFieldError />
+                  </TextField>
+                )}
+              </form.AppField>
+
+              {discoveryError && (
+                <Description role="alert" className="text-danger">
+                  {discoveryError}
+                </Description>
+              )}
+
+              <form.AuthFormServerError />
+              <form.AuthFormSubmitButton
+                className="w-full"
+                isDisabled={isPending}
+              >
+                {isDiscovering && <Spinner color="current" size="sm" />}
+                {ssoLocalization.continueWithEmail}
+              </form.AuthFormSubmitButton>
+            </form.AuthFormRoot>
+          ) : (
+            <div className="flex flex-col gap-4">
+              {socialPosition === "top" && (
+                <>
+                  {!!socialProviders?.length && (
+                    <ProviderButtons
+                      socialLayout={socialLayout}
+                      view="signIn"
+                    />
+                  )}
+                  {showSocialSeparator && (
+                    <FieldSeparator>{localization.auth.or}</FieldSeparator>
+                  )}
+                </>
+              )}
+
+              {discoveryError && (
+                <Description role="status">{discoveryError}</Description>
+              )}
+
+              {emailAndPassword.enabled && (
+                <form.AuthFormRoot className="flex flex-col gap-4">
+                  <form.AppField
+                    name="password"
+                    validators={{
+                      onChange: ({ value }) =>
+                        validateStringLength(value, {
+                          maxLength: emailAndPassword.maxPasswordLength,
+                          maxLengthMessage: localization.auth.tooLong.replace(
+                            "{{max}}",
+                            String(emailAndPassword.maxPasswordLength)
+                          ),
+                          minLength: emailAndPassword.minPasswordLength,
+                          minLengthMessage: localization.auth.tooShort.replace(
+                            "{{min}}",
+                            String(emailAndPassword.minPasswordLength)
+                          ),
+                          requiredMessage: localization.auth.fieldRequired
+                        })
+                    }}
+                  >
+                    {(field) => (
+                      <TextField
+                        isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                        name={field.name}
+                        autoComplete={withPasskeyAutoFill(
+                          "current-password",
+                          passkeyAutoFill
+                        )}
+                        isDisabled={isPending}
+                        validationBehavior="aria"
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={field.handleChange}
                       >
-                        {isPasswordVisible ? <EyeSlash /> : <Eye />}
-                      </Button>
-                    </InputGroup.Suffix>
-                  </InputGroup>
-                  <FieldError />
-                </TextField>
+                        <Label>{localization.auth.password}</Label>
+                        <InputGroup
+                          variant={
+                            variant === "transparent" ? "primary" : "secondary"
+                          }
+                        >
+                          <InputGroup.Input
+                            autoFocus
+                            placeholder={localization.auth.passwordPlaceholder}
+                            type={isPasswordVisible ? "text" : "password"}
+                          />
+                          <InputGroup.Suffix className="px-0">
+                            <Button
+                              isIconOnly
+                              aria-label={
+                                isPasswordVisible
+                                  ? localization.auth.hidePassword
+                                  : localization.auth.showPassword
+                              }
+                              size="sm"
+                              variant="ghost"
+                              onPress={() =>
+                                setIsPasswordVisible((visible) => !visible)
+                              }
+                            >
+                              {isPasswordVisible ? <EyeSlash /> : <Eye />}
+                            </Button>
+                          </InputGroup.Suffix>
+                        </InputGroup>
+                        <field.AuthFormFieldError />
+                      </TextField>
+                    )}
+                  </form.AppField>
 
-                {emailAndPassword.rememberMe && (
-                  <Checkbox name="rememberMe" isDisabled={isPending}>
-                    <Checkbox.Content>
-                      <Checkbox.Control>
-                        <Checkbox.Indicator />
-                      </Checkbox.Control>
-                      {localization.auth.rememberMe}
-                    </Checkbox.Content>
-                  </Checkbox>
-                )}
+                  {emailAndPassword.rememberMe && (
+                    <form.AppField name="rememberMe">
+                      {(field) => (
+                        <Checkbox
+                          name={field.name}
+                          isDisabled={isPending}
+                          isSelected={field.state.value}
+                          onChange={field.handleChange}
+                        >
+                          <Checkbox.Content>
+                            <Checkbox.Control>
+                              <Checkbox.Indicator />
+                            </Checkbox.Control>
+                            {localization.auth.rememberMe}
+                          </Checkbox.Content>
+                        </Checkbox>
+                      )}
+                    </form.AppField>
+                  )}
 
-                {Captcha && (
-                  <div className="flex justify-center">{Captcha}</div>
-                )}
+                  {Captcha && (
+                    <div className="flex justify-center">{Captcha}</div>
+                  )}
 
-                <Button
-                  type="submit"
-                  className="w-full"
-                  isPending={isSigningIn}
-                >
-                  {isSigningIn && <Spinner color="current" size="sm" />}
-                  {localization.auth.signIn}
-                </Button>
-              </Form>
-            )}
+                  <form.AuthFormServerError />
+                  <form.AuthFormSubmitButton
+                    className="w-full"
+                    isDisabled={isPending}
+                  >
+                    {isSigningIn && <Spinner color="current" size="sm" />}
+                    {localization.auth.signIn}
+                  </form.AuthFormSubmitButton>
+                </form.AuthFormRoot>
+              )}
 
-            {plugins.flatMap((plugin) =>
-              (plugin.authButtons ?? []).map((AuthButton) => (
-                <AuthButton
-                  autoFill={false}
-                  key={getAuthButtonKey(plugin.id, AuthButton)}
-                  view="signIn"
-                />
-              ))
-            )}
+              {plugins.flatMap((plugin) =>
+                (plugin.authButtons ?? []).map((AuthButton) => (
+                  <AuthButton
+                    autoFill={false}
+                    key={getAuthButtonKey(plugin.id, AuthButton)}
+                    view="signIn"
+                  />
+                ))
+              )}
 
-            {socialPosition === "bottom" && (
-              <>
-                {showSocialSeparator && (
-                  <FieldSeparator>{localization.auth.or}</FieldSeparator>
-                )}
-                {!!socialProviders?.length && (
-                  <ProviderButtons socialLayout={socialLayout} view="signIn" />
-                )}
-              </>
-            )}
+              {socialPosition === "bottom" && (
+                <>
+                  {showSocialSeparator && (
+                    <FieldSeparator>{localization.auth.or}</FieldSeparator>
+                  )}
+                  {!!socialProviders?.length && (
+                    <ProviderButtons
+                      socialLayout={socialLayout}
+                      view="signIn"
+                    />
+                  )}
+                </>
+              )}
 
-            <Button variant="ghost" className="w-full" onPress={startOver}>
-              {ssoLocalization.useDifferentEmail}
-            </Button>
-          </div>
-        )}
+              <Button variant="ghost" className="w-full" onPress={startOver}>
+                {ssoLocalization.useDifferentEmail}
+              </Button>
+            </div>
+          )}
+        </form.AppForm>
       </Card.Content>
 
       {emailAndPassword.enabled && (

--- a/packages/heroui/src/components/auth/sso/email-first-sign-in.tsx
+++ b/packages/heroui/src/components/auth/sso/email-first-sign-in.tsx
@@ -143,15 +143,11 @@ export function EmailFirstSignIn({
       if (step === "email") {
         setDiscoveryError("")
         setSsoFallbackEmail(value.email)
-        try {
-          await signInSso({
-            callbackURL: `${baseURL}${redirectTo}`,
-            email: value.email,
-            loginHint: value.email
-          })
-        } catch (error) {
-          if ((error as { status?: number }).status !== 404) throw error
-        }
+        await signInSso({
+          callbackURL: `${baseURL}${redirectTo}`,
+          email: value.email,
+          loginHint: value.email
+        }).catch(() => undefined)
         return
       }
 

--- a/packages/heroui/src/components/auth/sso/email-first-sign-in.tsx
+++ b/packages/heroui/src/components/auth/sso/email-first-sign-in.tsx
@@ -43,7 +43,11 @@ import { useState } from "react"
 
 import { ssoPlugin } from "../../../lib/auth/sso-plugin"
 import { useSignInContinuation } from "../../../lib/auth/use-sign-in-continuation"
-import { isAuthFormFieldInvalid, useAuthForm } from "../auth-form"
+import {
+  clearAuthFormServerError,
+  isAuthFormFieldInvalid,
+  useAuthForm
+} from "../auth-form"
 import { FieldSeparator } from "../field-separator"
 import { ProviderButtons, type SocialLayout } from "../provider-buttons"
 
@@ -166,6 +170,7 @@ export function EmailFirstSignIn({
   const startOver = () => {
     setStep("email")
     form.setFieldValue("password", "")
+    clearAuthFormServerError(form)
     setDiscoveryError("")
   }
 

--- a/packages/heroui/src/components/auth/sso/sso-domain-verification.tsx
+++ b/packages/heroui/src/components/auth/sso/sso-domain-verification.tsx
@@ -67,9 +67,9 @@ export function SsoDomainVerification({
   })
   const form = useAuthForm({
     defaultValues: { providerId: defaultProviderId },
-    onSubmit: ({ value }) => {
+    onSubmit: async ({ value }) => {
       setVerified(false)
-      verify.mutate({ providerId: value.providerId })
+      await verify.mutateAsync({ providerId: value.providerId })
     }
   })
   const providerId = useSelector(form.store, (state) => state.values.providerId)

--- a/packages/heroui/src/components/auth/table-bridge.ts
+++ b/packages/heroui/src/components/auth/table-bridge.ts
@@ -1,0 +1,47 @@
+import type { Selection, SortDescriptor } from "@heroui/react"
+import type { RowSelectionState, SortingState } from "@tanstack/react-table"
+
+export function getHeroUISortDescriptor(
+  sorting: SortingState
+): SortDescriptor | undefined {
+  const primary = sorting[0]
+  return primary
+    ? {
+        column: primary.id,
+        direction: primary.desc ? "descending" : "ascending"
+      }
+    : undefined
+}
+
+export function getTanStackSorting(descriptor: SortDescriptor): SortingState {
+  return [
+    {
+      desc: descriptor.direction === "descending",
+      id: String(descriptor.column)
+    }
+  ]
+}
+
+export function getHeroUISelection(
+  rowSelection: RowSelectionState
+): Set<string> {
+  return new Set(
+    Object.entries(rowSelection).flatMap(([id, selected]) =>
+      selected ? [id] : []
+    )
+  )
+}
+
+export function getTanStackRowSelection(
+  selection: Selection,
+  rowIds: readonly string[]
+): RowSelectionState {
+  const selectedIds =
+    selection === "all"
+      ? new Set(rowIds)
+      : new Set(Array.from(selection, (key) => String(key)))
+
+  return Object.fromEntries(
+    rowIds.flatMap((id) => (selectedIds.has(id) ? [[id, true]] : []))
+  )
+}

--- a/packages/heroui/src/components/auth/two-factor/disable-two-factor-dialog.tsx
+++ b/packages/heroui/src/components/auth/two-factor/disable-two-factor-dialog.tsx
@@ -37,7 +37,7 @@ export function DisableTwoFactorDialog({
   const { isPending: isResolvingPasswordRequirement, requiresPassword } =
     useTwoFactorPasswordRequirement()
 
-  const { mutate: disableTwoFactor, isPending: isDisabling } =
+  const { mutateAsync: disableTwoFactor, isPending: isDisabling } =
     useDisableTwoFactor(authClient as TwoFactorAuthClient, {
       onSuccess: () => {
         toast.success(twoFactorLocalization.twoFactorDisabled)
@@ -49,8 +49,10 @@ export function DisableTwoFactorDialog({
 
   const form = useAuthForm({
     defaultValues: { password: "" },
-    onSubmit: ({ value }) =>
-      disableTwoFactor(requiresPassword ? { password: value.password } : {})
+    onSubmit: async ({ value }) =>
+      await disableTwoFactor(
+        requiresPassword ? { password: value.password } : {}
+      )
   })
 
   return (

--- a/packages/heroui/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/packages/heroui/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -1,4 +1,4 @@
-import { createQrCodeSvgData } from "@better-auth-ui/core"
+import { createQrCodeSvgData, validateStringLength } from "@better-auth-ui/core"
 import type {
   TwoFactorAuthClient,
   TwoFactorMethod
@@ -16,8 +16,6 @@ import { Check, Copy, ShieldCheck } from "@gravity-ui/icons"
 import {
   AlertDialog,
   Button,
-  FieldError,
-  Form,
   Input,
   InputGroup,
   Label,
@@ -26,10 +24,15 @@ import {
   TextField,
   toast
 } from "@heroui/react"
-import { type SyntheticEvent, useMemo, useState } from "react"
+import { useMemo, useState } from "react"
 
 import { twoFactorPlugin } from "../../../lib/auth/two-factor-plugin"
 import { useTwoFactorPasswordRequirement } from "../../../lib/auth/use-two-factor-password"
+import {
+  isAuthFormFieldInvalid,
+  submitAuthForm,
+  useAuthForm
+} from "../auth-form"
 import { OtpField } from "../otp-field"
 import { BackupCodes } from "./backup-codes"
 
@@ -70,7 +73,6 @@ export function EnableTwoFactorDialog({
   )
   const [totpUri, setTotpUri] = useState("")
   const [backupCodes, setBackupCodes] = useState<string[]>([])
-  const [code, setCode] = useState("")
   const {
     copied: setupKeyCopied,
     copy: copySetupKeyValue,
@@ -102,7 +104,7 @@ export function EnableTwoFactorDialog({
   }
 
   const {
-    mutate: enableTwoFactor,
+    mutateAsync: enableTwoFactor,
     isPending: isEnabling,
     reset: resetEnrollment
   } = useEnableTwoFactor(twoFactorClient, {
@@ -119,10 +121,10 @@ export function EnableTwoFactorDialog({
     }
   })
 
-  const { mutate: verifyTotp, isPending: isVerifying } = useVerifyTotp(
+  const { mutateAsync: verifyTotp, isPending: isVerifying } = useVerifyTotp(
     twoFactorClient,
     {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: () => {
         toast.success(twoFactorLocalization.twoFactorEnabled)
         setStep("backupCodes")
@@ -132,12 +134,29 @@ export function EnableTwoFactorDialog({
 
   const isPending = isEnabling || isVerifying || isResolvingPasswordRequirement
 
-  const verifyCode = (completedCode: string) => {
+  const form = useAuthForm({
+    defaultValues: { code: "", password: "" },
+    onSubmit: async ({ value }) => {
+      if (step === "backupCodes") {
+        handleOpenChange(false)
+        return
+      }
+      if (step === "verify") {
+        await verifyCode(value.code)
+        return
+      }
+      await enableTwoFactor(
+        requiresPassword ? { method, password: value.password } : { method }
+      )
+    }
+  })
+
+  const verifyCode = async (completedCode: string) => {
     if (isPending || step !== "verify" || completedCode.length !== codeLength) {
       return
     }
 
-    verifyTotp({ code: completedCode })
+    await verifyTotp({ code: completedCode })
   }
 
   const handleOpenChange = (open: boolean) => {
@@ -148,30 +167,11 @@ export function EnableTwoFactorDialog({
       setMethod(enrollmentMethods[0] ?? "totp")
       setTotpUri("")
       setBackupCodes([])
-      setCode("")
+      form.reset()
       resetSetupKeyCopy()
       // Clears the resolved TOTP URI and backup codes from the mutation cache.
       resetEnrollment()
     }
-  }
-
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    if (step === "backupCodes") {
-      handleOpenChange(false)
-      return
-    }
-
-    if (step === "verify") {
-      verifyCode(code)
-      return
-    }
-
-    const formData = new FormData(e.currentTarget)
-    const password = formData.get("password") as string
-
-    enableTwoFactor(requiresPassword ? { method, password } : { method })
   }
 
   const submitLabel =
@@ -185,180 +185,211 @@ export function EnableTwoFactorDialog({
     <AlertDialog.Backdrop isOpen={isOpen} onOpenChange={handleOpenChange}>
       <AlertDialog.Container>
         <AlertDialog.Dialog>
-          <Form onSubmit={handleSubmit}>
-            <AlertDialog.CloseTrigger />
+          <form.AppForm>
+            <form.AuthFormRoot>
+              <AlertDialog.CloseTrigger />
 
-            <AlertDialog.Header>
-              <AlertDialog.Icon status="default">
-                <ShieldCheck />
-              </AlertDialog.Icon>
+              <AlertDialog.Header>
+                <AlertDialog.Icon status="default">
+                  <ShieldCheck />
+                </AlertDialog.Icon>
 
-              <AlertDialog.Heading>
-                {twoFactorLocalization.twoFactor}
-              </AlertDialog.Heading>
-            </AlertDialog.Header>
+                <AlertDialog.Heading>
+                  {twoFactorLocalization.twoFactor}
+                </AlertDialog.Heading>
+              </AlertDialog.Header>
 
-            <AlertDialog.Body className="overflow-visible">
-              {step === "password" && (
-                <>
-                  <p className="text-muted text-sm">
-                    {requiresPassword
-                      ? twoFactorLocalization.passwordConfirmation
-                      : twoFactorLocalization.twoFactorDescription}
-                  </p>
+              <AlertDialog.Body className="overflow-visible">
+                {step === "password" && (
+                  <>
+                    <p className="text-muted text-sm">
+                      {requiresPassword
+                        ? twoFactorLocalization.passwordConfirmation
+                        : twoFactorLocalization.twoFactorDescription}
+                    </p>
 
-                  {enrollmentMethods.length > 1 && (
-                    <Tabs
-                      className="mt-4"
-                      selectedKey={method}
-                      onSelectionChange={(key) =>
-                        setMethod(String(key) as TwoFactorMethod)
-                      }
-                      variant="secondary"
-                    >
-                      <Tabs.ListContainer>
-                        <Tabs.List
-                          aria-label={
-                            twoFactorLocalization.chooseEnrollmentMethod
-                          }
-                        >
-                          {enrollmentMethods.includes("totp") && (
-                            <Tabs.Tab id="totp">
-                              {twoFactorLocalization.authenticatorApp}
-                              <Tabs.Indicator />
-                            </Tabs.Tab>
-                          )}
-                          {enrollmentMethods.includes("otp") && (
-                            <Tabs.Tab id="otp">
-                              {twoFactorLocalization.deliveredCode}
-                              <Tabs.Indicator />
-                            </Tabs.Tab>
-                          )}
-                        </Tabs.List>
-                      </Tabs.ListContainer>
-                    </Tabs>
-                  )}
-
-                  <p className="text-muted mt-4 text-sm">
-                    {method === "totp"
-                      ? twoFactorLocalization.authenticatorAppDescription
-                      : twoFactorLocalization.deliveredCodeDescription}
-                  </p>
-
-                  {requiresPassword && (
-                    <TextField
-                      className="mt-4"
-                      name="password"
-                      autoComplete="current-password"
-                      isDisabled={isPending}
-                    >
-                      <Label>{localization.auth.password}</Label>
-
-                      <Input
-                        autoFocus
-                        required
-                        type="password"
-                        placeholder={localization.auth.passwordPlaceholder}
+                    {enrollmentMethods.length > 1 && (
+                      <Tabs
+                        className="mt-4"
+                        selectedKey={method}
+                        onSelectionChange={(key) =>
+                          setMethod(String(key) as TwoFactorMethod)
+                        }
                         variant="secondary"
-                      />
-
-                      <FieldError />
-                    </TextField>
-                  )}
-                </>
-              )}
-
-              {step === "verify" && (
-                <div className="flex flex-col items-center gap-4">
-                  <p className="text-muted text-sm">
-                    {twoFactorLocalization.scanQrCode}
-                  </p>
-
-                  {qrCode && (
-                    <svg
-                      aria-hidden="true"
-                      className="size-44 rounded-lg border border-border"
-                      viewBox={`0 0 ${qrCode.size} ${qrCode.size}`}
-                    >
-                      <path
-                        fill="white"
-                        d={`M0 0h${qrCode.size}v${qrCode.size}H0z`}
-                      />
-                      <path
-                        fill="black"
-                        d={qrCode.path}
-                        shapeRendering="crispEdges"
-                      />
-                    </svg>
-                  )}
-
-                  {setupKey && (
-                    <TextField fullWidth value={setupKey}>
-                      <Label className="text-muted text-xs">
-                        {twoFactorLocalization.setupKey}
-                      </Label>
-
-                      <InputGroup fullWidth variant="secondary">
-                        <InputGroup.Input
-                          readOnly
-                          className="font-mono text-xs"
-                        />
-
-                        <InputGroup.Suffix className="px-0">
-                          <Button
-                            isIconOnly
+                      >
+                        <Tabs.ListContainer>
+                          <Tabs.List
                             aria-label={
-                              setupKeyCopied
-                                ? twoFactorLocalization.setupKeyCopied
-                                : localization.settings.copyToClipboard
+                              twoFactorLocalization.chooseEnrollmentMethod
                             }
-                            size="sm"
-                            type="button"
-                            variant="ghost"
-                            onPress={copySetupKey}
                           >
-                            {setupKeyCopied ? <Check /> : <Copy />}
-                          </Button>
-                        </InputGroup.Suffix>
-                      </InputGroup>
-                    </TextField>
-                  )}
+                            {enrollmentMethods.includes("totp") && (
+                              <Tabs.Tab id="totp">
+                                {twoFactorLocalization.authenticatorApp}
+                                <Tabs.Indicator />
+                              </Tabs.Tab>
+                            )}
+                            {enrollmentMethods.includes("otp") && (
+                              <Tabs.Tab id="otp">
+                                {twoFactorLocalization.deliveredCode}
+                                <Tabs.Indicator />
+                              </Tabs.Tab>
+                            )}
+                          </Tabs.List>
+                        </Tabs.ListContainer>
+                      </Tabs>
+                    )}
 
-                  <OtpField
-                    autoFocus
-                    className="w-full"
+                    <p className="text-muted mt-4 text-sm">
+                      {method === "totp"
+                        ? twoFactorLocalization.authenticatorAppDescription
+                        : twoFactorLocalization.deliveredCodeDescription}
+                    </p>
+
+                    {requiresPassword && (
+                      <form.AppField
+                        name="password"
+                        validators={{
+                          onChange: ({ value }) =>
+                            validateStringLength(value, {
+                              requiredMessage: localization.auth.fieldRequired
+                            })
+                        }}
+                      >
+                        {(field) => (
+                          <TextField
+                            className="mt-4"
+                            isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                            name={field.name}
+                            autoComplete="current-password"
+                            isDisabled={isPending}
+                            validationBehavior="aria"
+                            value={field.state.value}
+                            onBlur={field.handleBlur}
+                            onChange={field.handleChange}
+                          >
+                            <Label>{localization.auth.password}</Label>
+                            <Input
+                              autoFocus
+                              type="password"
+                              placeholder={
+                                localization.auth.passwordPlaceholder
+                              }
+                              variant="secondary"
+                            />
+                            <field.AuthFormFieldError />
+                          </TextField>
+                        )}
+                      </form.AppField>
+                    )}
+                  </>
+                )}
+
+                {step === "verify" && (
+                  <div className="flex flex-col items-center gap-4">
+                    <p className="text-muted text-sm">
+                      {twoFactorLocalization.scanQrCode}
+                    </p>
+
+                    {qrCode && (
+                      <svg
+                        aria-hidden="true"
+                        className="size-44 rounded-lg border border-border"
+                        viewBox={`0 0 ${qrCode.size} ${qrCode.size}`}
+                      >
+                        <path
+                          fill="white"
+                          d={`M0 0h${qrCode.size}v${qrCode.size}H0z`}
+                        />
+                        <path
+                          fill="black"
+                          d={qrCode.path}
+                          shapeRendering="crispEdges"
+                        />
+                      </svg>
+                    )}
+
+                    {setupKey && (
+                      <TextField fullWidth value={setupKey}>
+                        <Label className="text-muted text-xs">
+                          {twoFactorLocalization.setupKey}
+                        </Label>
+
+                        <InputGroup fullWidth variant="secondary">
+                          <InputGroup.Input
+                            readOnly
+                            className="font-mono text-xs"
+                          />
+
+                          <InputGroup.Suffix className="px-0">
+                            <Button
+                              isIconOnly
+                              aria-label={
+                                setupKeyCopied
+                                  ? twoFactorLocalization.setupKeyCopied
+                                  : localization.settings.copyToClipboard
+                              }
+                              size="sm"
+                              type="button"
+                              variant="ghost"
+                              onPress={copySetupKey}
+                            >
+                              {setupKeyCopied ? <Check /> : <Copy />}
+                            </Button>
+                          </InputGroup.Suffix>
+                        </InputGroup>
+                      </TextField>
+                    )}
+
+                    <form.AppField name="code">
+                      {(field) => (
+                        <OtpField
+                          autoFocus
+                          className="w-full"
+                          isDisabled={isPending}
+                          label={twoFactorLocalization.authenticatorCode}
+                          length={codeLength}
+                          name={field.name}
+                          value={field.state.value}
+                          onChange={field.handleChange}
+                          onComplete={() => void submitAuthForm(form)}
+                        />
+                      )}
+                    </form.AppField>
+                  </div>
+                )}
+
+                {step === "backupCodes" && <BackupCodes codes={backupCodes} />}
+              </AlertDialog.Body>
+
+              <AlertDialog.Footer>
+                {step !== "backupCodes" && (
+                  <Button
+                    slot="close"
+                    variant="tertiary"
                     isDisabled={isPending}
-                    label={twoFactorLocalization.authenticatorCode}
-                    length={codeLength}
-                    name="code"
-                    value={code}
-                    onChange={setCode}
-                    onComplete={verifyCode}
-                  />
-                </div>
-              )}
+                  >
+                    {localization.settings.cancel}
+                  </Button>
+                )}
 
-              {step === "backupCodes" && <BackupCodes codes={backupCodes} />}
-            </AlertDialog.Body>
-
-            <AlertDialog.Footer>
-              {step !== "backupCodes" && (
-                <Button slot="close" variant="tertiary" isDisabled={isPending}>
-                  {localization.settings.cancel}
-                </Button>
-              )}
-
-              <Button
-                type="submit"
-                isDisabled={step === "verify" && code.length !== codeLength}
-                isPending={isPending}
-              >
-                {isPending && <Spinner color="current" size="sm" />}
-
-                {submitLabel}
-              </Button>
-            </AlertDialog.Footer>
-          </Form>
+                <form.Subscribe selector={(state) => state.values.code}>
+                  {(code) => (
+                    <form.AuthFormSubmitButton
+                      isDisabled={
+                        isPending ||
+                        (step === "verify" && code.length !== codeLength)
+                      }
+                    >
+                      {isPending && <Spinner color="current" size="sm" />}
+                      {submitLabel}
+                    </form.AuthFormSubmitButton>
+                  )}
+                </form.Subscribe>
+              </AlertDialog.Footer>
+              <form.AuthFormServerError />
+            </form.AuthFormRoot>
+          </form.AppForm>
         </AlertDialog.Dialog>
       </AlertDialog.Container>
     </AlertDialog.Backdrop>

--- a/packages/heroui/src/components/auth/two-factor/regenerate-backup-codes-dialog.tsx
+++ b/packages/heroui/src/components/auth/two-factor/regenerate-backup-codes-dialog.tsx
@@ -45,7 +45,7 @@ export function RegenerateBackupCodesDialog({
   const [codes, setCodes] = useState<string[]>([])
 
   const {
-    mutate: generateBackupCodes,
+    mutateAsync: generateBackupCodes,
     isPending: isGenerating,
     reset: resetGeneration
   } = useGenerateBackupCodes(authClient as TwoFactorAuthClient, {
@@ -69,13 +69,15 @@ export function RegenerateBackupCodesDialog({
 
   const form = useAuthForm({
     defaultValues: { password: "" },
-    onSubmit: ({ value }) => {
+    onSubmit: async ({ value }) => {
       if (codes.length) {
         handleOpenChange(false)
         return
       }
 
-      generateBackupCodes(requiresPassword ? { password: value.password } : {})
+      await generateBackupCodes(
+        requiresPassword ? { password: value.password } : {}
+      )
     }
   })
 

--- a/packages/heroui/src/components/auth/two-factor/two-factor-challenge.tsx
+++ b/packages/heroui/src/components/auth/two-factor/two-factor-challenge.tsx
@@ -35,8 +35,10 @@ import {
   useResendCooldown
 } from "../../../lib/auth/use-resend-cooldown"
 import {
+  clearAuthFormServerError,
   isAuthFormFieldInvalid,
   setAuthFormServerError,
+  submitAuthForm,
   useAuthForm
 } from "../auth-form"
 import { OtpField } from "../otp-field"
@@ -147,6 +149,7 @@ export function TwoFactorChallenge({
   })
 
   const switchMethod = (next: ChallengeMethod) => {
+    clearAuthFormServerError(form)
     form.setFieldValue("code", "")
     form.setFieldValue("backupCode", "")
     setMethod(next)
@@ -271,7 +274,13 @@ export function TwoFactorChallenge({
                     value={field.state.value}
                     variant={variant}
                     onChange={field.handleChange}
-                    onComplete={(code) => void verifyCode(code)}
+                    onComplete={(code) => {
+                      form.setFieldValue("code", code)
+                      void submitAuthForm(
+                        form,
+                        localization.auth.callbackFailedTitle
+                      )
+                    }}
                   />
                 )}
               </form.AppField>

--- a/packages/heroui/src/components/auth/two-factor/two-factor-challenge.tsx
+++ b/packages/heroui/src/components/auth/two-factor/two-factor-challenge.tsx
@@ -1,4 +1,4 @@
-import { authQueryKeys } from "@better-auth-ui/core"
+import { authQueryKeys, validateStringLength } from "@better-auth-ui/core"
 import {
   clearTwoFactorMethods,
   readTwoFactorMethods,
@@ -19,8 +19,6 @@ import {
   Checkbox,
   cn,
   Description,
-  FieldError,
-  Form,
   Input,
   Label,
   Link,
@@ -29,13 +27,18 @@ import {
   useIsHydrated
 } from "@heroui/react"
 import { useQueryClient } from "@tanstack/react-query"
-import { type SyntheticEvent, useEffect, useState } from "react"
+import { useEffect, useState } from "react"
 
 import { twoFactorPlugin } from "../../../lib/auth/two-factor-plugin"
 import {
   RESEND_COOLDOWN_SECONDS,
   useResendCooldown
 } from "../../../lib/auth/use-resend-cooldown"
+import {
+  isAuthFormFieldInvalid,
+  setAuthFormServerError,
+  useAuthForm
+} from "../auth-form"
 import { OtpField } from "../otp-field"
 
 /** Challenge surfaces the view can render, in the order they are offered. */
@@ -87,8 +90,6 @@ export function TwoFactorChallenge({
   const [method, setMethod] = useState<ChallengeMethod>(
     () => methods[0] ?? "totp"
   )
-  const [code, setCode] = useState("")
-  const [trustDevice, setTrustDevice] = useState(false)
   const [otpRequested, setOtpRequested] = useState(false)
   const { cooldown, isCoolingDown, startCooldown } = useResendCooldown()
 
@@ -106,7 +107,7 @@ export function TwoFactorChallenge({
     navigate({ to: redirectTo })
   }
 
-  const { mutate: sendTwoFactorOtp, isPending: isSendingOtp } =
+  const { mutateAsync: sendTwoFactorOtp, isPending: isSendingOtp } =
     useSendTwoFactorOtp(twoFactorClient, {
       onSuccess: () => {
         setOtpRequested(true)
@@ -114,30 +115,44 @@ export function TwoFactorChallenge({
       }
     })
 
-  const { mutate: verifyTotp, isPending: isVerifyingTotp } = useVerifyTotp(
+  const { mutateAsync: verifyTotp, isPending: isVerifyingTotp } = useVerifyTotp(
     twoFactorClient,
-    { onError: () => setCode(""), onSuccess: onVerified }
+    { onError: () => form.setFieldValue("code", ""), onSuccess: onVerified }
   )
 
-  const { mutate: verifyTwoFactorOtp, isPending: isVerifyingOtp } =
+  const { mutateAsync: verifyTwoFactorOtp, isPending: isVerifyingOtp } =
     useVerifyTwoFactorOtp(twoFactorClient, {
-      onError: () => setCode(""),
+      onError: () => form.setFieldValue("code", ""),
       onSuccess: onVerified
     })
 
-  const { mutate: verifyBackupCode, isPending: isVerifyingBackupCode } =
+  const { mutateAsync: verifyBackupCode, isPending: isVerifyingBackupCode } =
     useVerifyBackupCode(twoFactorClient, { onSuccess: onVerified })
 
   const isPending =
     isSendingOtp || isVerifyingTotp || isVerifyingOtp || isVerifyingBackupCode
   const needsOtpRequest = method === "otp" && !otpRequested
 
+  const form = useAuthForm({
+    defaultValues: { backupCode: "", code: "", trustDevice: false },
+    onSubmit: async ({ value }) => {
+      const trust = trustDeviceEnabled ? { trustDevice: value.trustDevice } : {}
+      if (method === "backup") {
+        await verifyBackupCode({ code: value.backupCode.trim(), ...trust })
+        return
+      }
+
+      await verifyCode(value.code)
+    }
+  })
+
   const switchMethod = (next: ChallengeMethod) => {
-    setCode("")
+    form.setFieldValue("code", "")
+    form.setFieldValue("backupCode", "")
     setMethod(next)
   }
 
-  const verifyCode = (completedCode: string) => {
+  const verifyCode = async (completedCode: string) => {
     if (
       isPending ||
       needsOtpRequest ||
@@ -147,31 +162,24 @@ export function TwoFactorChallenge({
       return
     }
 
-    const trust = trustDeviceEnabled ? { trustDevice } : {}
+    const trust = trustDeviceEnabled
+      ? { trustDevice: form.state.values.trustDevice }
+      : {}
 
     if (method === "otp") {
-      verifyTwoFactorOtp({ code: completedCode, ...trust })
+      await verifyTwoFactorOtp({ code: completedCode, ...trust })
       return
     }
 
-    verifyTotp({ code: completedCode, ...trust })
+    await verifyTotp({ code: completedCode, ...trust })
   }
 
-  const handleSubmit = (e: SyntheticEvent<HTMLFormElement>) => {
-    e.preventDefault()
-
-    const trust = trustDeviceEnabled ? { trustDevice } : {}
-
-    if (method === "backup") {
-      const formData = new FormData(e.currentTarget)
-      verifyBackupCode({
-        code: (formData.get("backupCode") as string).trim(),
-        ...trust
-      })
-      return
+  const requestOtp = async () => {
+    try {
+      await sendTwoFactorOtp()
+    } catch (error) {
+      setAuthFormServerError(form, error, twoFactorLocalization.sendEmailCode)
     }
-
-    verifyCode(code)
   }
 
   const description =
@@ -212,112 +220,146 @@ export function TwoFactorChallenge({
       </Card.Header>
 
       <Card.Content className="gap-4">
-        <Form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          {method === "backup" ? (
-            <TextField
-              name="backupCode"
-              autoComplete="one-time-code"
-              isDisabled={isPending}
-            >
-              <Label>{twoFactorLocalization.backupCode}</Label>
-
-              <Input
-                autoFocus
-                required
-                variant={variant === "transparent" ? "primary" : "secondary"}
-              />
-
-              <FieldError />
-            </TextField>
-          ) : (
-            <OtpField
-              autoFocus
-              isDisabled={isPending || needsOtpRequest}
-              label={
-                method === "otp"
-                  ? twoFactorLocalization.emailedCode
-                  : twoFactorLocalization.authenticatorCode
-              }
-              length={codeLength}
-              name="code"
-              value={code}
-              variant={variant}
-              onChange={setCode}
-              onComplete={verifyCode}
-            />
-          )}
-
-          {trustDeviceEnabled && (
-            <Checkbox
-              isDisabled={isPending}
-              isSelected={trustDevice}
-              name="trustDevice"
-              variant={variant === "transparent" ? "primary" : "secondary"}
-              onChange={setTrustDevice}
-            >
-              <Checkbox.Content>
-                <Checkbox.Control>
-                  <Checkbox.Indicator />
-                </Checkbox.Control>
-
-                {twoFactorLocalization.trustDevice}
-              </Checkbox.Content>
-            </Checkbox>
-          )}
-
-          <div className="flex flex-col gap-3">
-            {needsOtpRequest ? (
-              <Button
-                className="w-full"
-                isPending={isSendingOtp}
-                onPress={() => sendTwoFactorOtp()}
+        <form.AppForm>
+          <form.AuthFormRoot className="flex flex-col gap-4">
+            {method === "backup" ? (
+              <form.AppField
+                name="backupCode"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
               >
-                {isSendingOtp && <Spinner color="current" size="sm" />}
-
-                {twoFactorLocalization.sendEmailCode}
-              </Button>
+                {(field) => (
+                  <TextField
+                    isInvalid={isAuthFormFieldInvalid(field.state.meta)}
+                    name={field.name}
+                    autoComplete="one-time-code"
+                    isDisabled={isPending}
+                    validationBehavior="aria"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={field.handleChange}
+                  >
+                    <Label>{twoFactorLocalization.backupCode}</Label>
+                    <Input
+                      autoFocus
+                      variant={
+                        variant === "transparent" ? "primary" : "secondary"
+                      }
+                    />
+                    <field.AuthFormFieldError />
+                  </TextField>
+                )}
+              </form.AppField>
             ) : (
-              <Button
-                type="submit"
-                className="w-full"
-                isDisabled={method !== "backup" && code.length !== codeLength}
-                isPending={isPending}
-              >
-                {isPending && <Spinner color="current" size="sm" />}
-
-                {twoFactorLocalization.verify}
-              </Button>
+              <form.AppField name="code">
+                {(field) => (
+                  <OtpField
+                    autoFocus
+                    isDisabled={isPending || needsOtpRequest}
+                    label={
+                      method === "otp"
+                        ? twoFactorLocalization.emailedCode
+                        : twoFactorLocalization.authenticatorCode
+                    }
+                    length={codeLength}
+                    name={field.name}
+                    value={field.state.value}
+                    variant={variant}
+                    onChange={field.handleChange}
+                    onComplete={(code) => void verifyCode(code)}
+                  />
+                )}
+              </form.AppField>
             )}
 
-            {method === "otp" && otpRequested && (
-              <Button
-                className="w-full"
-                variant="tertiary"
-                isDisabled={isPending || isCoolingDown}
-                onPress={() => sendTwoFactorOtp()}
-              >
-                {isCoolingDown
-                  ? localization.auth.resendIn.replace(
-                      "{{seconds}}",
-                      String(cooldown)
-                    )
-                  : localization.auth.resend}
-              </Button>
+            {trustDeviceEnabled && (
+              <form.AppField name="trustDevice">
+                {(field) => (
+                  <Checkbox
+                    isDisabled={isPending}
+                    isSelected={field.state.value}
+                    name={field.name}
+                    variant={
+                      variant === "transparent" ? "primary" : "secondary"
+                    }
+                    onChange={field.handleChange}
+                  >
+                    <Checkbox.Content>
+                      <Checkbox.Control>
+                        <Checkbox.Indicator />
+                      </Checkbox.Control>
+
+                      {twoFactorLocalization.trustDevice}
+                    </Checkbox.Content>
+                  </Checkbox>
+                )}
+              </form.AppField>
             )}
 
-            {alternatives.map((alternative) => (
-              <Button
-                className="w-full"
-                isDisabled={isPending}
-                key={alternative.key}
-                variant="ghost"
-                onPress={() => switchMethod(alternative.key)}
-              >
-                {alternative.label}
-              </Button>
-            ))}
-          </div>
-        </Form>
+            <div className="flex flex-col gap-3">
+              {needsOtpRequest ? (
+                <Button
+                  className="w-full"
+                  isPending={isSendingOtp}
+                  onPress={() => void requestOtp()}
+                >
+                  {isSendingOtp && <Spinner color="current" size="sm" />}
+
+                  {twoFactorLocalization.sendEmailCode}
+                </Button>
+              ) : (
+                <form.Subscribe selector={(state) => state.values.code}>
+                  {(code) => (
+                    <form.AuthFormSubmitButton
+                      className="w-full"
+                      isDisabled={
+                        method !== "backup" && code.length !== codeLength
+                      }
+                    >
+                      {isPending && <Spinner color="current" size="sm" />}
+
+                      {twoFactorLocalization.verify}
+                    </form.AuthFormSubmitButton>
+                  )}
+                </form.Subscribe>
+              )}
+
+              {method === "otp" && otpRequested && (
+                <Button
+                  className="w-full"
+                  variant="tertiary"
+                  isDisabled={isPending || isCoolingDown}
+                  onPress={() => void requestOtp()}
+                >
+                  {isCoolingDown
+                    ? localization.auth.resendIn.replace(
+                        "{{seconds}}",
+                        String(cooldown)
+                      )
+                    : localization.auth.resend}
+                </Button>
+              )}
+
+              {alternatives.map((alternative) => (
+                <Button
+                  className="w-full"
+                  isDisabled={isPending}
+                  key={alternative.key}
+                  variant="ghost"
+                  onPress={() => switchMethod(alternative.key)}
+                >
+                  {alternative.label}
+                </Button>
+              ))}
+            </div>
+            <form.AuthFormServerError />
+          </form.AuthFormRoot>
+        </form.AppForm>
       </Card.Content>
 
       <Card.Footer className="flex-col gap-3">

--- a/packages/heroui/src/components/auth/two-factor/two-factor-challenge.tsx
+++ b/packages/heroui/src/components/auth/two-factor/two-factor-challenge.tsx
@@ -178,6 +178,7 @@ export function TwoFactorChallenge({
   }
 
   const requestOtp = async () => {
+    clearAuthFormServerError(form)
     try {
       await sendTwoFactorOtp()
     } catch (error) {

--- a/packages/heroui/src/components/auth/username/sign-in-username.tsx
+++ b/packages/heroui/src/components/auth/username/sign-in-username.tsx
@@ -1,4 +1,4 @@
-import { authMutationKeys } from "@better-auth-ui/core"
+import { authMutationKeys, validateStringLength } from "@better-auth-ui/core"
 import {
   isPasskeyAutoFillEnabled,
   withPasskeyAutoFill
@@ -20,7 +20,6 @@ import {
   Checkbox,
   cn,
   Description,
-  FieldError,
   Input,
   InputGroup,
   Label,
@@ -77,7 +76,7 @@ export function SignInUsername({
     return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)
   }
 
-  const { mutate: signInEmail, isPending: isSignInEmailPending } =
+  const { mutateAsync: signInEmail, isPending: isSignInEmailPending } =
     useSignInEmail(authClient, {
       onError: (error, { email }) => {
         form.setFieldValue("password", "")
@@ -97,7 +96,7 @@ export function SignInUsername({
       }
     })
 
-  const { mutate: signInUsername, isPending: isSignInUsernamePending } =
+  const { mutateAsync: signInUsername, isPending: isSignInUsernamePending } =
     useSignInUsername(authClient as UsernameAuthClient, {
       onError: (error) => {
         form.setFieldValue("password", "")
@@ -120,10 +119,10 @@ export function SignInUsername({
 
   const form = useAuthForm({
     defaultValues: { email: "", password: "", rememberMe: false },
-    onSubmit: ({ value }) => {
+    onSubmit: async ({ value }) => {
       const email = value.email
       if (isEmail(email)) {
-        signInEmail({
+        await signInEmail({
           email,
           password: value.password,
           ...(emailAndPassword?.rememberMe
@@ -132,7 +131,7 @@ export function SignInUsername({
           fetchOptions
         })
       } else {
-        signInUsername({
+        await signInUsername({
           username: email,
           password: value.password,
           ...(emailAndPassword?.rememberMe
@@ -189,7 +188,16 @@ export function SignInUsername({
         {emailAndPassword?.enabled && (
           <form.AppForm>
             <form.AuthFormRoot className="flex flex-col gap-4">
-              <form.AppField name="email">
+              <form.AppField
+                name="email"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      requiredMessage: localization.auth.fieldRequired,
+                      trim: true
+                    })
+                }}
+              >
                 {(field) => (
                   <TextField
                     name={field.name}
@@ -202,9 +210,7 @@ export function SignInUsername({
                     value={field.state.value}
                     onBlur={field.handleBlur}
                     onChange={field.handleChange}
-                    validate={(value) => {
-                      if (!value) return localization.auth.fieldRequired
-                    }}
+                    validationBehavior="aria"
                   >
                     <Label>{usernameLocalization.username}</Label>
 
@@ -218,12 +224,30 @@ export function SignInUsername({
                       required
                     />
 
-                    <FieldError />
+                    <field.AuthFormFieldError />
                   </TextField>
                 )}
               </form.AppField>
 
-              <form.AppField name="password">
+              <form.AppField
+                name="password"
+                validators={{
+                  onChange: ({ value }) =>
+                    validateStringLength(value, {
+                      maxLength: emailAndPassword?.maxPasswordLength,
+                      maxLengthMessage: localization.auth.tooLong.replace(
+                        "{{max}}",
+                        String(emailAndPassword?.maxPasswordLength)
+                      ),
+                      minLength: emailAndPassword?.minPasswordLength,
+                      minLengthMessage: localization.auth.tooShort.replace(
+                        "{{min}}",
+                        String(emailAndPassword?.minPasswordLength)
+                      ),
+                      requiredMessage: localization.auth.fieldRequired
+                    })
+                }}
+              >
                 {(field) => (
                   <TextField
                     minLength={emailAndPassword?.minPasswordLength}
@@ -237,21 +261,7 @@ export function SignInUsername({
                     value={field.state.value}
                     onBlur={field.handleBlur}
                     onChange={field.handleChange}
-                    validate={(value) => {
-                      if (!value) return localization.auth.fieldRequired
-                      const min = emailAndPassword?.minPasswordLength
-                      const max = emailAndPassword?.maxPasswordLength
-                      if (min && value.length < min)
-                        return localization.auth.tooShort.replace(
-                          "{{min}}",
-                          String(min)
-                        )
-                      if (max && value.length > max)
-                        return localization.auth.tooLong.replace(
-                          "{{max}}",
-                          String(max)
-                        )
-                    }}
+                    validationBehavior="aria"
                   >
                     <Label>{localization.auth.password}</Label>
 
@@ -286,7 +296,7 @@ export function SignInUsername({
                       </InputGroup.Suffix>
                     </InputGroup>
 
-                    <FieldError />
+                    <field.AuthFormFieldError />
                   </TextField>
                 )}
               </form.AppField>
@@ -316,6 +326,8 @@ export function SignInUsername({
               )}
 
               {Captcha && <div className="flex justify-center">{Captcha}</div>}
+
+              <form.AuthFormServerError />
 
               <div className="flex flex-col gap-3">
                 <form.AuthFormSubmitButton

--- a/packages/heroui/tests/auth-form.test.tsx
+++ b/packages/heroui/tests/auth-form.test.tsx
@@ -22,6 +22,39 @@ function TestAuthForm({ onSubmit }: { onSubmit: () => Promise<void> }) {
   )
 }
 
+function TestFieldForm({
+  onSubmit
+}: {
+  onSubmit: (value: { email: string }) => Promise<void>
+}) {
+  const form = useAuthForm({
+    defaultValues: { email: "" },
+    onSubmit: ({ value }) => onSubmit(value)
+  })
+
+  return (
+    <form.AppForm>
+      <form.AuthFormRoot>
+        <form.AppField
+          name="email"
+          validators={{
+            onChange: ({ value }) => (value ? undefined : "Email is required")
+          }}
+        >
+          {(field) => (
+            <field.AuthFormTextField
+              label="Email"
+              inputProps={{ type: "email" }}
+            />
+          )}
+        </form.AppField>
+        <form.AuthFormServerError />
+        <form.AuthFormSubmitButton>Continue</form.AuthFormSubmitButton>
+      </form.AuthFormRoot>
+    </form.AppForm>
+  )
+}
+
 describe("AuthFormRoot", () => {
   it("rejects concurrent submission and disables the submit button", async () => {
     let finishSubmission!: () => void
@@ -42,6 +75,26 @@ describe("AuthFormRoot", () => {
 
     finishSubmission()
     await waitFor(() => expect(submitButton).toBeEnabled())
+  })
+
+  it("keeps validation and rejected submission errors in TanStack state", async () => {
+    const onSubmit = vi.fn(async () => {
+      throw {
+        body: {
+          fieldErrors: { email: "This email cannot be used" },
+          message: "Account creation failed"
+        }
+      }
+    })
+    render(<TestFieldForm onSubmit={onSubmit} />)
+    const input = screen.getByRole("textbox", { name: "Email" })
+
+    fireEvent.change(input, { target: { value: "ada@example.com" } })
+    fireEvent.click(screen.getByRole("button", { name: /Continue/ }))
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce())
+    expect(await screen.findByText("This email cannot be used")).toBeVisible()
+    expect(screen.getByText("Account creation failed")).toBeVisible()
   })
 })
 

--- a/packages/heroui/tests/auth-form.test.tsx
+++ b/packages/heroui/tests/auth-form.test.tsx
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import {
   getAuthAdditionalFieldValidators,
+  setAuthFormServerError,
   useAuthForm
 } from "../src/components/auth/auth-form"
 
@@ -23,13 +24,20 @@ function TestAuthForm({ onSubmit }: { onSubmit: () => Promise<void> }) {
 }
 
 function TestFieldForm({
+  mutationError,
   onSubmit
 }: {
+  mutationError?: unknown
   onSubmit: (value: { email: string }) => Promise<void>
 }) {
   const form = useAuthForm({
     defaultValues: { email: "" },
-    onSubmit: ({ value }) => onSubmit(value)
+    onSubmit: async ({ value }) => {
+      if (mutationError) {
+        setAuthFormServerError(form, mutationError, "Fallback submission error")
+      }
+      await onSubmit(value)
+    }
   })
 
   return (
@@ -95,6 +103,30 @@ describe("AuthFormRoot", () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce())
     expect(await screen.findByText("This email cannot be used")).toBeVisible()
     expect(screen.getByText("Account creation failed")).toBeVisible()
+  })
+
+  it("preserves server errors set by a mutation error handler", async () => {
+    render(
+      <TestFieldForm
+        mutationError={{
+          fields: { email: "This password is compromised" },
+          message: "Mutation-owned form error"
+        }}
+        onSubmit={async () => {
+          throw new Error("Mutation rejected")
+        }}
+      />
+    )
+    const input = screen.getByRole("textbox", { name: "Email" })
+
+    fireEvent.change(input, { target: { value: "ada@example.com" } })
+    fireEvent.click(screen.getByRole("button", { name: /Continue/ }))
+
+    expect(
+      await screen.findByText("This password is compromised")
+    ).toBeVisible()
+    expect(screen.getByText("Mutation-owned form error")).toBeVisible()
+    expect(screen.queryByText("Mutation rejected")).toBeNull()
   })
 })
 

--- a/packages/heroui/tests/delete-user.test.tsx
+++ b/packages/heroui/tests/delete-user.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { AuthProvider } from "../src/components/auth/auth-provider"
+import { DeleteAccount } from "../src/components/auth/delete-user/delete-account"
+import { deleteUserPlugin } from "../src/lib/auth/delete-user-plugin"
+
+function createMockAuthClient() {
+  const deleteUser = vi.fn(async () => ({ data: {}, error: null }))
+
+  return {
+    deleteUser,
+    getSession: async () => ({
+      session: { id: "session-1" },
+      user: { id: "user-1", email: "user@example.com", name: "User" }
+    }),
+    listAccounts: vi.fn(async () => [{ providerId: "credential" }])
+  } as unknown as Parameters<typeof AuthProvider>[0]["authClient"] & {
+    deleteUser: typeof deleteUser
+  }
+}
+
+describe("<DeleteAccount />", () => {
+  it("does not delete a credential account when password is empty", async () => {
+    const user = userEvent.setup()
+    const authClient = createMockAuthClient()
+
+    render(
+      <AuthProvider
+        authClient={authClient}
+        navigate={vi.fn()}
+        plugins={[deleteUserPlugin()]}
+      >
+        <DeleteAccount />
+      </AuthProvider>
+    )
+
+    const openDialog = screen.getByRole("button", { name: /delete account/i })
+    await waitFor(() => expect(openDialog).toBeEnabled())
+    await user.click(openDialog)
+
+    const dialog = await screen.findByRole("alertdialog")
+    await user.click(
+      within(dialog).getByRole("button", { name: /delete account/i })
+    )
+
+    expect(
+      await within(dialog).findByText("This field is required")
+    ).toBeVisible()
+    expect(authClient.deleteUser).not.toHaveBeenCalled()
+  })
+})

--- a/packages/heroui/tests/magic-link.test.tsx
+++ b/packages/heroui/tests/magic-link.test.tsx
@@ -105,6 +105,7 @@ describe("<MagicLink />", () => {
     })
 
     expect(screen.getByLabelText(/email/i)).toHaveValue("user@example.com")
+    expect(await screen.findByText("network down")).toBeVisible()
     expect(
       screen.getByRole("button", { name: /send magic link/i })
     ).toBeInTheDocument()

--- a/packages/heroui/tests/organization-table.test.tsx
+++ b/packages/heroui/tests/organization-table.test.tsx
@@ -1,3 +1,4 @@
+import type { TablePersistenceAdapters } from "@better-auth-ui/core"
 import { organizationLocalization } from "@better-auth-ui/core/plugins/organization"
 import {
   act,
@@ -13,6 +14,7 @@ import {
   createOrganizationColumnHelper,
   useOrganizationTable
 } from "../src/components/auth/organization/organization-table"
+import { OrganizationTableRenderer } from "../src/components/auth/organization/organization-table-renderer"
 import { OrganizationTableSelectRow } from "../src/components/auth/organization/organization-table-selection"
 import { useOrganizationTableState } from "../src/components/auth/organization/organization-table-state"
 
@@ -24,8 +26,16 @@ type TestRow = {
 
 const columnHelper = createOrganizationColumnHelper<TestRow>()
 const columns = columnHelper.columns([
-  columnHelper.accessor("group", { filterFn: "includesString" }),
-  columnHelper.accessor("name", { filterFn: "includesString" })
+  columnHelper.accessor("group", {
+    cell: ({ getValue }) => getValue(),
+    filterFn: "includesString",
+    header: "Group"
+  }),
+  columnHelper.accessor("name", {
+    cell: ({ getValue }) => getValue(),
+    filterFn: "includesString",
+    header: "Name"
+  })
 ])
 const rows: TestRow[] = [
   { group: "b", id: "1", name: "Ada" },
@@ -40,6 +50,28 @@ afterEach(() => {
 })
 
 describe("organization table state", () => {
+  it("renders header groups and visible cells through column renderers", () => {
+    function TableFixture() {
+      const table = useOrganizationTable({
+        columns,
+        data: rows.slice(0, 1),
+        getRowId: (row) => row.id
+      })
+
+      return (
+        <table.AppTable>
+          <OrganizationTableRenderer ariaLabel="People" empty="No people" />
+        </table.AppTable>
+      )
+    }
+
+    render(<TableFixture />)
+
+    expect(screen.getByRole("columnheader", { name: "Group" })).toBeVisible()
+    expect(screen.getByRole("columnheader", { name: "Name" })).toBeVisible()
+    expect(screen.getByRole("gridcell", { name: "Ada" })).toBeVisible()
+  })
+
   it("preserves Shift for keyboard range selection", () => {
     const toggleSelected = vi.fn()
     const { result } = renderHook(() =>
@@ -200,6 +232,42 @@ describe("organization table state", () => {
       expect(
         new URL(window.location.href).searchParams.get("test.search")
       ).toBe("Ada")
+    })
+  })
+
+  it("restores state when a router adapter reports navigation", async () => {
+    let params = new URLSearchParams("router.search=first")
+    let notifyNavigation = () => undefined
+    const adapters: TablePersistenceAdapters = {
+      search: {
+        read: () => new URLSearchParams(params),
+        replace: (next) => {
+          params = new URLSearchParams(next)
+        },
+        subscribe: (listener) => {
+          notifyNavigation = listener
+          return () => {
+            notifyNavigation = () => undefined
+          }
+        }
+      }
+    }
+    const { result } = renderHook(() =>
+      useOrganizationTableState("router", 10, TEST_COLUMN_IDS, adapters)
+    )
+
+    await waitFor(() => expect(result.current.ready).toBe(true))
+    expect(result.current.globalFilter).toBe("first")
+
+    params = new URLSearchParams(
+      "router.search=restored&router.sort=name.desc&router.page=2"
+    )
+    act(() => notifyNavigation())
+
+    await waitFor(() => {
+      expect(result.current.globalFilter).toBe("restored")
+      expect(result.current.sorting).toEqual([{ desc: true, id: "name" }])
+      expect(result.current.pagination.pageIndex).toBe(1)
     })
   })
 })

--- a/packages/heroui/tests/siwe.test.tsx
+++ b/packages/heroui/tests/siwe.test.tsx
@@ -1,5 +1,8 @@
-import { describe, expect, it } from "vitest"
+import { render, screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
 
+import { AuthProvider } from "../src/components/auth/auth-provider"
 import { SignInEthereumButton } from "../src/components/auth/siwe/sign-in-ethereum-button"
 import { WalletAccounts } from "../src/components/auth/siwe/wallet-accounts"
 import { siwePlugin } from "../src/lib/auth/siwe-plugin"
@@ -27,5 +30,54 @@ describe("siwePlugin (heroui)", () => {
     })
 
     expect(plugin.securityCards).toEqual([WalletAccounts])
+  })
+
+  it("does not connect a wallet when required email is empty", async () => {
+    const user = userEvent.setup()
+    const connect = vi.fn(async () => ({
+      address: "0x123",
+      chainId: 1
+    }))
+    const requiredEmailConnector = {
+      id: "injected",
+      label: "Ethereum",
+      connect,
+      signMessage: vi.fn(async () => "0xsigned")
+    }
+    const authClient = {
+      siwe: {
+        nonce: vi.fn(async () => ({ data: { nonce: "nonce" } })),
+        verify: vi.fn(async () => ({ data: {}, error: null }))
+      },
+      useSession: () => ({ data: null, isPending: false, error: null })
+    } as unknown as Parameters<typeof AuthProvider>[0]["authClient"]
+
+    render(
+      <AuthProvider
+        authClient={authClient}
+        navigate={vi.fn()}
+        plugins={[
+          siwePlugin({
+            connector: requiredEmailConnector,
+            domain: "app.example.com",
+            email: "required",
+            uri: "https://app.example.com"
+          })
+        ]}
+      >
+        <SignInEthereumButton />
+      </AuthProvider>
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: /continue with ethereum/i })
+    )
+    const dialog = await screen.findByRole("dialog")
+    await user.click(within(dialog).getByRole("button", { name: /sign/i }))
+
+    expect(
+      await within(dialog).findByText("This field is required")
+    ).toBeVisible()
+    expect(connect).not.toHaveBeenCalled()
   })
 })

--- a/packages/heroui/tests/table-bridge.test.ts
+++ b/packages/heroui/tests/table-bridge.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+import {
+  getHeroUISelection,
+  getHeroUISortDescriptor,
+  getTanStackRowSelection,
+  getTanStackSorting
+} from "../src/components/auth/table-bridge"
+
+describe("HeroUI table bridge", () => {
+  it("round trips the primary sort descriptor", () => {
+    const sorting = [{ desc: true, id: "createdAt" }]
+    const descriptor = getHeroUISortDescriptor(sorting)
+
+    expect(descriptor).toEqual({
+      column: "createdAt",
+      direction: "descending"
+    })
+    if (!descriptor) {
+      throw new Error("Expected a HeroUI sort descriptor")
+    }
+    expect(getTanStackSorting(descriptor)).toEqual(sorting)
+  })
+
+  it("converts explicit and all-row selection", () => {
+    expect(getHeroUISelection({ first: true, ignored: false })).toEqual(
+      new Set(["first"])
+    )
+    expect(
+      getTanStackRowSelection(new Set(["second"]), ["first", "second"])
+    ).toEqual({ second: true })
+    expect(getTanStackRowSelection("all", ["first", "second"])).toEqual({
+      first: true,
+      second: true
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- make TanStack Form the validation and asynchronous submission owner across React, HeroUI, and Solid auth flows
- add shared form adapters, normalized server errors, per-kit table renderers, HeroUI sorting and selection bridges, and router-aware table persistence
- add cross-platform contracts for validation, pending state, filtering, sorting, pagination, selection, and URL restoration
- keep column ordering, sizing, and virtualization out until a consuming table requires them

## Verification

- core: 367 tests passed
- HeroUI: 181 tests passed
- docs/shadcn: 55 tests passed
- Solid auth routes: 64 tests passed
- Solid browser contracts: 6 tests passed
- migration-specific registry contracts: 5 tests passed
- core, HeroUI, docs, and Solid typechecks passed
- Biome, docs lint, and git diff checks passed

## Known unrelated failures

The full Solid registry suite still reports 7 pre-existing documentation and information-architecture assertion failures involving static assets, type tables, missing documentation links, and quick-start copy. The migration-specific registry contracts pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reusable organization tables with sorting, row selection, empty states, and customizable rendering across Solid and HeroUI.
  * Added restoration of organization table filters, sorting, pagination, and column visibility during navigation.
* **Improvements**
  * Standardized authentication forms with consistent validation, server-error messages, and submission states.
  * Authentication actions now wait for completion before advancing workflows or closing dialogs.
* **Bug Fixes**
  * Preserved field-specific server errors when additional submission errors occur.
* **Tests**
  * Expanded coverage for authentication forms and organization table behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->