### PR TITLE
refactor(tanstack): tighten form and table integrations

### DIFF
--- a/apps/docs/src/components/auth/admin/admin-users.tsx
+++ b/apps/docs/src/components/auth/admin/admin-users.tsx
@@ -276,16 +276,19 @@ export function AdminUsers({
     total,
     users.isSuccess
   ])
-  const table = useAdminTable({
-    atoms: tableState.atoms,
-    columns: adminColumns,
-    data: users.data?.users ?? EMPTY_USERS,
-    getRowId: (user) => user.id,
-    manualFiltering: true,
-    manualPagination: true,
-    manualSorting: true,
-    rowCount: total
-  })
+  const table = useAdminTable(
+    {
+      atoms: tableState.atoms,
+      columns: adminColumns,
+      data: users.data?.users ?? EMPTY_USERS,
+      getRowId: (user) => user.id,
+      manualFiltering: true,
+      manualPagination: true,
+      manualSorting: true,
+      rowCount: total
+    },
+    () => null
+  )
   const from = total ? pagination.pageIndex * pagination.pageSize + 1 : 0
   const to = Math.min(total, (pagination.pageIndex + 1) * pagination.pageSize)
 

--- a/apps/docs/src/components/auth/api-key/api-keys.tsx
+++ b/apps/docs/src/components/auth/api-key/api-keys.tsx
@@ -128,15 +128,18 @@ export function ApiKeys({
     setPagination
   ])
 
-  const table = useApiKeyTable({
-    atoms: tableState.atoms,
-    columns: apiKeyColumns,
-    data: page.rows,
-    getRowId: (apiKey) => apiKey.id,
-    manualPagination: true,
-    pageCount: -1,
-    manualSorting: true
-  })
+  const table = useApiKeyTable(
+    {
+      atoms: tableState.atoms,
+      columns: apiKeyColumns,
+      data: page.rows,
+      getRowId: (apiKey) => apiKey.id,
+      manualPagination: true,
+      pageCount: -1,
+      manualSorting: true
+    },
+    () => null
+  )
 
   const [createOpen, setCreateOpen] = useState(false)
 

--- a/apps/docs/src/components/auth/auth-form.tsx
+++ b/apps/docs/src/components/auth/auth-form.tsx
@@ -90,8 +90,24 @@ export function setAuthFormServerError(
 }
 
 export function clearAuthFormServerError(form: AnyFormApi) {
-  if (!form.state.errorMap.onServer) return
+  form.setErrorMap({ onServer: { fields: {} } })
+}
+
+export function clearAuthFormFieldServerError(
+  form: AnyFormApi,
+  fieldName: string
+) {
   form.setErrorMap({ onServer: undefined })
+  if (!fieldName) return
+
+  const fieldMeta = form.getFieldMeta(fieldName as never)
+  if (!fieldMeta?.errorMap.onServer) return
+
+  form.setFieldMeta(fieldName as never, (current = fieldMeta) => ({
+    ...current,
+    errorMap: { ...current.errorMap, onServer: undefined },
+    errorSourceMap: { ...current.errorSourceMap, onServer: undefined }
+  }))
 }
 
 export async function runAuthFormAction(
@@ -164,7 +180,14 @@ function AuthFormRoot({
         focusFirstInvalidAuthFormControl(event.currentTarget)
       }
       onInput={(event) => {
-        clearAuthFormServerError(form)
+        const target = event.target
+        const fieldName =
+          target instanceof HTMLInputElement ||
+          target instanceof HTMLSelectElement ||
+          target instanceof HTMLTextAreaElement
+            ? target.name
+            : ""
+        clearAuthFormFieldServerError(form, fieldName)
         onInput?.(event)
       }}
       onSubmit={submit}
@@ -204,7 +227,7 @@ function AuthFormTextField({
         name={field.name}
         onBlur={field.handleBlur}
         onChange={(event) => {
-          clearAuthFormServerError(form)
+          clearAuthFormFieldServerError(form, field.name)
           field.handleChange(event.target.value)
         }}
         value={field.state.value}
@@ -261,7 +284,7 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
       name={field.name}
       onBlur={field.handleBlur}
       onChange={(value) => {
-        clearAuthFormServerError(form)
+        clearAuthFormFieldServerError(form, field.name)
         field.handleChange(value)
       }}
       value={field.state.value}
@@ -269,7 +292,11 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   )
 }
 
-export const { useAppForm: useAuthForm } = createFormHook({
+export const {
+  useAppForm: useAuthForm,
+  withFieldGroup: withAuthFieldGroup,
+  withForm: withAuthForm
+} = createFormHook({
   fieldComponents: {
     AuthFormAdditionalField,
     AuthFormFieldError,

--- a/apps/docs/src/components/auth/dash/activity.tsx
+++ b/apps/docs/src/components/auth/dash/activity.tsx
@@ -310,15 +310,18 @@ function ActivityFeed({
     ready,
     setPagination
   ])
-  const table = useActivityTable({
-    atoms: tableState.atoms,
-    columns: activityColumns,
-    data: data?.events ?? EMPTY_EVENTS,
-    getRowId: getDashEventKey,
-    manualFiltering: true,
-    manualPagination: true,
-    rowCount: data?.total ?? 0
-  })
+  const table = useActivityTable(
+    {
+      atoms: tableState.atoms,
+      columns: activityColumns,
+      data: data?.events ?? EMPTY_EVENTS,
+      getRowId: getDashEventKey,
+      manualFiltering: true,
+      manualPagination: true,
+      rowCount: data?.total ?? 0
+    },
+    () => null
+  )
 
   return (
     <Card

--- a/apps/docs/src/components/auth/organization/organization-invitations.tsx
+++ b/apps/docs/src/components/auth/organization/organization-invitations.tsx
@@ -111,21 +111,20 @@ export function OrganizationInvitations({
     ORGANIZATION_TABLE_PAGE_SIZE,
     INVITATION_COLUMN_IDS
   )
-  const { columnVisibility, globalFilter, pagination } = tableState
+  const { globalFilter, pagination } = tableState
 
-  const table = useOrganizationTable({
-    atoms: tableState.atoms,
-    columns: invitationColumns,
-    data: invitations ?? EMPTY_INVITATIONS,
-    enableRowSelection: (row) =>
-      canCancel.data?.success === true && row.original.status === "pending",
-    globalFilterFn: "includesString",
-    getRowId: (invitation) => invitation.id,
-    state: {
-      columnVisibility
+  const table = useOrganizationTable(
+    {
+      atoms: tableState.atoms,
+      columns: invitationColumns,
+      data: invitations ?? EMPTY_INVITATIONS,
+      enableRowSelection: (row) =>
+        canCancel.data?.success === true && row.original.status === "pending",
+      globalFilterFn: "includesString",
+      getRowId: (invitation) => invitation.id
     },
-    onColumnVisibilityChange: tableState.setColumnVisibility
-  })
+    () => null
+  )
 
   const cancelInvitations = useCancelInvitation(authClient)
   const roleFilter = String(table.getColumn("role")?.getFilterValue() ?? "all")

--- a/apps/docs/src/components/auth/organization/organization-members.tsx
+++ b/apps/docs/src/components/auth/organization/organization-members.tsx
@@ -77,6 +77,9 @@ const memberColumns = memberColumnHelper.columns([
     enableSorting: false
   })
 ])
+const memberColumnsWithoutTeams = memberColumns.filter(
+  (column) => column.id !== "teams"
+)
 const EMPTY_MEMBERS: MemberRow[] = []
 const MEMBER_COLUMN_IDS = ["user", "role", "teams"] as const
 
@@ -133,8 +136,7 @@ export function OrganizationMembers({
     validatedPageSize ?? ORGANIZATION_TABLE_PAGE_SIZE,
     MEMBER_COLUMN_IDS
   )
-  const { columnFilters, columnVisibility, globalFilter, pagination, sorting } =
-    tableState
+  const { columnFilters, globalFilter, pagination, sorting } = tableState
   const roleFilter = String(
     columnFilters.find((filter) => filter.id === "role")?.value ?? "all"
   )
@@ -249,33 +251,29 @@ export function OrganizationMembers({
     total
   ])
 
-  const table = useOrganizationTable({
-    atoms: tableState.atoms,
-    columns: memberColumns,
-    data: membersData?.members ?? EMPTY_MEMBERS,
-    enableRowSelection: (row) => {
-      const targetIsOwner = hasMemberRole(row.original.role, creatorRole)
-      return (
-        canDeleteMembers.data?.success === true &&
-        row.original.userId !== session?.user.id &&
-        (isOwner || !targetIsOwner) &&
-        !(targetIsOwner && (ownerCount === undefined || ownerCount <= 1))
-      )
+  const table = useOrganizationTable<MemberRow, null>(
+    {
+      atoms: tableState.atoms,
+      columns: showTeams ? memberColumns : memberColumnsWithoutTeams,
+      data: membersData?.members ?? EMPTY_MEMBERS,
+      enableRowSelection: (row) => {
+        const targetIsOwner = hasMemberRole(row.original.role, creatorRole)
+        return (
+          canDeleteMembers.data?.success === true &&
+          row.original.userId !== session?.user.id &&
+          (isOwner || !targetIsOwner) &&
+          !(targetIsOwner && (ownerCount === undefined || ownerCount <= 1))
+        )
+      },
+      globalFilterFn: "includesString",
+      getRowId: (member) => member.id,
+      manualFiltering: paged,
+      manualPagination: paged,
+      manualSorting: paged,
+      rowCount: paged ? total : undefined
     },
-    globalFilterFn: "includesString",
-    getRowId: (member) => member.id,
-    manualFiltering: paged,
-    manualPagination: paged,
-    manualSorting: paged,
-    rowCount: paged ? total : undefined,
-    state: {
-      columnVisibility: {
-        ...columnVisibility,
-        teams: showTeams && columnVisibility.teams !== false
-      }
-    },
-    onColumnVisibilityChange: tableState.setColumnVisibility
-  })
+    () => null
+  )
 
   const removeMembers = useRemoveMember(authClient)
   const roleFacetRows = table.getColumn("role")?.getFacetedRowModel().flatRows

--- a/apps/docs/src/components/auth/organization/organization-roles.tsx
+++ b/apps/docs/src/components/auth/organization/organization-roles.tsx
@@ -158,32 +158,35 @@ export function OrganizationRoles({
     ORGANIZATION_TABLE_PAGE_SIZE,
     ROLE_COLUMN_IDS
   )
-  const { columnVisibility, globalFilter, pagination } = tableState
-  const table = useOrganizationTable({
-    atoms: tableState.atoms,
-    columns: roleColumns,
-    data: roles.data ?? EMPTY_ROLES,
-    enableRowSelection: canDelete.data?.success === true,
-    globalFilterFn: (row, _columnId, value) => {
-      const query = String(value).toLowerCase()
-      return (
-        row.original.role.toLowerCase().includes(query) ||
-        Object.entries(row.original.permission).some(
-          ([resource, actions]) =>
-            resource.toLowerCase().includes(query) ||
-            actions.some((action) => action.toLowerCase().includes(query))
+  const { globalFilter, pagination } = tableState
+  useEffect(() => {
+    tableState.setColumnVisibility((current) =>
+      current.permissionResources === false
+        ? current
+        : { ...current, permissionResources: false }
+    )
+  }, [tableState.setColumnVisibility])
+  const table = useOrganizationTable(
+    {
+      atoms: tableState.atoms,
+      columns: roleColumns,
+      data: roles.data ?? EMPTY_ROLES,
+      enableRowSelection: canDelete.data?.success === true,
+      globalFilterFn: (row, _columnId, value) => {
+        const query = String(value).toLowerCase()
+        return (
+          row.original.role.toLowerCase().includes(query) ||
+          Object.entries(row.original.permission).some(
+            ([resource, actions]) =>
+              resource.toLowerCase().includes(query) ||
+              actions.some((action) => action.toLowerCase().includes(query))
+          )
         )
-      )
+      },
+      getRowId: (role) => role.id
     },
-    getRowId: (role) => role.id,
-    state: {
-      columnVisibility: {
-        ...columnVisibility,
-        permissionResources: false
-      }
-    },
-    onColumnVisibilityChange: tableState.setColumnVisibility
-  })
+    () => null
+  )
   const deleteRoles = useDeleteRole(authClient, organizationId)
   const permissionFilter = String(
     table.getColumn("permissionResources")?.getFilterValue() ?? "all"

--- a/apps/docs/src/components/auth/organization/organization-table-state.ts
+++ b/apps/docs/src/components/auth/organization/organization-table-state.ts
@@ -116,6 +116,7 @@ export function useOrganizationTableState(
   const atoms = useMemo(
     () => ({
       columnFilters: columnFiltersAtom,
+      columnVisibility: columnVisibilityAtom,
       globalFilter: globalFilterAtom,
       pagination: paginationAtom,
       rowSelection: rowSelectionAtom,
@@ -123,6 +124,7 @@ export function useOrganizationTableState(
     }),
     [
       columnFiltersAtom,
+      columnVisibilityAtom,
       globalFilterAtom,
       paginationAtom,
       rowSelectionAtom,

--- a/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/next-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -276,16 +276,19 @@ export function AdminUsers({
     total,
     users.isSuccess
   ])
-  const table = useAdminTable({
-    atoms: tableState.atoms,
-    columns: adminColumns,
-    data: users.data?.users ?? EMPTY_USERS,
-    getRowId: (user) => user.id,
-    manualFiltering: true,
-    manualPagination: true,
-    manualSorting: true,
-    rowCount: total
-  })
+  const table = useAdminTable(
+    {
+      atoms: tableState.atoms,
+      columns: adminColumns,
+      data: users.data?.users ?? EMPTY_USERS,
+      getRowId: (user) => user.id,
+      manualFiltering: true,
+      manualPagination: true,
+      manualSorting: true,
+      rowCount: total
+    },
+    () => null
+  )
   const from = total ? pagination.pageIndex * pagination.pageSize + 1 : 0
   const to = Math.min(total, (pagination.pageIndex + 1) * pagination.pageSize)
 

--- a/examples/next-shadcn-example/src/components/auth/api-key/api-keys.tsx
+++ b/examples/next-shadcn-example/src/components/auth/api-key/api-keys.tsx
@@ -128,15 +128,18 @@ export function ApiKeys({
     setPagination
   ])
 
-  const table = useApiKeyTable({
-    atoms: tableState.atoms,
-    columns: apiKeyColumns,
-    data: page.rows,
-    getRowId: (apiKey) => apiKey.id,
-    manualPagination: true,
-    pageCount: -1,
-    manualSorting: true
-  })
+  const table = useApiKeyTable(
+    {
+      atoms: tableState.atoms,
+      columns: apiKeyColumns,
+      data: page.rows,
+      getRowId: (apiKey) => apiKey.id,
+      manualPagination: true,
+      pageCount: -1,
+      manualSorting: true
+    },
+    () => null
+  )
 
   const [createOpen, setCreateOpen] = useState(false)
 

--- a/examples/next-shadcn-example/src/components/auth/auth-form.tsx
+++ b/examples/next-shadcn-example/src/components/auth/auth-form.tsx
@@ -90,8 +90,24 @@ export function setAuthFormServerError(
 }
 
 export function clearAuthFormServerError(form: AnyFormApi) {
-  if (!form.state.errorMap.onServer) return
+  form.setErrorMap({ onServer: { fields: {} } })
+}
+
+export function clearAuthFormFieldServerError(
+  form: AnyFormApi,
+  fieldName: string
+) {
   form.setErrorMap({ onServer: undefined })
+  if (!fieldName) return
+
+  const fieldMeta = form.getFieldMeta(fieldName as never)
+  if (!fieldMeta?.errorMap.onServer) return
+
+  form.setFieldMeta(fieldName as never, (current = fieldMeta) => ({
+    ...current,
+    errorMap: { ...current.errorMap, onServer: undefined },
+    errorSourceMap: { ...current.errorSourceMap, onServer: undefined }
+  }))
 }
 
 export async function runAuthFormAction(
@@ -164,7 +180,14 @@ function AuthFormRoot({
         focusFirstInvalidAuthFormControl(event.currentTarget)
       }
       onInput={(event) => {
-        clearAuthFormServerError(form)
+        const target = event.target
+        const fieldName =
+          target instanceof HTMLInputElement ||
+          target instanceof HTMLSelectElement ||
+          target instanceof HTMLTextAreaElement
+            ? target.name
+            : ""
+        clearAuthFormFieldServerError(form, fieldName)
         onInput?.(event)
       }}
       onSubmit={submit}
@@ -204,7 +227,7 @@ function AuthFormTextField({
         name={field.name}
         onBlur={field.handleBlur}
         onChange={(event) => {
-          clearAuthFormServerError(form)
+          clearAuthFormFieldServerError(form, field.name)
           field.handleChange(event.target.value)
         }}
         value={field.state.value}
@@ -261,7 +284,7 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
       name={field.name}
       onBlur={field.handleBlur}
       onChange={(value) => {
-        clearAuthFormServerError(form)
+        clearAuthFormFieldServerError(form, field.name)
         field.handleChange(value)
       }}
       value={field.state.value}
@@ -269,7 +292,11 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   )
 }
 
-export const { useAppForm: useAuthForm } = createFormHook({
+export const {
+  useAppForm: useAuthForm,
+  withFieldGroup: withAuthFieldGroup,
+  withForm: withAuthForm
+} = createFormHook({
   fieldComponents: {
     AuthFormAdditionalField,
     AuthFormFieldError,

--- a/examples/next-shadcn-example/src/components/auth/dash/activity.tsx
+++ b/examples/next-shadcn-example/src/components/auth/dash/activity.tsx
@@ -310,15 +310,18 @@ function ActivityFeed({
     ready,
     setPagination
   ])
-  const table = useActivityTable({
-    atoms: tableState.atoms,
-    columns: activityColumns,
-    data: data?.events ?? EMPTY_EVENTS,
-    getRowId: getDashEventKey,
-    manualFiltering: true,
-    manualPagination: true,
-    rowCount: data?.total ?? 0
-  })
+  const table = useActivityTable(
+    {
+      atoms: tableState.atoms,
+      columns: activityColumns,
+      data: data?.events ?? EMPTY_EVENTS,
+      getRowId: getDashEventKey,
+      manualFiltering: true,
+      manualPagination: true,
+      rowCount: data?.total ?? 0
+    },
+    () => null
+  )
 
   return (
     <Card

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-invitations.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-invitations.tsx
@@ -111,21 +111,20 @@ export function OrganizationInvitations({
     ORGANIZATION_TABLE_PAGE_SIZE,
     INVITATION_COLUMN_IDS
   )
-  const { columnVisibility, globalFilter, pagination } = tableState
+  const { globalFilter, pagination } = tableState
 
-  const table = useOrganizationTable({
-    atoms: tableState.atoms,
-    columns: invitationColumns,
-    data: invitations ?? EMPTY_INVITATIONS,
-    enableRowSelection: (row) =>
-      canCancel.data?.success === true && row.original.status === "pending",
-    globalFilterFn: "includesString",
-    getRowId: (invitation) => invitation.id,
-    state: {
-      columnVisibility
+  const table = useOrganizationTable(
+    {
+      atoms: tableState.atoms,
+      columns: invitationColumns,
+      data: invitations ?? EMPTY_INVITATIONS,
+      enableRowSelection: (row) =>
+        canCancel.data?.success === true && row.original.status === "pending",
+      globalFilterFn: "includesString",
+      getRowId: (invitation) => invitation.id
     },
-    onColumnVisibilityChange: tableState.setColumnVisibility
-  })
+    () => null
+  )
 
   const cancelInvitations = useCancelInvitation(authClient)
   const roleFilter = String(table.getColumn("role")?.getFilterValue() ?? "all")

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-members.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-members.tsx
@@ -77,6 +77,9 @@ const memberColumns = memberColumnHelper.columns([
     enableSorting: false
   })
 ])
+const memberColumnsWithoutTeams = memberColumns.filter(
+  (column) => column.id !== "teams"
+)
 const EMPTY_MEMBERS: MemberRow[] = []
 const MEMBER_COLUMN_IDS = ["user", "role", "teams"] as const
 
@@ -133,8 +136,7 @@ export function OrganizationMembers({
     validatedPageSize ?? ORGANIZATION_TABLE_PAGE_SIZE,
     MEMBER_COLUMN_IDS
   )
-  const { columnFilters, columnVisibility, globalFilter, pagination, sorting } =
-    tableState
+  const { columnFilters, globalFilter, pagination, sorting } = tableState
   const roleFilter = String(
     columnFilters.find((filter) => filter.id === "role")?.value ?? "all"
   )
@@ -249,33 +251,29 @@ export function OrganizationMembers({
     total
   ])
 
-  const table = useOrganizationTable({
-    atoms: tableState.atoms,
-    columns: memberColumns,
-    data: membersData?.members ?? EMPTY_MEMBERS,
-    enableRowSelection: (row) => {
-      const targetIsOwner = hasMemberRole(row.original.role, creatorRole)
-      return (
-        canDeleteMembers.data?.success === true &&
-        row.original.userId !== session?.user.id &&
-        (isOwner || !targetIsOwner) &&
-        !(targetIsOwner && (ownerCount === undefined || ownerCount <= 1))
-      )
+  const table = useOrganizationTable<MemberRow, null>(
+    {
+      atoms: tableState.atoms,
+      columns: showTeams ? memberColumns : memberColumnsWithoutTeams,
+      data: membersData?.members ?? EMPTY_MEMBERS,
+      enableRowSelection: (row) => {
+        const targetIsOwner = hasMemberRole(row.original.role, creatorRole)
+        return (
+          canDeleteMembers.data?.success === true &&
+          row.original.userId !== session?.user.id &&
+          (isOwner || !targetIsOwner) &&
+          !(targetIsOwner && (ownerCount === undefined || ownerCount <= 1))
+        )
+      },
+      globalFilterFn: "includesString",
+      getRowId: (member) => member.id,
+      manualFiltering: paged,
+      manualPagination: paged,
+      manualSorting: paged,
+      rowCount: paged ? total : undefined
     },
-    globalFilterFn: "includesString",
-    getRowId: (member) => member.id,
-    manualFiltering: paged,
-    manualPagination: paged,
-    manualSorting: paged,
-    rowCount: paged ? total : undefined,
-    state: {
-      columnVisibility: {
-        ...columnVisibility,
-        teams: showTeams && columnVisibility.teams !== false
-      }
-    },
-    onColumnVisibilityChange: tableState.setColumnVisibility
-  })
+    () => null
+  )
 
   const removeMembers = useRemoveMember(authClient)
   const roleFacetRows = table.getColumn("role")?.getFacetedRowModel().flatRows

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-roles.tsx
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-roles.tsx
@@ -158,32 +158,35 @@ export function OrganizationRoles({
     ORGANIZATION_TABLE_PAGE_SIZE,
     ROLE_COLUMN_IDS
   )
-  const { columnVisibility, globalFilter, pagination } = tableState
-  const table = useOrganizationTable({
-    atoms: tableState.atoms,
-    columns: roleColumns,
-    data: roles.data ?? EMPTY_ROLES,
-    enableRowSelection: canDelete.data?.success === true,
-    globalFilterFn: (row, _columnId, value) => {
-      const query = String(value).toLowerCase()
-      return (
-        row.original.role.toLowerCase().includes(query) ||
-        Object.entries(row.original.permission).some(
-          ([resource, actions]) =>
-            resource.toLowerCase().includes(query) ||
-            actions.some((action) => action.toLowerCase().includes(query))
+  const { globalFilter, pagination } = tableState
+  useEffect(() => {
+    tableState.setColumnVisibility((current) =>
+      current.permissionResources === false
+        ? current
+        : { ...current, permissionResources: false }
+    )
+  }, [tableState.setColumnVisibility])
+  const table = useOrganizationTable(
+    {
+      atoms: tableState.atoms,
+      columns: roleColumns,
+      data: roles.data ?? EMPTY_ROLES,
+      enableRowSelection: canDelete.data?.success === true,
+      globalFilterFn: (row, _columnId, value) => {
+        const query = String(value).toLowerCase()
+        return (
+          row.original.role.toLowerCase().includes(query) ||
+          Object.entries(row.original.permission).some(
+            ([resource, actions]) =>
+              resource.toLowerCase().includes(query) ||
+              actions.some((action) => action.toLowerCase().includes(query))
+          )
         )
-      )
+      },
+      getRowId: (role) => role.id
     },
-    getRowId: (role) => role.id,
-    state: {
-      columnVisibility: {
-        ...columnVisibility,
-        permissionResources: false
-      }
-    },
-    onColumnVisibilityChange: tableState.setColumnVisibility
-  })
+    () => null
+  )
   const deleteRoles = useDeleteRole(authClient, organizationId)
   const permissionFilter = String(
     table.getColumn("permissionResources")?.getFilterValue() ?? "all"

--- a/examples/next-shadcn-example/src/components/auth/organization/organization-table-state.ts
+++ b/examples/next-shadcn-example/src/components/auth/organization/organization-table-state.ts
@@ -116,6 +116,7 @@ export function useOrganizationTableState(
   const atoms = useMemo(
     () => ({
       columnFilters: columnFiltersAtom,
+      columnVisibility: columnVisibilityAtom,
       globalFilter: globalFilterAtom,
       pagination: paginationAtom,
       rowSelection: rowSelectionAtom,
@@ -123,6 +124,7 @@ export function useOrganizationTableState(
     }),
     [
       columnFiltersAtom,
+      columnVisibilityAtom,
       globalFilterAtom,
       paginationAtom,
       rowSelectionAtom,

--- a/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/admin/admin-users.tsx
@@ -291,16 +291,19 @@ export function AdminUsers({
     total,
     users.isSuccess
   ])
-  const table = useAdminTable({
-    atoms: tableState.atoms,
-    columns: adminColumns,
-    data: users.data?.users ?? EMPTY_USERS,
-    getRowId: (user) => user.id,
-    manualFiltering: true,
-    manualPagination: true,
-    manualSorting: true,
-    rowCount: total
-  })
+  const table = useAdminTable(
+    {
+      atoms: tableState.atoms,
+      columns: adminColumns,
+      data: users.data?.users ?? EMPTY_USERS,
+      getRowId: (user) => user.id,
+      manualFiltering: true,
+      manualPagination: true,
+      manualSorting: true,
+      rowCount: total
+    },
+    () => null
+  )
   const from = total ? pagination.pageIndex * pagination.pageSize + 1 : 0
   const to = Math.min(total, (pagination.pageIndex + 1) * pagination.pageSize)
 

--- a/examples/start-shadcn-baseui-example/src/components/auth/api-key/api-keys.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/api-key/api-keys.tsx
@@ -134,15 +134,18 @@ export function ApiKeys({
     pagination.pageIndex,
     setPagination
   ])
-  const table = useApiKeyTable({
-    atoms: tableState.atoms,
-    columns: apiKeyColumns,
-    data: page.rows,
-    getRowId: (apiKey) => apiKey.id,
-    manualPagination: true,
-    pageCount: -1,
-    manualSorting: true
-  })
+  const table = useApiKeyTable(
+    {
+      atoms: tableState.atoms,
+      columns: apiKeyColumns,
+      data: page.rows,
+      getRowId: (apiKey) => apiKey.id,
+      manualPagination: true,
+      pageCount: -1,
+      manualSorting: true
+    },
+    () => null
+  )
 
   const [createOpen, setCreateOpen] = useState(false)
 

--- a/examples/start-shadcn-baseui-example/src/components/auth/auth-form.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/auth-form.tsx
@@ -90,8 +90,24 @@ export function setAuthFormServerError(
 }
 
 export function clearAuthFormServerError(form: AnyFormApi) {
-  if (!form.state.errorMap.onServer) return
+  form.setErrorMap({ onServer: { fields: {} } })
+}
+
+export function clearAuthFormFieldServerError(
+  form: AnyFormApi,
+  fieldName: string
+) {
   form.setErrorMap({ onServer: undefined })
+  if (!fieldName) return
+
+  const fieldMeta = form.getFieldMeta(fieldName as never)
+  if (!fieldMeta?.errorMap.onServer) return
+
+  form.setFieldMeta(fieldName as never, (current = fieldMeta) => ({
+    ...current,
+    errorMap: { ...current.errorMap, onServer: undefined },
+    errorSourceMap: { ...current.errorSourceMap, onServer: undefined }
+  }))
 }
 
 export async function runAuthFormAction(
@@ -164,7 +180,14 @@ function AuthFormRoot({
         focusFirstInvalidAuthFormControl(event.currentTarget)
       }
       onInput={(event) => {
-        clearAuthFormServerError(form)
+        const target = event.target
+        const fieldName =
+          target instanceof HTMLInputElement ||
+          target instanceof HTMLSelectElement ||
+          target instanceof HTMLTextAreaElement
+            ? target.name
+            : ""
+        clearAuthFormFieldServerError(form, fieldName)
         onInput?.(event)
       }}
       onSubmit={submit}
@@ -204,7 +227,7 @@ function AuthFormTextField({
         name={field.name}
         onBlur={field.handleBlur}
         onChange={(event) => {
-          clearAuthFormServerError(form)
+          clearAuthFormFieldServerError(form, field.name)
           field.handleChange(event.target.value)
         }}
         value={field.state.value}
@@ -261,7 +284,7 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
       name={field.name}
       onBlur={field.handleBlur}
       onChange={(value) => {
-        clearAuthFormServerError(form)
+        clearAuthFormFieldServerError(form, field.name)
         field.handleChange(value)
       }}
       value={field.state.value}
@@ -269,7 +292,11 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   )
 }
 
-export const { useAppForm: useAuthForm } = createFormHook({
+export const {
+  useAppForm: useAuthForm,
+  withFieldGroup: withAuthFieldGroup,
+  withForm: withAuthForm
+} = createFormHook({
   fieldComponents: {
     AuthFormAdditionalField,
     AuthFormFieldError,

--- a/examples/start-shadcn-baseui-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/dash/activity.tsx
@@ -314,15 +314,18 @@ function ActivityFeed({
     ready,
     setPagination
   ])
-  const table = useActivityTable({
-    atoms: tableState.atoms,
-    columns: activityColumns,
-    data: data?.events ?? EMPTY_EVENTS,
-    getRowId: getDashEventKey,
-    manualFiltering: true,
-    manualPagination: true,
-    rowCount: data?.total ?? 0
-  })
+  const table = useActivityTable(
+    {
+      atoms: tableState.atoms,
+      columns: activityColumns,
+      data: data?.events ?? EMPTY_EVENTS,
+      getRowId: getDashEventKey,
+      manualFiltering: true,
+      manualPagination: true,
+      rowCount: data?.total ?? 0
+    },
+    () => null
+  )
 
   return (
     <Card

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-invitations.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-invitations.tsx
@@ -111,21 +111,20 @@ export function OrganizationInvitations({
     ORGANIZATION_TABLE_PAGE_SIZE,
     INVITATION_COLUMN_IDS
   )
-  const { columnVisibility, globalFilter, pagination } = tableState
+  const { globalFilter, pagination } = tableState
 
-  const table = useOrganizationTable({
-    atoms: tableState.atoms,
-    columns: invitationColumns,
-    data: invitations ?? EMPTY_INVITATIONS,
-    enableRowSelection: (row) =>
-      canCancel.data?.success === true && row.original.status === "pending",
-    globalFilterFn: "includesString",
-    getRowId: (invitation) => invitation.id,
-    state: {
-      columnVisibility
+  const table = useOrganizationTable(
+    {
+      atoms: tableState.atoms,
+      columns: invitationColumns,
+      data: invitations ?? EMPTY_INVITATIONS,
+      enableRowSelection: (row) =>
+        canCancel.data?.success === true && row.original.status === "pending",
+      globalFilterFn: "includesString",
+      getRowId: (invitation) => invitation.id
     },
-    onColumnVisibilityChange: tableState.setColumnVisibility
-  })
+    () => null
+  )
 
   const cancelInvitations = useCancelInvitation(authClient)
   const roleFilter = String(table.getColumn("role")?.getFilterValue() ?? "all")

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-members.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-members.tsx
@@ -77,6 +77,9 @@ const memberColumns = memberColumnHelper.columns([
     enableSorting: false
   })
 ])
+const memberColumnsWithoutTeams = memberColumns.filter(
+  (column) => column.id !== "teams"
+)
 const EMPTY_MEMBERS: MemberRow[] = []
 const MEMBER_COLUMN_IDS = ["user", "role", "teams"] as const
 
@@ -133,8 +136,7 @@ export function OrganizationMembers({
     validatedPageSize ?? ORGANIZATION_TABLE_PAGE_SIZE,
     MEMBER_COLUMN_IDS
   )
-  const { columnFilters, columnVisibility, globalFilter, pagination, sorting } =
-    tableState
+  const { columnFilters, globalFilter, pagination, sorting } = tableState
   const roleFilter = String(
     columnFilters.find((filter) => filter.id === "role")?.value ?? "all"
   )
@@ -249,33 +251,29 @@ export function OrganizationMembers({
     total
   ])
 
-  const table = useOrganizationTable({
-    atoms: tableState.atoms,
-    columns: memberColumns,
-    data: membersData?.members ?? EMPTY_MEMBERS,
-    enableRowSelection: (row) => {
-      const targetIsOwner = hasMemberRole(row.original.role, creatorRole)
-      return (
-        canDeleteMembers.data?.success === true &&
-        row.original.userId !== session?.user.id &&
-        (isOwner || !targetIsOwner) &&
-        !(targetIsOwner && (ownerCount === undefined || ownerCount <= 1))
-      )
+  const table = useOrganizationTable<MemberRow, null>(
+    {
+      atoms: tableState.atoms,
+      columns: showTeams ? memberColumns : memberColumnsWithoutTeams,
+      data: membersData?.members ?? EMPTY_MEMBERS,
+      enableRowSelection: (row) => {
+        const targetIsOwner = hasMemberRole(row.original.role, creatorRole)
+        return (
+          canDeleteMembers.data?.success === true &&
+          row.original.userId !== session?.user.id &&
+          (isOwner || !targetIsOwner) &&
+          !(targetIsOwner && (ownerCount === undefined || ownerCount <= 1))
+        )
+      },
+      globalFilterFn: "includesString",
+      getRowId: (member) => member.id,
+      manualFiltering: paged,
+      manualPagination: paged,
+      manualSorting: paged,
+      rowCount: paged ? total : undefined
     },
-    globalFilterFn: "includesString",
-    getRowId: (member) => member.id,
-    manualFiltering: paged,
-    manualPagination: paged,
-    manualSorting: paged,
-    rowCount: paged ? total : undefined,
-    state: {
-      columnVisibility: {
-        ...columnVisibility,
-        teams: showTeams && columnVisibility.teams !== false
-      }
-    },
-    onColumnVisibilityChange: tableState.setColumnVisibility
-  })
+    () => null
+  )
 
   const removeMembers = useRemoveMember(authClient)
   const roleFacetRows = table.getColumn("role")?.getFacetedRowModel().flatRows

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-roles.tsx
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-roles.tsx
@@ -158,32 +158,35 @@ export function OrganizationRoles({
     ORGANIZATION_TABLE_PAGE_SIZE,
     ROLE_COLUMN_IDS
   )
-  const { columnVisibility, globalFilter, pagination } = tableState
-  const table = useOrganizationTable({
-    atoms: tableState.atoms,
-    columns: roleColumns,
-    data: roles.data ?? EMPTY_ROLES,
-    enableRowSelection: canDelete.data?.success === true,
-    globalFilterFn: (row, _columnId, value) => {
-      const query = String(value).toLowerCase()
-      return (
-        row.original.role.toLowerCase().includes(query) ||
-        Object.entries(row.original.permission).some(
-          ([resource, actions]) =>
-            resource.toLowerCase().includes(query) ||
-            actions.some((action) => action.toLowerCase().includes(query))
+  const { globalFilter, pagination } = tableState
+  useEffect(() => {
+    tableState.setColumnVisibility((current) =>
+      current.permissionResources === false
+        ? current
+        : { ...current, permissionResources: false }
+    )
+  }, [tableState.setColumnVisibility])
+  const table = useOrganizationTable(
+    {
+      atoms: tableState.atoms,
+      columns: roleColumns,
+      data: roles.data ?? EMPTY_ROLES,
+      enableRowSelection: canDelete.data?.success === true,
+      globalFilterFn: (row, _columnId, value) => {
+        const query = String(value).toLowerCase()
+        return (
+          row.original.role.toLowerCase().includes(query) ||
+          Object.entries(row.original.permission).some(
+            ([resource, actions]) =>
+              resource.toLowerCase().includes(query) ||
+              actions.some((action) => action.toLowerCase().includes(query))
+          )
         )
-      )
+      },
+      getRowId: (role) => role.id
     },
-    getRowId: (role) => role.id,
-    state: {
-      columnVisibility: {
-        ...columnVisibility,
-        permissionResources: false
-      }
-    },
-    onColumnVisibilityChange: tableState.setColumnVisibility
-  })
+    () => null
+  )
   const deleteRoles = useDeleteRole(authClient, organizationId)
   const permissionFilter = String(
     table.getColumn("permissionResources")?.getFilterValue() ?? "all"

--- a/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-table-state.ts
+++ b/examples/start-shadcn-baseui-example/src/components/auth/organization/organization-table-state.ts
@@ -116,6 +116,7 @@ export function useOrganizationTableState(
   const atoms = useMemo(
     () => ({
       columnFilters: columnFiltersAtom,
+      columnVisibility: columnVisibilityAtom,
       globalFilter: globalFilterAtom,
       pagination: paginationAtom,
       rowSelection: rowSelectionAtom,
@@ -123,6 +124,7 @@ export function useOrganizationTableState(
     }),
     [
       columnFiltersAtom,
+      columnVisibilityAtom,
       globalFilterAtom,
       paginationAtom,
       rowSelectionAtom,

--- a/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
+++ b/examples/start-shadcn-example/src/components/auth/admin/admin-users.tsx
@@ -276,16 +276,19 @@ export function AdminUsers({
     total,
     users.isSuccess
   ])
-  const table = useAdminTable({
-    atoms: tableState.atoms,
-    columns: adminColumns,
-    data: users.data?.users ?? EMPTY_USERS,
-    getRowId: (user) => user.id,
-    manualFiltering: true,
-    manualPagination: true,
-    manualSorting: true,
-    rowCount: total
-  })
+  const table = useAdminTable(
+    {
+      atoms: tableState.atoms,
+      columns: adminColumns,
+      data: users.data?.users ?? EMPTY_USERS,
+      getRowId: (user) => user.id,
+      manualFiltering: true,
+      manualPagination: true,
+      manualSorting: true,
+      rowCount: total
+    },
+    () => null
+  )
   const from = total ? pagination.pageIndex * pagination.pageSize + 1 : 0
   const to = Math.min(total, (pagination.pageIndex + 1) * pagination.pageSize)
 

--- a/examples/start-shadcn-example/src/components/auth/api-key/api-keys.tsx
+++ b/examples/start-shadcn-example/src/components/auth/api-key/api-keys.tsx
@@ -128,15 +128,18 @@ export function ApiKeys({
     setPagination
   ])
 
-  const table = useApiKeyTable({
-    atoms: tableState.atoms,
-    columns: apiKeyColumns,
-    data: page.rows,
-    getRowId: (apiKey) => apiKey.id,
-    manualPagination: true,
-    pageCount: -1,
-    manualSorting: true
-  })
+  const table = useApiKeyTable(
+    {
+      atoms: tableState.atoms,
+      columns: apiKeyColumns,
+      data: page.rows,
+      getRowId: (apiKey) => apiKey.id,
+      manualPagination: true,
+      pageCount: -1,
+      manualSorting: true
+    },
+    () => null
+  )
 
   const [createOpen, setCreateOpen] = useState(false)
 

--- a/examples/start-shadcn-example/src/components/auth/auth-form.tsx
+++ b/examples/start-shadcn-example/src/components/auth/auth-form.tsx
@@ -90,8 +90,24 @@ export function setAuthFormServerError(
 }
 
 export function clearAuthFormServerError(form: AnyFormApi) {
-  if (!form.state.errorMap.onServer) return
+  form.setErrorMap({ onServer: { fields: {} } })
+}
+
+export function clearAuthFormFieldServerError(
+  form: AnyFormApi,
+  fieldName: string
+) {
   form.setErrorMap({ onServer: undefined })
+  if (!fieldName) return
+
+  const fieldMeta = form.getFieldMeta(fieldName as never)
+  if (!fieldMeta?.errorMap.onServer) return
+
+  form.setFieldMeta(fieldName as never, (current = fieldMeta) => ({
+    ...current,
+    errorMap: { ...current.errorMap, onServer: undefined },
+    errorSourceMap: { ...current.errorSourceMap, onServer: undefined }
+  }))
 }
 
 export async function runAuthFormAction(
@@ -164,7 +180,14 @@ function AuthFormRoot({
         focusFirstInvalidAuthFormControl(event.currentTarget)
       }
       onInput={(event) => {
-        clearAuthFormServerError(form)
+        const target = event.target
+        const fieldName =
+          target instanceof HTMLInputElement ||
+          target instanceof HTMLSelectElement ||
+          target instanceof HTMLTextAreaElement
+            ? target.name
+            : ""
+        clearAuthFormFieldServerError(form, fieldName)
         onInput?.(event)
       }}
       onSubmit={submit}
@@ -204,7 +227,7 @@ function AuthFormTextField({
         name={field.name}
         onBlur={field.handleBlur}
         onChange={(event) => {
-          clearAuthFormServerError(form)
+          clearAuthFormFieldServerError(form, field.name)
           field.handleChange(event.target.value)
         }}
         value={field.state.value}
@@ -261,7 +284,7 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
       name={field.name}
       onBlur={field.handleBlur}
       onChange={(value) => {
-        clearAuthFormServerError(form)
+        clearAuthFormFieldServerError(form, field.name)
         field.handleChange(value)
       }}
       value={field.state.value}
@@ -269,7 +292,11 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   )
 }
 
-export const { useAppForm: useAuthForm } = createFormHook({
+export const {
+  useAppForm: useAuthForm,
+  withFieldGroup: withAuthFieldGroup,
+  withForm: withAuthForm
+} = createFormHook({
   fieldComponents: {
     AuthFormAdditionalField,
     AuthFormFieldError,

--- a/examples/start-shadcn-example/src/components/auth/dash/activity.tsx
+++ b/examples/start-shadcn-example/src/components/auth/dash/activity.tsx
@@ -310,15 +310,18 @@ function ActivityFeed({
     ready,
     setPagination
   ])
-  const table = useActivityTable({
-    atoms: tableState.atoms,
-    columns: activityColumns,
-    data: data?.events ?? EMPTY_EVENTS,
-    getRowId: getDashEventKey,
-    manualFiltering: true,
-    manualPagination: true,
-    rowCount: data?.total ?? 0
-  })
+  const table = useActivityTable(
+    {
+      atoms: tableState.atoms,
+      columns: activityColumns,
+      data: data?.events ?? EMPTY_EVENTS,
+      getRowId: getDashEventKey,
+      manualFiltering: true,
+      manualPagination: true,
+      rowCount: data?.total ?? 0
+    },
+    () => null
+  )
 
   return (
     <Card

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-invitations.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-invitations.tsx
@@ -111,21 +111,20 @@ export function OrganizationInvitations({
     ORGANIZATION_TABLE_PAGE_SIZE,
     INVITATION_COLUMN_IDS
   )
-  const { columnVisibility, globalFilter, pagination } = tableState
+  const { globalFilter, pagination } = tableState
 
-  const table = useOrganizationTable({
-    atoms: tableState.atoms,
-    columns: invitationColumns,
-    data: invitations ?? EMPTY_INVITATIONS,
-    enableRowSelection: (row) =>
-      canCancel.data?.success === true && row.original.status === "pending",
-    globalFilterFn: "includesString",
-    getRowId: (invitation) => invitation.id,
-    state: {
-      columnVisibility
+  const table = useOrganizationTable(
+    {
+      atoms: tableState.atoms,
+      columns: invitationColumns,
+      data: invitations ?? EMPTY_INVITATIONS,
+      enableRowSelection: (row) =>
+        canCancel.data?.success === true && row.original.status === "pending",
+      globalFilterFn: "includesString",
+      getRowId: (invitation) => invitation.id
     },
-    onColumnVisibilityChange: tableState.setColumnVisibility
-  })
+    () => null
+  )
 
   const cancelInvitations = useCancelInvitation(authClient)
   const roleFilter = String(table.getColumn("role")?.getFilterValue() ?? "all")

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-members.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-members.tsx
@@ -77,6 +77,9 @@ const memberColumns = memberColumnHelper.columns([
     enableSorting: false
   })
 ])
+const memberColumnsWithoutTeams = memberColumns.filter(
+  (column) => column.id !== "teams"
+)
 const EMPTY_MEMBERS: MemberRow[] = []
 const MEMBER_COLUMN_IDS = ["user", "role", "teams"] as const
 
@@ -133,8 +136,7 @@ export function OrganizationMembers({
     validatedPageSize ?? ORGANIZATION_TABLE_PAGE_SIZE,
     MEMBER_COLUMN_IDS
   )
-  const { columnFilters, columnVisibility, globalFilter, pagination, sorting } =
-    tableState
+  const { columnFilters, globalFilter, pagination, sorting } = tableState
   const roleFilter = String(
     columnFilters.find((filter) => filter.id === "role")?.value ?? "all"
   )
@@ -249,33 +251,29 @@ export function OrganizationMembers({
     total
   ])
 
-  const table = useOrganizationTable({
-    atoms: tableState.atoms,
-    columns: memberColumns,
-    data: membersData?.members ?? EMPTY_MEMBERS,
-    enableRowSelection: (row) => {
-      const targetIsOwner = hasMemberRole(row.original.role, creatorRole)
-      return (
-        canDeleteMembers.data?.success === true &&
-        row.original.userId !== session?.user.id &&
-        (isOwner || !targetIsOwner) &&
-        !(targetIsOwner && (ownerCount === undefined || ownerCount <= 1))
-      )
+  const table = useOrganizationTable<MemberRow, null>(
+    {
+      atoms: tableState.atoms,
+      columns: showTeams ? memberColumns : memberColumnsWithoutTeams,
+      data: membersData?.members ?? EMPTY_MEMBERS,
+      enableRowSelection: (row) => {
+        const targetIsOwner = hasMemberRole(row.original.role, creatorRole)
+        return (
+          canDeleteMembers.data?.success === true &&
+          row.original.userId !== session?.user.id &&
+          (isOwner || !targetIsOwner) &&
+          !(targetIsOwner && (ownerCount === undefined || ownerCount <= 1))
+        )
+      },
+      globalFilterFn: "includesString",
+      getRowId: (member) => member.id,
+      manualFiltering: paged,
+      manualPagination: paged,
+      manualSorting: paged,
+      rowCount: paged ? total : undefined
     },
-    globalFilterFn: "includesString",
-    getRowId: (member) => member.id,
-    manualFiltering: paged,
-    manualPagination: paged,
-    manualSorting: paged,
-    rowCount: paged ? total : undefined,
-    state: {
-      columnVisibility: {
-        ...columnVisibility,
-        teams: showTeams && columnVisibility.teams !== false
-      }
-    },
-    onColumnVisibilityChange: tableState.setColumnVisibility
-  })
+    () => null
+  )
 
   const removeMembers = useRemoveMember(authClient)
   const roleFacetRows = table.getColumn("role")?.getFacetedRowModel().flatRows

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-roles.tsx
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-roles.tsx
@@ -158,32 +158,35 @@ export function OrganizationRoles({
     ORGANIZATION_TABLE_PAGE_SIZE,
     ROLE_COLUMN_IDS
   )
-  const { columnVisibility, globalFilter, pagination } = tableState
-  const table = useOrganizationTable({
-    atoms: tableState.atoms,
-    columns: roleColumns,
-    data: roles.data ?? EMPTY_ROLES,
-    enableRowSelection: canDelete.data?.success === true,
-    globalFilterFn: (row, _columnId, value) => {
-      const query = String(value).toLowerCase()
-      return (
-        row.original.role.toLowerCase().includes(query) ||
-        Object.entries(row.original.permission).some(
-          ([resource, actions]) =>
-            resource.toLowerCase().includes(query) ||
-            actions.some((action) => action.toLowerCase().includes(query))
+  const { globalFilter, pagination } = tableState
+  useEffect(() => {
+    tableState.setColumnVisibility((current) =>
+      current.permissionResources === false
+        ? current
+        : { ...current, permissionResources: false }
+    )
+  }, [tableState.setColumnVisibility])
+  const table = useOrganizationTable(
+    {
+      atoms: tableState.atoms,
+      columns: roleColumns,
+      data: roles.data ?? EMPTY_ROLES,
+      enableRowSelection: canDelete.data?.success === true,
+      globalFilterFn: (row, _columnId, value) => {
+        const query = String(value).toLowerCase()
+        return (
+          row.original.role.toLowerCase().includes(query) ||
+          Object.entries(row.original.permission).some(
+            ([resource, actions]) =>
+              resource.toLowerCase().includes(query) ||
+              actions.some((action) => action.toLowerCase().includes(query))
+          )
         )
-      )
+      },
+      getRowId: (role) => role.id
     },
-    getRowId: (role) => role.id,
-    state: {
-      columnVisibility: {
-        ...columnVisibility,
-        permissionResources: false
-      }
-    },
-    onColumnVisibilityChange: tableState.setColumnVisibility
-  })
+    () => null
+  )
   const deleteRoles = useDeleteRole(authClient, organizationId)
   const permissionFilter = String(
     table.getColumn("permissionResources")?.getFilterValue() ?? "all"

--- a/examples/start-shadcn-example/src/components/auth/organization/organization-table-state.ts
+++ b/examples/start-shadcn-example/src/components/auth/organization/organization-table-state.ts
@@ -116,6 +116,7 @@ export function useOrganizationTableState(
   const atoms = useMemo(
     () => ({
       columnFilters: columnFiltersAtom,
+      columnVisibility: columnVisibilityAtom,
       globalFilter: globalFilterAtom,
       pagination: paginationAtom,
       rowSelection: rowSelectionAtom,
@@ -123,6 +124,7 @@ export function useOrganizationTableState(
     }),
     [
       columnFiltersAtom,
+      columnVisibilityAtom,
       globalFilterAtom,
       paginationAtom,
       rowSelectionAtom,

--- a/examples/start-shadcn-example/tests/auth-form.browser.test.tsx
+++ b/examples/start-shadcn-example/tests/auth-form.browser.test.tsx
@@ -96,6 +96,40 @@ function AsyncValidatedAuthForm({
   )
 }
 
+function MultiFieldServerErrorForm() {
+  const form = useAuthForm({
+    defaultValues: { email: "", password: "" },
+    onSubmit: async () => {
+      setAuthFormServerError(
+        form,
+        {
+          fields: {
+            email: "Email is unavailable",
+            password: "Password is compromised"
+          },
+          message: "Update the highlighted fields"
+        },
+        "Fallback submission error"
+      )
+    }
+  })
+
+  return (
+    <form.AppForm>
+      <form.AuthFormRoot>
+        <form.AppField name="email">
+          {(field) => <field.AuthFormTextField label="Email" />}
+        </form.AppField>
+        <form.AppField name="password">
+          {(field) => <field.AuthFormTextField label="Password" />}
+        </form.AppField>
+        <form.AuthFormServerError />
+        <form.AuthFormSubmitButton>Continue</form.AuthFormSubmitButton>
+      </form.AuthFormRoot>
+    </form.AppForm>
+  )
+}
+
 function ServerTableStateFixture() {
   const state = useServerTableState({ pageSize: 10 })
 
@@ -278,6 +312,28 @@ describe("shadcn TanStack form integration", () => {
 
     finishValidation()
     await waitFor(() => expect(input).not.toHaveAttribute("aria-busy"))
+  })
+
+  it("preserves unrelated server field errors while editing", async () => {
+    render(<MultiFieldServerErrorForm />)
+    const email = screen.getByRole("textbox", { name: "Email" })
+    const password = screen.getByRole("textbox", { name: "Password" })
+
+    fireEvent.change(email, { target: { value: "ada@example.com" } })
+    fireEvent.change(password, { target: { value: "password" } })
+    fireEvent.click(screen.getByRole("button", { name: /Continue/ }))
+
+    expect(await screen.findByText("Email is unavailable")).toBeVisible()
+    expect(screen.getByText("Password is compromised")).toBeVisible()
+    expect(screen.getByText("Update the highlighted fields")).toBeVisible()
+
+    fireEvent.change(password, { target: { value: "safer password" } })
+
+    await waitFor(() =>
+      expect(screen.queryByText("Password is compromised")).toBeNull()
+    )
+    expect(screen.getByText("Email is unavailable")).toBeVisible()
+    expect(screen.queryByText("Update the highlighted fields")).toBeNull()
   })
 
   it("surfaces a rejected phone code resend in the form", async () => {

--- a/examples/start-solid-zaidan-example/src/components/auth/auth-form.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/auth-form.tsx
@@ -108,8 +108,24 @@ export function setAuthFormServerError(
 }
 
 export function clearAuthFormServerError(form: AnyFormApi) {
-  if (!form.state.errorMap.onServer) return
+  form.setErrorMap({ onServer: { fields: {} } })
+}
+
+export function clearAuthFormFieldServerError(
+  form: AnyFormApi,
+  fieldName: string
+) {
   form.setErrorMap({ onServer: undefined })
+  if (!fieldName) return
+
+  const fieldMeta = form.getFieldMeta(fieldName as never)
+  if (!fieldMeta?.errorMap.onServer) return
+
+  form.setFieldMeta(fieldName as never, (current = fieldMeta) => ({
+    ...current,
+    errorMap: { ...current.errorMap, onServer: undefined },
+    errorSourceMap: { ...current.errorSourceMap, onServer: undefined }
+  }))
 }
 
 export async function submitAuthForm(
@@ -145,7 +161,16 @@ function AuthFormRoot(props: AuthFormRootProps) {
   onMount(() => {
     if (!formElement) return
 
-    const clearServerError = () => clearAuthFormServerError(form)
+    const clearServerError = (event: Event) => {
+      const target = event.target
+      const fieldName =
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLSelectElement ||
+        target instanceof HTMLTextAreaElement
+          ? target.name
+          : ""
+      clearAuthFormFieldServerError(form, fieldName)
+    }
     formElement.addEventListener("input", clearServerError)
     onCleanup(() => formElement?.removeEventListener("input", clearServerError))
   })
@@ -208,7 +233,7 @@ function AuthFormTextField(props: AuthFormTextFieldProps) {
         name={field().name}
         onBlur={field().handleBlur}
         onInput={(event) => {
-          clearAuthFormServerError(form)
+          clearAuthFormFieldServerError(form, field().name)
           field().handleChange(event.currentTarget.value)
         }}
         value={field().state.value}
@@ -270,7 +295,7 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
       name={field().name}
       onBlur={field().handleBlur}
       onChange={(value) => {
-        clearAuthFormServerError(form)
+        clearAuthFormFieldServerError(form, field().name)
         field().handleChange(value)
       }}
       value={field().state.value}
@@ -278,7 +303,11 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   )
 }
 
-export const { useAppForm: createAuthForm } = createFormHook({
+export const {
+  useAppForm: createAuthForm,
+  withFieldGroup: withAuthFieldGroup,
+  withForm: withAuthForm
+} = createFormHook({
   fieldComponents: {
     AuthFormAdditionalField,
     AuthFormFieldError,

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-invitations.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-invitations.tsx
@@ -243,13 +243,7 @@ export function OrganizationInvitations(props: OrganizationInvitationsProps) {
     enableRowSelection: (row) =>
       canCancel.data?.success === true && row.original.status === "pending",
     globalFilterFn: "includesString",
-    get state() {
-      return {
-        columnVisibility: tableState.columnVisibility()
-      }
-    },
-    getRowId: (invitation) => invitation.id,
-    onColumnVisibilityChange: tableState.setColumnVisibility
+    getRowId: (invitation) => invitation.id
   })
   const canCancel = useHasPermission(auth.authClient, () => ({
     permissions: { invitation: ["cancel"] }

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-members.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-members.tsx
@@ -637,7 +637,11 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
                   <TableRow>
                     <TableCell
                       class="text-muted-foreground text-sm"
-                      colSpan={showTeams() ? 4 : 3}
+                      colSpan={
+                        table.getVisibleLeafColumns().length +
+                        1 +
+                        Number(canDeleteMembers.data?.success === true)
+                      }
                     >
                       No members match the current filters.
                     </TableCell>

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-members.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-members.tsx
@@ -102,7 +102,7 @@ const memberColumnHelper = createOrganizationColumnHelper<OrganizationMember>()
 const memberColumns = memberColumnHelper.columns([
   memberColumnHelper.accessor(
     (member) => member.user?.name ?? member.user?.email ?? "",
-    { id: "name", enableHiding: false, filterFn: "includesString" }
+    { id: "user", enableHiding: false, filterFn: "includesString" }
   ),
   memberColumnHelper.accessor((member) => member.role ?? "", {
     id: "role",
@@ -116,7 +116,10 @@ const memberColumns = memberColumnHelper.columns([
     enableSorting: false
   })
 ])
-const MEMBER_COLUMN_IDS = ["name", "role", "teams"] as const
+const memberColumnsWithoutTeams = memberColumns.filter(
+  (column) => column.id !== "teams"
+)
+const MEMBER_COLUMN_IDS = ["user", "role", "teams"] as const
 
 type RoleMap = Record<string, string>
 
@@ -361,6 +364,11 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
   const ownerCount = () => owners.data?.total ?? owners.data?.members.length
   const showTeams = () =>
     config.teams && canListMemberTeams.data?.success === true
+  const isPending = () =>
+    members.isPending ||
+    owners.isPending ||
+    canDeleteMembers.isPending ||
+    (config.teams && canListMemberTeams.isPending)
 
   const total = () => members.data?.total ?? memberRows().length
 
@@ -379,7 +387,9 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
   })
   const table = createOrganizationTable({
     atoms: tableState.atoms,
-    columns: memberColumns,
+    get columns() {
+      return showTeams() ? memberColumns : memberColumnsWithoutTeams
+    },
     get data() {
       return memberRows()
     },
@@ -406,16 +416,7 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
     get rowCount() {
       return paged() ? total() : undefined
     },
-    get state() {
-      return {
-        columnVisibility: {
-          ...tableState.columnVisibility(),
-          teams: showTeams() && tableState.columnVisibility().teams !== false
-        }
-      }
-    },
-    getRowId: (member) => member.id,
-    onColumnVisibilityChange: tableState.setColumnVisibility
+    getRowId: (member) => member.id
   })
   const removeMembers = useRemoveMember(auth.authClient)
   const selectedMembers = () => table.getSelectedRowModel().rows
@@ -467,243 +468,223 @@ export function OrganizationMembers(props: OrganizationMembersProps) {
           </Button>
         </Show>
       </div>
-      <Show
-        when={
-          !members.isPending &&
-          !owners.isPending &&
-          !(config.teams && canListMemberTeams.isPending)
-        }
-        fallback={
-          <Card class="z-card-padding-none">
-            <Table>
-              <TableBody>
-                <OrganizationMemberRowSkeleton showTeams={config.teams} />
-                <OrganizationMemberRowSkeleton showTeams={config.teams} />
-              </TableBody>
-            </Table>
-          </Card>
-        }
-      >
-        <Show
-          when={memberRows().length > 0}
-          fallback={
-            <p class="rounded-md border border-dashed p-4 text-sm text-muted-foreground">
-              No members found for this organization.
-            </p>
-          }
-        >
-          <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
-            {/* list-members has no search parameter, so a search box would
+      <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
+        {/* list-members has no search parameter, so a search box would
                 only ever filter the page in front of you. */}
-            <Show when={!paged()}>
-              <InputGroup class="min-w-0 sm:w-[220px]">
-                <InputGroupAddon>
-                  <Search class="size-4 text-muted-foreground" />
-                </InputGroupAddon>
-                <InputGroupInput
-                  aria-label={localization().search}
-                  onInput={(event) =>
-                    table.setGlobalFilter(event.currentTarget.value)
-                  }
-                  placeholder={localization().search}
-                  type="search"
-                  value={tableState.globalFilter()}
-                />
-              </InputGroup>
-            </Show>
-            <DropdownMenu>
-              <DropdownMenuTrigger
-                as={Button}
-                class="shrink-0"
-                variant="outline"
-              >
-                <Filter class="size-4" />
-                {localization().role}
-              </DropdownMenuTrigger>
-              <DropdownMenuContent>
-                <DropdownMenuRadioGroup
-                  onChange={(value) =>
-                    table
-                      .getColumn("role")
-                      ?.setFilterValue(value === "all" ? undefined : value)
-                  }
-                  value={memberRoleFilter()}
-                >
-                  <DropdownMenuRadioItem value="all">
-                    {localization().all}
-                  </DropdownMenuRadioItem>
-                  <For each={Object.entries(roles())}>
-                    {([role, label]) => (
-                      <DropdownMenuRadioItem value={role}>
-                        {label}
-                        {!paged()
-                          ? ` (${roleFacetRows()?.filter((row) => hasMemberRole(row.original.role, role)).length ?? 0})`
-                          : ""}
-                      </DropdownMenuRadioItem>
-                    )}
-                  </For>
-                </DropdownMenuRadioGroup>
-              </DropdownMenuContent>
-            </DropdownMenu>
-            <div class="ms-auto">
-              <OrganizationTableViewOptions
-                columns={[
-                  {
-                    id: "role",
-                    label: localization().role,
-                    visible: table.getColumn("role")?.getIsVisible() ?? true,
-                    onVisibleChange: (visible) =>
-                      table.getColumn("role")?.toggleVisibility(visible)
-                  },
-                  ...(showTeams()
-                    ? [
-                        {
-                          id: "teams",
-                          label: localization().teams,
-                          visible:
-                            table.getColumn("teams")?.getIsVisible() ?? true,
-                          onVisibleChange: (visible: boolean) =>
-                            table.getColumn("teams")?.toggleVisibility(visible)
-                        }
-                      ]
-                    : [])
-                ]}
-                localization={localization()}
-              />
-            </div>
-          </div>
-          <Show when={memberRoleFilter() !== "all"}>
-            <div class="flex flex-wrap gap-2">
-              <Show when={memberRoleFilter() !== "all"}>
-                <Badge class="gap-1 pr-1" variant="secondary">
-                  {localization().role}: {selectedRoleLabel()}
-                  <Button
-                    aria-label={`${localization().clear} member role filter`}
-                    class="size-4 rounded-sm"
-                    onClick={() =>
-                      table.getColumn("role")?.setFilterValue(undefined)
-                    }
-                    size="icon-xs"
-                    type="button"
-                    variant="ghost"
-                  >
-                    <X class="size-3" />
-                  </Button>
-                </Badge>
-              </Show>
-            </div>
-          </Show>
-          <OrganizationTableBulkAction
-            cancelLabel={auth.localization.settings.cancel}
-            confirmLabel={localization().removeSelectedMembers}
-            description={localization().removeSelectedMembersDescription}
-            localization={localization()}
-            onConfirm={removeSelectedMembers}
-            pending={removeMembers.isPending}
-            selectedCount={selectedMembers().length}
-            title={localization().removeSelectedMembers}
-          />
-          <Card class="z-card-padding-none">
-            <Table aria-label="Members">
-              <TableHeader>
-                <TableRow>
-                  <Show when={canDeleteMembers.data?.success}>
-                    <TableHead>
-                      <OrganizationTableSelectAll
-                        allSelected={table.getIsAllPageRowsSelected()}
-                        localization={localization()}
-                        onCheckedChange={(checked) =>
-                          table.toggleAllPageRowsSelected(checked)
-                        }
-                        someSelected={table.getIsSomePageRowsSelected()}
-                      />
-                    </TableHead>
-                  </Show>
-                  {/* Name and email live on the joined user row, which
-                      list-members cannot sort by. */}
-                  <Show
-                    when={!paged()}
-                    fallback={<TableHead>{localization().member}</TableHead>}
-                  >
-                    <OrganizationSortableTableHead
-                      column={table.getColumn("name")}
-                    >
-                      {localization().member}
-                    </OrganizationSortableTableHead>
-                  </Show>
-                  <Show when={table.getColumn("role")?.getIsVisible()}>
-                    <OrganizationSortableTableHead
-                      column={table.getColumn("role")}
-                    >
-                      {localization().role}
-                    </OrganizationSortableTableHead>
-                  </Show>
-                  <Show
-                    when={
-                      showTeams() && table.getColumn("teams")?.getIsVisible()
-                    }
-                  >
-                    <TableHead>{localization().teams}</TableHead>
-                  </Show>
-                  <TableHead class="z-table-head-align-end">Actions</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                <Show
-                  when={table.getRowModel().rows.length > 0}
-                  fallback={
-                    <TableRow>
-                      <TableCell
-                        class="text-muted-foreground text-sm"
-                        colSpan={showTeams() ? 4 : 3}
-                      >
-                        No members match the current filters.
-                      </TableCell>
-                    </TableRow>
-                  }
-                >
-                  <For each={table.getRowModel().rows}>
-                    {(row) => (
-                      <OrganizationMemberRow
-                        isOwner={isOwner()}
-                        localization={localization()}
-                        member={row.original}
-                        ownerCount={ownerCount()}
-                        roles={roles()}
-                        selectableRow={
-                          canDeleteMembers.data?.success ? row : undefined
-                        }
-                        showRole={table.getColumn("role")?.getIsVisible()}
-                        showTeams={
-                          showTeams() &&
-                          table.getColumn("teams")?.getIsVisible() === true
-                        }
-                      />
-                    )}
-                  </For>
-                </Show>
-              </TableBody>
-            </Table>
-          </Card>
-
-          <OrganizationTablePagination
-            canNextPage={table.getCanNextPage()}
-            canPreviousPage={table.getCanPreviousPage()}
-            disabled={members.isPending}
-            localization={localization()}
-            onFirstPage={() => table.firstPage()}
-            onLastPage={() => table.lastPage()}
-            onNextPage={() => table.nextPage()}
-            onPageSizeChange={(size) => table.setPageSize(size)}
-            onPreviousPage={() => table.previousPage()}
-            pageCount={table.getPageCount()}
-            pageIndex={tableState.pagination().pageIndex}
-            pageSize={tableState.pagination().pageSize}
-            rowCount={table.getRowCount()}
-            visibleRowCount={table.getRowModel().rows.length}
-          />
+        <Show when={!paged()}>
+          <InputGroup class="min-w-0 sm:w-[220px]">
+            <InputGroupAddon>
+              <Search class="size-4 text-muted-foreground" />
+            </InputGroupAddon>
+            <InputGroupInput
+              aria-label={localization().search}
+              disabled={isPending()}
+              onInput={(event) =>
+                table.setGlobalFilter(event.currentTarget.value)
+              }
+              placeholder={localization().search}
+              type="search"
+              value={tableState.globalFilter()}
+            />
+          </InputGroup>
         </Show>
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            as={Button}
+            class="shrink-0"
+            disabled={isPending()}
+            variant="outline"
+          >
+            <Filter class="size-4" />
+            {localization().role}
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuRadioGroup
+              onChange={(value) =>
+                table
+                  .getColumn("role")
+                  ?.setFilterValue(value === "all" ? undefined : value)
+              }
+              value={memberRoleFilter()}
+            >
+              <DropdownMenuRadioItem value="all">
+                {localization().all}
+              </DropdownMenuRadioItem>
+              <For each={Object.entries(roles())}>
+                {([role, label]) => (
+                  <DropdownMenuRadioItem value={role}>
+                    {label}
+                    {!paged()
+                      ? ` (${roleFacetRows()?.filter((row) => hasMemberRole(row.original.role, role)).length ?? 0})`
+                      : ""}
+                  </DropdownMenuRadioItem>
+                )}
+              </For>
+            </DropdownMenuRadioGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <div class="ms-auto">
+          <OrganizationTableViewOptions
+            columns={[
+              {
+                id: "role",
+                label: localization().role,
+                visible: table.getColumn("role")?.getIsVisible() ?? true,
+                onVisibleChange: (visible) =>
+                  table.getColumn("role")?.toggleVisibility(visible)
+              },
+              ...(showTeams()
+                ? [
+                    {
+                      id: "teams",
+                      label: localization().teams,
+                      visible: table.getColumn("teams")?.getIsVisible() ?? true,
+                      onVisibleChange: (visible: boolean) =>
+                        table.getColumn("teams")?.toggleVisibility(visible)
+                    }
+                  ]
+                : [])
+            ]}
+            disabled={isPending()}
+            localization={localization()}
+          />
+        </div>
+      </div>
+      <Show when={memberRoleFilter() !== "all"}>
+        <div class="flex flex-wrap gap-2">
+          <Show when={memberRoleFilter() !== "all"}>
+            <Badge class="gap-1 pr-1" variant="secondary">
+              {localization().role}: {selectedRoleLabel()}
+              <Button
+                aria-label={`${localization().clear} member role filter`}
+                class="size-4 rounded-sm"
+                onClick={() =>
+                  table.getColumn("role")?.setFilterValue(undefined)
+                }
+                size="icon-xs"
+                type="button"
+                variant="ghost"
+              >
+                <X class="size-3" />
+              </Button>
+            </Badge>
+          </Show>
+        </div>
       </Show>
+      <OrganizationTableBulkAction
+        cancelLabel={auth.localization.settings.cancel}
+        confirmLabel={localization().removeSelectedMembers}
+        description={localization().removeSelectedMembersDescription}
+        localization={localization()}
+        onConfirm={removeSelectedMembers}
+        pending={removeMembers.isPending}
+        selectedCount={selectedMembers().length}
+        title={localization().removeSelectedMembers}
+      />
+      <Card class="z-card-padding-none">
+        <Table aria-label="Members">
+          <TableHeader>
+            <TableRow>
+              <Show when={canDeleteMembers.data?.success}>
+                <TableHead>
+                  <OrganizationTableSelectAll
+                    allSelected={table.getIsAllPageRowsSelected()}
+                    disabled={isPending()}
+                    localization={localization()}
+                    onCheckedChange={(checked) =>
+                      table.toggleAllPageRowsSelected(checked)
+                    }
+                    someSelected={table.getIsSomePageRowsSelected()}
+                  />
+                </TableHead>
+              </Show>
+              {/* Name and email live on the joined user row, which
+                      list-members cannot sort by. */}
+              <Show
+                when={!paged()}
+                fallback={<TableHead>{localization().member}</TableHead>}
+              >
+                <OrganizationSortableTableHead column={table.getColumn("user")}>
+                  {localization().member}
+                </OrganizationSortableTableHead>
+              </Show>
+              <Show when={table.getColumn("role")?.getIsVisible()}>
+                <OrganizationSortableTableHead column={table.getColumn("role")}>
+                  {localization().role}
+                </OrganizationSortableTableHead>
+              </Show>
+              <Show
+                when={showTeams() && table.getColumn("teams")?.getIsVisible()}
+              >
+                <TableHead>{localization().teams}</TableHead>
+              </Show>
+              <TableHead class="z-table-head-align-end">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <Show
+              when={!members.isPending}
+              fallback={
+                <>
+                  <OrganizationMemberRowSkeleton showTeams={showTeams()} />
+                  <OrganizationMemberRowSkeleton showTeams={showTeams()} />
+                </>
+              }
+            >
+              <Show
+                when={table.getRowModel().rows.length > 0}
+                fallback={
+                  <TableRow>
+                    <TableCell
+                      class="text-muted-foreground text-sm"
+                      colSpan={showTeams() ? 4 : 3}
+                    >
+                      No members match the current filters.
+                    </TableCell>
+                  </TableRow>
+                }
+              >
+                <For each={table.getRowModel().rows}>
+                  {(row) => (
+                    <OrganizationMemberRow
+                      isOwner={isOwner()}
+                      localization={localization()}
+                      member={row.original}
+                      ownerCount={ownerCount()}
+                      roles={roles()}
+                      selectableRow={
+                        canDeleteMembers.data?.success ? row : undefined
+                      }
+                      showRole={table.getColumn("role")?.getIsVisible()}
+                      showTeams={
+                        showTeams() &&
+                        table.getColumn("teams")?.getIsVisible() === true
+                      }
+                    />
+                  )}
+                </For>
+              </Show>
+            </Show>
+          </TableBody>
+        </Table>
+      </Card>
+
+      <OrganizationTablePagination
+        canNextPage={table.getCanNextPage()}
+        canPreviousPage={table.getCanPreviousPage()}
+        disabled={isPending()}
+        localization={localization()}
+        onFirstPage={() => table.firstPage()}
+        onLastPage={() => table.lastPage()}
+        onNextPage={() => table.nextPage()}
+        onPageSizeChange={(size) => table.setPageSize(size)}
+        onPreviousPage={() => table.previousPage()}
+        pageCount={table.getPageCount()}
+        pageIndex={tableState.pagination().pageIndex}
+        pageSize={tableState.pagination().pageSize}
+        rowCount={table.getRowCount()}
+        visibleRowCount={table.getRowModel().rows.length}
+      />
       <Show when={canInvite.data?.success}>
         <InviteMemberDialog open={inviteOpen()} onOpenChange={setInviteOpen} />
       </Show>

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-roles.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-roles.tsx
@@ -152,6 +152,13 @@ export function OrganizationRoles(props: { organizationId: string }) {
     ORGANIZATION_TABLE_PAGE_SIZE,
     ROLE_COLUMN_IDS
   )
+  createEffect(() => {
+    tableState.setColumnVisibility((current) =>
+      current.permissionResources === false
+        ? current
+        : { ...current, permissionResources: false }
+    )
+  })
   const table = createOrganizationTable({
     atoms: tableState.atoms,
     columns: roleColumns,
@@ -172,16 +179,7 @@ export function OrganizationRoles(props: { organizationId: string }) {
         )
       )
     },
-    get state() {
-      return {
-        columnVisibility: {
-          ...tableState.columnVisibility(),
-          permissionResources: false
-        }
-      }
-    },
-    getRowId: (role) => role.id,
-    onColumnVisibilityChange: tableState.setColumnVisibility
+    getRowId: (role) => role.id
   })
   const deleteRoles = useDeleteRole(auth.authClient, () => props.organizationId)
   const permissionFilter = () =>

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-sortable-table-head.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-sortable-table-head.tsx
@@ -1,3 +1,4 @@
+import type { Column, RowData } from "@tanstack/solid-table"
 import { ChevronUp } from "lucide-solid"
 import type { JSX } from "solid-js"
 import { Show } from "solid-js"
@@ -5,16 +6,11 @@ import { Show } from "solid-js"
 import { Button } from "@/components/ui/button"
 import { TableHead } from "@/components/ui/table"
 import { cn } from "@/lib/utils"
+import type { organizationTableFeatures } from "./organization-table"
 
-type SortableColumn = {
-  getIsSorted: () => false | "asc" | "desc"
-  getSortIndex: () => number
-  getToggleSortingHandler: () => undefined | ((event: unknown) => void)
-}
-
-export function OrganizationSortableTableHead(props: {
+export function OrganizationSortableTableHead<TData extends RowData>(props: {
   children: JSX.Element
-  column?: SortableColumn
+  column?: Column<typeof organizationTableFeatures, TData>
 }) {
   const column = props.column
 

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-table-selection.tsx
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-table-selection.tsx
@@ -1,14 +1,12 @@
 import type { OrganizationLocalization } from "@better-auth-ui/core/plugins/organization"
+import type { Row, RowData } from "@tanstack/solid-table"
 import { Checkbox } from "@/components/ui/checkbox"
+import type { organizationTableFeatures } from "./organization-table"
 
-export type OrganizationSelectableRow = {
-  getCanSelect: () => boolean
-  getIsSelected: () => boolean
-  getToggleSelectedHandler: () => (event: {
-    shiftKey: boolean
-    target: { checked: boolean }
-  }) => void
-}
+export type OrganizationSelectableRow<TData extends RowData = RowData> = Pick<
+  Row<typeof organizationTableFeatures, TData>,
+  "getCanSelect" | "getIsSelected" | "getToggleSelectedHandler"
+>
 
 export function OrganizationTableSelectAll(props: {
   allSelected: boolean
@@ -28,10 +26,10 @@ export function OrganizationTableSelectAll(props: {
   )
 }
 
-export function OrganizationTableSelectRow(props: {
+export function OrganizationTableSelectRow<TData extends RowData>(props: {
   disabled?: boolean
   localization: Pick<OrganizationLocalization, "selectRow">
-  row: OrganizationSelectableRow
+  row: OrganizationSelectableRow<TData>
 }) {
   let shiftKey = false
 

--- a/examples/start-solid-zaidan-example/src/components/auth/organization/organization-table-state.ts
+++ b/examples/start-solid-zaidan-example/src/components/auth/organization/organization-table-state.ts
@@ -64,6 +64,7 @@ export function createOrganizationTableState(
   let syncedSearch = ""
   const atoms = {
     columnFilters: columnFiltersAtom,
+    columnVisibility: columnVisibilityAtom,
     globalFilter: globalFilterAtom,
     pagination: paginationAtom,
     rowSelection: rowSelectionAtom,

--- a/examples/start-solid-zaidan-example/tests/auth-form.browser.test.tsx
+++ b/examples/start-solid-zaidan-example/tests/auth-form.browser.test.tsx
@@ -10,10 +10,10 @@ import {
   createOrganizationColumnHelper,
   createOrganizationTable
 } from "../src/components/auth/organization/organization-table"
-import { OrganizationTableRenderer } from "../src/components/auth/organization/organization-table-renderer"
 import { OrganizationTableSelectRow } from "../src/components/auth/organization/organization-table-selection"
 import { createOrganizationTableState } from "../src/components/auth/organization/organization-table-state"
 import { createServerTableState } from "../src/components/auth/server-table-state"
+import { OrganizationTableRenderer } from "./organization-table-renderer"
 
 afterEach(cleanup)
 
@@ -122,6 +122,40 @@ function AsyncValidatedAuthForm(props: { validate: () => Promise<undefined> }) {
       >
         {(field) => <field.AuthFormTextField label="Handle" />}
       </form.AppField>
+    </form.AppForm>
+  )
+}
+
+function MultiFieldServerErrorForm() {
+  const form = createAuthForm(() => ({
+    defaultValues: { email: "", password: "" },
+    onSubmit: async () => {
+      setAuthFormServerError(
+        form,
+        {
+          fields: {
+            email: "Email is unavailable",
+            password: "Password is compromised"
+          },
+          message: "Update the highlighted fields"
+        },
+        "Fallback submission error"
+      )
+    }
+  }))
+
+  return (
+    <form.AppForm>
+      <form.AuthFormRoot>
+        <form.AppField name="email">
+          {(field) => <field.AuthFormTextField label="Email" />}
+        </form.AppField>
+        <form.AppField name="password">
+          {(field) => <field.AuthFormTextField label="Password" />}
+        </form.AppField>
+        <form.AuthFormServerError />
+        <form.AuthFormSubmitButton>Continue</form.AuthFormSubmitButton>
+      </form.AuthFormRoot>
     </form.AppForm>
   )
 }
@@ -315,6 +349,30 @@ describe("Solid auth form", () => {
 
     finishValidation()
     await vi.waitFor(() => expect(input).not.toHaveAttribute("aria-busy"))
+  })
+
+  it("preserves unrelated server field errors while editing", async () => {
+    const view = render(() => <MultiFieldServerErrorForm />)
+    const email = view.getByRole("textbox", { name: "Email" })
+    const password = view.getByRole("textbox", { name: "Password" })
+
+    fireEvent.input(email, { target: { value: "ada@example.com" } })
+    fireEvent.input(password, { target: { value: "password" } })
+    fireEvent.click(view.getByRole("button", { name: /Continue/ }))
+
+    await vi.waitFor(() =>
+      expect(view.getByText("Email is unavailable")).toBeVisible()
+    )
+    expect(view.getByText("Password is compromised")).toBeVisible()
+    expect(view.getByText("Update the highlighted fields")).toBeVisible()
+
+    fireEvent.input(password, { target: { value: "safer password" } })
+
+    await vi.waitFor(() =>
+      expect(view.queryByText("Password is compromised")).toBeNull()
+    )
+    expect(view.getByText("Email is unavailable")).toBeVisible()
+    expect(view.queryByText("Update the highlighted fields")).toBeNull()
   })
 })
 

--- a/examples/start-solid-zaidan-example/tests/organization-table-renderer.tsx
+++ b/examples/start-solid-zaidan-example/tests/organization-table-renderer.tsx
@@ -8,7 +8,7 @@ import {
   TableHeader,
   TableRow
 } from "@/components/ui/table"
-import type { organizationTableFeatures } from "./organization-table"
+import type { organizationTableFeatures } from "../src/components/auth/organization/organization-table"
 
 type OrganizationTableInstance<TData extends RowData> = AppSolidTable<
   typeof organizationTableFeatures,

--- a/packages/heroui/src/components/auth/admin/admin-users.tsx
+++ b/packages/heroui/src/components/auth/admin/admin-users.tsx
@@ -228,16 +228,19 @@ export function AdminUsers({
     total,
     users.isSuccess
   ])
-  const table = useAdminTable({
-    atoms: tableState.atoms,
-    columns: adminColumns,
-    data: users.data?.users ?? EMPTY_USERS,
-    getRowId: (user) => user.id,
-    manualFiltering: true,
-    manualPagination: true,
-    manualSorting: true,
-    rowCount: total
-  })
+  const table = useAdminTable(
+    {
+      atoms: tableState.atoms,
+      columns: adminColumns,
+      data: users.data?.users ?? EMPTY_USERS,
+      getRowId: (user) => user.id,
+      manualFiltering: true,
+      manualPagination: true,
+      manualSorting: true,
+      rowCount: total
+    },
+    () => null
+  )
 
   return (
     <section className={cn("flex flex-col gap-4", className)}>

--- a/packages/heroui/src/components/auth/api-key/api-keys.tsx
+++ b/packages/heroui/src/components/auth/api-key/api-keys.tsx
@@ -126,15 +126,18 @@ export function ApiKeys({
     setPagination
   ])
 
-  const table = useApiKeyTable({
-    atoms: tableState.atoms,
-    columns: apiKeyColumns,
-    data: page.rows,
-    getRowId: (apiKey) => apiKey.id,
-    manualPagination: true,
-    pageCount: -1,
-    manualSorting: true
-  })
+  const table = useApiKeyTable(
+    {
+      atoms: tableState.atoms,
+      columns: apiKeyColumns,
+      data: page.rows,
+      getRowId: (apiKey) => apiKey.id,
+      manualPagination: true,
+      pageCount: -1,
+      manualSorting: true
+    },
+    () => null
+  )
 
   const [createOpen, setCreateOpen] = useState(false)
 

--- a/packages/heroui/src/components/auth/auth-form.tsx
+++ b/packages/heroui/src/components/auth/auth-form.tsx
@@ -90,8 +90,24 @@ export function setAuthFormServerError(
 }
 
 export function clearAuthFormServerError(form: AnyFormApi) {
-  if (!form.state.errorMap.onServer) return
+  form.setErrorMap({ onServer: { fields: {} } })
+}
+
+export function clearAuthFormFieldServerError(
+  form: AnyFormApi,
+  fieldName: string
+) {
   form.setErrorMap({ onServer: undefined })
+  if (!fieldName) return
+
+  const fieldMeta = form.getFieldMeta(fieldName as never)
+  if (!fieldMeta?.errorMap.onServer) return
+
+  form.setFieldMeta(fieldName as never, (current = fieldMeta) => ({
+    ...current,
+    errorMap: { ...current.errorMap, onServer: undefined },
+    errorSourceMap: { ...current.errorSourceMap, onServer: undefined }
+  }))
 }
 
 export async function submitAuthForm(
@@ -129,7 +145,16 @@ function AuthFormRoot({
     const formElement = formElementRef.current
     if (!formElement) return
 
-    const clearServerError = () => clearAuthFormServerError(form)
+    const clearServerError = (event: Event) => {
+      const target = event.target
+      const fieldName =
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLSelectElement ||
+        target instanceof HTMLTextAreaElement
+          ? target.name
+          : ""
+      clearAuthFormFieldServerError(form, fieldName)
+    }
     formElement.addEventListener("input", clearServerError)
     return () => formElement.removeEventListener("input", clearServerError)
   }, [form])
@@ -190,7 +215,7 @@ function AuthFormTextField({
       name={field.name}
       onBlur={field.handleBlur}
       onChange={(value) => {
-        clearAuthFormServerError(form)
+        clearAuthFormFieldServerError(form, field.name)
         field.handleChange(value)
       }}
       validationBehavior="aria"
@@ -255,7 +280,7 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
       name={field.name}
       onBlur={field.handleBlur}
       onChange={(value) => {
-        clearAuthFormServerError(form)
+        clearAuthFormFieldServerError(form, field.name)
         field.handleChange(value)
       }}
       value={field.state.value}
@@ -263,7 +288,11 @@ function AuthFormAdditionalField(props: AuthFormAdditionalFieldProps) {
   )
 }
 
-export const { useAppForm: useAuthForm } = createFormHook({
+export const {
+  useAppForm: useAuthForm,
+  withFieldGroup: withAuthFieldGroup,
+  withForm: withAuthForm
+} = createFormHook({
   fieldComponents: {
     AuthFormAdditionalField,
     AuthFormFieldError,

--- a/packages/heroui/src/components/auth/dash/activity.tsx
+++ b/packages/heroui/src/components/auth/dash/activity.tsx
@@ -305,15 +305,18 @@ function ActivityFeed({
     ready,
     setPagination
   ])
-  const table = useActivityTable({
-    atoms: tableState.atoms,
-    columns: activityColumns,
-    data: data?.events ?? EMPTY_EVENTS,
-    getRowId: getDashEventKey,
-    manualFiltering: true,
-    manualPagination: true,
-    rowCount: data?.total ?? 0
-  })
+  const table = useActivityTable(
+    {
+      atoms: tableState.atoms,
+      columns: activityColumns,
+      data: data?.events ?? EMPTY_EVENTS,
+      getRowId: getDashEventKey,
+      manualFiltering: true,
+      manualPagination: true,
+      rowCount: data?.total ?? 0
+    },
+    () => null
+  )
 
   return (
     <div className={cn("flex flex-col gap-3", className)}>

--- a/packages/heroui/src/components/auth/organization/organization-invitations.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-invitations.tsx
@@ -24,7 +24,7 @@ import type { Invitation } from "better-auth/client"
 import { type ComponentProps, useState } from "react"
 
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
-import { getHeroUISortDescriptor } from "../table-bridge"
+import { getHeroUISortDescriptor, getTanStackSorting } from "../table-bridge"
 import { InviteMemberDialog } from "./invite-member-dialog"
 import { OrganizationInvitationTableRow } from "./organization-invitation-row"
 import { OrganizationInvitationRowSkeleton } from "./organization-invitation-row-skeleton"
@@ -95,21 +95,20 @@ export function OrganizationInvitations({
     ORGANIZATION_TABLE_PAGE_SIZE,
     INVITATION_COLUMN_IDS
   )
-  const { columnVisibility, globalFilter, pagination } = tableState
+  const { globalFilter, pagination } = tableState
 
-  const table = useOrganizationTable({
-    atoms: tableState.atoms,
-    columns: invitationColumns,
-    data: invitations ?? EMPTY_INVITATIONS,
-    enableRowSelection: (row) =>
-      canCancel.data?.success === true && row.original.status === "pending",
-    globalFilterFn: "includesString",
-    getRowId: (invitation) => invitation.id,
-    state: {
-      columnVisibility
+  const table = useOrganizationTable(
+    {
+      atoms: tableState.atoms,
+      columns: invitationColumns,
+      data: invitations ?? EMPTY_INVITATIONS,
+      enableRowSelection: (row) =>
+        canCancel.data?.success === true && row.original.status === "pending",
+      globalFilterFn: "includesString",
+      getRowId: (invitation) => invitation.id
     },
-    onColumnVisibilityChange: tableState.setColumnVisibility
-  })
+    () => null
+  )
 
   const cancelInvitations = useCancelInvitation(
     authClient as OrganizationAuthClient
@@ -371,6 +370,11 @@ export function OrganizationInvitations({
           <Table.ScrollContainer>
             <Table.Content
               aria-label={organizationLocalization.invitations}
+              onSortChange={(descriptor) =>
+                table.setSorting(
+                  getTanStackSorting(descriptor, tableState.sorting)
+                )
+              }
               sortDescriptor={getHeroUISortDescriptor(tableState.sorting)}
             >
               <Table.Header>
@@ -388,40 +392,56 @@ export function OrganizationInvitations({
                   </Table.Column>
                 )}
                 <Table.Column allowsSorting id="email" isRowHeader>
-                  <OrganizationSortableTableHeader
-                    column={table.getColumn("email")}
-                  >
-                    {localization.auth.email}
-                  </OrganizationSortableTableHeader>
+                  {({ sortDirection }) => (
+                    <OrganizationSortableTableHeader
+                      column={table.getColumn("email")}
+                      interactive={false}
+                      nativeSortDirection={sortDirection}
+                    >
+                      {localization.auth.email}
+                    </OrganizationSortableTableHeader>
+                  )}
                 </Table.Column>
 
                 {table.getColumn("createdAt")?.getIsVisible() && (
                   <Table.Column allowsSorting id="createdAt">
-                    <OrganizationSortableTableHeader
-                      column={table.getColumn("createdAt")}
-                    >
-                      {organizationLocalization.invitedAt}
-                    </OrganizationSortableTableHeader>
+                    {({ sortDirection }) => (
+                      <OrganizationSortableTableHeader
+                        column={table.getColumn("createdAt")}
+                        interactive={false}
+                        nativeSortDirection={sortDirection}
+                      >
+                        {organizationLocalization.invitedAt}
+                      </OrganizationSortableTableHeader>
+                    )}
                   </Table.Column>
                 )}
 
                 {table.getColumn("role")?.getIsVisible() && (
                   <Table.Column allowsSorting id="role">
-                    <OrganizationSortableTableHeader
-                      column={table.getColumn("role")}
-                    >
-                      {organizationLocalization.role}
-                    </OrganizationSortableTableHeader>
+                    {({ sortDirection }) => (
+                      <OrganizationSortableTableHeader
+                        column={table.getColumn("role")}
+                        interactive={false}
+                        nativeSortDirection={sortDirection}
+                      >
+                        {organizationLocalization.role}
+                      </OrganizationSortableTableHeader>
+                    )}
                   </Table.Column>
                 )}
 
                 {table.getColumn("status")?.getIsVisible() && (
                   <Table.Column allowsSorting id="status">
-                    <OrganizationSortableTableHeader
-                      column={table.getColumn("status")}
-                    >
-                      {organizationLocalization.status}
-                    </OrganizationSortableTableHeader>
+                    {({ sortDirection }) => (
+                      <OrganizationSortableTableHeader
+                        column={table.getColumn("status")}
+                        interactive={false}
+                        nativeSortDirection={sortDirection}
+                      >
+                        {organizationLocalization.status}
+                      </OrganizationSortableTableHeader>
+                    )}
                   </Table.Column>
                 )}
 

--- a/packages/heroui/src/components/auth/organization/organization-members.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-members.tsx
@@ -27,7 +27,7 @@ import type { Member, User } from "better-auth/client"
 import { type ComponentProps, useEffect, useRef, useState } from "react"
 
 import { organizationPlugin } from "../../../lib/auth/organization-plugin"
-import { getHeroUISortDescriptor } from "../table-bridge"
+import { getHeroUISortDescriptor, getTanStackSorting } from "../table-bridge"
 import { InviteMemberDialog } from "./invite-member-dialog"
 import { OrganizationMemberRow } from "./organization-member-row"
 import { OrganizationMemberRowSkeleton } from "./organization-member-row-skeleton"
@@ -62,6 +62,9 @@ const memberColumns = memberColumnHelper.columns([
     enableSorting: false
   })
 ])
+const memberColumnsWithoutTeams = memberColumns.filter(
+  (column) => column.id !== "teams"
+)
 const EMPTY_MEMBERS: MemberRow[] = []
 const MEMBER_COLUMN_IDS = ["user", "role", "teams"] as const
 
@@ -118,8 +121,7 @@ export function OrganizationMembers({
     validatedPageSize ?? ORGANIZATION_TABLE_PAGE_SIZE,
     MEMBER_COLUMN_IDS
   )
-  const { columnFilters, columnVisibility, globalFilter, pagination, sorting } =
-    tableState
+  const { columnFilters, globalFilter, pagination, sorting } = tableState
   const roleFilter = String(
     columnFilters.find((filter) => filter.id === "role")?.value ?? "all"
   )
@@ -244,33 +246,29 @@ export function OrganizationMembers({
   const ownerCount = owners.data?.total ?? owners.data?.members.length
   const showTeams = teams && canListMemberTeams.data?.success === true
 
-  const table = useOrganizationTable({
-    atoms: tableState.atoms,
-    columns: memberColumns,
-    data: membersData?.members ?? EMPTY_MEMBERS,
-    enableRowSelection: (row) => {
-      const targetIsOwner = hasMemberRole(row.original.role, creatorRole)
-      return (
-        canDeleteMembers.data?.success === true &&
-        row.original.userId !== session?.user.id &&
-        (isOwner || !targetIsOwner) &&
-        !(targetIsOwner && (ownerCount === undefined || ownerCount <= 1))
-      )
+  const table = useOrganizationTable<MemberRow, null>(
+    {
+      atoms: tableState.atoms,
+      columns: showTeams ? memberColumns : memberColumnsWithoutTeams,
+      data: membersData?.members ?? EMPTY_MEMBERS,
+      enableRowSelection: (row) => {
+        const targetIsOwner = hasMemberRole(row.original.role, creatorRole)
+        return (
+          canDeleteMembers.data?.success === true &&
+          row.original.userId !== session?.user.id &&
+          (isOwner || !targetIsOwner) &&
+          !(targetIsOwner && (ownerCount === undefined || ownerCount <= 1))
+        )
+      },
+      globalFilterFn: "includesString",
+      getRowId: (member) => member.id,
+      manualFiltering: paged,
+      manualPagination: paged,
+      manualSorting: paged,
+      rowCount: paged ? total : undefined
     },
-    globalFilterFn: "includesString",
-    getRowId: (member) => member.id,
-    manualFiltering: paged,
-    manualPagination: paged,
-    manualSorting: paged,
-    rowCount: paged ? total : undefined,
-    state: {
-      columnVisibility: {
-        ...columnVisibility,
-        teams: showTeams && columnVisibility.teams !== false
-      }
-    },
-    onColumnVisibilityChange: tableState.setColumnVisibility
-  })
+    () => null
+  )
 
   const removeMembers = useRemoveMember(authClient as OrganizationAuthClient)
   const roleFacetRows = table.getColumn("role")?.getFacetedRowModel().flatRows
@@ -463,6 +461,9 @@ export function OrganizationMembers({
           <Table.ScrollContainer>
             <Table.Content
               aria-label={organizationLocalization.members}
+              onSortChange={(descriptor) =>
+                table.setSorting(getTanStackSorting(descriptor, sorting))
+              }
               sortDescriptor={getHeroUISortDescriptor(sorting)}
             >
               <Table.Header>
@@ -487,21 +488,29 @@ export function OrganizationMembers({
                   </Table.Column>
                 ) : (
                   <Table.Column allowsSorting id="user" isRowHeader>
-                    <OrganizationSortableTableHeader
-                      column={table.getColumn("user")}
-                    >
-                      {organizationLocalization.member}
-                    </OrganizationSortableTableHeader>
+                    {({ sortDirection }) => (
+                      <OrganizationSortableTableHeader
+                        column={table.getColumn("user")}
+                        interactive={false}
+                        nativeSortDirection={sortDirection}
+                      >
+                        {organizationLocalization.member}
+                      </OrganizationSortableTableHeader>
+                    )}
                   </Table.Column>
                 )}
 
                 {table.getColumn("role")?.getIsVisible() && (
                   <Table.Column allowsSorting id="role">
-                    <OrganizationSortableTableHeader
-                      column={table.getColumn("role")}
-                    >
-                      {organizationLocalization.role}
-                    </OrganizationSortableTableHeader>
+                    {({ sortDirection }) => (
+                      <OrganizationSortableTableHeader
+                        column={table.getColumn("role")}
+                        interactive={false}
+                        nativeSortDirection={sortDirection}
+                      >
+                        {organizationLocalization.role}
+                      </OrganizationSortableTableHeader>
+                    )}
                   </Table.Column>
                 )}
 

--- a/packages/heroui/src/components/auth/organization/organization-roles.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-roles.tsx
@@ -41,7 +41,7 @@ import {
   isAuthFormFieldInvalid,
   useAuthForm
 } from "../auth-form"
-import { getHeroUISortDescriptor } from "../table-bridge"
+import { getHeroUISortDescriptor, getTanStackSorting } from "../table-bridge"
 import { OrganizationSortableTableHeader } from "./organization-sortable-table-header"
 import {
   createOrganizationColumnHelper,
@@ -126,29 +126,35 @@ export function OrganizationRoles({
     ORGANIZATION_TABLE_PAGE_SIZE,
     ROLE_COLUMN_IDS
   )
-  const { columnVisibility, globalFilter, pagination } = tableState
-  const table = useOrganizationTable({
-    atoms: tableState.atoms,
-    columns: roleColumns,
-    data: roles.data ?? EMPTY_ROLES,
-    enableRowSelection: canDelete.data?.success === true,
-    globalFilterFn: (row, _columnId, value) => {
-      const query = String(value).toLowerCase()
-      return (
-        row.original.role.toLowerCase().includes(query) ||
-        Object.entries(row.original.permission).some(
-          ([resource, actions]) =>
-            resource.toLowerCase().includes(query) ||
-            actions.some((action) => action.toLowerCase().includes(query))
+  const { globalFilter, pagination } = tableState
+  useEffect(() => {
+    tableState.setColumnVisibility((current) =>
+      current.permissionResources === false
+        ? current
+        : { ...current, permissionResources: false }
+    )
+  }, [tableState.setColumnVisibility])
+  const table = useOrganizationTable(
+    {
+      atoms: tableState.atoms,
+      columns: roleColumns,
+      data: roles.data ?? EMPTY_ROLES,
+      enableRowSelection: canDelete.data?.success === true,
+      globalFilterFn: (row, _columnId, value) => {
+        const query = String(value).toLowerCase()
+        return (
+          row.original.role.toLowerCase().includes(query) ||
+          Object.entries(row.original.permission).some(
+            ([resource, actions]) =>
+              resource.toLowerCase().includes(query) ||
+              actions.some((action) => action.toLowerCase().includes(query))
+          )
         )
-      )
+      },
+      getRowId: (role) => role.id
     },
-    getRowId: (role) => role.id,
-    state: {
-      columnVisibility: { ...columnVisibility, permissionResources: false }
-    },
-    onColumnVisibilityChange: tableState.setColumnVisibility
-  })
+    () => null
+  )
   const deleteRoles = useDeleteRole(client, organizationId)
   const permissionFilter = String(
     table.getColumn("permissionResources")?.getFilterValue() ?? "all"
@@ -323,6 +329,11 @@ export function OrganizationRoles({
           <Table.ScrollContainer>
             <Table.Content
               aria-label={localization.roles}
+              onSortChange={(descriptor) =>
+                table.setSorting(
+                  getTanStackSorting(descriptor, tableState.sorting)
+                )
+              }
               sortDescriptor={getHeroUISortDescriptor(tableState.sorting)}
             >
               <Table.Header>
@@ -340,19 +351,27 @@ export function OrganizationRoles({
                   </Table.Column>
                 )}
                 <Table.Column allowsSorting id="role" isRowHeader>
-                  <OrganizationSortableTableHeader
-                    column={table.getColumn("role")}
-                  >
-                    {localization.roleName}
-                  </OrganizationSortableTableHeader>
+                  {({ sortDirection }) => (
+                    <OrganizationSortableTableHeader
+                      column={table.getColumn("role")}
+                      interactive={false}
+                      nativeSortDirection={sortDirection}
+                    >
+                      {localization.roleName}
+                    </OrganizationSortableTableHeader>
+                  )}
                 </Table.Column>
                 {table.getColumn("permissions")?.getIsVisible() && (
                   <Table.Column allowsSorting id="permissions">
-                    <OrganizationSortableTableHeader
-                      column={table.getColumn("permissions")}
-                    >
-                      {localization.permissions}
-                    </OrganizationSortableTableHeader>
+                    {({ sortDirection }) => (
+                      <OrganizationSortableTableHeader
+                        column={table.getColumn("permissions")}
+                        interactive={false}
+                        nativeSortDirection={sortDirection}
+                      >
+                        {localization.permissions}
+                      </OrganizationSortableTableHeader>
+                    )}
                   </Table.Column>
                 )}
                 <Table.Column className="text-end">

--- a/packages/heroui/src/components/auth/organization/organization-sortable-table-header.tsx
+++ b/packages/heroui/src/components/auth/organization/organization-sortable-table-header.tsx
@@ -1,17 +1,21 @@
 import { ChevronUp } from "@gravity-ui/icons"
-import { Button, cn } from "@heroui/react"
+import { Button, cn, Table } from "@heroui/react"
 import { type Column, type RowData, Subscribe } from "@tanstack/react-table"
-import type { ReactNode } from "react"
+import type { ComponentProps, ReactNode } from "react"
 import type { organizationTableFeatures } from "./organization-table"
 
 export function OrganizationSortableTableHeader<TData extends RowData>({
   children,
   column,
-  interactive = true
+  interactive = true,
+  nativeSortDirection
 }: {
   children: ReactNode
   column?: Column<typeof organizationTableFeatures, TData>
   interactive?: boolean
+  nativeSortDirection?: ComponentProps<
+    typeof Table.SortableColumnHeader
+  >["sortDirection"]
 }) {
   const onPress = column?.getToggleSortingHandler()
 
@@ -26,23 +30,31 @@ export function OrganizationSortableTableHeader<TData extends RowData>({
         const content = (
           <>
             {children}
+            {sortDirection && nativeSortDirection === undefined ? (
+              <ChevronUp
+                className={cn(
+                  "size-3 transition-transform duration-100 ease-out",
+                  sortDirection === "desc" && "rotate-180"
+                )}
+              />
+            ) : null}
             {sortDirection ? (
-              <>
-                <ChevronUp
-                  className={cn(
-                    "size-3 transition-transform duration-100 ease-out",
-                    sortDirection === "desc" && "rotate-180"
-                  )}
-                />
-                <span className="text-muted text-[10px] tabular-nums">
-                  {sortIndex + 1}
-                </span>
-              </>
+              <span className="text-muted text-[10px] tabular-nums">
+                {sortIndex + 1}
+              </span>
             ) : null}
           </>
         )
 
-        return interactive ? (
+        if (!interactive) {
+          return (
+            <Table.SortableColumnHeader sortDirection={nativeSortDirection}>
+              <span className="flex items-center gap-1">{content}</span>
+            </Table.SortableColumnHeader>
+          )
+        }
+
+        return (
           <Button
             className="h-auto min-w-0 justify-start gap-1 p-0 font-medium"
             onPress={(event) => onPress(event)}
@@ -51,8 +63,6 @@ export function OrganizationSortableTableHeader<TData extends RowData>({
           >
             {content}
           </Button>
-        ) : (
-          <span className="flex items-center gap-1">{content}</span>
         )
       }}
     </Subscribe>

--- a/packages/heroui/src/components/auth/organization/organization-table-state.ts
+++ b/packages/heroui/src/components/auth/organization/organization-table-state.ts
@@ -114,6 +114,7 @@ export function useOrganizationTableState(
   const atoms = useMemo(
     () => ({
       columnFilters: columnFiltersAtom,
+      columnVisibility: columnVisibilityAtom,
       globalFilter: globalFilterAtom,
       pagination: paginationAtom,
       rowSelection: rowSelectionAtom,
@@ -121,6 +122,7 @@ export function useOrganizationTableState(
     }),
     [
       columnFiltersAtom,
+      columnVisibilityAtom,
       globalFilterAtom,
       paginationAtom,
       rowSelectionAtom,

--- a/packages/heroui/tests/auth-form.test.tsx
+++ b/packages/heroui/tests/auth-form.test.tsx
@@ -83,6 +83,40 @@ function AsyncValidatedAuthForm({
   )
 }
 
+function MultiFieldServerErrorForm() {
+  const form = useAuthForm({
+    defaultValues: { email: "", password: "" },
+    onSubmit: async () => {
+      setAuthFormServerError(
+        form,
+        {
+          fields: {
+            email: "Email is unavailable",
+            password: "Password is compromised"
+          },
+          message: "Update the highlighted fields"
+        },
+        "Fallback submission error"
+      )
+    }
+  })
+
+  return (
+    <form.AppForm>
+      <form.AuthFormRoot>
+        <form.AppField name="email">
+          {(field) => <field.AuthFormTextField label="Email" />}
+        </form.AppField>
+        <form.AppField name="password">
+          {(field) => <field.AuthFormTextField label="Password" />}
+        </form.AppField>
+        <form.AuthFormServerError />
+        <form.AuthFormSubmitButton>Continue</form.AuthFormSubmitButton>
+      </form.AuthFormRoot>
+    </form.AppForm>
+  )
+}
+
 function ServerTableStateFixture() {
   const state = useServerTableState({ pageSize: 10 })
 
@@ -216,6 +250,28 @@ describe("AuthFormRoot", () => {
 
     finishValidation()
     await waitFor(() => expect(input).not.toHaveAttribute("aria-busy"))
+  })
+
+  it("preserves unrelated server field errors while editing", async () => {
+    render(<MultiFieldServerErrorForm />)
+    const email = screen.getByRole("textbox", { name: "Email" })
+    const password = screen.getByRole("textbox", { name: "Password" })
+
+    fireEvent.change(email, { target: { value: "ada@example.com" } })
+    fireEvent.change(password, { target: { value: "password" } })
+    fireEvent.click(screen.getByRole("button", { name: /Continue/ }))
+
+    expect(await screen.findByText("Email is unavailable")).toBeVisible()
+    expect(screen.getByText("Password is compromised")).toBeVisible()
+    expect(screen.getByText("Update the highlighted fields")).toBeVisible()
+
+    fireEvent.change(password, { target: { value: "safer password" } })
+
+    await waitFor(() =>
+      expect(screen.queryByText("Password is compromised")).toBeNull()
+    )
+    expect(screen.getByText("Email is unavailable")).toBeVisible()
+    expect(screen.queryByText("Update the highlighted fields")).toBeNull()
   })
 })
 

--- a/packages/heroui/tests/organization-table-renderer.tsx
+++ b/packages/heroui/tests/organization-table-renderer.tsx
@@ -1,13 +1,13 @@
 import { Table } from "@heroui/react"
 import type { ReactNode } from "react"
+import { OrganizationSortableTableHeader } from "../src/components/auth/organization/organization-sortable-table-header"
+import { useOrganizationTableContext } from "../src/components/auth/organization/organization-table"
 import {
   getHeroUISelection,
   getHeroUISortDescriptor,
   getTanStackRowSelection,
   getTanStackSorting
-} from "../table-bridge"
-import { OrganizationSortableTableHeader } from "./organization-sortable-table-header"
-import { useOrganizationTableContext } from "./organization-table"
+} from "../src/components/auth/table-bridge"
 
 export function OrganizationTableRenderer({
   ariaLabel,
@@ -50,16 +50,19 @@ export function OrganizationTableRenderer({
                   isRowHeader={header.column === rowHeaderColumn}
                   key={header.id}
                 >
-                  {header.isPlaceholder ? null : header.column.getCanSort() ? (
-                    <OrganizationSortableTableHeader
-                      column={header.column}
-                      interactive={false}
-                    >
+                  {({ sortDirection }) =>
+                    header.isPlaceholder ? null : header.column.getCanSort() ? (
+                      <OrganizationSortableTableHeader
+                        column={header.column}
+                        interactive={false}
+                        nativeSortDirection={sortDirection}
+                      >
+                        <table.FlexRender header={header} />
+                      </OrganizationSortableTableHeader>
+                    ) : (
                       <table.FlexRender header={header} />
-                    </OrganizationSortableTableHeader>
-                  ) : (
-                    <table.FlexRender header={header} />
-                  )}
+                    )
+                  }
                 </Table.Column>
               ))
             )}

--- a/packages/heroui/tests/organization-table.test.tsx
+++ b/packages/heroui/tests/organization-table.test.tsx
@@ -14,9 +14,9 @@ import {
   createOrganizationColumnHelper,
   useOrganizationTable
 } from "../src/components/auth/organization/organization-table"
-import { OrganizationTableRenderer } from "../src/components/auth/organization/organization-table-renderer"
 import { OrganizationTableSelectRow } from "../src/components/auth/organization/organization-table-selection"
 import { useOrganizationTableState } from "../src/components/auth/organization/organization-table-state"
+import { OrganizationTableRenderer } from "./organization-table-renderer"
 
 type TestRow = {
   group: string
@@ -258,14 +258,15 @@ describe("organization table state", () => {
 
     const { result } = renderHook(() => {
       const state = useOrganizationTableState("test", 10, TEST_COLUMN_IDS)
-      const table = useOrganizationTable({
-        atoms: state.atoms,
-        columns,
-        data: rows,
-        getRowId: (row) => row.id,
-        state: { columnVisibility: state.columnVisibility },
-        onColumnVisibilityChange: state.setColumnVisibility
-      })
+      const table = useOrganizationTable<TestRow, null>(
+        {
+          atoms: state.atoms,
+          columns,
+          data: rows,
+          getRowId: (row) => row.id
+        },
+        () => null
+      )
       return { state, table }
     })
 
@@ -284,6 +285,9 @@ describe("organization table state", () => {
 
     expect(result.current.state.pagination.pageIndex).toBe(0)
     expect(result.current.state.rowSelection).toEqual({})
+
+    act(() => result.current.table.getColumn("group")?.toggleVisibility(false))
+    expect(result.current.state.columnVisibility).toEqual({ group: false })
 
     await waitFor(() => {
       expect(


### PR DESCRIPTION
## Summary

- make TanStack Table state fully atom-controlled across React, Solid, shadcn/ui, HeroUI, and Zaidan consumers
- use narrow React table subscriptions, permission-safe columns, stronger Solid typing, and leaf-level loading states
- connect HeroUI organization tables to native sorting semantics while retaining TanStack state and multi-sort order
- expose TanStack Form composition helpers and clear only the edited field server error
- move test-only table renderers out of production sources and add behavioral regression coverage

## Validation

- bun nx run-many -t typecheck -p @better-auth-ui/core @better-auth-ui/heroui start-shadcn-example start-shadcn-baseui-example start-solid-zaidan-example docs --outputStyle=static
- bun nx run-many -t lint --outputStyle=static
- bun nx run-many -t registry:build -p start-shadcn-example start-solid-zaidan-example --outputStyle=static
- bun nx run-many -t test -p @better-auth-ui/core @better-auth-ui/heroui start-shadcn-example --outputStyle=static
- bun nx run start-solid-zaidan-example:test -- tests/auth-form.browser.test.tsx --run
- bun nx run start-solid-zaidan-example:test -- tests/auth-route.test.ts --run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Editing a form field now clears only its server-side error, preserving errors on other fields.
  * Organization tables now maintain sorting and column visibility more reliably.
  * Member tables provide clearer loading and empty-state displays.

* **Improvements**
  * Added native sorting indicators and non-interactive sortable headers.
  * Expanded form hooks with field-group and form helpers.
  * Improved table behavior across administrative and organization views.

* **Tests**
  * Added coverage for multi-field server errors and column visibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->