### PR TITLE
refactor(tanstack): harden table and form integrations

### DIFF
--- a/apps/docs/src/components/auth/admin/admin-users.tsx
+++ b/apps/docs/src/components/auth/admin/admin-users.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import {
+  DEFAULT_TABLE_SEARCH_DEBOUNCE_MS,
   fieldsWithModelValues,
   getAdditionalFieldDefaultValues,
   getAdditionalFieldSubmitValues,
@@ -29,14 +30,9 @@ import {
   useAdminUserSessions,
   useAdminUsers
 } from "@better-auth-ui/react/plugins/admin"
+import { useDebouncedValue } from "@tanstack/react-pacer"
 import { keepPreviousData, useMutation } from "@tanstack/react-query"
-import {
-  type ColumnFiltersState,
-  functionalUpdate,
-  type PaginationState,
-  type SortingState,
-  type Updater
-} from "@tanstack/react-table"
+import type { SortingState } from "@tanstack/react-table"
 import type { BetterFetchError } from "better-auth/react"
 import {
   BanIcon,
@@ -51,13 +47,7 @@ import {
   Trash2Icon,
   UserPlusIcon
 } from "lucide-react"
-import {
-  type FormEvent,
-  useDeferredValue,
-  useEffect,
-  useMemo,
-  useState
-} from "react"
+import { type FormEvent, useEffect, useMemo, useState } from "react"
 import { UserAvatar } from "@/components/auth/user/user-avatar"
 import {
   AlertDialog,
@@ -123,6 +113,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { adminPlugin } from "@/lib/auth/admin-plugin"
 import { getAuthAdditionalFieldValidators, useAuthForm } from "../auth-form"
+import { useServerTableState } from "../server-table-state"
 
 import { createAdminColumnHelper, useAdminTable } from "./admin-table"
 
@@ -188,6 +179,7 @@ const adminColumns = adminColumnHelper.columns([
   })
 ])
 const EMPTY_USERS: AdminUser[] = []
+const INITIAL_ADMIN_SORTING: SortingState = [{ id: "createdAt", desc: true }]
 
 /** Server-paginated user management with optional controlled inspector state. */
 export function AdminUsers({
@@ -199,22 +191,19 @@ export function AdminUsers({
   const config = useAuthPlugin(adminPlugin)
   const { localization } = config
   const [localSelectedUserId, setLocalSelectedUserId] = useState<string>()
-  const [globalFilter, setGlobalFilterState] = useState("")
-  const [columnFilters, setColumnFiltersState] = useState<ColumnFiltersState>(
-    []
-  )
-  const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: 0,
+  const tableState = useServerTableState({
+    initialSorting: INITIAL_ADMIN_SORTING,
     pageSize: config.pageSize
   })
-  const [sorting, setSortingState] = useState<SortingState>([
-    { id: "createdAt", desc: true }
-  ])
+  const { columnFilters, globalFilter, pagination, setPagination, sorting } =
+    tableState
   const [searchField, setSearchField] = useState<SearchField>("email")
   const [searchOperator, setSearchOperator] =
     useState<SearchOperator>("contains")
   const [createOpen, setCreateOpen] = useState(false)
-  const deferredSearch = useDeferredValue(globalFilter.trim())
+  const [debouncedSearch] = useDebouncedValue(globalFilter.trim(), {
+    wait: DEFAULT_TABLE_SEARCH_DEBOUNCE_MS
+  })
   const status = String(
     columnFilters.find((filter) => filter.id === "status")?.value ?? "all"
   ) as StatusFilter
@@ -237,7 +226,7 @@ export function AdminUsers({
       offset: pagination.pageIndex * pagination.pageSize,
       searchField,
       searchOperator,
-      searchValue: deferredSearch || undefined,
+      searchValue: debouncedSearch || undefined,
       sortBy,
       sortDirection,
       ...(status === "all"
@@ -249,7 +238,7 @@ export function AdminUsers({
           })
     }),
     [
-      deferredSearch,
+      debouncedSearch,
       pagination.pageIndex,
       pagination.pageSize,
       searchField,
@@ -278,36 +267,24 @@ export function AdminUsers({
       total
     )
     if (pageIndex !== pagination.pageIndex) {
-      setPaginationState((current) => ({ ...current, pageIndex }))
+      setPagination((current) => ({ ...current, pageIndex }))
     }
-  }, [pagination.pageIndex, pagination.pageSize, total, users.isSuccess])
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
-    setColumnFiltersState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setGlobalFilter = (updater: Updater<string>) => {
-    setGlobalFilterState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setSorting = (updater: Updater<SortingState>) => {
-    setSortingState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
+  }, [
+    pagination.pageIndex,
+    pagination.pageSize,
+    setPagination,
+    total,
+    users.isSuccess
+  ])
   const table = useAdminTable({
+    atoms: tableState.atoms,
     columns: adminColumns,
     data: users.data?.users ?? EMPTY_USERS,
     getRowId: (user) => user.id,
     manualFiltering: true,
     manualPagination: true,
     manualSorting: true,
-    rowCount: total,
-    state: { columnFilters, globalFilter, pagination, sorting },
-    onColumnFiltersChange: setColumnFilters,
-    onGlobalFilterChange: setGlobalFilter,
-    onPaginationChange: setPagination,
-    onSortingChange: setSorting
+    rowCount: total
   })
   const from = total ? pagination.pageIndex * pagination.pageSize + 1 : 0
   const to = Math.min(total, (pagination.pageIndex + 1) * pagination.pageSize)

--- a/apps/docs/src/components/auth/api-key/api-keys.tsx
+++ b/apps/docs/src/components/auth/api-key/api-keys.tsx
@@ -9,13 +9,10 @@ import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useListApiKeys } from "@better-auth-ui/react/plugins/api-key"
 import {
   createTableHook,
-  functionalUpdate,
-  type PaginationState,
   rowPaginationFeature,
   rowSortingFeature,
   type SortingState,
-  tableFeatures,
-  type Updater
+  tableFeatures
 } from "@tanstack/react-table"
 import { Fragment, useEffect, useMemo, useState } from "react"
 
@@ -31,6 +28,7 @@ import {
 } from "@/components/ui/select"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
 import { cn } from "@/lib/utils"
+import { useServerTableState } from "../server-table-state"
 import { ApiKey } from "./api-key"
 import { ApiKeySkeleton } from "./api-key-skeleton"
 import { ApiKeysEmpty } from "./api-keys-empty"
@@ -49,6 +47,7 @@ const apiKeyColumns = apiKeyColumnHelper.columns([
   apiKeyColumnHelper.accessor("name", { id: "name" })
 ])
 const EMPTY_API_KEYS: ListedApiKey[] = []
+const INITIAL_API_KEY_SORTING: SortingState = [{ id: "createdAt", desc: true }]
 
 export type ApiKeysProps = {
   className?: string
@@ -75,13 +74,11 @@ export function ApiKeys({
   const { authClient } = useAuth<ApiKeyAuthClient>()
   const { localization: apiKeyLocalization, pageSize } =
     useAuthPlugin(apiKeyPlugin)
-  const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: 0,
+  const tableState = useServerTableState({
+    initialSorting: INITIAL_API_KEY_SORTING,
     pageSize
   })
-  const [sorting, setSortingState] = useState<SortingState>([
-    { id: "createdAt", desc: true }
-  ])
+  const { pagination, setPagination, sorting } = tableState
   const primarySort = sorting[0]
   const sortBy = primarySort?.id === "name" ? "name" : "createdAt"
   const sortDirection = primarySort?.desc ? "desc" : "asc"
@@ -111,13 +108,6 @@ export function ApiKeys({
       ),
     [listData?.apiKeys, pagination.pageSize]
   )
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setSorting = (updater: Updater<SortingState>) => {
-    setSortingState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-
   useEffect(() => {
     if (
       isListSuccess &&
@@ -125,22 +115,27 @@ export function ApiKeys({
       pagination.pageIndex > 0 &&
       page.rows.length === 0
     ) {
-      setPaginationState((current) => ({
+      setPagination((current) => ({
         ...current,
         pageIndex: Math.max(0, current.pageIndex - 1)
       }))
     }
-  }, [isListSuccess, isPendingProp, page.rows.length, pagination.pageIndex])
+  }, [
+    isListSuccess,
+    isPendingProp,
+    page.rows.length,
+    pagination.pageIndex,
+    setPagination
+  ])
 
   const table = useApiKeyTable({
+    atoms: tableState.atoms,
     columns: apiKeyColumns,
     data: page.rows,
     getRowId: (apiKey) => apiKey.id,
     manualPagination: true,
-    manualSorting: true,
-    state: { pagination, sorting },
-    onPaginationChange: setPagination,
-    onSortingChange: setSorting
+    pageCount: -1,
+    manualSorting: true
   })
 
   const [createOpen, setCreateOpen] = useState(false)

--- a/apps/docs/src/components/auth/auth-form.tsx
+++ b/apps/docs/src/components/auth/auth-form.tsx
@@ -90,6 +90,7 @@ export function setAuthFormServerError(
 }
 
 export function clearAuthFormServerError(form: AnyFormApi) {
+  if (!form.state.errorMap.onServer) return
   form.setErrorMap({ onServer: undefined })
 }
 
@@ -134,6 +135,7 @@ type AuthFormRootProps = Omit<ComponentProps<"form">, "onSubmit"> & {
 function AuthFormRoot({
   children,
   onBeforeSubmit,
+  onInput,
   serverErrorMessage = DEFAULT_AUTH_FORM_SERVER_ERROR,
   ...props
 }: AuthFormRootProps) {
@@ -161,6 +163,10 @@ function AuthFormRoot({
       onInvalid={(event) =>
         focusFirstInvalidAuthFormControl(event.currentTarget)
       }
+      onInput={(event) => {
+        clearAuthFormServerError(form)
+        onInput?.(event)
+      }}
       onSubmit={submit}
     >
       {children}
@@ -183,6 +189,7 @@ function AuthFormTextField({
   ...props
 }: AuthFormTextFieldProps) {
   const field = useFieldContext<string>()
+  const form = useFormContext()
   const isInvalid = isAuthFormFieldInvalid(field.state.meta)
   const inputId = id ?? field.name
 
@@ -191,11 +198,15 @@ function AuthFormTextField({
       <FieldLabel htmlFor={inputId}>{label}</FieldLabel>
       <Input
         {...props}
+        aria-busy={field.state.meta.isValidating || undefined}
         aria-invalid={isInvalid}
         id={inputId}
         name={field.name}
         onBlur={field.handleBlur}
-        onChange={(event) => field.handleChange(event.target.value)}
+        onChange={(event) => {
+          clearAuthFormServerError(form)
+          field.handleChange(event.target.value)
+        }}
         value={field.state.value}
       />
       {description ? <FieldDescription>{description}</FieldDescription> : null}
@@ -213,13 +224,13 @@ function AuthFormSubmitButton({
 
   return (
     <form.Subscribe
-      selector={(state) => [state.canSubmit, state.isSubmitting] as const}
+      selector={(state) => [state.isSubmitting, state.isValidating] as const}
     >
-      {([canSubmit, isSubmitting]) => (
+      {([isSubmitting, isValidating]) => (
         <Button
           {...props}
-          aria-disabled={disabled || !canSubmit || isSubmitting || undefined}
-          disabled={disabled || isSubmitting}
+          aria-disabled={disabled || isSubmitting || isValidating || undefined}
+          disabled={disabled || isSubmitting || isValidating}
           type="submit"
         >
           {isSubmitting ? <Spinner data-icon="inline-start" /> : null}
@@ -237,6 +248,7 @@ type AuthFormAdditionalFieldProps = Omit<
 
 function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   const field = useFieldContext<AdditionalFieldFormValue>()
+  const form = useFormContext()
   const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
   return (
@@ -248,18 +260,16 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
       isInvalid={isInvalid}
       name={field.name}
       onBlur={field.handleBlur}
-      onChange={field.handleChange}
+      onChange={(value) => {
+        clearAuthFormServerError(form)
+        field.handleChange(value)
+      }}
       value={field.state.value}
     />
   )
 }
 
-export const {
-  useAppForm: useAuthForm,
-  useTypedAppFormContext: useTypedAuthFormContext,
-  withFieldGroup: withAuthFieldGroup,
-  withForm: withAuthForm
-} = createFormHook({
+export const { useAppForm: useAuthForm } = createFormHook({
   fieldComponents: {
     AuthFormAdditionalField,
     AuthFormFieldError,

--- a/apps/docs/src/components/auth/dash/activity.tsx
+++ b/apps/docs/src/components/auth/dash/activity.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import { getClampedTablePageIndex } from "@better-auth-ui/core"
+import {
+  DEFAULT_TABLE_SEARCH_DEBOUNCE_MS,
+  getClampedTablePageIndex
+} from "@better-auth-ui/core"
 import {
   type DashAuditLog,
   type DashAuthClient,
@@ -20,17 +23,14 @@ import {
   useDashUserAuditLogs
 } from "@better-auth-ui/react/plugins/dash"
 import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
+import { useDebouncedValue } from "@tanstack/react-pacer"
 import { keepPreviousData } from "@tanstack/react-query"
 import {
-  type ColumnFiltersState,
   columnFilteringFeature,
   createTableHook,
-  functionalUpdate,
   globalFilteringFeature,
-  type PaginationState,
   rowPaginationFeature,
-  tableFeatures,
-  type Updater
+  tableFeatures
 } from "@tanstack/react-table"
 import {
   Activity,
@@ -43,7 +43,7 @@ import {
   UserRound,
   Users
 } from "lucide-react"
-import { Fragment, useDeferredValue, useEffect, useMemo, useState } from "react"
+import { Fragment, useEffect, useMemo } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -83,6 +83,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { dashPlugin } from "@/lib/auth/dash-plugin"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
+import { useServerTableState } from "../server-table-state"
 
 type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
 
@@ -238,18 +239,14 @@ function ActivityFeed({
 }: ActivityFeedProps) {
   const { authClient } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
-  const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: 0,
-    pageSize
-  })
-  const [columnFilters, setColumnFiltersState] = useState<ColumnFiltersState>(
-    []
-  )
-  const [globalFilter, setGlobalFilterState] = useState("")
+  const tableState = useServerTableState({ pageSize })
+  const { columnFilters, globalFilter, pagination, setPagination } = tableState
   const eventType = String(
     columnFilters.find((filter) => filter.id === "eventType")?.value ?? "all"
   )
-  const deferredIdentifier = useDeferredValue(globalFilter.trim())
+  const [debouncedIdentifier] = useDebouncedValue(globalFilter.trim(), {
+    wait: DEFAULT_TABLE_SEARCH_DEBOUNCE_MS
+  })
   const eventOptions = useMemo(
     () => Object.entries(localization.eventLabels),
     [localization.eventLabels]
@@ -257,7 +254,7 @@ function ActivityFeed({
   const offset = pagination.pageIndex * pagination.pageSize
   const params = {
     eventType: eventType === "all" ? undefined : eventType,
-    identifier: deferredIdentifier || undefined,
+    identifier: debouncedIdentifier || undefined,
     limit: pagination.pageSize,
     offset,
     organizationId
@@ -303,36 +300,24 @@ function ActivityFeed({
       data?.total ?? 0
     )
     if (pageIndex !== pagination.pageIndex) {
-      setPaginationState((current) => ({ ...current, pageIndex }))
+      setPagination((current) => ({ ...current, pageIndex }))
     }
   }, [
     data?.total,
     pagination.pageIndex,
     pagination.pageSize,
     query.isSuccess,
-    ready
+    ready,
+    setPagination
   ])
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
-    setColumnFiltersState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setGlobalFilter = (updater: Updater<string>) => {
-    setGlobalFilterState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
   const table = useActivityTable({
+    atoms: tableState.atoms,
     columns: activityColumns,
     data: data?.events ?? EMPTY_EVENTS,
     getRowId: getDashEventKey,
     manualFiltering: true,
     manualPagination: true,
-    rowCount: data?.total ?? 0,
-    state: { columnFilters, globalFilter, pagination },
-    onColumnFiltersChange: setColumnFilters,
-    onGlobalFilterChange: setGlobalFilter,
-    onPaginationChange: setPagination
+    rowCount: data?.total ?? 0
   })
 
   return (

--- a/apps/docs/src/components/auth/organization/organization-sortable-table-head.tsx
+++ b/apps/docs/src/components/auth/organization/organization-sortable-table-head.tsx
@@ -1,63 +1,65 @@
 "use client"
 
+import { type Column, type RowData, Subscribe } from "@tanstack/react-table"
 import { ChevronUp } from "lucide-react"
 import type { MouseEvent, ReactNode } from "react"
 
 import { Button } from "@/components/ui/button"
 import { TableHead } from "@/components/ui/table"
 import { cn } from "@/lib/utils"
+import type { organizationTableFeatures } from "./organization-table"
 
-type SortableColumn = {
-  getIsSorted: () => false | "asc" | "desc"
-  getSortIndex: () => number
-  getToggleSortingHandler: () => undefined | ((event: unknown) => void)
-}
-
-export function OrganizationSortableTableHead({
+export function OrganizationSortableTableHead<TData extends RowData>({
   children,
   column
 }: {
   children: ReactNode
-  column?: SortableColumn
+  column?: Column<typeof organizationTableFeatures, TData>
 }) {
   if (!column) return <TableHead>{children}</TableHead>
 
-  const sortDirection = column.getIsSorted()
   const onClick = column.getToggleSortingHandler()
 
   return (
-    <TableHead
-      aria-sort={
-        sortDirection === "asc"
-          ? "ascending"
-          : sortDirection === "desc"
-            ? "descending"
-            : "none"
-      }
+    <Subscribe
+      source={column.table.atoms.sorting}
+      selector={() => [column.getIsSorted(), column.getSortIndex()] as const}
     >
-      <Button
-        className="h-auto w-full justify-start p-0 font-medium hover:bg-transparent"
-        onClick={(event: MouseEvent<HTMLButtonElement>) => onClick?.(event)}
-        size="sm"
-        type="button"
-        variant="ghost"
-      >
-        {children}
+      {([sortDirection, sortIndex]) => (
+        <TableHead
+          aria-sort={
+            sortDirection === "asc"
+              ? "ascending"
+              : sortDirection === "desc"
+                ? "descending"
+                : "none"
+          }
+        >
+          <Button
+            className="h-auto w-full justify-start p-0 font-medium hover:bg-transparent"
+            onClick={(event: MouseEvent<HTMLButtonElement>) => onClick?.(event)}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            {children}
 
-        {sortDirection && (
-          <>
-            <ChevronUp
-              className={cn(
-                "size-3 transition-transform duration-100 ease-out",
-                sortDirection === "desc" && "rotate-180"
-              )}
-            />
-            <span className="text-muted-foreground text-[10px] tabular-nums">
-              {column.getSortIndex() + 1}
-            </span>
-          </>
-        )}
-      </Button>
-    </TableHead>
+            {sortDirection ? (
+              <>
+                <ChevronUp
+                  className={cn(
+                    "size-3 transition-transform duration-100 ease-out",
+                    sortDirection === "desc" && "rotate-180"
+                  )}
+                />
+                <span className="text-muted-foreground text-[10px] tabular-nums">
+                  {sortIndex + 1}
+                </span>
+              </>
+            ) : null}
+          </Button>
+        </TableHead>
+      )}
+    </Subscribe>
   )
 }

--- a/apps/docs/src/components/auth/server-table-state.ts
+++ b/apps/docs/src/components/auth/server-table-state.ts
@@ -1,0 +1,74 @@
+"use client"
+
+import { useCreateAtom, useSelector } from "@tanstack/react-store"
+import {
+  type ColumnFiltersState,
+  functionalUpdate,
+  type PaginationState,
+  type SortingState,
+  type Updater
+} from "@tanstack/react-table"
+import { useCallback, useEffect, useMemo } from "react"
+
+export function useServerTableState({
+  initialSorting = [],
+  pageSize
+}: {
+  initialSorting?: SortingState
+  pageSize: number
+}) {
+  const columnFiltersAtom = useCreateAtom<ColumnFiltersState>([])
+  const globalFilterAtom = useCreateAtom("")
+  const paginationAtom = useCreateAtom<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const sortingAtom = useCreateAtom<SortingState>(initialSorting)
+  const columnFilters = useSelector(columnFiltersAtom)
+  const globalFilter = useSelector(globalFilterAtom)
+  const pagination = useSelector(paginationAtom)
+  const sorting = useSelector(sortingAtom)
+  const atoms = useMemo(
+    () => ({
+      columnFilters: columnFiltersAtom,
+      globalFilter: globalFilterAtom,
+      pagination: paginationAtom,
+      sorting: sortingAtom
+    }),
+    [columnFiltersAtom, globalFilterAtom, paginationAtom, sortingAtom]
+  )
+
+  useEffect(() => {
+    const resetPage = () => {
+      const current = paginationAtom.get()
+      if (current.pageIndex !== 0) {
+        paginationAtom.set({ ...current, pageIndex: 0 })
+      }
+    }
+    const subscriptions = [
+      columnFiltersAtom.subscribe(resetPage),
+      globalFilterAtom.subscribe(resetPage),
+      sortingAtom.subscribe(resetPage)
+    ]
+
+    return () => {
+      for (const subscription of subscriptions) subscription.unsubscribe()
+    }
+  }, [columnFiltersAtom, globalFilterAtom, paginationAtom, sortingAtom])
+
+  const setPagination = useCallback(
+    (updater: Updater<PaginationState>) => {
+      paginationAtom.set((current) => functionalUpdate(updater, current))
+    },
+    [paginationAtom]
+  )
+
+  return {
+    atoms,
+    columnFilters,
+    globalFilter,
+    pagination,
+    setPagination,
+    sorting
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -400,6 +400,7 @@
         "@solid-primitives/debounce": "^1.3.0",
         "@solidjs-email/main": "^2.0.0",
         "@tanstack/solid-form": "^1.33.5",
+        "@tanstack/solid-pacer": "^0.22.0",
         "@tanstack/solid-query": "^5.101.2",
         "@tanstack/solid-router": "^1.170.21",
         "@tanstack/solid-start": "^1.168.37",
@@ -1796,6 +1797,8 @@
     "@tanstack/router-utils": ["@tanstack/router-utils@1.162.2", "", { "dependencies": { "@babel/generator": "^7.28.5", "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "ansis": "^4.1.0", "babel-dead-code-elimination": "^1.0.12", "diff": "^8.0.2", "pathe": "^2.0.3", "tinyglobby": "^0.2.15" } }, "sha512-hTWqJtqIFFdvuCl8WXNyrodp2L9zo2G37xKRrcVmVRWpAB2h+U1LuRAfS4tsFTiWOIoE/B+WDVFB8JpoEdw6jQ=="],
 
     "@tanstack/solid-form": ["@tanstack/solid-form@1.33.5", "", { "dependencies": { "@tanstack/form-core": "1.33.5", "@tanstack/solid-store": "^0.11.0" }, "peerDependencies": { "solid-js": ">=1.9.9" } }, "sha512-azYHYzNwop64bedJRKgjCpi5w9cHu7cNz+dAdSXzaqy9M6JO+GlKNQn54VFhCLYJo45sgNjcdrnz4eyTmgzJ/w=="],
+
+    "@tanstack/solid-pacer": ["@tanstack/solid-pacer@0.22.0", "", { "dependencies": { "@tanstack/pacer": "0.22.0", "@tanstack/solid-store": "^0.11.1" }, "peerDependencies": { "solid-js": ">=1.9.5" } }, "sha512-ksaEPdz67DJHkyHIbQxJPAqDxPhT+eU29J0Bf73Ehh26RYo+GaQvwxn95C4nEQRJoR26hEid+Tt8/yoCjqtqOg=="],
 
     "@tanstack/solid-query": ["@tanstack/solid-query@5.101.4", "", { "dependencies": { "@tanstack/query-core": "5.101.4" }, "peerDependencies": { "solid-js": "^1.6.0" } }, "sha512-w+QNX4al4zkfOfO6FYILouPX3yAxLANvBNz0cZqaBrSRKfBP3qNC179wu/eS2w1asH+QqEeI0rR2/s7gRGxnFA=="],
 

--- a/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import {
+  DEFAULT_TABLE_SEARCH_DEBOUNCE_MS,
   fieldsWithModelValues,
   getAdditionalFieldDefaultValues,
   getAdditionalFieldSubmitValues,
@@ -29,14 +30,9 @@ import {
   useAdminUserSessions,
   useAdminUsers
 } from "@better-auth-ui/react/plugins/admin"
+import { useDebouncedValue } from "@tanstack/react-pacer"
 import { keepPreviousData, useMutation } from "@tanstack/react-query"
-import {
-  type ColumnFiltersState,
-  functionalUpdate,
-  type PaginationState,
-  type SortingState,
-  type Updater
-} from "@tanstack/react-table"
+import type { SortingState } from "@tanstack/react-table"
 import type { BetterFetchError } from "better-auth/react"
 import {
   BanIcon,
@@ -51,13 +47,7 @@ import {
   Trash2Icon,
   UserPlusIcon
 } from "lucide-react"
-import {
-  type FormEvent,
-  useDeferredValue,
-  useEffect,
-  useMemo,
-  useState
-} from "react"
+import { type FormEvent, useEffect, useMemo, useState } from "react"
 import { UserAvatar } from "@/components/auth/user/user-avatar"
 import {
   AlertDialog,
@@ -123,6 +113,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { adminPlugin } from "@/lib/auth/admin-plugin"
 import { getAuthAdditionalFieldValidators, useAuthForm } from "../auth-form"
+import { useServerTableState } from "../server-table-state"
 
 import { createAdminColumnHelper, useAdminTable } from "./admin-table"
 
@@ -188,6 +179,7 @@ const adminColumns = adminColumnHelper.columns([
   })
 ])
 const EMPTY_USERS: AdminUser[] = []
+const INITIAL_ADMIN_SORTING: SortingState = [{ id: "createdAt", desc: true }]
 
 /** Server-paginated user management with optional controlled inspector state. */
 export function AdminUsers({
@@ -199,22 +191,19 @@ export function AdminUsers({
   const config = useAuthPlugin(adminPlugin)
   const { localization } = config
   const [localSelectedUserId, setLocalSelectedUserId] = useState<string>()
-  const [globalFilter, setGlobalFilterState] = useState("")
-  const [columnFilters, setColumnFiltersState] = useState<ColumnFiltersState>(
-    []
-  )
-  const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: 0,
+  const tableState = useServerTableState({
+    initialSorting: INITIAL_ADMIN_SORTING,
     pageSize: config.pageSize
   })
-  const [sorting, setSortingState] = useState<SortingState>([
-    { id: "createdAt", desc: true }
-  ])
+  const { columnFilters, globalFilter, pagination, setPagination, sorting } =
+    tableState
   const [searchField, setSearchField] = useState<SearchField>("email")
   const [searchOperator, setSearchOperator] =
     useState<SearchOperator>("contains")
   const [createOpen, setCreateOpen] = useState(false)
-  const deferredSearch = useDeferredValue(globalFilter.trim())
+  const [debouncedSearch] = useDebouncedValue(globalFilter.trim(), {
+    wait: DEFAULT_TABLE_SEARCH_DEBOUNCE_MS
+  })
   const status = String(
     columnFilters.find((filter) => filter.id === "status")?.value ?? "all"
   ) as StatusFilter
@@ -237,7 +226,7 @@ export function AdminUsers({
       offset: pagination.pageIndex * pagination.pageSize,
       searchField,
       searchOperator,
-      searchValue: deferredSearch || undefined,
+      searchValue: debouncedSearch || undefined,
       sortBy,
       sortDirection,
       ...(status === "all"
@@ -249,7 +238,7 @@ export function AdminUsers({
           })
     }),
     [
-      deferredSearch,
+      debouncedSearch,
       pagination.pageIndex,
       pagination.pageSize,
       searchField,
@@ -278,36 +267,24 @@ export function AdminUsers({
       total
     )
     if (pageIndex !== pagination.pageIndex) {
-      setPaginationState((current) => ({ ...current, pageIndex }))
+      setPagination((current) => ({ ...current, pageIndex }))
     }
-  }, [pagination.pageIndex, pagination.pageSize, total, users.isSuccess])
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
-    setColumnFiltersState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setGlobalFilter = (updater: Updater<string>) => {
-    setGlobalFilterState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setSorting = (updater: Updater<SortingState>) => {
-    setSortingState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
+  }, [
+    pagination.pageIndex,
+    pagination.pageSize,
+    setPagination,
+    total,
+    users.isSuccess
+  ])
   const table = useAdminTable({
+    atoms: tableState.atoms,
     columns: adminColumns,
     data: users.data?.users ?? EMPTY_USERS,
     getRowId: (user) => user.id,
     manualFiltering: true,
     manualPagination: true,
     manualSorting: true,
-    rowCount: total,
-    state: { columnFilters, globalFilter, pagination, sorting },
-    onColumnFiltersChange: setColumnFilters,
-    onGlobalFilterChange: setGlobalFilter,
-    onPaginationChange: setPagination,
-    onSortingChange: setSorting
+    rowCount: total
   })
   const from = total ? pagination.pageIndex * pagination.pageSize + 1 : 0
   const to = Math.min(total, (pagination.pageIndex + 1) * pagination.pageSize)

--- a/examples/next-shadcn-example/src/components/auth/api-key/api-keys.tsx
+++ b/examples/next-shadcn-example/src/components/auth/api-key/api-keys.tsx
@@ -9,13 +9,10 @@ import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useListApiKeys } from "@better-auth-ui/react/plugins/api-key"
 import {
   createTableHook,
-  functionalUpdate,
-  type PaginationState,
   rowPaginationFeature,
   rowSortingFeature,
   type SortingState,
-  tableFeatures,
-  type Updater
+  tableFeatures
 } from "@tanstack/react-table"
 import { Fragment, useEffect, useMemo, useState } from "react"
 
@@ -31,6 +28,7 @@ import {
 } from "@/components/ui/select"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
 import { cn } from "@/lib/utils"
+import { useServerTableState } from "../server-table-state"
 import { ApiKey } from "./api-key"
 import { ApiKeySkeleton } from "./api-key-skeleton"
 import { ApiKeysEmpty } from "./api-keys-empty"
@@ -49,6 +47,7 @@ const apiKeyColumns = apiKeyColumnHelper.columns([
   apiKeyColumnHelper.accessor("name", { id: "name" })
 ])
 const EMPTY_API_KEYS: ListedApiKey[] = []
+const INITIAL_API_KEY_SORTING: SortingState = [{ id: "createdAt", desc: true }]
 
 export type ApiKeysProps = {
   className?: string
@@ -75,13 +74,11 @@ export function ApiKeys({
   const { authClient } = useAuth<ApiKeyAuthClient>()
   const { localization: apiKeyLocalization, pageSize } =
     useAuthPlugin(apiKeyPlugin)
-  const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: 0,
+  const tableState = useServerTableState({
+    initialSorting: INITIAL_API_KEY_SORTING,
     pageSize
   })
-  const [sorting, setSortingState] = useState<SortingState>([
-    { id: "createdAt", desc: true }
-  ])
+  const { pagination, setPagination, sorting } = tableState
   const primarySort = sorting[0]
   const sortBy = primarySort?.id === "name" ? "name" : "createdAt"
   const sortDirection = primarySort?.desc ? "desc" : "asc"
@@ -111,13 +108,6 @@ export function ApiKeys({
       ),
     [listData?.apiKeys, pagination.pageSize]
   )
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setSorting = (updater: Updater<SortingState>) => {
-    setSortingState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-
   useEffect(() => {
     if (
       isListSuccess &&
@@ -125,22 +115,27 @@ export function ApiKeys({
       pagination.pageIndex > 0 &&
       page.rows.length === 0
     ) {
-      setPaginationState((current) => ({
+      setPagination((current) => ({
         ...current,
         pageIndex: Math.max(0, current.pageIndex - 1)
       }))
     }
-  }, [isListSuccess, isPendingProp, page.rows.length, pagination.pageIndex])
+  }, [
+    isListSuccess,
+    isPendingProp,
+    page.rows.length,
+    pagination.pageIndex,
+    setPagination
+  ])
 
   const table = useApiKeyTable({
+    atoms: tableState.atoms,
     columns: apiKeyColumns,
     data: page.rows,
     getRowId: (apiKey) => apiKey.id,
     manualPagination: true,
-    manualSorting: true,
-    state: { pagination, sorting },
-    onPaginationChange: setPagination,
-    onSortingChange: setSorting
+    pageCount: -1,
+    manualSorting: true
   })
 
   const [createOpen, setCreateOpen] = useState(false)

--- a/examples/next-shadcn-example/src/components/auth/auth-form.tsx
+++ b/examples/next-shadcn-example/src/components/auth/auth-form.tsx
@@ -90,6 +90,7 @@ export function setAuthFormServerError(
 }
 
 export function clearAuthFormServerError(form: AnyFormApi) {
+  if (!form.state.errorMap.onServer) return
   form.setErrorMap({ onServer: undefined })
 }
 
@@ -134,6 +135,7 @@ type AuthFormRootProps = Omit<ComponentProps<"form">, "onSubmit"> & {
 function AuthFormRoot({
   children,
   onBeforeSubmit,
+  onInput,
   serverErrorMessage = DEFAULT_AUTH_FORM_SERVER_ERROR,
   ...props
 }: AuthFormRootProps) {
@@ -161,6 +163,10 @@ function AuthFormRoot({
       onInvalid={(event) =>
         focusFirstInvalidAuthFormControl(event.currentTarget)
       }
+      onInput={(event) => {
+        clearAuthFormServerError(form)
+        onInput?.(event)
+      }}
       onSubmit={submit}
     >
       {children}
@@ -183,6 +189,7 @@ function AuthFormTextField({
   ...props
 }: AuthFormTextFieldProps) {
   const field = useFieldContext<string>()
+  const form = useFormContext()
   const isInvalid = isAuthFormFieldInvalid(field.state.meta)
   const inputId = id ?? field.name
 
@@ -191,11 +198,15 @@ function AuthFormTextField({
       <FieldLabel htmlFor={inputId}>{label}</FieldLabel>
       <Input
         {...props}
+        aria-busy={field.state.meta.isValidating || undefined}
         aria-invalid={isInvalid}
         id={inputId}
         name={field.name}
         onBlur={field.handleBlur}
-        onChange={(event) => field.handleChange(event.target.value)}
+        onChange={(event) => {
+          clearAuthFormServerError(form)
+          field.handleChange(event.target.value)
+        }}
         value={field.state.value}
       />
       {description ? <FieldDescription>{description}</FieldDescription> : null}
@@ -213,13 +224,13 @@ function AuthFormSubmitButton({
 
   return (
     <form.Subscribe
-      selector={(state) => [state.canSubmit, state.isSubmitting] as const}
+      selector={(state) => [state.isSubmitting, state.isValidating] as const}
     >
-      {([canSubmit, isSubmitting]) => (
+      {([isSubmitting, isValidating]) => (
         <Button
           {...props}
-          aria-disabled={disabled || !canSubmit || isSubmitting || undefined}
-          disabled={disabled || isSubmitting}
+          aria-disabled={disabled || isSubmitting || isValidating || undefined}
+          disabled={disabled || isSubmitting || isValidating}
           type="submit"
         >
           {isSubmitting ? <Spinner data-icon="inline-start" /> : null}
@@ -237,6 +248,7 @@ type AuthFormAdditionalFieldProps = Omit<
 
 function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   const field = useFieldContext<AdditionalFieldFormValue>()
+  const form = useFormContext()
   const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
   return (
@@ -248,18 +260,16 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
       isInvalid={isInvalid}
       name={field.name}
       onBlur={field.handleBlur}
-      onChange={field.handleChange}
+      onChange={(value) => {
+        clearAuthFormServerError(form)
+        field.handleChange(value)
+      }}
       value={field.state.value}
     />
   )
 }
 
-export const {
-  useAppForm: useAuthForm,
-  useTypedAppFormContext: useTypedAuthFormContext,
-  withFieldGroup: withAuthFieldGroup,
-  withForm: withAuthForm
-} = createFormHook({
+export const { useAppForm: useAuthForm } = createFormHook({
   fieldComponents: {
     AuthFormAdditionalField,
     AuthFormFieldError,

--- a/examples/next-shadcn-example/src/components/auth/dash/activity.tsx
+++ b/examples/next-shadcn-example/src/components/auth/dash/activity.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import { getClampedTablePageIndex } from "@better-auth-ui/core"
+import {
+  DEFAULT_TABLE_SEARCH_DEBOUNCE_MS,
+  getClampedTablePageIndex
+} from "@better-auth-ui/core"
 import {
   type DashAuditLog,
   type DashAuthClient,
@@ -20,17 +23,14 @@ import {
   useDashUserAuditLogs
 } from "@better-auth-ui/react/plugins/dash"
 import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
+import { useDebouncedValue } from "@tanstack/react-pacer"
 import { keepPreviousData } from "@tanstack/react-query"
 import {
-  type ColumnFiltersState,
   columnFilteringFeature,
   createTableHook,
-  functionalUpdate,
   globalFilteringFeature,
-  type PaginationState,
   rowPaginationFeature,
-  tableFeatures,
-  type Updater
+  tableFeatures
 } from "@tanstack/react-table"
 import {
   Activity,
@@ -43,7 +43,7 @@ import {
   UserRound,
   Users
 } from "lucide-react"
-import { Fragment, useDeferredValue, useEffect, useMemo, useState } from "react"
+import { Fragment, useEffect, useMemo } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -83,6 +83,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { dashPlugin } from "@/lib/auth/dash-plugin"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
+import { useServerTableState } from "../server-table-state"
 
 type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
 
@@ -238,18 +239,14 @@ function ActivityFeed({
 }: ActivityFeedProps) {
   const { authClient } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
-  const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: 0,
-    pageSize
-  })
-  const [columnFilters, setColumnFiltersState] = useState<ColumnFiltersState>(
-    []
-  )
-  const [globalFilter, setGlobalFilterState] = useState("")
+  const tableState = useServerTableState({ pageSize })
+  const { columnFilters, globalFilter, pagination, setPagination } = tableState
   const eventType = String(
     columnFilters.find((filter) => filter.id === "eventType")?.value ?? "all"
   )
-  const deferredIdentifier = useDeferredValue(globalFilter.trim())
+  const [debouncedIdentifier] = useDebouncedValue(globalFilter.trim(), {
+    wait: DEFAULT_TABLE_SEARCH_DEBOUNCE_MS
+  })
   const eventOptions = useMemo(
     () => Object.entries(localization.eventLabels),
     [localization.eventLabels]
@@ -257,7 +254,7 @@ function ActivityFeed({
   const offset = pagination.pageIndex * pagination.pageSize
   const params = {
     eventType: eventType === "all" ? undefined : eventType,
-    identifier: deferredIdentifier || undefined,
+    identifier: debouncedIdentifier || undefined,
     limit: pagination.pageSize,
     offset,
     organizationId
@@ -303,36 +300,24 @@ function ActivityFeed({
       data?.total ?? 0
     )
     if (pageIndex !== pagination.pageIndex) {
-      setPaginationState((current) => ({ ...current, pageIndex }))
+      setPagination((current) => ({ ...current, pageIndex }))
     }
   }, [
     data?.total,
     pagination.pageIndex,
     pagination.pageSize,
     query.isSuccess,
-    ready
+    ready,
+    setPagination
   ])
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
-    setColumnFiltersState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setGlobalFilter = (updater: Updater<string>) => {
-    setGlobalFilterState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
   const table = useActivityTable({
+    atoms: tableState.atoms,
     columns: activityColumns,
     data: data?.events ?? EMPTY_EVENTS,
     getRowId: getDashEventKey,
     manualFiltering: true,
     manualPagination: true,
-    rowCount: data?.total ?? 0,
-    state: { columnFilters, globalFilter, pagination },
-    onColumnFiltersChange: setColumnFilters,
-    onGlobalFilterChange: setGlobalFilter,
-    onPaginationChange: setPagination
+    rowCount: data?.total ?? 0
   })
 
   return (

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-sortable-table-head.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-sortable-table-head.tsx
@@ -1,63 +1,65 @@
 "use client"
 
+import { type Column, type RowData, Subscribe } from "@tanstack/react-table"
 import { ChevronUp } from "lucide-react"
 import type { MouseEvent, ReactNode } from "react"
 
 import { Button } from "@/components/ui/button"
 import { TableHead } from "@/components/ui/table"
 import { cn } from "@/lib/utils"
+import type { organizationTableFeatures } from "./organization-table"
 
-type SortableColumn = {
-  getIsSorted: () => false | "asc" | "desc"
-  getSortIndex: () => number
-  getToggleSortingHandler: () => undefined | ((event: unknown) => void)
-}
-
-export function OrganizationSortableTableHead({
+export function OrganizationSortableTableHead<TData extends RowData>({
   children,
   column
 }: {
   children: ReactNode
-  column?: SortableColumn
+  column?: Column<typeof organizationTableFeatures, TData>
 }) {
   if (!column) return <TableHead>{children}</TableHead>
 
-  const sortDirection = column.getIsSorted()
   const onClick = column.getToggleSortingHandler()
 
   return (
-    <TableHead
-      aria-sort={
-        sortDirection === "asc"
-          ? "ascending"
-          : sortDirection === "desc"
-            ? "descending"
-            : "none"
-      }
+    <Subscribe
+      source={column.table.atoms.sorting}
+      selector={() => [column.getIsSorted(), column.getSortIndex()] as const}
     >
-      <Button
-        className="h-auto w-full justify-start p-0 font-medium hover:bg-transparent"
-        onClick={(event: MouseEvent<HTMLButtonElement>) => onClick?.(event)}
-        size="sm"
-        type="button"
-        variant="ghost"
-      >
-        {children}
+      {([sortDirection, sortIndex]) => (
+        <TableHead
+          aria-sort={
+            sortDirection === "asc"
+              ? "ascending"
+              : sortDirection === "desc"
+                ? "descending"
+                : "none"
+          }
+        >
+          <Button
+            className="h-auto w-full justify-start p-0 font-medium hover:bg-transparent"
+            onClick={(event: MouseEvent<HTMLButtonElement>) => onClick?.(event)}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            {children}
 
-        {sortDirection && (
-          <>
-            <ChevronUp
-              className={cn(
-                "size-3 transition-transform duration-100 ease-out",
-                sortDirection === "desc" && "rotate-180"
-              )}
-            />
-            <span className="text-muted-foreground text-[10px] tabular-nums">
-              {column.getSortIndex() + 1}
-            </span>
-          </>
-        )}
-      </Button>
-    </TableHead>
+            {sortDirection ? (
+              <>
+                <ChevronUp
+                  className={cn(
+                    "size-3 transition-transform duration-100 ease-out",
+                    sortDirection === "desc" && "rotate-180"
+                  )}
+                />
+                <span className="text-muted-foreground text-[10px] tabular-nums">
+                  {sortIndex + 1}
+                </span>
+              </>
+            ) : null}
+          </Button>
+        </TableHead>
+      )}
+    </Subscribe>
   )
 }

--- a/examples/next-shadcn-example/src/components/auth/server-table-state.ts
+++ b/examples/next-shadcn-example/src/components/auth/server-table-state.ts
@@ -1,0 +1,74 @@
+"use client"
+
+import { useCreateAtom, useSelector } from "@tanstack/react-store"
+import {
+  type ColumnFiltersState,
+  functionalUpdate,
+  type PaginationState,
+  type SortingState,
+  type Updater
+} from "@tanstack/react-table"
+import { useCallback, useEffect, useMemo } from "react"
+
+export function useServerTableState({
+  initialSorting = [],
+  pageSize
+}: {
+  initialSorting?: SortingState
+  pageSize: number
+}) {
+  const columnFiltersAtom = useCreateAtom<ColumnFiltersState>([])
+  const globalFilterAtom = useCreateAtom("")
+  const paginationAtom = useCreateAtom<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const sortingAtom = useCreateAtom<SortingState>(initialSorting)
+  const columnFilters = useSelector(columnFiltersAtom)
+  const globalFilter = useSelector(globalFilterAtom)
+  const pagination = useSelector(paginationAtom)
+  const sorting = useSelector(sortingAtom)
+  const atoms = useMemo(
+    () => ({
+      columnFilters: columnFiltersAtom,
+      globalFilter: globalFilterAtom,
+      pagination: paginationAtom,
+      sorting: sortingAtom
+    }),
+    [columnFiltersAtom, globalFilterAtom, paginationAtom, sortingAtom]
+  )
+
+  useEffect(() => {
+    const resetPage = () => {
+      const current = paginationAtom.get()
+      if (current.pageIndex !== 0) {
+        paginationAtom.set({ ...current, pageIndex: 0 })
+      }
+    }
+    const subscriptions = [
+      columnFiltersAtom.subscribe(resetPage),
+      globalFilterAtom.subscribe(resetPage),
+      sortingAtom.subscribe(resetPage)
+    ]
+
+    return () => {
+      for (const subscription of subscriptions) subscription.unsubscribe()
+    }
+  }, [columnFiltersAtom, globalFilterAtom, paginationAtom, sortingAtom])
+
+  const setPagination = useCallback(
+    (updater: Updater<PaginationState>) => {
+      paginationAtom.set((current) => functionalUpdate(updater, current))
+    },
+    [paginationAtom]
+  )
+
+  return {
+    atoms,
+    columnFilters,
+    globalFilter,
+    pagination,
+    setPagination,
+    sorting
+  }
+}

--- a/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import {
+  DEFAULT_TABLE_SEARCH_DEBOUNCE_MS,
   fieldsWithModelValues,
   getAdditionalFieldDefaultValues,
   getAdditionalFieldSubmitValues,
@@ -29,14 +30,9 @@ import {
   useAdminUserSessions,
   useAdminUsers
 } from "@better-auth-ui/react/plugins/admin"
+import { useDebouncedValue } from "@tanstack/react-pacer"
 import { keepPreviousData, useMutation } from "@tanstack/react-query"
-import {
-  type ColumnFiltersState,
-  functionalUpdate,
-  type PaginationState,
-  type SortingState,
-  type Updater
-} from "@tanstack/react-table"
+import type { SortingState } from "@tanstack/react-table"
 import type { BetterFetchError } from "better-auth/react"
 import {
   BanIcon,
@@ -51,13 +47,7 @@ import {
   Trash2Icon,
   UserPlusIcon
 } from "lucide-react"
-import {
-  type FormEvent,
-  useDeferredValue,
-  useEffect,
-  useMemo,
-  useState
-} from "react"
+import { type FormEvent, useEffect, useMemo, useState } from "react"
 import { UserAvatar } from "@/components/auth/user/user-avatar"
 import {
   AlertDialog,
@@ -124,6 +114,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { adminPlugin } from "@/lib/auth/admin-plugin"
 import { getAuthAdditionalFieldValidators, useAuthForm } from "../auth-form"
+import { useServerTableState } from "../server-table-state"
 
 import { createAdminColumnHelper, useAdminTable } from "./admin-table"
 
@@ -189,6 +180,7 @@ const adminColumns = adminColumnHelper.columns([
   })
 ])
 const EMPTY_USERS: AdminUser[] = []
+const INITIAL_ADMIN_SORTING: SortingState = [{ id: "createdAt", desc: true }]
 
 /** Server-paginated user management with optional controlled inspector state. */
 export function AdminUsers({
@@ -200,22 +192,19 @@ export function AdminUsers({
   const config = useAuthPlugin(adminPlugin)
   const { localization } = config
   const [localSelectedUserId, setLocalSelectedUserId] = useState<string>()
-  const [globalFilter, setGlobalFilterState] = useState("")
-  const [columnFilters, setColumnFiltersState] = useState<ColumnFiltersState>(
-    []
-  )
-  const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: 0,
+  const tableState = useServerTableState({
+    initialSorting: INITIAL_ADMIN_SORTING,
     pageSize: config.pageSize
   })
-  const [sorting, setSortingState] = useState<SortingState>([
-    { id: "createdAt", desc: true }
-  ])
+  const { columnFilters, globalFilter, pagination, setPagination, sorting } =
+    tableState
   const [searchField, setSearchField] = useState<SearchField>("email")
   const [searchOperator, setSearchOperator] =
     useState<SearchOperator>("contains")
   const [createOpen, setCreateOpen] = useState(false)
-  const deferredSearch = useDeferredValue(globalFilter.trim())
+  const [debouncedSearch] = useDebouncedValue(globalFilter.trim(), {
+    wait: DEFAULT_TABLE_SEARCH_DEBOUNCE_MS
+  })
   const status = String(
     columnFilters.find((filter) => filter.id === "status")?.value ?? "all"
   ) as StatusFilter
@@ -252,7 +241,7 @@ export function AdminUsers({
       offset: pagination.pageIndex * pagination.pageSize,
       searchField,
       searchOperator,
-      searchValue: deferredSearch || undefined,
+      searchValue: debouncedSearch || undefined,
       sortBy,
       sortDirection,
       ...(status === "all"
@@ -264,7 +253,7 @@ export function AdminUsers({
           })
     }),
     [
-      deferredSearch,
+      debouncedSearch,
       pagination.pageIndex,
       pagination.pageSize,
       searchField,
@@ -293,36 +282,24 @@ export function AdminUsers({
       total
     )
     if (pageIndex !== pagination.pageIndex) {
-      setPaginationState((current) => ({ ...current, pageIndex }))
+      setPagination((current) => ({ ...current, pageIndex }))
     }
-  }, [pagination.pageIndex, pagination.pageSize, total, users.isSuccess])
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
-    setColumnFiltersState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setGlobalFilter = (updater: Updater<string>) => {
-    setGlobalFilterState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setSorting = (updater: Updater<SortingState>) => {
-    setSortingState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
+  }, [
+    pagination.pageIndex,
+    pagination.pageSize,
+    setPagination,
+    total,
+    users.isSuccess
+  ])
   const table = useAdminTable({
+    atoms: tableState.atoms,
     columns: adminColumns,
     data: users.data?.users ?? EMPTY_USERS,
     getRowId: (user) => user.id,
     manualFiltering: true,
     manualPagination: true,
     manualSorting: true,
-    rowCount: total,
-    state: { columnFilters, globalFilter, pagination, sorting },
-    onColumnFiltersChange: setColumnFilters,
-    onGlobalFilterChange: setGlobalFilter,
-    onPaginationChange: setPagination,
-    onSortingChange: setSorting
+    rowCount: total
   })
   const from = total ? pagination.pageIndex * pagination.pageSize + 1 : 0
   const to = Math.min(total, (pagination.pageIndex + 1) * pagination.pageSize)

--- a/examples/start-shadcn-baseui-example/src/components/auth/api-key/api-keys.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/api-key/api-keys.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { getLookaheadPage } from "@better-auth-ui/core"
 import type {
   ApiKeyAuthClient,
   ListedApiKey
@@ -8,15 +9,12 @@ import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useListApiKeys } from "@better-auth-ui/react/plugins/api-key"
 import {
   createTableHook,
-  functionalUpdate,
-  type PaginationState,
   rowPaginationFeature,
   rowSortingFeature,
   type SortingState,
-  tableFeatures,
-  type Updater
+  tableFeatures
 } from "@tanstack/react-table"
-import { Fragment, useState } from "react"
+import { Fragment, useEffect, useMemo, useState } from "react"
 
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
@@ -31,6 +29,7 @@ import {
 } from "@/components/ui/select"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
 import { cn } from "@/lib/utils"
+import { useServerTableState } from "../server-table-state"
 import { ApiKey } from "./api-key"
 import { ApiKeySkeleton } from "./api-key-skeleton"
 import { ApiKeysEmpty } from "./api-keys-empty"
@@ -49,6 +48,7 @@ const apiKeyColumns = apiKeyColumnHelper.columns([
   apiKeyColumnHelper.accessor("name", { id: "name" })
 ])
 const EMPTY_API_KEYS: ListedApiKey[] = []
+const INITIAL_API_KEY_SORTING: SortingState = [{ id: "createdAt", desc: true }]
 
 export type ApiKeysProps = {
   className?: string
@@ -75,13 +75,11 @@ export function ApiKeys({
   const { authClient } = useAuth<ApiKeyAuthClient>()
   const { localization: apiKeyLocalization, pageSize } =
     useAuthPlugin(apiKeyPlugin)
-  const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: 0,
+  const tableState = useServerTableState({
+    initialSorting: INITIAL_API_KEY_SORTING,
     pageSize
   })
-  const [sorting, setSortingState] = useState<SortingState>([
-    { id: "createdAt", desc: true }
-  ])
+  const { pagination, setPagination, sorting } = tableState
   const primarySort = sorting[0]
   const sortBy = primarySort?.id === "name" ? "name" : "createdAt"
   const sortDirection = primarySort?.desc ? "desc" : "asc"
@@ -93,36 +91,57 @@ export function ApiKeys({
     { label: apiKeyLocalization.nameDescending, value: "name:desc" }
   ]
 
-  const { data: listData, isPending: isListPending } = useListApiKeys(
-    authClient,
-    {
-      enabled: !isPendingProp,
-      query: {
-        limit: pagination.pageSize,
-        offset: pagination.pageIndex * pagination.pageSize,
-        sortBy,
-        sortDirection,
-        ...(organizationId ? { organizationId, configId: "organization" } : {})
-      }
+  const {
+    data: listData,
+    isPending: isListPending,
+    isSuccess: isListSuccess
+  } = useListApiKeys(authClient, {
+    enabled: !isPendingProp,
+    query: {
+      limit: pagination.pageSize + 1,
+      offset: pagination.pageIndex * pagination.pageSize,
+      sortBy,
+      sortDirection,
+      ...(organizationId ? { organizationId, configId: "organization" } : {})
     }
-  )
+  })
 
   const isPending = isPendingProp || isListPending
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setSorting = (updater: Updater<SortingState>) => {
-    setSortingState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
+  const page = useMemo(
+    () =>
+      getLookaheadPage(
+        listData?.apiKeys ?? EMPTY_API_KEYS,
+        pagination.pageSize
+      ),
+    [listData?.apiKeys, pagination.pageSize]
+  )
+  useEffect(() => {
+    if (
+      isListSuccess &&
+      !isPendingProp &&
+      pagination.pageIndex > 0 &&
+      page.rows.length === 0
+    ) {
+      setPagination((current) => ({
+        ...current,
+        pageIndex: Math.max(0, current.pageIndex - 1)
+      }))
+    }
+  }, [
+    isListSuccess,
+    isPendingProp,
+    page.rows.length,
+    pagination.pageIndex,
+    setPagination
+  ])
   const table = useApiKeyTable({
+    atoms: tableState.atoms,
     columns: apiKeyColumns,
-    data: listData?.apiKeys ?? EMPTY_API_KEYS,
+    data: page.rows,
     getRowId: (apiKey) => apiKey.id,
     manualPagination: true,
-    manualSorting: true,
-    state: { pagination, sorting },
-    onPaginationChange: setPagination,
-    onSortingChange: setSorting
+    pageCount: -1,
+    manualSorting: true
   })
 
   const [createOpen, setCreateOpen] = useState(false)
@@ -171,7 +190,7 @@ export function ApiKeys({
         <CardContent className="p-0">
           {isPending ? (
             <ApiKeySkeleton />
-          ) : !listData?.apiKeys.length ? (
+          ) : page.rows.length === 0 ? (
             <ApiKeysEmpty
               onCreatePress={() => setCreateOpen(true)}
               hideCreate={hideCreate}
@@ -193,8 +212,7 @@ export function ApiKeys({
           )}
         </CardContent>
       </Card>
-      {(pagination.pageIndex > 0 ||
-        (listData?.apiKeys.length ?? 0) === pagination.pageSize) && (
+      {(pagination.pageIndex > 0 || page.hasNextPage) && (
         <div className="flex justify-end gap-2">
           <Button
             variant="outline"
@@ -207,7 +225,7 @@ export function ApiKeys({
           <Button
             variant="outline"
             size="sm"
-            disabled={(listData?.apiKeys.length ?? 0) < pagination.pageSize}
+            disabled={!page.hasNextPage}
             onClick={() => table.nextPage()}
           >
             {apiKeyLocalization.nextPage}

--- a/examples/start-shadcn-baseui-example/src/components/auth/auth-form.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/auth-form.tsx
@@ -90,6 +90,7 @@ export function setAuthFormServerError(
 }
 
 export function clearAuthFormServerError(form: AnyFormApi) {
+  if (!form.state.errorMap.onServer) return
   form.setErrorMap({ onServer: undefined })
 }
 
@@ -134,6 +135,7 @@ type AuthFormRootProps = Omit<ComponentProps<"form">, "onSubmit"> & {
 function AuthFormRoot({
   children,
   onBeforeSubmit,
+  onInput,
   serverErrorMessage = DEFAULT_AUTH_FORM_SERVER_ERROR,
   ...props
 }: AuthFormRootProps) {
@@ -161,6 +163,10 @@ function AuthFormRoot({
       onInvalid={(event) =>
         focusFirstInvalidAuthFormControl(event.currentTarget)
       }
+      onInput={(event) => {
+        clearAuthFormServerError(form)
+        onInput?.(event)
+      }}
       onSubmit={submit}
     >
       {children}
@@ -183,6 +189,7 @@ function AuthFormTextField({
   ...props
 }: AuthFormTextFieldProps) {
   const field = useFieldContext<string>()
+  const form = useFormContext()
   const isInvalid = isAuthFormFieldInvalid(field.state.meta)
   const inputId = id ?? field.name
 
@@ -191,11 +198,15 @@ function AuthFormTextField({
       <FieldLabel htmlFor={inputId}>{label}</FieldLabel>
       <Input
         {...props}
+        aria-busy={field.state.meta.isValidating || undefined}
         aria-invalid={isInvalid}
         id={inputId}
         name={field.name}
         onBlur={field.handleBlur}
-        onChange={(event) => field.handleChange(event.target.value)}
+        onChange={(event) => {
+          clearAuthFormServerError(form)
+          field.handleChange(event.target.value)
+        }}
         value={field.state.value}
       />
       {description ? <FieldDescription>{description}</FieldDescription> : null}
@@ -213,13 +224,13 @@ function AuthFormSubmitButton({
 
   return (
     <form.Subscribe
-      selector={(state) => [state.canSubmit, state.isSubmitting] as const}
+      selector={(state) => [state.isSubmitting, state.isValidating] as const}
     >
-      {([canSubmit, isSubmitting]) => (
+      {([isSubmitting, isValidating]) => (
         <Button
           {...props}
-          aria-disabled={disabled || !canSubmit || isSubmitting || undefined}
-          disabled={disabled || isSubmitting}
+          aria-disabled={disabled || isSubmitting || isValidating || undefined}
+          disabled={disabled || isSubmitting || isValidating}
           type="submit"
         >
           {isSubmitting ? <Spinner data-icon="inline-start" /> : null}
@@ -237,6 +248,7 @@ type AuthFormAdditionalFieldProps = Omit<
 
 function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   const field = useFieldContext<AdditionalFieldFormValue>()
+  const form = useFormContext()
   const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
   return (
@@ -248,18 +260,16 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
       isInvalid={isInvalid}
       name={field.name}
       onBlur={field.handleBlur}
-      onChange={field.handleChange}
+      onChange={(value) => {
+        clearAuthFormServerError(form)
+        field.handleChange(value)
+      }}
       value={field.state.value}
     />
   )
 }
 
-export const {
-  useAppForm: useAuthForm,
-  useTypedAppFormContext: useTypedAuthFormContext,
-  withFieldGroup: withAuthFieldGroup,
-  withForm: withAuthForm
-} = createFormHook({
+export const { useAppForm: useAuthForm } = createFormHook({
   fieldComponents: {
     AuthFormAdditionalField,
     AuthFormFieldError,

--- a/examples/start-shadcn-baseui-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/dash/activity.tsx
@@ -1,6 +1,10 @@
 "use client"
 
 import {
+  DEFAULT_TABLE_SEARCH_DEBOUNCE_MS,
+  getClampedTablePageIndex
+} from "@better-auth-ui/core"
+import {
   type DashAuditLog,
   type DashAuthClient,
   formatDashEventName,
@@ -19,17 +23,14 @@ import {
   useDashUserAuditLogs
 } from "@better-auth-ui/react/plugins/dash"
 import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
+import { useDebouncedValue } from "@tanstack/react-pacer"
 import { keepPreviousData } from "@tanstack/react-query"
 import {
-  type ColumnFiltersState,
   columnFilteringFeature,
   createTableHook,
-  functionalUpdate,
   globalFilteringFeature,
-  type PaginationState,
   rowPaginationFeature,
-  tableFeatures,
-  type Updater
+  tableFeatures
 } from "@tanstack/react-table"
 import {
   Activity,
@@ -42,7 +43,7 @@ import {
   UserRound,
   Users
 } from "lucide-react"
-import { Fragment, useDeferredValue, useMemo, useState } from "react"
+import { Fragment, useEffect, useMemo } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -83,6 +84,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { dashPlugin } from "@/lib/auth/dash-plugin"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
+import { useServerTableState } from "../server-table-state"
 
 type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
 
@@ -238,18 +240,14 @@ function ActivityFeed({
 }: ActivityFeedProps) {
   const { authClient } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
-  const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: 0,
-    pageSize
-  })
-  const [columnFilters, setColumnFiltersState] = useState<ColumnFiltersState>(
-    []
-  )
-  const [globalFilter, setGlobalFilterState] = useState("")
+  const tableState = useServerTableState({ pageSize })
+  const { columnFilters, globalFilter, pagination, setPagination } = tableState
   const eventType = String(
     columnFilters.find((filter) => filter.id === "eventType")?.value ?? "all"
   )
-  const deferredIdentifier = useDeferredValue(globalFilter.trim())
+  const [debouncedIdentifier] = useDebouncedValue(globalFilter.trim(), {
+    wait: DEFAULT_TABLE_SEARCH_DEBOUNCE_MS
+  })
   const eventOptions = useMemo(
     () => Object.entries(localization.eventLabels),
     [localization.eventLabels]
@@ -261,7 +259,7 @@ function ActivityFeed({
   const offset = pagination.pageIndex * pagination.pageSize
   const params = {
     eventType: eventType === "all" ? undefined : eventType,
-    identifier: deferredIdentifier || undefined,
+    identifier: debouncedIdentifier || undefined,
     limit: pagination.pageSize,
     offset,
     organizationId
@@ -298,27 +296,32 @@ function ActivityFeed({
   const { data, error, isFetching, isPending } = query
   const showPending = !ready || isPending
   const pageEnd = offset + (data?.events.length ?? 0)
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
-    setColumnFiltersState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setGlobalFilter = (updater: Updater<string>) => {
-    setGlobalFilterState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
+  useEffect(() => {
+    if (!ready || !query.isSuccess) return
+    const pageIndex = getClampedTablePageIndex(
+      pagination.pageIndex,
+      pagination.pageSize,
+      data?.total ?? 0
+    )
+    if (pageIndex !== pagination.pageIndex) {
+      setPagination((current) => ({ ...current, pageIndex }))
+    }
+  }, [
+    data?.total,
+    pagination.pageIndex,
+    pagination.pageSize,
+    query.isSuccess,
+    ready,
+    setPagination
+  ])
   const table = useActivityTable({
+    atoms: tableState.atoms,
     columns: activityColumns,
     data: data?.events ?? EMPTY_EVENTS,
     getRowId: getDashEventKey,
     manualFiltering: true,
     manualPagination: true,
-    rowCount: data?.total ?? 0,
-    state: { columnFilters, globalFilter, pagination },
-    onColumnFiltersChange: setColumnFilters,
-    onGlobalFilterChange: setGlobalFilter,
-    onPaginationChange: setPagination
+    rowCount: data?.total ?? 0
   })
 
   return (

--- a/examples/start-shadcn-baseui-example/src/components/auth/oauth-provider/oauth-clients.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/oauth-provider/oauth-clients.tsx
@@ -511,11 +511,11 @@ export function OAuthClients({
               </DialogClose>
               <form.Subscribe
                 selector={(state) =>
-                  [state.canSubmit, state.isSubmitting] as const
+                  [state.isSubmitting, state.isValidating] as const
                 }
               >
-                {([canSubmit, isSubmitting]) => (
-                  <Button type="submit" disabled={!canSubmit || isSubmitting}>
+                {([isSubmitting, isValidating]) => (
+                  <Button type="submit" disabled={isSubmitting || isValidating}>
                     {isSubmitting && <Spinner />}
                     {editingClient
                       ? oauthLocalization.saveChanges

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-sortable-table-head.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-sortable-table-head.tsx
@@ -1,63 +1,65 @@
 "use client"
 
+import { type Column, type RowData, Subscribe } from "@tanstack/react-table"
 import { ChevronUp } from "lucide-react"
 import type { MouseEvent, ReactNode } from "react"
 
 import { Button } from "@/components/ui/button"
 import { TableHead } from "@/components/ui/table"
 import { cn } from "@/lib/utils"
+import type { organizationTableFeatures } from "./organization-table"
 
-type SortableColumn = {
-  getIsSorted: () => false | "asc" | "desc"
-  getSortIndex: () => number
-  getToggleSortingHandler: () => undefined | ((event: unknown) => void)
-}
-
-export function OrganizationSortableTableHead({
+export function OrganizationSortableTableHead<TData extends RowData>({
   children,
   column
 }: {
   children: ReactNode
-  column?: SortableColumn
+  column?: Column<typeof organizationTableFeatures, TData>
 }) {
   if (!column) return <TableHead>{children}</TableHead>
 
-  const sortDirection = column.getIsSorted()
   const onClick = column.getToggleSortingHandler()
 
   return (
-    <TableHead
-      aria-sort={
-        sortDirection === "asc"
-          ? "ascending"
-          : sortDirection === "desc"
-            ? "descending"
-            : "none"
-      }
+    <Subscribe
+      source={column.table.atoms.sorting}
+      selector={() => [column.getIsSorted(), column.getSortIndex()] as const}
     >
-      <Button
-        className="h-auto w-full justify-start p-0 font-medium hover:bg-transparent"
-        onClick={(event: MouseEvent<HTMLButtonElement>) => onClick?.(event)}
-        size="sm"
-        type="button"
-        variant="ghost"
-      >
-        {children}
+      {([sortDirection, sortIndex]) => (
+        <TableHead
+          aria-sort={
+            sortDirection === "asc"
+              ? "ascending"
+              : sortDirection === "desc"
+                ? "descending"
+                : "none"
+          }
+        >
+          <Button
+            className="h-auto w-full justify-start p-0 font-medium hover:bg-transparent"
+            onClick={(event: MouseEvent<HTMLButtonElement>) => onClick?.(event)}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            {children}
 
-        {sortDirection && (
-          <>
-            <ChevronUp
-              className={cn(
-                "size-3 transition-transform duration-100 ease-out",
-                sortDirection === "desc" && "rotate-180"
-              )}
-            />
-            <span className="text-muted-foreground text-[10px] tabular-nums">
-              {column.getSortIndex() + 1}
-            </span>
-          </>
-        )}
-      </Button>
-    </TableHead>
+            {sortDirection ? (
+              <>
+                <ChevronUp
+                  className={cn(
+                    "size-3 transition-transform duration-100 ease-out",
+                    sortDirection === "desc" && "rotate-180"
+                  )}
+                />
+                <span className="text-muted-foreground text-[10px] tabular-nums">
+                  {sortIndex + 1}
+                </span>
+              </>
+            ) : null}
+          </Button>
+        </TableHead>
+      )}
+    </Subscribe>
   )
 }

--- a/examples/start-shadcn-baseui-example/src/components/auth/server-table-state.ts
+++ b/examples/start-shadcn-baseui-example/src/components/auth/server-table-state.ts
@@ -1,0 +1,74 @@
+"use client"
+
+import { useCreateAtom, useSelector } from "@tanstack/react-store"
+import {
+  type ColumnFiltersState,
+  functionalUpdate,
+  type PaginationState,
+  type SortingState,
+  type Updater
+} from "@tanstack/react-table"
+import { useCallback, useEffect, useMemo } from "react"
+
+export function useServerTableState({
+  initialSorting = [],
+  pageSize
+}: {
+  initialSorting?: SortingState
+  pageSize: number
+}) {
+  const columnFiltersAtom = useCreateAtom<ColumnFiltersState>([])
+  const globalFilterAtom = useCreateAtom("")
+  const paginationAtom = useCreateAtom<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const sortingAtom = useCreateAtom<SortingState>(initialSorting)
+  const columnFilters = useSelector(columnFiltersAtom)
+  const globalFilter = useSelector(globalFilterAtom)
+  const pagination = useSelector(paginationAtom)
+  const sorting = useSelector(sortingAtom)
+  const atoms = useMemo(
+    () => ({
+      columnFilters: columnFiltersAtom,
+      globalFilter: globalFilterAtom,
+      pagination: paginationAtom,
+      sorting: sortingAtom
+    }),
+    [columnFiltersAtom, globalFilterAtom, paginationAtom, sortingAtom]
+  )
+
+  useEffect(() => {
+    const resetPage = () => {
+      const current = paginationAtom.get()
+      if (current.pageIndex !== 0) {
+        paginationAtom.set({ ...current, pageIndex: 0 })
+      }
+    }
+    const subscriptions = [
+      columnFiltersAtom.subscribe(resetPage),
+      globalFilterAtom.subscribe(resetPage),
+      sortingAtom.subscribe(resetPage)
+    ]
+
+    return () => {
+      for (const subscription of subscriptions) subscription.unsubscribe()
+    }
+  }, [columnFiltersAtom, globalFilterAtom, paginationAtom, sortingAtom])
+
+  const setPagination = useCallback(
+    (updater: Updater<PaginationState>) => {
+      paginationAtom.set((current) => functionalUpdate(updater, current))
+    },
+    [paginationAtom]
+  )
+
+  return {
+    atoms,
+    columnFilters,
+    globalFilter,
+    pagination,
+    setPagination,
+    sorting
+  }
+}

--- a/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import {
+  DEFAULT_TABLE_SEARCH_DEBOUNCE_MS,
   fieldsWithModelValues,
   getAdditionalFieldDefaultValues,
   getAdditionalFieldSubmitValues,
@@ -29,14 +30,9 @@ import {
   useAdminUserSessions,
   useAdminUsers
 } from "@better-auth-ui/react/plugins/admin"
+import { useDebouncedValue } from "@tanstack/react-pacer"
 import { keepPreviousData, useMutation } from "@tanstack/react-query"
-import {
-  type ColumnFiltersState,
-  functionalUpdate,
-  type PaginationState,
-  type SortingState,
-  type Updater
-} from "@tanstack/react-table"
+import type { SortingState } from "@tanstack/react-table"
 import type { BetterFetchError } from "better-auth/react"
 import {
   BanIcon,
@@ -51,13 +47,7 @@ import {
   Trash2Icon,
   UserPlusIcon
 } from "lucide-react"
-import {
-  type FormEvent,
-  useDeferredValue,
-  useEffect,
-  useMemo,
-  useState
-} from "react"
+import { type FormEvent, useEffect, useMemo, useState } from "react"
 import { UserAvatar } from "@/components/auth/user/user-avatar"
 import {
   AlertDialog,
@@ -123,6 +113,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { adminPlugin } from "@/lib/auth/admin-plugin"
 import { getAuthAdditionalFieldValidators, useAuthForm } from "../auth-form"
+import { useServerTableState } from "../server-table-state"
 
 import { createAdminColumnHelper, useAdminTable } from "./admin-table"
 
@@ -188,6 +179,7 @@ const adminColumns = adminColumnHelper.columns([
   })
 ])
 const EMPTY_USERS: AdminUser[] = []
+const INITIAL_ADMIN_SORTING: SortingState = [{ id: "createdAt", desc: true }]
 
 /** Server-paginated user management with optional controlled inspector state. */
 export function AdminUsers({
@@ -199,22 +191,19 @@ export function AdminUsers({
   const config = useAuthPlugin(adminPlugin)
   const { localization } = config
   const [localSelectedUserId, setLocalSelectedUserId] = useState<string>()
-  const [globalFilter, setGlobalFilterState] = useState("")
-  const [columnFilters, setColumnFiltersState] = useState<ColumnFiltersState>(
-    []
-  )
-  const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: 0,
+  const tableState = useServerTableState({
+    initialSorting: INITIAL_ADMIN_SORTING,
     pageSize: config.pageSize
   })
-  const [sorting, setSortingState] = useState<SortingState>([
-    { id: "createdAt", desc: true }
-  ])
+  const { columnFilters, globalFilter, pagination, setPagination, sorting } =
+    tableState
   const [searchField, setSearchField] = useState<SearchField>("email")
   const [searchOperator, setSearchOperator] =
     useState<SearchOperator>("contains")
   const [createOpen, setCreateOpen] = useState(false)
-  const deferredSearch = useDeferredValue(globalFilter.trim())
+  const [debouncedSearch] = useDebouncedValue(globalFilter.trim(), {
+    wait: DEFAULT_TABLE_SEARCH_DEBOUNCE_MS
+  })
   const status = String(
     columnFilters.find((filter) => filter.id === "status")?.value ?? "all"
   ) as StatusFilter
@@ -237,7 +226,7 @@ export function AdminUsers({
       offset: pagination.pageIndex * pagination.pageSize,
       searchField,
       searchOperator,
-      searchValue: deferredSearch || undefined,
+      searchValue: debouncedSearch || undefined,
       sortBy,
       sortDirection,
       ...(status === "all"
@@ -249,7 +238,7 @@ export function AdminUsers({
           })
     }),
     [
-      deferredSearch,
+      debouncedSearch,
       pagination.pageIndex,
       pagination.pageSize,
       searchField,
@@ -278,36 +267,24 @@ export function AdminUsers({
       total
     )
     if (pageIndex !== pagination.pageIndex) {
-      setPaginationState((current) => ({ ...current, pageIndex }))
+      setPagination((current) => ({ ...current, pageIndex }))
     }
-  }, [pagination.pageIndex, pagination.pageSize, total, users.isSuccess])
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
-    setColumnFiltersState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setGlobalFilter = (updater: Updater<string>) => {
-    setGlobalFilterState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setSorting = (updater: Updater<SortingState>) => {
-    setSortingState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
+  }, [
+    pagination.pageIndex,
+    pagination.pageSize,
+    setPagination,
+    total,
+    users.isSuccess
+  ])
   const table = useAdminTable({
+    atoms: tableState.atoms,
     columns: adminColumns,
     data: users.data?.users ?? EMPTY_USERS,
     getRowId: (user) => user.id,
     manualFiltering: true,
     manualPagination: true,
     manualSorting: true,
-    rowCount: total,
-    state: { columnFilters, globalFilter, pagination, sorting },
-    onColumnFiltersChange: setColumnFilters,
-    onGlobalFilterChange: setGlobalFilter,
-    onPaginationChange: setPagination,
-    onSortingChange: setSorting
+    rowCount: total
   })
   const from = total ? pagination.pageIndex * pagination.pageSize + 1 : 0
   const to = Math.min(total, (pagination.pageIndex + 1) * pagination.pageSize)

--- a/examples/start-shadcn-example/src/components/auth/api-key/api-keys.tsx
+++ b/examples/start-shadcn-example/src/components/auth/api-key/api-keys.tsx
@@ -9,13 +9,10 @@ import { useAuth, useAuthPlugin } from "@better-auth-ui/react"
 import { useListApiKeys } from "@better-auth-ui/react/plugins/api-key"
 import {
   createTableHook,
-  functionalUpdate,
-  type PaginationState,
   rowPaginationFeature,
   rowSortingFeature,
   type SortingState,
-  tableFeatures,
-  type Updater
+  tableFeatures
 } from "@tanstack/react-table"
 import { Fragment, useEffect, useMemo, useState } from "react"
 
@@ -31,6 +28,7 @@ import {
 } from "@/components/ui/select"
 import { apiKeyPlugin } from "@/lib/auth/api-key-plugin"
 import { cn } from "@/lib/utils"
+import { useServerTableState } from "../server-table-state"
 import { ApiKey } from "./api-key"
 import { ApiKeySkeleton } from "./api-key-skeleton"
 import { ApiKeysEmpty } from "./api-keys-empty"
@@ -49,6 +47,7 @@ const apiKeyColumns = apiKeyColumnHelper.columns([
   apiKeyColumnHelper.accessor("name", { id: "name" })
 ])
 const EMPTY_API_KEYS: ListedApiKey[] = []
+const INITIAL_API_KEY_SORTING: SortingState = [{ id: "createdAt", desc: true }]
 
 export type ApiKeysProps = {
   className?: string
@@ -75,13 +74,11 @@ export function ApiKeys({
   const { authClient } = useAuth<ApiKeyAuthClient>()
   const { localization: apiKeyLocalization, pageSize } =
     useAuthPlugin(apiKeyPlugin)
-  const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: 0,
+  const tableState = useServerTableState({
+    initialSorting: INITIAL_API_KEY_SORTING,
     pageSize
   })
-  const [sorting, setSortingState] = useState<SortingState>([
-    { id: "createdAt", desc: true }
-  ])
+  const { pagination, setPagination, sorting } = tableState
   const primarySort = sorting[0]
   const sortBy = primarySort?.id === "name" ? "name" : "createdAt"
   const sortDirection = primarySort?.desc ? "desc" : "asc"
@@ -111,13 +108,6 @@ export function ApiKeys({
       ),
     [listData?.apiKeys, pagination.pageSize]
   )
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setSorting = (updater: Updater<SortingState>) => {
-    setSortingState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-
   useEffect(() => {
     if (
       isListSuccess &&
@@ -125,22 +115,27 @@ export function ApiKeys({
       pagination.pageIndex > 0 &&
       page.rows.length === 0
     ) {
-      setPaginationState((current) => ({
+      setPagination((current) => ({
         ...current,
         pageIndex: Math.max(0, current.pageIndex - 1)
       }))
     }
-  }, [isListSuccess, isPendingProp, page.rows.length, pagination.pageIndex])
+  }, [
+    isListSuccess,
+    isPendingProp,
+    page.rows.length,
+    pagination.pageIndex,
+    setPagination
+  ])
 
   const table = useApiKeyTable({
+    atoms: tableState.atoms,
     columns: apiKeyColumns,
     data: page.rows,
     getRowId: (apiKey) => apiKey.id,
     manualPagination: true,
-    manualSorting: true,
-    state: { pagination, sorting },
-    onPaginationChange: setPagination,
-    onSortingChange: setSorting
+    pageCount: -1,
+    manualSorting: true
   })
 
   const [createOpen, setCreateOpen] = useState(false)

--- a/examples/start-shadcn-example/src/components/auth/auth-form.tsx
+++ b/examples/start-shadcn-example/src/components/auth/auth-form.tsx
@@ -90,6 +90,7 @@ export function setAuthFormServerError(
 }
 
 export function clearAuthFormServerError(form: AnyFormApi) {
+  if (!form.state.errorMap.onServer) return
   form.setErrorMap({ onServer: undefined })
 }
 
@@ -134,6 +135,7 @@ type AuthFormRootProps = Omit<ComponentProps<"form">, "onSubmit"> & {
 function AuthFormRoot({
   children,
   onBeforeSubmit,
+  onInput,
   serverErrorMessage = DEFAULT_AUTH_FORM_SERVER_ERROR,
   ...props
 }: AuthFormRootProps) {
@@ -161,6 +163,10 @@ function AuthFormRoot({
       onInvalid={(event) =>
         focusFirstInvalidAuthFormControl(event.currentTarget)
       }
+      onInput={(event) => {
+        clearAuthFormServerError(form)
+        onInput?.(event)
+      }}
       onSubmit={submit}
     >
       {children}
@@ -183,6 +189,7 @@ function AuthFormTextField({
   ...props
 }: AuthFormTextFieldProps) {
   const field = useFieldContext<string>()
+  const form = useFormContext()
   const isInvalid = isAuthFormFieldInvalid(field.state.meta)
   const inputId = id ?? field.name
 
@@ -191,11 +198,15 @@ function AuthFormTextField({
       <FieldLabel htmlFor={inputId}>{label}</FieldLabel>
       <Input
         {...props}
+        aria-busy={field.state.meta.isValidating || undefined}
         aria-invalid={isInvalid}
         id={inputId}
         name={field.name}
         onBlur={field.handleBlur}
-        onChange={(event) => field.handleChange(event.target.value)}
+        onChange={(event) => {
+          clearAuthFormServerError(form)
+          field.handleChange(event.target.value)
+        }}
         value={field.state.value}
       />
       {description ? <FieldDescription>{description}</FieldDescription> : null}
@@ -213,13 +224,13 @@ function AuthFormSubmitButton({
 
   return (
     <form.Subscribe
-      selector={(state) => [state.canSubmit, state.isSubmitting] as const}
+      selector={(state) => [state.isSubmitting, state.isValidating] as const}
     >
-      {([canSubmit, isSubmitting]) => (
+      {([isSubmitting, isValidating]) => (
         <Button
           {...props}
-          aria-disabled={disabled || !canSubmit || isSubmitting || undefined}
-          disabled={disabled || isSubmitting}
+          aria-disabled={disabled || isSubmitting || isValidating || undefined}
+          disabled={disabled || isSubmitting || isValidating}
           type="submit"
         >
           {isSubmitting ? <Spinner data-icon="inline-start" /> : null}
@@ -237,6 +248,7 @@ type AuthFormAdditionalFieldProps = Omit<
 
 function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   const field = useFieldContext<AdditionalFieldFormValue>()
+  const form = useFormContext()
   const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
   return (
@@ -248,18 +260,16 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
       isInvalid={isInvalid}
       name={field.name}
       onBlur={field.handleBlur}
-      onChange={field.handleChange}
+      onChange={(value) => {
+        clearAuthFormServerError(form)
+        field.handleChange(value)
+      }}
       value={field.state.value}
     />
   )
 }
 
-export const {
-  useAppForm: useAuthForm,
-  useTypedAppFormContext: useTypedAuthFormContext,
-  withFieldGroup: withAuthFieldGroup,
-  withForm: withAuthForm
-} = createFormHook({
+export const { useAppForm: useAuthForm } = createFormHook({
   fieldComponents: {
     AuthFormAdditionalField,
     AuthFormFieldError,

--- a/examples/start-shadcn-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-shadcn-example/src/components/auth/dash/activity.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import { getClampedTablePageIndex } from "@better-auth-ui/core"
+import {
+  DEFAULT_TABLE_SEARCH_DEBOUNCE_MS,
+  getClampedTablePageIndex
+} from "@better-auth-ui/core"
 import {
   type DashAuditLog,
   type DashAuthClient,
@@ -20,17 +23,14 @@ import {
   useDashUserAuditLogs
 } from "@better-auth-ui/react/plugins/dash"
 import { useActiveMemberRole } from "@better-auth-ui/react/plugins/organization"
+import { useDebouncedValue } from "@tanstack/react-pacer"
 import { keepPreviousData } from "@tanstack/react-query"
 import {
-  type ColumnFiltersState,
   columnFilteringFeature,
   createTableHook,
-  functionalUpdate,
   globalFilteringFeature,
-  type PaginationState,
   rowPaginationFeature,
-  tableFeatures,
-  type Updater
+  tableFeatures
 } from "@tanstack/react-table"
 import {
   Activity,
@@ -43,7 +43,7 @@ import {
   UserRound,
   Users
 } from "lucide-react"
-import { Fragment, useDeferredValue, useEffect, useMemo, useState } from "react"
+import { Fragment, useEffect, useMemo } from "react"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -83,6 +83,7 @@ import { Spinner } from "@/components/ui/spinner"
 import { dashPlugin } from "@/lib/auth/dash-plugin"
 import { organizationPlugin } from "@/lib/auth/organization-plugin"
 import { cn } from "@/lib/utils"
+import { useServerTableState } from "../server-table-state"
 
 type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
 
@@ -238,18 +239,14 @@ function ActivityFeed({
 }: ActivityFeedProps) {
   const { authClient } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
-  const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: 0,
-    pageSize
-  })
-  const [columnFilters, setColumnFiltersState] = useState<ColumnFiltersState>(
-    []
-  )
-  const [globalFilter, setGlobalFilterState] = useState("")
+  const tableState = useServerTableState({ pageSize })
+  const { columnFilters, globalFilter, pagination, setPagination } = tableState
   const eventType = String(
     columnFilters.find((filter) => filter.id === "eventType")?.value ?? "all"
   )
-  const deferredIdentifier = useDeferredValue(globalFilter.trim())
+  const [debouncedIdentifier] = useDebouncedValue(globalFilter.trim(), {
+    wait: DEFAULT_TABLE_SEARCH_DEBOUNCE_MS
+  })
   const eventOptions = useMemo(
     () => Object.entries(localization.eventLabels),
     [localization.eventLabels]
@@ -257,7 +254,7 @@ function ActivityFeed({
   const offset = pagination.pageIndex * pagination.pageSize
   const params = {
     eventType: eventType === "all" ? undefined : eventType,
-    identifier: deferredIdentifier || undefined,
+    identifier: debouncedIdentifier || undefined,
     limit: pagination.pageSize,
     offset,
     organizationId
@@ -303,36 +300,24 @@ function ActivityFeed({
       data?.total ?? 0
     )
     if (pageIndex !== pagination.pageIndex) {
-      setPaginationState((current) => ({ ...current, pageIndex }))
+      setPagination((current) => ({ ...current, pageIndex }))
     }
   }, [
     data?.total,
     pagination.pageIndex,
     pagination.pageSize,
     query.isSuccess,
-    ready
+    ready,
+    setPagination
   ])
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
-    setColumnFiltersState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setGlobalFilter = (updater: Updater<string>) => {
-    setGlobalFilterState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
   const table = useActivityTable({
+    atoms: tableState.atoms,
     columns: activityColumns,
     data: data?.events ?? EMPTY_EVENTS,
     getRowId: getDashEventKey,
     manualFiltering: true,
     manualPagination: true,
-    rowCount: data?.total ?? 0,
-    state: { columnFilters, globalFilter, pagination },
-    onColumnFiltersChange: setColumnFilters,
-    onGlobalFilterChange: setGlobalFilter,
-    onPaginationChange: setPagination
+    rowCount: data?.total ?? 0
   })
 
   return (

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-sortable-table-head.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-sortable-table-head.tsx
@@ -1,63 +1,65 @@
 "use client"
 
+import { type Column, type RowData, Subscribe } from "@tanstack/react-table"
 import { ChevronUp } from "lucide-react"
 import type { MouseEvent, ReactNode } from "react"
 
 import { Button } from "@/components/ui/button"
 import { TableHead } from "@/components/ui/table"
 import { cn } from "@/lib/utils"
+import type { organizationTableFeatures } from "./organization-table"
 
-type SortableColumn = {
-  getIsSorted: () => false | "asc" | "desc"
-  getSortIndex: () => number
-  getToggleSortingHandler: () => undefined | ((event: unknown) => void)
-}
-
-export function OrganizationSortableTableHead({
+export function OrganizationSortableTableHead<TData extends RowData>({
   children,
   column
 }: {
   children: ReactNode
-  column?: SortableColumn
+  column?: Column<typeof organizationTableFeatures, TData>
 }) {
   if (!column) return <TableHead>{children}</TableHead>
 
-  const sortDirection = column.getIsSorted()
   const onClick = column.getToggleSortingHandler()
 
   return (
-    <TableHead
-      aria-sort={
-        sortDirection === "asc"
-          ? "ascending"
-          : sortDirection === "desc"
-            ? "descending"
-            : "none"
-      }
+    <Subscribe
+      source={column.table.atoms.sorting}
+      selector={() => [column.getIsSorted(), column.getSortIndex()] as const}
     >
-      <Button
-        className="h-auto w-full justify-start p-0 font-medium hover:bg-transparent"
-        onClick={(event: MouseEvent<HTMLButtonElement>) => onClick?.(event)}
-        size="sm"
-        type="button"
-        variant="ghost"
-      >
-        {children}
+      {([sortDirection, sortIndex]) => (
+        <TableHead
+          aria-sort={
+            sortDirection === "asc"
+              ? "ascending"
+              : sortDirection === "desc"
+                ? "descending"
+                : "none"
+          }
+        >
+          <Button
+            className="h-auto w-full justify-start p-0 font-medium hover:bg-transparent"
+            onClick={(event: MouseEvent<HTMLButtonElement>) => onClick?.(event)}
+            size="sm"
+            type="button"
+            variant="ghost"
+          >
+            {children}
 
-        {sortDirection && (
-          <>
-            <ChevronUp
-              className={cn(
-                "size-3 transition-transform duration-100 ease-out",
-                sortDirection === "desc" && "rotate-180"
-              )}
-            />
-            <span className="text-muted-foreground text-[10px] tabular-nums">
-              {column.getSortIndex() + 1}
-            </span>
-          </>
-        )}
-      </Button>
-    </TableHead>
+            {sortDirection ? (
+              <>
+                <ChevronUp
+                  className={cn(
+                    "size-3 transition-transform duration-100 ease-out",
+                    sortDirection === "desc" && "rotate-180"
+                  )}
+                />
+                <span className="text-muted-foreground text-[10px] tabular-nums">
+                  {sortIndex + 1}
+                </span>
+              </>
+            ) : null}
+          </Button>
+        </TableHead>
+      )}
+    </Subscribe>
   )
 }

--- a/examples/start-shadcn-example/src/components/auth/server-table-state.ts
+++ b/examples/start-shadcn-example/src/components/auth/server-table-state.ts
@@ -1,0 +1,74 @@
+"use client"
+
+import { useCreateAtom, useSelector } from "@tanstack/react-store"
+import {
+  type ColumnFiltersState,
+  functionalUpdate,
+  type PaginationState,
+  type SortingState,
+  type Updater
+} from "@tanstack/react-table"
+import { useCallback, useEffect, useMemo } from "react"
+
+export function useServerTableState({
+  initialSorting = [],
+  pageSize
+}: {
+  initialSorting?: SortingState
+  pageSize: number
+}) {
+  const columnFiltersAtom = useCreateAtom<ColumnFiltersState>([])
+  const globalFilterAtom = useCreateAtom("")
+  const paginationAtom = useCreateAtom<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const sortingAtom = useCreateAtom<SortingState>(initialSorting)
+  const columnFilters = useSelector(columnFiltersAtom)
+  const globalFilter = useSelector(globalFilterAtom)
+  const pagination = useSelector(paginationAtom)
+  const sorting = useSelector(sortingAtom)
+  const atoms = useMemo(
+    () => ({
+      columnFilters: columnFiltersAtom,
+      globalFilter: globalFilterAtom,
+      pagination: paginationAtom,
+      sorting: sortingAtom
+    }),
+    [columnFiltersAtom, globalFilterAtom, paginationAtom, sortingAtom]
+  )
+
+  useEffect(() => {
+    const resetPage = () => {
+      const current = paginationAtom.get()
+      if (current.pageIndex !== 0) {
+        paginationAtom.set({ ...current, pageIndex: 0 })
+      }
+    }
+    const subscriptions = [
+      columnFiltersAtom.subscribe(resetPage),
+      globalFilterAtom.subscribe(resetPage),
+      sortingAtom.subscribe(resetPage)
+    ]
+
+    return () => {
+      for (const subscription of subscriptions) subscription.unsubscribe()
+    }
+  }, [columnFiltersAtom, globalFilterAtom, paginationAtom, sortingAtom])
+
+  const setPagination = useCallback(
+    (updater: Updater<PaginationState>) => {
+      paginationAtom.set((current) => functionalUpdate(updater, current))
+    },
+    [paginationAtom]
+  )
+
+  return {
+    atoms,
+    columnFilters,
+    globalFilter,
+    pagination,
+    setPagination,
+    sorting
+  }
+}

--- a/examples/start-shadcn-example/tests/auth-form.browser.test.tsx
+++ b/examples/start-shadcn-example/tests/auth-form.browser.test.tsx
@@ -16,6 +16,7 @@ import {
 import { AuthProvider } from "../src/components/auth/auth-provider"
 import { useOrganizationTableState } from "../src/components/auth/organization/organization-table-state"
 import { PhoneNumber } from "../src/components/auth/phone-number/phone-number"
+import { useServerTableState } from "../src/components/auth/server-table-state"
 import { EmailFirstSignIn } from "../src/components/auth/sso/email-first-sign-in"
 import { phoneNumberPlugin } from "../src/lib/auth/phone-number-plugin"
 import { ssoPlugin } from "../src/lib/auth/sso-plugin"
@@ -73,6 +74,46 @@ function ValidatedAuthForm() {
         <form.AuthFormServerError />
       </form.AuthFormRoot>
     </form.AppForm>
+  )
+}
+
+function AsyncValidatedAuthForm({
+  validate
+}: {
+  validate: () => Promise<undefined>
+}) {
+  const form = useAuthForm({ defaultValues: { handle: "" } })
+
+  return (
+    <form.AppForm>
+      <form.AppField
+        name="handle"
+        validators={{ onChangeAsync: validate, onChangeAsyncDebounceMs: 0 }}
+      >
+        {(field) => <field.AuthFormTextField label="Handle" />}
+      </form.AppField>
+    </form.AppForm>
+  )
+}
+
+function ServerTableStateFixture() {
+  const state = useServerTableState({ pageSize: 10 })
+
+  return (
+    <>
+      <button
+        onClick={() => state.setPagination({ pageIndex: 2, pageSize: 10 })}
+        type="button"
+      >
+        Go to page three
+      </button>
+      <button onClick={() => state.atoms.globalFilter.set("ada")} type="button">
+        Filter users
+      </button>
+      <output aria-label="Server table state">
+        {state.globalFilter}|{state.pagination.pageIndex}
+      </output>
+    </>
   )
 }
 
@@ -199,7 +240,7 @@ describe("shadcn TanStack form integration", () => {
     fireEvent.change(email, { target: { value: "ada@example.com" } })
     fireEvent.change(email, { target: { value: "" } })
 
-    await waitFor(() => expect(submit).toHaveAttribute("aria-disabled", "true"))
+    await waitFor(() => expect(submit).not.toHaveAttribute("aria-disabled"))
     expect(submit).not.toHaveAttribute("disabled")
 
     fireEvent.click(submit)
@@ -213,6 +254,30 @@ describe("shadcn TanStack form integration", () => {
       await screen.findByText("This email is already registered")
     ).toBeVisible()
     expect(screen.getByText("Account creation failed")).toBeVisible()
+
+    fireEvent.change(email, { target: { value: "grace@example.com" } })
+    await waitFor(() =>
+      expect(screen.queryByText("Account creation failed")).toBeNull()
+    )
+  })
+
+  it("announces asynchronous field validation without blocking input", async () => {
+    let finishValidation!: () => void
+    const validate = vi.fn(
+      () =>
+        new Promise<undefined>((resolve) => {
+          finishValidation = () => resolve(undefined)
+        })
+    )
+    render(<AsyncValidatedAuthForm validate={validate} />)
+    const input = screen.getByRole("textbox", { name: "Handle" })
+
+    fireEvent.change(input, { target: { value: "ada" } })
+    await waitFor(() => expect(input).toHaveAttribute("aria-busy", "true"))
+    expect(input).toHaveValue("ada")
+
+    finishValidation()
+    await waitFor(() => expect(input).not.toHaveAttribute("aria-busy"))
   })
 
   it("surfaces a rejected phone code resend in the form", async () => {
@@ -292,6 +357,22 @@ describe("shadcn TanStack form integration", () => {
     fireEvent.click(screen.getByRole("button", { name: "Continue with email" }))
 
     expect(await screen.findByText("SSO discovery failed")).toBeVisible()
+  })
+})
+
+describe("shadcn TanStack server table state", () => {
+  it("returns to the first page when a query input changes", async () => {
+    render(<ServerTableStateFixture />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Go to page three" }))
+    expect(screen.getByLabelText("Server table state")).toHaveTextContent("|2")
+
+    fireEvent.click(screen.getByRole("button", { name: "Filter users" }))
+    await waitFor(() =>
+      expect(screen.getByLabelText("Server table state")).toHaveTextContent(
+        "ada|0"
+      )
+    )
   })
 })
 

--- a/examples/start-solid-zaidan-example/package.json
+++ b/examples/start-solid-zaidan-example/package.json
@@ -80,6 +80,7 @@
     "@solid-primitives/debounce": "^1.3.0",
     "@solidjs-email/main": "^2.0.0",
     "@tanstack/solid-form": "^1.33.5",
+    "@tanstack/solid-pacer": "^0.22.0",
     "@tanstack/solid-query": "^5.101.2",
     "@tanstack/solid-router": "^1.170.21",
     "@tanstack/solid-store": "^0.11.1",

--- a/examples/start-solid-zaidan-example/registry.manifest.ts
+++ b/examples/start-solid-zaidan-example/registry.manifest.ts
@@ -465,13 +465,19 @@ const solidRegistryBaseManifest = {
       title: "Solid Dash Activity",
       description:
         "Filtered Solid personal and organization audit logs, plus an administrator view across organizations the current administrator can manage, backed by Better Auth Infrastructure Dash.",
-      dependencies: [...solidAuthDependencies, "@better-auth/infra@latest"],
+      dependencies: [
+        ...solidAuthDependencies,
+        "@better-auth/infra@latest",
+        "@tanstack/solid-pacer",
+        "@tanstack/solid-table"
+      ],
       registryDependencies: [
         betterAuthSolidRegistryDependency("auth-provider"),
         betterAuthSolidRegistryDependency("organization")
       ],
       files: [
         libFile("src/lib/auth/dash-plugin.tsx"),
+        componentFile("src/components/auth/server-table-state.ts"),
         componentFile("src/components/auth/dash/activity.tsx"),
         ...zaidanInteractiveSupportFiles
       ]
@@ -566,9 +572,14 @@ const solidRegistryBaseManifest = {
       type: "registry:component",
       title: "Solid API Keys",
       description: "Solid API key management cards and dialogs.",
-      dependencies: [...solidAuthDependencies, "@better-auth/api-key"],
+      dependencies: [
+        ...solidAuthDependencies,
+        "@better-auth/api-key",
+        "@tanstack/solid-table"
+      ],
       files: [
         libFile("src/lib/auth/api-key-plugin.ts"),
+        componentFile("src/components/auth/server-table-state.ts"),
         componentFile("src/components/auth/api-key/api-keys.tsx"),
         componentFile("src/components/auth/api-key/api-key.tsx"),
         componentFile("src/components/auth/api-key/api-keys-empty.tsx"),
@@ -968,7 +979,11 @@ const solidRegistryBaseManifest = {
       title: "Solid Admin",
       description:
         "Static administration shell with user management, a user inspector, session details, and the stop-impersonating action.",
-      dependencies: [...solidAuthDependencies, "@tanstack/solid-table"],
+      dependencies: [
+        ...solidAuthDependencies,
+        "@tanstack/solid-pacer",
+        "@tanstack/solid-table"
+      ],
       registryDependencies: [
         betterAuthSolidRegistryDependency("auth-provider"),
         betterAuthSolidRegistryDependency("user-button"),
@@ -984,6 +999,7 @@ const solidRegistryBaseManifest = {
       ],
       files: [
         libFile("src/lib/auth/admin-plugin.ts"),
+        componentFile("src/components/auth/server-table-state.ts"),
         componentFile("src/components/auth/admin/admin.tsx"),
         componentFile("src/components/auth/admin/admin-table.ts"),
         componentFile("src/components/auth/admin/admin-users.tsx"),

--- a/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/admin/admin-users.tsx
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_TABLE_SEARCH_DEBOUNCE_MS,
   fieldsWithModelValues,
   getAdditionalFieldDefaultValues,
   getAdditionalFieldSubmitValues,
@@ -28,14 +29,8 @@ import {
   useUnbanAdminUser,
   useUpdateAdminUser
 } from "@better-auth-ui/solid/plugins/admin"
-import { createDebounce } from "@solid-primitives/debounce"
-import {
-  type ColumnFiltersState,
-  functionalUpdate,
-  type PaginationState,
-  type SortingState,
-  type Updater
-} from "@tanstack/solid-table"
+import { createDebouncedValue } from "@tanstack/solid-pacer"
+import type { SortingState } from "@tanstack/solid-table"
 import {
   Ban,
   Copy,
@@ -48,6 +43,7 @@ import {
 } from "lucide-solid"
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js"
 import { Dynamic } from "solid-js/web"
+import { createServerTableState } from "@/components/auth/server-table-state"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -176,6 +172,7 @@ const adminColumns = adminColumnHelper.columns([
   })
 ])
 const EMPTY_USERS: AdminUser[] = []
+const INITIAL_ADMIN_SORTING: SortingState = [{ id: "createdAt", desc: true }]
 
 /** Zaidan presentation for the static Admin users view. */
 export function AdminUsers(props: AdminUsersProps) {
@@ -186,21 +183,17 @@ export function AdminUsers(props: AdminUsersProps) {
     (auth.plugins.find((plugin) => plugin.id === adminPlugin.id) ??
       defaults) as typeof defaults
   const [localSelectedUserId, setLocalSelectedUserId] = createSignal<string>()
-  const [globalFilter, setGlobalFilterState] = createSignal("")
-  const [debouncedSearch, setDebouncedSearch] = createSignal("")
-  const [columnFilters, setColumnFiltersState] =
-    createSignal<ColumnFiltersState>([])
-  const [pagination, setPaginationState] = createSignal<PaginationState>({
-    pageIndex: 0,
+  const tableState = createServerTableState({
+    initialSorting: INITIAL_ADMIN_SORTING,
     pageSize: config().pageSize
   })
-  const [sorting, setSortingState] = createSignal<SortingState>([
-    { id: "createdAt", desc: true }
-  ])
+  const { columnFilters, globalFilter, pagination, sorting } = tableState
+  const [debouncedSearch] = createDebouncedValue(() => globalFilter().trim(), {
+    wait: DEFAULT_TABLE_SEARCH_DEBOUNCE_MS
+  })
   const [searchField, setSearchField] = createSignal<"email" | "name">("email")
   const [searchOperator, setSearchOperator] =
     createSignal<SearchOperator>("contains")
-  const updateDebouncedSearch = createDebounce(setDebouncedSearch, 300)
   const status = () =>
     String(
       columnFilters().find((filter) => filter.id === "status")?.value ?? "all"
@@ -257,26 +250,11 @@ export function AdminUsers(props: AdminUsersProps) {
       total()
     )
     if (pageIndex !== current.pageIndex) {
-      setPaginationState({ ...current, pageIndex })
+      tableState.setPagination({ ...current, pageIndex })
     }
   })
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
-    setColumnFiltersState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setGlobalFilter = (updater: Updater<string>) => {
-    const next = functionalUpdate(updater, globalFilter())
-    setGlobalFilterState(next)
-    updateDebouncedSearch(next.trim())
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setSorting = (updater: Updater<SortingState>) => {
-    setSortingState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
   const table = createAdminTable({
+    atoms: tableState.atoms,
     columns: adminColumns,
     get data() {
       return users.data?.users ?? EMPTY_USERS
@@ -284,22 +262,10 @@ export function AdminUsers(props: AdminUsersProps) {
     get rowCount() {
       return total()
     },
-    get state() {
-      return {
-        columnFilters: columnFilters(),
-        globalFilter: globalFilter(),
-        pagination: pagination(),
-        sorting: sorting()
-      }
-    },
     getRowId: (user) => user.id,
     manualFiltering: true,
     manualPagination: true,
-    manualSorting: true,
-    onColumnFiltersChange: setColumnFilters,
-    onGlobalFilterChange: setGlobalFilter,
-    onPaginationChange: setPagination,
-    onSortingChange: setSorting
+    manualSorting: true
   })
 
   return (

--- a/examples/start-solid-zaidan-example/src/components/auth/api-key/api-keys.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/api-key/api-keys.tsx
@@ -8,19 +8,17 @@ import { useAuth, useAuthPlugin } from "@better-auth-ui/solid"
 import { useListApiKeys } from "@better-auth-ui/solid/plugins/api-key"
 import {
   createTableHook,
-  functionalUpdate,
-  type PaginationState,
   rowPaginationFeature,
   rowSortingFeature,
   type SortingState,
-  tableFeatures,
-  type Updater
+  tableFeatures
 } from "@tanstack/solid-table"
 import { createEffect, createMemo, createSignal, For, Show } from "solid-js"
 import { ApiKey } from "@/components/auth/api-key/api-key"
 import { ApiKeySkeleton } from "@/components/auth/api-key/api-key-skeleton"
 import { ApiKeysEmpty } from "@/components/auth/api-key/api-keys-empty"
 import { CreateApiKeyDialog } from "@/components/auth/api-key/create-api-key-dialog"
+import { createServerTableState } from "@/components/auth/server-table-state"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Dialog, DialogTrigger } from "@/components/ui/dialog"
@@ -49,6 +47,7 @@ const apiKeyColumns = apiKeyColumnHelper.columns([
   apiKeyColumnHelper.accessor("name", { id: "name" })
 ])
 const EMPTY_API_KEYS: ListedApiKey[] = []
+const INITIAL_API_KEY_SORTING: SortingState = [{ id: "createdAt", desc: true }]
 
 export type ApiKeysProps = {
   class?: string
@@ -64,13 +63,11 @@ export function ApiKeys(props: ApiKeysProps = {}) {
   const config = useAuthPlugin(apiKeyPlugin)
   const [isCreateDialogOpen, setIsCreateDialogOpen] = createSignal(false)
   const pageSize = config.pageSize
-  const [pagination, setPaginationState] = createSignal<PaginationState>({
-    pageIndex: 0,
+  const tableState = createServerTableState({
+    initialSorting: INITIAL_API_KEY_SORTING,
     pageSize
   })
-  const [sorting, setSortingState] = createSignal<SortingState>([
-    { id: "createdAt", desc: true }
-  ])
+  const { pagination, sorting } = tableState
   const sort = () => {
     const primarySort = sorting()[0]
     const id = primarySort?.id === "name" ? "name" : "createdAt"
@@ -110,13 +107,6 @@ export function ApiKeys(props: ApiKeysProps = {}) {
     )
   )
   const pending = () => Boolean(props.isPending || apiKeys.isPending)
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setSorting = (updater: Updater<SortingState>) => {
-    setSortingState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-
   createEffect(() => {
     if (
       apiKeys.isSuccess &&
@@ -124,7 +114,7 @@ export function ApiKeys(props: ApiKeysProps = {}) {
       pagination().pageIndex > 0 &&
       page().rows.length === 0
     ) {
-      setPaginationState((current) => ({
+      tableState.setPagination((current) => ({
         ...current,
         pageIndex: Math.max(0, current.pageIndex - 1)
       }))
@@ -132,18 +122,15 @@ export function ApiKeys(props: ApiKeysProps = {}) {
   })
 
   const table = createApiKeyTable({
+    atoms: tableState.atoms,
     columns: apiKeyColumns,
     get data() {
       return page().rows
     },
-    get state() {
-      return { pagination: pagination(), sorting: sorting() }
-    },
     getRowId: (apiKey) => apiKey.id,
     manualPagination: true,
-    manualSorting: true,
-    onPaginationChange: setPagination,
-    onSortingChange: setSorting
+    pageCount: -1,
+    manualSorting: true
   })
 
   return (

--- a/examples/start-solid-zaidan-example/src/components/auth/auth-form.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/auth-form.tsx
@@ -12,7 +12,14 @@ import {
   createFormHook,
   createFormHookContexts
 } from "@tanstack/solid-form"
-import { type ComponentProps, type JSX, Show, splitProps } from "solid-js"
+import {
+  type ComponentProps,
+  type JSX,
+  onCleanup,
+  onMount,
+  Show,
+  splitProps
+} from "solid-js"
 
 import { Button } from "@/components/ui/button"
 import {
@@ -101,6 +108,7 @@ export function setAuthFormServerError(
 }
 
 export function clearAuthFormServerError(form: AnyFormApi) {
+  if (!form.state.errorMap.onServer) return
   form.setErrorMap({ onServer: undefined })
 }
 
@@ -131,7 +139,16 @@ function AuthFormRoot(props: AuthFormRootProps) {
     "onBeforeSubmit",
     "serverErrorMessage"
   ])
+  let formElement: HTMLFormElement | undefined
   let submitting = false
+
+  onMount(() => {
+    if (!formElement) return
+
+    const clearServerError = () => clearAuthFormServerError(form)
+    formElement.addEventListener("input", clearServerError)
+    onCleanup(() => formElement?.removeEventListener("input", clearServerError))
+  })
 
   const submit = async (event: SubmitEvent) => {
     event.preventDefault()
@@ -154,6 +171,7 @@ function AuthFormRoot(props: AuthFormRootProps) {
   return (
     <form
       {...formProps}
+      ref={formElement}
       on:invalid={{
         capture: true,
         handleEvent: (event) =>
@@ -174,6 +192,7 @@ type AuthFormTextFieldProps = Omit<
 
 function AuthFormTextField(props: AuthFormTextFieldProps) {
   const field = useFieldContext<string>()
+  const form = useFormContext()
   const [local, inputProps] = splitProps(props, ["description", "id", "label"])
   const isInvalid = () => isAuthFormFieldInvalid(field().state.meta)
   const inputId = () => local.id ?? field().name
@@ -183,11 +202,15 @@ function AuthFormTextField(props: AuthFormTextFieldProps) {
       <FieldLabel for={inputId()}>{local.label}</FieldLabel>
       <Input
         {...inputProps}
+        aria-busy={field().state.meta.isValidating || undefined}
         aria-invalid={isInvalid()}
         id={inputId()}
         name={field().name}
         onBlur={field().handleBlur}
-        onInput={(event) => field().handleChange(event.currentTarget.value)}
+        onInput={(event) => {
+          clearAuthFormServerError(form)
+          field().handleChange(event.currentTarget.value)
+        }}
         value={field().state.value}
       />
       <Show when={local.description}>
@@ -205,19 +228,19 @@ function AuthFormSubmitButton(
 
   return (
     <form.Subscribe
-      selector={(state) => [state.canSubmit, state.isSubmitting] as const}
+      selector={(state) => [state.isSubmitting, state.isValidating] as const}
     >
       {(state) => (
         <Button
           {...props}
           aria-disabled={
-            props.disabled || !state()[0] || state()[1] || undefined
+            props.disabled || state()[0] || state()[1] || undefined
           }
           class={props.class}
-          disabled={props.disabled || state()[1]}
+          disabled={props.disabled || state()[0] || state()[1]}
           type="submit"
         >
-          <Show when={state()[1]}>
+          <Show when={state()[0]}>
             <Spinner />
           </Show>
           {props.children}
@@ -234,6 +257,7 @@ type AuthFormAdditionalFieldProps = Omit<
 
 function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   const field = useFieldContext<AdditionalFieldFormValue>()
+  const form = useFormContext()
   const isInvalid = () => isAuthFormFieldInvalid(field().state.meta)
 
   return (
@@ -245,17 +269,16 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
       isInvalid={isInvalid()}
       name={field().name}
       onBlur={field().handleBlur}
-      onChange={field().handleChange}
+      onChange={(value) => {
+        clearAuthFormServerError(form)
+        field().handleChange(value)
+      }}
       value={field().state.value}
     />
   )
 }
 
-export const {
-  useAppForm: createAuthForm,
-  withFieldGroup: withAuthFieldGroup,
-  withForm: withAuthForm
-} = createFormHook({
+export const { useAppForm: createAuthForm } = createFormHook({
   fieldComponents: {
     AuthFormAdditionalField,
     AuthFormFieldError,

--- a/examples/start-solid-zaidan-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/dash/activity.tsx
@@ -1,4 +1,7 @@
-import { getClampedTablePageIndex } from "@better-auth-ui/core"
+import {
+  DEFAULT_TABLE_SEARCH_DEBOUNCE_MS,
+  getClampedTablePageIndex
+} from "@better-auth-ui/core"
 import {
   type DashAuditLog,
   type DashAuthClient,
@@ -18,17 +21,14 @@ import {
   useDashUserAuditLogs
 } from "@better-auth-ui/solid/plugins/dash"
 import { useActiveMemberRole } from "@better-auth-ui/solid/plugins/organization"
+import { createDebouncedValue } from "@tanstack/solid-pacer"
 import { keepPreviousData } from "@tanstack/solid-query"
 import {
-  type ColumnFiltersState,
   columnFilteringFeature,
   createTableHook,
-  functionalUpdate,
   globalFilteringFeature,
-  type PaginationState,
   rowPaginationFeature,
-  tableFeatures,
-  type Updater
+  tableFeatures
 } from "@tanstack/solid-table"
 import {
   Activity,
@@ -41,16 +41,9 @@ import {
   UserRound,
   Users
 } from "lucide-solid"
-import {
-  createDeferred,
-  createEffect,
-  createMemo,
-  createSignal,
-  For,
-  on,
-  Show
-} from "solid-js"
+import { createEffect, createMemo, For, on, Show } from "solid-js"
 import { Dynamic } from "solid-js/web"
+import { createServerTableState } from "@/components/auth/server-table-state"
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -236,33 +229,32 @@ function ActivityRowSkeleton() {
 function ActivityFeed(props: ActivityFeedProps) {
   const auth = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
-  const [pagination, setPaginationState] = createSignal<PaginationState>({
-    pageIndex: 0,
-    pageSize
-  })
-  const [columnFilters, setColumnFiltersState] =
-    createSignal<ColumnFiltersState>([])
-  const [globalFilter, setGlobalFilterState] = createSignal("")
+  const tableState = createServerTableState({ pageSize })
+  const { columnFilters, globalFilter, pagination } = tableState
   const eventType = () =>
     String(
       columnFilters().find((filter) => filter.id === "eventType")?.value ??
         "all"
     )
-  const deferredIdentifier = createDeferred(() => globalFilter().trim())
+  const [debouncedIdentifier] = createDebouncedValue(
+    () => globalFilter().trim(),
+    { wait: DEFAULT_TABLE_SEARCH_DEBOUNCE_MS }
+  )
   const eventOptions = createMemo(() =>
     Object.entries(localization.eventLabels)
   )
   createEffect(
     on(
       () => [props.access, props.organizationId, props.userId] as const,
-      () => setPaginationState((current) => ({ ...current, pageIndex: 0 })),
+      () =>
+        tableState.setPagination((current) => ({ ...current, pageIndex: 0 })),
       { defer: true }
     )
   )
   const offset = () => pagination().pageIndex * pagination().pageSize
   const params = () => ({
     eventType: eventType() === "all" ? undefined : eventType(),
-    identifier: deferredIdentifier() || undefined,
+    identifier: debouncedIdentifier() || undefined,
     limit: pagination().pageSize,
     offset: offset(),
     organizationId: props.organizationId
@@ -313,20 +305,11 @@ function ActivityFeed(props: ActivityFeedProps) {
       query().data?.total ?? 0
     )
     if (pageIndex !== current.pageIndex) {
-      setPaginationState({ ...current, pageIndex })
+      tableState.setPagination({ ...current, pageIndex })
     }
   })
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
-    setColumnFiltersState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setGlobalFilter = (updater: Updater<string>) => {
-    setGlobalFilterState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
   const table = createActivityTable({
+    atoms: tableState.atoms,
     columns: activityColumns,
     get data() {
       return query().data?.events ?? EMPTY_EVENTS
@@ -334,19 +317,9 @@ function ActivityFeed(props: ActivityFeedProps) {
     get rowCount() {
       return query().data?.total ?? 0
     },
-    get state() {
-      return {
-        columnFilters: columnFilters(),
-        globalFilter: globalFilter(),
-        pagination: pagination()
-      }
-    },
     getRowId: getDashEventKey,
     manualFiltering: true,
-    manualPagination: true,
-    onColumnFiltersChange: setColumnFilters,
-    onGlobalFilterChange: setGlobalFilter,
-    onPaginationChange: setPagination
+    manualPagination: true
   })
 
   return (

--- a/examples/start-solid-zaidan-example/src/components/auth/device-authorization/device-authorization.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/device-authorization/device-authorization.tsx
@@ -278,7 +278,7 @@ function DeviceCodeForm(props: DeviceCodeFormProps) {
     onSubmit: async ({ value }) => props.onSubmit(value.userCode)
   }))
   createEffect(() => {
-    if (form.state.values.userCode !== props.userCode) {
+    if (form.getFieldValue("userCode") !== props.userCode) {
       form.setFieldValue("userCode", props.userCode)
     }
   })

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/change-email-otp.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/change-email-otp.tsx
@@ -94,9 +94,9 @@ export function ChangeEmailOtp(props: ChangeEmailOtpProps = {}) {
       } as Parameters<typeof changeEmail.mutateAsync>[0])
     }
   }))
-  const code = () => form.state.values.code
-  const codeTarget = () =>
-    step() === "currentCode" ? currentEmail() : form.state.values.email
+  const code = form.useSelector((state) => state.values.code)
+  const email = form.useSelector((state) => state.values.email)
+  const codeTarget = () => (step() === "currentCode" ? currentEmail() : email())
   const submitCode = async (completedCode: string) => {
     if (isPending() || step() === "email") return
     form.setFieldValue("code", completedCode)

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/email-otp.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/email-otp.tsx
@@ -90,8 +90,8 @@ export function EmailOtp(props: EmailOtpProps) {
       } as Parameters<typeof signIn.mutateAsync>[0])
     }
   }))
-  const email = () => form.state.values.email
-  const code = () => form.state.values.code
+  const email = form.useSelector((state) => state.values.email)
+  const code = form.useSelector((state) => state.values.code)
 
   const requestCode = async () => {
     try {

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/reset-password-otp.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/reset-password-otp.tsx
@@ -110,8 +110,8 @@ export function ResetPasswordOtp(props: ResetPasswordOtpProps) {
       } as Parameters<typeof resetPassword.mutateAsync>[0])
     }
   }))
-  const email = () => form.state.values.email
-  const password = () => form.state.values.password
+  const email = form.useSelector((state) => state.values.email)
+  const password = form.useSelector((state) => state.values.password)
 
   return (
     <Card class={cn("w-full max-w-sm", props.class)}>

--- a/examples/start-solid-zaidan-example/src/components/auth/email-otp/verify-email-otp.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/email-otp/verify-email-otp.tsx
@@ -103,8 +103,8 @@ export function VerifyEmailOtp(props: VerifyEmailOtpProps) {
       } as Parameters<typeof verifyEmail.mutateAsync>[0])
     }
   }))
-  const email = () => form.state.values.email
-  const code = () => form.state.values.code
+  const email = form.useSelector((state) => state.values.email)
+  const code = form.useSelector((state) => state.values.code)
   const verifyCode = async (completedCode: string) => {
     if (isPending() || !email()) return
     form.setFieldValue("code", completedCode)

--- a/examples/start-solid-zaidan-example/src/components/auth/phone-number/change-phone-number.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/phone-number/change-phone-number.tsx
@@ -101,8 +101,8 @@ export function ChangePhoneNumber(props: ChangePhoneNumberProps = {}) {
       } as Parameters<typeof verify.mutateAsync>[0])
     }
   }))
-  const phoneNumber = () => form.state.values.phoneNumber
-  const code = () => form.state.values.code
+  const phoneNumber = form.useSelector((state) => state.values.phoneNumber)
+  const code = form.useSelector((state) => state.values.code)
   const removePhoneNumber = () =>
     remove.mutate({
       phoneNumber: null

--- a/examples/start-solid-zaidan-example/src/components/auth/phone-number/phone-number.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/phone-number/phone-number.tsx
@@ -142,8 +142,8 @@ export function PhoneNumber(props: PhoneNumberProps) {
       } as Parameters<typeof verify.mutateAsync>[0])
     }
   }))
-  const phoneNumber = () => form.state.values.phoneNumber
-  const code = () => form.state.values.code
+  const phoneNumber = form.useSelector((state) => state.values.phoneNumber)
+  const code = form.useSelector((state) => state.values.code)
   const requestCode = async () => {
     try {
       await sendOtp.mutateAsync({

--- a/examples/start-solid-zaidan-example/src/components/auth/phone-number/reset-phone-number-password.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/phone-number/reset-phone-number-password.tsx
@@ -95,8 +95,8 @@ export function ResetPhoneNumberPassword(props: ResetPhoneNumberPasswordProps) {
       } as Parameters<typeof resetPassword.mutateAsync>[0])
     }
   }))
-  const phoneNumber = () => form.state.values.phoneNumber
-  const password = () => form.state.values.password
+  const phoneNumber = form.useSelector((state) => state.values.phoneNumber)
+  const password = form.useSelector((state) => state.values.password)
   return (
     <Card class={cn("w-full max-w-sm", props.class)}>
       <CardHeader>

--- a/examples/start-solid-zaidan-example/src/components/auth/server-table-state.ts
+++ b/examples/start-solid-zaidan-example/src/components/auth/server-table-state.ts
@@ -1,0 +1,61 @@
+import { createAtom, useSelector } from "@tanstack/solid-store"
+import {
+  type ColumnFiltersState,
+  functionalUpdate,
+  type PaginationState,
+  type SortingState,
+  type Updater
+} from "@tanstack/solid-table"
+import { onCleanup } from "solid-js"
+
+export function createServerTableState({
+  initialSorting = [],
+  pageSize
+}: {
+  initialSorting?: SortingState
+  pageSize: number
+}) {
+  const columnFiltersAtom = createAtom<ColumnFiltersState>([])
+  const globalFilterAtom = createAtom("")
+  const paginationAtom = createAtom<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const sortingAtom = createAtom<SortingState>(initialSorting)
+  const columnFilters = useSelector(columnFiltersAtom)
+  const globalFilter = useSelector(globalFilterAtom)
+  const pagination = useSelector(paginationAtom)
+  const sorting = useSelector(sortingAtom)
+  const resetPage = () => {
+    const current = paginationAtom.get()
+    if (current.pageIndex !== 0) {
+      paginationAtom.set({ ...current, pageIndex: 0 })
+    }
+  }
+  const subscriptions = [
+    columnFiltersAtom.subscribe(resetPage),
+    globalFilterAtom.subscribe(resetPage),
+    sortingAtom.subscribe(resetPage)
+  ]
+  onCleanup(() => {
+    for (const subscription of subscriptions) subscription.unsubscribe()
+  })
+
+  const setPagination = (updater: Updater<PaginationState>) => {
+    paginationAtom.set((current) => functionalUpdate(updater, current))
+  }
+
+  return {
+    atoms: {
+      columnFilters: columnFiltersAtom,
+      globalFilter: globalFilterAtom,
+      pagination: paginationAtom,
+      sorting: sortingAtom
+    },
+    columnFilters,
+    globalFilter,
+    pagination,
+    setPagination,
+    sorting
+  }
+}

--- a/examples/start-solid-zaidan-example/src/components/auth/sso/sso-domain-verification.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/sso/sso-domain-verification.tsx
@@ -58,10 +58,6 @@ export function SsoDomainVerification(props: SsoDomainVerificationProps) {
   const verify = useVerifySsoDomain(auth.authClient as SsoAuthClient, () => ({
     onSuccess: () => setVerified(true)
   }))
-  const host = () =>
-    form.state.values.providerId
-      ? `_${props.tokenPrefix ?? "better-auth-token"}-${form.state.values.providerId}`
-      : ""
   const hostCopy = createCopyToClipboard({
     onError: (error) =>
       setCopyError(error instanceof Error ? error.message : String(error))
@@ -78,13 +74,18 @@ export function SsoDomainVerification(props: SsoDomainVerificationProps) {
       await verify.mutateAsync({ providerId: value.providerId.trim() })
     }
   }))
+  const providerId = form.useSelector((state) => state.values.providerId)
+  const host = () =>
+    providerId()
+      ? `_${props.tokenPrefix ?? "better-auth-token"}-${providerId()}`
+      : ""
 
   const requestNewToken = async () => {
     setCopyError("")
     setVerified(false)
     try {
       await requestToken.mutateAsync({
-        providerId: form.state.values.providerId.trim()
+        providerId: providerId().trim()
       })
     } catch (error) {
       setAuthFormServerError(
@@ -183,9 +184,7 @@ export function SsoDomainVerification(props: SsoDomainVerificationProps) {
               </Show>
               <div class="flex flex-wrap gap-2">
                 <Button
-                  disabled={
-                    !form.state.values.providerId || requestToken.isPending
-                  }
+                  disabled={!providerId() || requestToken.isPending}
                   onClick={() => void requestNewToken()}
                   type="button"
                   variant="outline"
@@ -196,7 +195,7 @@ export function SsoDomainVerification(props: SsoDomainVerificationProps) {
                   {localization.requestNewToken}
                 </Button>
                 <form.AuthFormSubmitButton
-                  disabled={!form.state.values.providerId || verify.isPending}
+                  disabled={!providerId() || verify.isPending}
                 >
                   {localization.verifyDomain}
                 </form.AuthFormSubmitButton>

--- a/examples/start-solid-zaidan-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/two-factor/enable-two-factor-dialog.tsx
@@ -147,7 +147,7 @@ export function EnableTwoFactorDialog(props: {
       )
     }
   }))
-  const code = () => form.state.values.code
+  const code = form.useSelector((state) => state.values.code)
 
   const submitLabel = () => {
     if (step() === "backupCodes") return twoFactorLocalization.done

--- a/examples/start-solid-zaidan-example/src/components/auth/two-factor/two-factor-challenge.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/two-factor/two-factor-challenge.tsx
@@ -153,7 +153,7 @@ export function TwoFactorChallenge(props: TwoFactorChallengeProps) {
       } as Parameters<typeof verifyTotp.mutateAsync>[0])
     }
   }))
-  const code = () => form.state.values.code
+  const code = form.useSelector((state) => state.values.code)
 
   const verifyCode = async (completedCode: string) => {
     if (

--- a/examples/start-solid-zaidan-example/tests/auth-form.browser.test.tsx
+++ b/examples/start-solid-zaidan-example/tests/auth-form.browser.test.tsx
@@ -13,6 +13,7 @@ import {
 import { OrganizationTableRenderer } from "../src/components/auth/organization/organization-table-renderer"
 import { OrganizationTableSelectRow } from "../src/components/auth/organization/organization-table-selection"
 import { createOrganizationTableState } from "../src/components/auth/organization/organization-table-state"
+import { createServerTableState } from "../src/components/auth/server-table-state"
 
 afterEach(cleanup)
 
@@ -104,6 +105,50 @@ function ValidatedAuthForm() {
         <form.AuthFormServerError />
       </form.AuthFormRoot>
     </form.AppForm>
+  )
+}
+
+function AsyncValidatedAuthForm(props: { validate: () => Promise<undefined> }) {
+  const form = createAuthForm(() => ({ defaultValues: { handle: "" } }))
+
+  return (
+    <form.AppForm>
+      <form.AppField
+        name="handle"
+        validators={{
+          onChangeAsync: props.validate,
+          onChangeAsyncDebounceMs: 0
+        }}
+      >
+        {(field) => <field.AuthFormTextField label="Handle" />}
+      </form.AppField>
+    </form.AppForm>
+  )
+}
+
+function ServerTableStateFixture() {
+  const state = createServerTableState({ pageSize: 10 })
+
+  return (
+    <>
+      <button
+        onClick={() => state.setPagination({ pageIndex: 2, pageSize: 10 })}
+        type="button"
+      >
+        Go to page three
+      </button>
+      <button
+        onClick={() =>
+          state.atoms.columnFilters.set([{ id: "status", value: "active" }])
+        }
+        type="button"
+      >
+        Filter users
+      </button>
+      <output aria-label="Server table state">
+        {state.columnFilters().length}|{state.pagination().pageIndex}
+      </output>
+    </>
   )
 }
 
@@ -227,6 +272,11 @@ describe("Solid auth form", () => {
       expect(view.getByText("This email is already registered")).toBeVisible()
     )
     expect(view.getByText("Account creation failed")).toBeVisible()
+
+    fireEvent.input(email, { target: { value: "grace@example.com" } })
+    await vi.waitFor(() =>
+      expect(view.queryByText("Account creation failed")).toBeNull()
+    )
   })
 
   it("keeps an invalid submit action reachable so TanStack can reveal errors", async () => {
@@ -237,9 +287,7 @@ describe("Solid auth form", () => {
     fireEvent.input(email, { target: { value: "ada@example.com" } })
     fireEvent.input(email, { target: { value: "" } })
 
-    await vi.waitFor(() =>
-      expect(submit).toHaveAttribute("aria-disabled", "true")
-    )
+    await vi.waitFor(() => expect(submit).not.toHaveAttribute("aria-disabled"))
     expect(submit).not.toHaveAttribute("disabled")
 
     fireEvent.click(submit)
@@ -248,6 +296,39 @@ describe("Solid auth form", () => {
       expect(view.getByText("Email is required")).toBeVisible()
     )
     await vi.waitFor(() => expect(email).toHaveFocus())
+  })
+
+  it("announces asynchronous field validation without blocking input", async () => {
+    let finishValidation!: () => void
+    const validate = vi.fn(
+      () =>
+        new Promise<undefined>((resolve) => {
+          finishValidation = () => resolve(undefined)
+        })
+    )
+    const view = render(() => <AsyncValidatedAuthForm validate={validate} />)
+    const input = view.getByRole("textbox", { name: "Handle" })
+
+    fireEvent.input(input, { target: { value: "ada" } })
+    await vi.waitFor(() => expect(input).toHaveAttribute("aria-busy", "true"))
+    expect(input).toHaveValue("ada")
+
+    finishValidation()
+    await vi.waitFor(() => expect(input).not.toHaveAttribute("aria-busy"))
+  })
+})
+
+describe("Solid TanStack server table state", () => {
+  it("returns to the first page when a filter changes", async () => {
+    const view = render(() => <ServerTableStateFixture />)
+
+    fireEvent.click(view.getByRole("button", { name: "Go to page three" }))
+    expect(view.getByLabelText("Server table state")).toHaveTextContent("0|2")
+
+    fireEvent.click(view.getByRole("button", { name: "Filter users" }))
+    await vi.waitFor(() =>
+      expect(view.getByLabelText("Server table state")).toHaveTextContent("1|0")
+    )
   })
 })
 

--- a/packages/core/src/lib/table-state.ts
+++ b/packages/core/src/lib/table-state.ts
@@ -34,6 +34,8 @@ export type TablePersistenceAdapters = {
   storage?: TableStorageAdapter
 }
 
+export const DEFAULT_TABLE_SEARCH_DEBOUNCE_MS = 300
+
 /**
  * Create a search adapter from a router's search and navigation primitives.
  *

--- a/packages/heroui/src/components/auth/admin/admin-users.tsx
+++ b/packages/heroui/src/components/auth/admin/admin-users.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import {
+  DEFAULT_TABLE_SEARCH_DEBOUNCE_MS,
   fieldsWithModelValues,
   getAdditionalFieldDefaultValues,
   getAdditionalFieldSubmitValues,
@@ -58,18 +59,14 @@ import {
   Tabs,
   TextField
 } from "@heroui/react"
+import { useDebouncedValue } from "@tanstack/react-pacer"
 import { keepPreviousData } from "@tanstack/react-query"
-import {
-  type ColumnFiltersState,
-  functionalUpdate,
-  type PaginationState,
-  type SortingState,
-  type Updater
-} from "@tanstack/react-table"
+import type { SortingState } from "@tanstack/react-table"
 import type { BetterFetchError } from "better-auth/client"
-import { useDeferredValue, useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { adminPlugin } from "../../../lib/auth/admin-plugin"
 import { getAuthAdditionalFieldValidators, useAuthForm } from "../auth-form"
+import { useServerTableState } from "../server-table-state"
 import { getHeroUISortDescriptor, getTanStackSorting } from "../table-bridge"
 import { UserAvatar } from "../user/user-avatar"
 import { createAdminColumnHelper, useAdminTable } from "./admin-table"
@@ -139,6 +136,7 @@ const adminColumns = adminColumnHelper.columns([
   })
 ])
 const EMPTY_USERS: AdminUser[] = []
+const INITIAL_ADMIN_SORTING: SortingState = [{ id: "createdAt", desc: true }]
 
 /** HeroUI presentation for the static Admin users view. */
 export function AdminUsers({
@@ -149,22 +147,19 @@ export function AdminUsers({
   const { authClient } = useAuth<AdminAuthClient>()
   const config = useAuthPlugin(adminPlugin)
   const [localSelectedUserId, setLocalSelectedUserId] = useState<string>()
-  const [globalFilter, setGlobalFilterState] = useState("")
-  const [columnFilters, setColumnFiltersState] = useState<ColumnFiltersState>(
-    []
-  )
-  const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: 0,
+  const tableState = useServerTableState({
+    initialSorting: INITIAL_ADMIN_SORTING,
     pageSize: config.pageSize
   })
-  const [sorting, setSortingState] = useState<SortingState>([
-    { id: "createdAt", desc: true }
-  ])
+  const { columnFilters, globalFilter, pagination, setPagination, sorting } =
+    tableState
   const [searchField, setSearchField] = useState<SearchFieldName>("email")
   const [searchOperator, setSearchOperator] =
     useState<SearchOperator>("contains")
   const [createOpen, setCreateOpen] = useState(false)
-  const deferredSearch = useDeferredValue(globalFilter.trim())
+  const [debouncedSearch] = useDebouncedValue(globalFilter.trim(), {
+    wait: DEFAULT_TABLE_SEARCH_DEBOUNCE_MS
+  })
   const status = String(
     columnFilters.find((filter) => filter.id === "status")?.value ?? "all"
   ) as StatusFilter
@@ -190,12 +185,12 @@ export function AdminUsers({
       offset: pagination.pageIndex * pagination.pageSize,
       searchField,
       searchOperator,
-      searchValue: deferredSearch || undefined,
+      searchValue: debouncedSearch || undefined,
       sortBy,
       sortDirection
     }
   }, [
-    deferredSearch,
+    debouncedSearch,
     pagination.pageIndex,
     pagination.pageSize,
     searchField,
@@ -224,36 +219,24 @@ export function AdminUsers({
       total
     )
     if (pageIndex !== pagination.pageIndex) {
-      setPaginationState((current) => ({ ...current, pageIndex }))
+      setPagination((current) => ({ ...current, pageIndex }))
     }
-  }, [pagination.pageIndex, pagination.pageSize, total, users.isSuccess])
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
-    setColumnFiltersState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setGlobalFilter = (updater: Updater<string>) => {
-    setGlobalFilterState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setSorting = (updater: Updater<SortingState>) => {
-    setSortingState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
+  }, [
+    pagination.pageIndex,
+    pagination.pageSize,
+    setPagination,
+    total,
+    users.isSuccess
+  ])
   const table = useAdminTable({
+    atoms: tableState.atoms,
     columns: adminColumns,
     data: users.data?.users ?? EMPTY_USERS,
     getRowId: (user) => user.id,
     manualFiltering: true,
     manualPagination: true,
     manualSorting: true,
-    rowCount: total,
-    state: { columnFilters, globalFilter, pagination, sorting },
-    onColumnFiltersChange: setColumnFilters,
-    onGlobalFilterChange: setGlobalFilter,
-    onPaginationChange: setPagination,
-    onSortingChange: setSorting
+    rowCount: total
   })
 
   return (
@@ -437,7 +420,7 @@ export function AdminUsers({
                 selectUser(userId == null ? undefined : String(userId))
               }}
               onSortChange={(descriptor) =>
-                setSorting(getTanStackSorting(descriptor))
+                table.setSorting(getTanStackSorting(descriptor))
               }
             >
               <Table.Header>

--- a/packages/heroui/src/components/auth/api-key/api-keys.tsx
+++ b/packages/heroui/src/components/auth/api-key/api-keys.tsx
@@ -16,17 +16,15 @@ import {
 } from "@heroui/react"
 import {
   createTableHook,
-  functionalUpdate,
-  type PaginationState,
   rowPaginationFeature,
   rowSortingFeature,
   type SortingState,
-  tableFeatures,
-  type Updater
+  tableFeatures
 } from "@tanstack/react-table"
 import { useEffect, useMemo, useState } from "react"
 
 import { apiKeyPlugin } from "../../../lib/auth/api-key-plugin"
+import { useServerTableState } from "../server-table-state"
 import { ApiKey } from "./api-key"
 import { ApiKeySkeleton } from "./api-key-skeleton"
 import { ApiKeysEmpty } from "./api-keys-empty"
@@ -45,6 +43,7 @@ const apiKeyColumns = apiKeyColumnHelper.columns([
   apiKeyColumnHelper.accessor("name", { id: "name" })
 ])
 const EMPTY_API_KEYS: ListedApiKey[] = []
+const INITIAL_API_KEY_SORTING: SortingState = [{ id: "createdAt", desc: true }]
 
 export type ApiKeysProps = {
   className?: string
@@ -73,13 +72,11 @@ export function ApiKeys({
   const { authClient } = useAuth()
   const { localization: apiKeyLocalization, pageSize } =
     useAuthPlugin(apiKeyPlugin)
-  const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: 0,
+  const tableState = useServerTableState({
+    initialSorting: INITIAL_API_KEY_SORTING,
     pageSize
   })
-  const [sorting, setSortingState] = useState<SortingState>([
-    { id: "createdAt", desc: true }
-  ])
+  const { pagination, setPagination, sorting } = tableState
   const primarySort = sorting[0]
   const sortBy = primarySort?.id === "name" ? "name" : "createdAt"
   const sortDirection = primarySort?.desc ? "desc" : "asc"
@@ -109,13 +106,6 @@ export function ApiKeys({
       ),
     [listData?.apiKeys, pagination.pageSize]
   )
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setSorting = (updater: Updater<SortingState>) => {
-    setSortingState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-
   useEffect(() => {
     if (
       isListSuccess &&
@@ -123,22 +113,27 @@ export function ApiKeys({
       pagination.pageIndex > 0 &&
       page.rows.length === 0
     ) {
-      setPaginationState((current) => ({
+      setPagination((current) => ({
         ...current,
         pageIndex: Math.max(0, current.pageIndex - 1)
       }))
     }
-  }, [isListSuccess, isPendingProp, page.rows.length, pagination.pageIndex])
+  }, [
+    isListSuccess,
+    isPendingProp,
+    page.rows.length,
+    pagination.pageIndex,
+    setPagination
+  ])
 
   const table = useApiKeyTable({
+    atoms: tableState.atoms,
     columns: apiKeyColumns,
     data: page.rows,
     getRowId: (apiKey) => apiKey.id,
     manualPagination: true,
-    manualSorting: true,
-    state: { pagination, sorting },
-    onPaginationChange: setPagination,
-    onSortingChange: setSorting
+    pageCount: -1,
+    manualSorting: true
   })
 
   const [createOpen, setCreateOpen] = useState(false)

--- a/packages/heroui/src/components/auth/auth-form.tsx
+++ b/packages/heroui/src/components/auth/auth-form.tsx
@@ -28,6 +28,7 @@ import {
   type ComponentProps,
   type FormEvent,
   type ReactNode,
+  useEffect,
   useRef
 } from "react"
 import { AdditionalField, type AdditionalFieldProps } from "./additional-field"
@@ -89,6 +90,7 @@ export function setAuthFormServerError(
 }
 
 export function clearAuthFormServerError(form: AnyFormApi) {
+  if (!form.state.errorMap.onServer) return
   form.setErrorMap({ onServer: undefined })
 }
 
@@ -120,7 +122,17 @@ function AuthFormRoot({
   ...props
 }: AuthFormRootProps) {
   const form = useFormContext()
+  const formElementRef = useRef<HTMLFormElement>(null)
   const submittingRef = useRef(false)
+
+  useEffect(() => {
+    const formElement = formElementRef.current
+    if (!formElement) return
+
+    const clearServerError = () => clearAuthFormServerError(form)
+    formElement.addEventListener("input", clearServerError)
+    return () => formElement.removeEventListener("input", clearServerError)
+  }, [form])
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -140,6 +152,7 @@ function AuthFormRoot({
   return (
     <Form
       {...props}
+      ref={formElementRef}
       validationBehavior="aria"
       onInvalid={(event) =>
         focusFirstInvalidAuthFormControl(event.currentTarget)
@@ -167,6 +180,7 @@ function AuthFormTextField({
   ...props
 }: AuthFormTextFieldProps) {
   const field = useFieldContext<string>()
+  const form = useFormContext()
   const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
   return (
@@ -175,12 +189,18 @@ function AuthFormTextField({
       isInvalid={isInvalid || undefined}
       name={field.name}
       onBlur={field.handleBlur}
-      onChange={field.handleChange}
+      onChange={(value) => {
+        clearAuthFormServerError(form)
+        field.handleChange(value)
+      }}
       validationBehavior="aria"
       value={field.state.value}
     >
       <Label>{label}</Label>
-      <Input {...inputProps} />
+      <Input
+        {...inputProps}
+        aria-busy={field.state.meta.isValidating || undefined}
+      />
       {description ? <Description>{description}</Description> : null}
       <AuthFormFieldError />
     </TextField>
@@ -196,13 +216,15 @@ function AuthFormSubmitButton({
 
   return (
     <form.Subscribe
-      selector={(state) => [state.canSubmit, state.isSubmitting] as const}
+      selector={(state) => [state.isSubmitting, state.isValidating] as const}
     >
-      {([canSubmit, isSubmitting]) => (
+      {([isSubmitting, isValidating]) => (
         <Button
           {...props}
-          aria-disabled={isDisabled || !canSubmit || isSubmitting || undefined}
-          isDisabled={isDisabled || isSubmitting}
+          aria-disabled={
+            isDisabled || isSubmitting || isValidating || undefined
+          }
+          isDisabled={isDisabled || isSubmitting || isValidating}
           type="submit"
         >
           {isSubmitting ? <Spinner /> : null}
@@ -220,6 +242,7 @@ type AuthFormAdditionalFieldProps = Omit<
 
 function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   const field = useFieldContext<AdditionalFieldFormValue>()
+  const form = useFormContext()
   const isInvalid = isAuthFormFieldInvalid(field.state.meta)
 
   return (
@@ -231,18 +254,16 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
       isInvalid={isInvalid}
       name={field.name}
       onBlur={field.handleBlur}
-      onChange={field.handleChange}
+      onChange={(value) => {
+        clearAuthFormServerError(form)
+        field.handleChange(value)
+      }}
       value={field.state.value}
     />
   )
 }
 
-export const {
-  useAppForm: useAuthForm,
-  useTypedAppFormContext: useTypedAuthFormContext,
-  withFieldGroup: withAuthFieldGroup,
-  withForm: withAuthForm
-} = createFormHook({
+export const { useAppForm: useAuthForm } = createFormHook({
   fieldComponents: {
     AuthFormAdditionalField,
     AuthFormFieldError,

--- a/packages/heroui/src/components/auth/dash/activity.tsx
+++ b/packages/heroui/src/components/auth/dash/activity.tsx
@@ -1,6 +1,9 @@
 "use client"
 
-import { getClampedTablePageIndex } from "@better-auth-ui/core"
+import {
+  DEFAULT_TABLE_SEARCH_DEBOUNCE_MS,
+  getClampedTablePageIndex
+} from "@better-auth-ui/core"
 import type {
   DashAuditLog,
   DashAuthClient
@@ -45,21 +48,19 @@ import {
   Skeleton,
   Spinner
 } from "@heroui/react"
+import { useDebouncedValue } from "@tanstack/react-pacer"
 import { keepPreviousData } from "@tanstack/react-query"
 import {
-  type ColumnFiltersState,
   columnFilteringFeature,
   createTableHook,
-  functionalUpdate,
   globalFilteringFeature,
-  type PaginationState,
   rowPaginationFeature,
-  tableFeatures,
-  type Updater
+  tableFeatures
 } from "@tanstack/react-table"
-import { useDeferredValue, useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo } from "react"
 import { dashPlugin } from "../../../lib/auth/dash-plugin"
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
+import { useServerTableState } from "../server-table-state"
 
 type ActivityAccess = "admin" | "admin-user" | "organization" | "user"
 
@@ -232,18 +233,14 @@ function ActivityFeed({
 }: ActivityFeedProps) {
   const { authClient, locale } = useAuth()
   const { localization, pageSize } = useAuthPlugin(dashPlugin)
-  const [pagination, setPaginationState] = useState<PaginationState>({
-    pageIndex: 0,
-    pageSize
-  })
-  const [columnFilters, setColumnFiltersState] = useState<ColumnFiltersState>(
-    []
-  )
-  const [globalFilter, setGlobalFilterState] = useState("")
+  const tableState = useServerTableState({ pageSize })
+  const { columnFilters, globalFilter, pagination, setPagination } = tableState
   const eventType = String(
     columnFilters.find((filter) => filter.id === "eventType")?.value ?? "all"
   )
-  const deferredIdentifier = useDeferredValue(globalFilter.trim())
+  const [debouncedIdentifier] = useDebouncedValue(globalFilter.trim(), {
+    wait: DEFAULT_TABLE_SEARCH_DEBOUNCE_MS
+  })
   const eventOptions = useMemo(
     () => Object.entries(localization.eventLabels),
     [localization.eventLabels]
@@ -252,7 +249,7 @@ function ActivityFeed({
   const offset = pagination.pageIndex * pagination.pageSize
   const params = {
     eventType: eventType === "all" ? undefined : eventType,
-    identifier: deferredIdentifier || undefined,
+    identifier: debouncedIdentifier || undefined,
     limit: pagination.pageSize,
     offset,
     organizationId
@@ -298,36 +295,24 @@ function ActivityFeed({
       data?.total ?? 0
     )
     if (pageIndex !== pagination.pageIndex) {
-      setPaginationState((current) => ({ ...current, pageIndex }))
+      setPagination((current) => ({ ...current, pageIndex }))
     }
   }, [
     data?.total,
     pagination.pageIndex,
     pagination.pageSize,
     query.isSuccess,
-    ready
+    ready,
+    setPagination
   ])
-  const setPagination = (updater: Updater<PaginationState>) =>
-    setPaginationState((current) => functionalUpdate(updater, current))
-  const setColumnFilters = (updater: Updater<ColumnFiltersState>) => {
-    setColumnFiltersState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
-  const setGlobalFilter = (updater: Updater<string>) => {
-    setGlobalFilterState((current) => functionalUpdate(updater, current))
-    setPaginationState((current) => ({ ...current, pageIndex: 0 }))
-  }
   const table = useActivityTable({
+    atoms: tableState.atoms,
     columns: activityColumns,
     data: data?.events ?? EMPTY_EVENTS,
     getRowId: getDashEventKey,
     manualFiltering: true,
     manualPagination: true,
-    rowCount: data?.total ?? 0,
-    state: { columnFilters, globalFilter, pagination },
-    onColumnFiltersChange: setColumnFilters,
-    onGlobalFilterChange: setGlobalFilter,
-    onPaginationChange: setPagination
+    rowCount: data?.total ?? 0
   })
 
   return (

--- a/packages/heroui/src/components/auth/organization/organization-sortable-table-header.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-sortable-table-header.tsx
@@ -1,60 +1,60 @@
 import { ChevronUp } from "@gravity-ui/icons"
 import { Button, cn } from "@heroui/react"
+import { type Column, type RowData, Subscribe } from "@tanstack/react-table"
 import type { ReactNode } from "react"
+import type { organizationTableFeatures } from "./organization-table"
 
-type SortableColumn = {
-  getCanSort: () => boolean
-  getIsSorted: () => false | "asc" | "desc"
-  getSortIndex: () => number
-  getToggleSortingHandler: () => undefined | ((event: unknown) => void)
-}
-
-export function OrganizationSortableTableHeader({
+export function OrganizationSortableTableHeader<TData extends RowData>({
   children,
   column,
   interactive = true
 }: {
   children: ReactNode
-  column?: SortableColumn
+  column?: Column<typeof organizationTableFeatures, TData>
   interactive?: boolean
 }) {
-  const sortDirection = column?.getIsSorted()
   const onPress = column?.getToggleSortingHandler()
 
-  if (!onPress) return children
-
-  const content = (
-    <>
-      {children}
-
-      {sortDirection && (
-        <>
-          <ChevronUp
-            className={cn(
-              "size-3 transition-transform duration-100 ease-out",
-              sortDirection === "desc" && "rotate-180"
-            )}
-          />
-          <span className="text-muted text-[10px] tabular-nums">
-            {(column?.getSortIndex() ?? 0) + 1}
-          </span>
-        </>
-      )}
-    </>
-  )
-
-  if (!interactive) {
-    return <span className="flex items-center gap-1">{content}</span>
-  }
+  if (!column || !onPress) return children
 
   return (
-    <Button
-      className="h-auto min-w-0 justify-start gap-1 p-0 font-medium"
-      onPress={(event) => onPress(event)}
-      size="sm"
-      variant="tertiary"
+    <Subscribe
+      source={column.table.atoms.sorting}
+      selector={() => [column.getIsSorted(), column.getSortIndex()] as const}
     >
-      {content}
-    </Button>
+      {([sortDirection, sortIndex]) => {
+        const content = (
+          <>
+            {children}
+            {sortDirection ? (
+              <>
+                <ChevronUp
+                  className={cn(
+                    "size-3 transition-transform duration-100 ease-out",
+                    sortDirection === "desc" && "rotate-180"
+                  )}
+                />
+                <span className="text-muted text-[10px] tabular-nums">
+                  {sortIndex + 1}
+                </span>
+              </>
+            ) : null}
+          </>
+        )
+
+        return interactive ? (
+          <Button
+            className="h-auto min-w-0 justify-start gap-1 p-0 font-medium"
+            onPress={(event) => onPress(event)}
+            size="sm"
+            variant="tertiary"
+          >
+            {content}
+          </Button>
+        ) : (
+          <span className="flex items-center gap-1">{content}</span>
+        )
+      }}
+    </Subscribe>
   )
 }

--- a/packages/heroui/src/components/auth/organization/organization-table-renderer.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-table-renderer.tsx
@@ -3,7 +3,8 @@ import type { ReactNode } from "react"
 import {
   getHeroUISelection,
   getHeroUISortDescriptor,
-  getTanStackRowSelection
+  getTanStackRowSelection,
+  getTanStackSorting
 } from "../table-bridge"
 import { OrganizationSortableTableHeader } from "./organization-sortable-table-header"
 import { useOrganizationTableContext } from "./organization-table"
@@ -32,9 +33,9 @@ export function OrganizationTableRenderer({
             table.setRowSelection(getTanStackRowSelection(selection, rowIds))
           }
           onSortChange={(descriptor) => {
-            const column = table.getColumn(String(descriptor.column))
-            const toggleSorting = column?.getToggleSortingHandler()
-            toggleSorting?.({ shiftKey: table.state.sorting.length > 1 })
+            table.setSorting(
+              getTanStackSorting(descriptor, table.state.sorting)
+            )
           }}
           selectedKeys={getHeroUISelection(table.state.rowSelection)}
           selectionMode={selectable ? "multiple" : "none"}

--- a/packages/heroui/src/components/auth/server-table-state.ts
+++ b/packages/heroui/src/components/auth/server-table-state.ts
@@ -1,0 +1,72 @@
+import { useCreateAtom, useSelector } from "@tanstack/react-store"
+import {
+  type ColumnFiltersState,
+  functionalUpdate,
+  type PaginationState,
+  type SortingState,
+  type Updater
+} from "@tanstack/react-table"
+import { useCallback, useEffect, useMemo } from "react"
+
+export function useServerTableState({
+  initialSorting = [],
+  pageSize
+}: {
+  initialSorting?: SortingState
+  pageSize: number
+}) {
+  const columnFiltersAtom = useCreateAtom<ColumnFiltersState>([])
+  const globalFilterAtom = useCreateAtom("")
+  const paginationAtom = useCreateAtom<PaginationState>({
+    pageIndex: 0,
+    pageSize
+  })
+  const sortingAtom = useCreateAtom<SortingState>(initialSorting)
+  const columnFilters = useSelector(columnFiltersAtom)
+  const globalFilter = useSelector(globalFilterAtom)
+  const pagination = useSelector(paginationAtom)
+  const sorting = useSelector(sortingAtom)
+  const atoms = useMemo(
+    () => ({
+      columnFilters: columnFiltersAtom,
+      globalFilter: globalFilterAtom,
+      pagination: paginationAtom,
+      sorting: sortingAtom
+    }),
+    [columnFiltersAtom, globalFilterAtom, paginationAtom, sortingAtom]
+  )
+
+  useEffect(() => {
+    const resetPage = () => {
+      const current = paginationAtom.get()
+      if (current.pageIndex !== 0) {
+        paginationAtom.set({ ...current, pageIndex: 0 })
+      }
+    }
+    const subscriptions = [
+      columnFiltersAtom.subscribe(resetPage),
+      globalFilterAtom.subscribe(resetPage),
+      sortingAtom.subscribe(resetPage)
+    ]
+
+    return () => {
+      for (const subscription of subscriptions) subscription.unsubscribe()
+    }
+  }, [columnFiltersAtom, globalFilterAtom, paginationAtom, sortingAtom])
+
+  const setPagination = useCallback(
+    (updater: Updater<PaginationState>) => {
+      paginationAtom.set((current) => functionalUpdate(updater, current))
+    },
+    [paginationAtom]
+  )
+
+  return {
+    atoms,
+    columnFilters,
+    globalFilter,
+    pagination,
+    setPagination,
+    sorting
+  }
+}

--- a/packages/heroui/src/components/auth/table-bridge.ts
+++ b/packages/heroui/src/components/auth/table-bridge.ts
@@ -13,12 +13,17 @@ export function getHeroUISortDescriptor(
     : undefined
 }
 
-export function getTanStackSorting(descriptor: SortDescriptor): SortingState {
+export function getTanStackSorting(
+  descriptor: SortDescriptor,
+  sorting: SortingState = []
+): SortingState {
+  const id = String(descriptor.column)
   return [
     {
       desc: descriptor.direction === "descending",
-      id: String(descriptor.column)
-    }
+      id
+    },
+    ...sorting.filter((sort) => sort.id !== id)
   ]
 }
 

--- a/packages/heroui/tests/auth-form.test.tsx
+++ b/packages/heroui/tests/auth-form.test.tsx
@@ -10,6 +10,7 @@ import {
   setAuthFormServerError,
   useAuthForm
 } from "../src/components/auth/auth-form"
+import { useServerTableState } from "../src/components/auth/server-table-state"
 
 function TestAuthForm({ onSubmit }: { onSubmit: () => Promise<void> }) {
   const form = useAuthForm({ defaultValues: {}, onSubmit })
@@ -63,6 +64,49 @@ function TestFieldForm({
   )
 }
 
+function AsyncValidatedAuthForm({
+  validate
+}: {
+  validate: () => Promise<undefined>
+}) {
+  const form = useAuthForm({ defaultValues: { handle: "" } })
+
+  return (
+    <form.AppForm>
+      <form.AppField
+        name="handle"
+        validators={{ onChangeAsync: validate, onChangeAsyncDebounceMs: 0 }}
+      >
+        {(field) => <field.AuthFormTextField label="Handle" />}
+      </form.AppField>
+    </form.AppForm>
+  )
+}
+
+function ServerTableStateFixture() {
+  const state = useServerTableState({ pageSize: 10 })
+
+  return (
+    <>
+      <button
+        onClick={() => state.setPagination({ pageIndex: 2, pageSize: 10 })}
+        type="button"
+      >
+        Go to page three
+      </button>
+      <button
+        onClick={() => state.atoms.sorting.set([{ id: "name", desc: false }])}
+        type="button"
+      >
+        Sort users
+      </button>
+      <output aria-label="Server table state">
+        {state.sorting[0]?.id ?? "none"}|{state.pagination.pageIndex}
+      </output>
+    </>
+  )
+}
+
 describe("AuthFormRoot", () => {
   it("rejects concurrent submission and disables the submit button", async () => {
     let finishSubmission!: () => void
@@ -103,6 +147,11 @@ describe("AuthFormRoot", () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce())
     expect(await screen.findByText("This email cannot be used")).toBeVisible()
     expect(screen.getByText("Account creation failed")).toBeVisible()
+
+    fireEvent.change(input, { target: { value: "grace@example.com" } })
+    await waitFor(() =>
+      expect(screen.queryByText("Account creation failed")).toBeNull()
+    )
   })
 
   it("keeps an invalid submit action reachable so TanStack can reveal errors", async () => {
@@ -115,7 +164,7 @@ describe("AuthFormRoot", () => {
     fireEvent.change(input, { target: { value: "" } })
 
     await waitFor(() =>
-      expect(submitButton).toHaveAttribute("aria-disabled", "true")
+      expect(submitButton).not.toHaveAttribute("aria-disabled")
     )
     expect(submitButton).not.toHaveAttribute("disabled")
 
@@ -149,6 +198,25 @@ describe("AuthFormRoot", () => {
     expect(screen.getByText("Mutation-owned form error")).toBeVisible()
     expect(screen.queryByText("Mutation rejected")).toBeNull()
   })
+
+  it("announces asynchronous field validation without blocking input", async () => {
+    let finishValidation!: () => void
+    const validate = vi.fn(
+      () =>
+        new Promise<undefined>((resolve) => {
+          finishValidation = () => resolve(undefined)
+        })
+    )
+    render(<AsyncValidatedAuthForm validate={validate} />)
+    const input = screen.getByRole("textbox", { name: "Handle" })
+
+    fireEvent.change(input, { target: { value: "ada" } })
+    await waitFor(() => expect(input).toHaveAttribute("aria-busy", "true"))
+    expect(input).toHaveValue("ada")
+
+    finishValidation()
+    await waitFor(() => expect(input).not.toHaveAttribute("aria-busy"))
+  })
 })
 
 describe("additional field validation", () => {
@@ -174,5 +242,23 @@ describe("additional field validation", () => {
         "Required"
       ).onChangeAsyncDebounceMs
     ).toBe(0)
+  })
+})
+
+describe("HeroUI TanStack server table state", () => {
+  it("returns to the first page when sorting changes", async () => {
+    render(<ServerTableStateFixture />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Go to page three" }))
+    expect(screen.getByLabelText("Server table state")).toHaveTextContent(
+      "none|2"
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Sort users" }))
+    await waitFor(() =>
+      expect(screen.getByLabelText("Server table state")).toHaveTextContent(
+        "name|0"
+      )
+    )
   })
 })

--- a/packages/heroui/tests/sign-up.test.tsx
+++ b/packages/heroui/tests/sign-up.test.tsx
@@ -208,7 +208,7 @@ describe("<SignUp />", () => {
     await user.type(password, "correct horse battery")
     await user.type(confirmPassword, "different horse battery")
     expect(screen.getByText("Passwords do not match")).toBeVisible()
-    expect(screen.getByRole("button", { name: "Sign Up" })).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Sign Up" })).toBeEnabled()
     expect(password).toHaveValue("correct horse battery")
     expect(confirmPassword).toHaveValue("different horse battery")
     expect(name).toHaveValue("Ada Lovelace")

--- a/packages/heroui/tests/sso.test.tsx
+++ b/packages/heroui/tests/sso.test.tsx
@@ -292,7 +292,7 @@ describe("SSO provider management", () => {
     expect(screen.getAllByText("This field is required")).toHaveLength(2)
     expect(
       screen.getByRole("button", { name: /add sso provider/i })
-    ).toBeDisabled()
+    ).toBeEnabled()
     expect(authClient.sso.register).not.toHaveBeenCalled()
   })
 

--- a/packages/heroui/tests/table-bridge.test.ts
+++ b/packages/heroui/tests/table-bridge.test.ts
@@ -21,6 +21,18 @@ describe("HeroUI table bridge", () => {
     expect(getTanStackSorting(descriptor)).toEqual(sorting)
   })
 
+  it("honors HeroUI direction changes without dropping secondary sorts", () => {
+    expect(
+      getTanStackSorting({ column: "name", direction: "descending" }, [
+        { id: "createdAt", desc: true },
+        { id: "name", desc: false }
+      ])
+    ).toEqual([
+      { id: "name", desc: true },
+      { id: "createdAt", desc: true }
+    ])
+  })
+
   it("converts explicit and all-row selection", () => {
     expect(getHeroUISelection({ first: true, ignored: false })).toEqual(
       new Set(["first"])


### PR DESCRIPTION
## Summary

- move server-backed admin, activity, and API-key tables to TanStack external atoms across React, Solid, shadcn, HeroUI, Base UI, Zaidan, and Next.js targets
- debounce remote filters, reset pagination from query-state changes, use lookahead pagination for unknown API-key totals, and preserve HeroUI multi-sort state
- make Solid form value reads reactive, keep invalid submit actions reachable, expose async validation state, and clear stale server errors after edits
- keep generated registries self-contained and add focused cross-platform regression coverage

## Validation

- `bun install --frozen-lockfile`
- `bun nx run workspace:lint --skip-nx-cache`
- affected typechecks for docs, shadcn, Base UI, HeroUI, Solid, and core
- `bun nx run next-shadcn-example:build --skip-nx-cache`
- shadcn auth-form browser tests: 10 passed
- Solid auth-form browser tests: 10 passed
- HeroUI focused form, table-bridge, sign-up, and SSO tests: 27 passed
- React and Solid registry builds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Server-side tables now provide consistent filtering, sorting, pagination, and debounced search across authentication and dashboard views.
  * Changing filters or sorting automatically returns results to the first page.
  * Table sorting better preserves secondary sort criteria.
  * Form fields now indicate asynchronous validation with `aria-busy`.

* **Bug Fixes**
  * Server-side form errors clear when users edit form fields.
  * Submit buttons remain reachable when validation errors are present, while disabling during validation or submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->